### PR TITLE
docs(release): point v1.1.0 notes at docs.tokenpak.ai subdomain

### DIFF
--- a/.github/RELEASE_NOTES_v1.1.0.md
+++ b/.github/RELEASE_NOTES_v1.1.0.md
@@ -12,7 +12,7 @@ Canonical wire headers, manifest schemas, telemetry event schema, profiles, and 
 
 Third-party adopters (adapter / plugin / alternate proxy implementers): `pip install tokenpak-tip-validator==0.1.0` for the separate conformance-testing package.
 
-Protocol docs: https://tokenpak.ai/protocol
+Protocol docs: https://docs.tokenpak.ai/protocol/
 
 ### Proxy + CLI consolidation
 
@@ -46,8 +46,8 @@ Drop-in. DeprecationWarning shims preserve every legacy import path through TIP-
 
 ## Architecture + operational docs
 
-- Protocol: https://tokenpak.ai/protocol
-- Quickstart: https://tokenpak.ai/quickstart
+- Protocol: https://docs.tokenpak.ai/protocol/
+- Quickstart: https://docs.tokenpak.ai/quickstart/
 - Canonical §1 subsystem layout: Architecture Standard §1 in the internal docs
 
 ## Acknowledgments


### PR DESCRIPTION
## Summary

- Three URL references in `.github/RELEASE_NOTES_v1.1.0.md` point at the apex domain for docs content; per `DECISION-MTC-03` (2026-04-22), docs live on `docs.tokenpak.ai` and the apex is marketing-only.
- Rewrites Protocol (×2) and Quickstart (×1) links to `docs.tokenpak.ai/protocol/` / `docs.tokenpak.ai/quickstart/`.
- The v1.1.0 GitHub release is still **draft** so the in-tree notes are still the source of truth — fix before promotion.

## Scope

Class-C cleanup item from `~/vault/03_AGENT_PACKS/Sue/memory/2026-04-22.md` (AM block, "Known follow-up debt"). No other behavior change.

Later release notes (`v1.2.0`..`v1.3.0`) already use the correct subdomain; no sweep needed there.

## Out of scope

- Three JSON Schema `$id` URLs in `tokenpak/schemas/*.json` (apex + singular `/schema/`). Those need a deliberate registry-path decision and are tracked separately — not touched here.
- `tokenpak.ai/pricing` references in `intelligence/{ab_router,cost_router}.py` — pricing = marketing = apex, correct under current decisions.

## Test plan

- [ ] `grep -nE 'tokenpak\\.ai/(protocol|quickstart)' .github/RELEASE_NOTES_v1.1.0.md` returns nothing.
- [ ] Rendered markdown preview on the PR shows all three links pointing at `docs.tokenpak.ai`.
- [ ] Update the v1.1.0 draft release body on GitHub (after merge) to match.