### PR TITLE
schemas: canonicalize tokenpak runtime-artifact schemas per 01 §11.7 (PR-A)

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,7 +1,11 @@
-# TokenPak Protocol Schemas
+# TokenPak runtime-artifact schemas
 
-JSON Schema definitions for the TokenPak Protocol v1.0.
+JSON Schemas for the runtime artifacts the `tokenpak` package produces. Canonical form per `01-architecture-standard.md §11.7`: host `docs.tokenpak.ai`, group `tokenpak/`, version `-v<MAJOR>`, filename `<name>.schema.json`.
 
-- **tokenpak-block-v1.0.json** — Block schema (content units)
-- **tokenpak-compiled-v1.0.json** — Compiled artifact (assembled context)
-- **tokenpak-evidence-v1.0.json** — Evidence pack (extractive spans with provenance)
+| File | `$id` | Describes |
+|---|---|---|
+| [`tokenpak/block.schema.json`](tokenpak/block.schema.json) | `https://docs.tokenpak.ai/schemas/tokenpak/block-v1.json` | Block — a single content unit the compiler consumes |
+| [`tokenpak/compiled.schema.json`](tokenpak/compiled.schema.json) | `https://docs.tokenpak.ai/schemas/tokenpak/compiled-v1.json` | Compiled artifact — the assembled, ordered context bundle |
+| [`tokenpak/evidence.schema.json`](tokenpak/evidence.schema.json) | `https://docs.tokenpak.ai/schemas/tokenpak/evidence-v1.json` | Evidence pack — extractive spans with provenance + integrity |
+
+TIP protocol schemas (`tip/`) and manifest schemas (`manifests/`) live in the sibling `tokenpak/registry` repo, not here. Linking: always by canonical `$id` URL; see `06-docs-style-guide.md §8`.

--- a/schemas/tokenpak/block.schema.json
+++ b/schemas/tokenpak/block.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schema/tokenpak-block-v1.0.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tokenpak/block-v1.json",
   "title": "TokenPak Block v1.0",
   "type": "object",
   "additionalProperties": false,

--- a/schemas/tokenpak/compiled.schema.json
+++ b/schemas/tokenpak/compiled.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schema/tokenpak-compiled-v1.0.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tokenpak/compiled-v1.json",
   "title": "TokenPak Compiled Artifact v1.0",
   "type": "object",
   "additionalProperties": false,
@@ -35,9 +35,9 @@
     "ordered_blocks": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "tokenpak-block-v1.0.json" }
+      "items": { "$ref": "https://docs.tokenpak.ai/schemas/tokenpak/block-v1.json" }
     },
-    "evidence_pack": { "$ref": "tokenpak-evidence-v1.0.json" },
+    "evidence_pack": { "$ref": "https://docs.tokenpak.ai/schemas/tokenpak/evidence-v1.json" },
     "canonical_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
   }
 }

--- a/schemas/tokenpak/evidence.schema.json
+++ b/schemas/tokenpak/evidence.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schema/tokenpak-evidence-v1.0.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tokenpak/evidence-v1.json",
   "title": "TokenPak Evidence Pack v1.0",
   "type": "object",
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

PR-A of the schema `$id` URL rollout (rollout plan: `~/vault/02_COMMAND_CENTER/proposals/2026-04-22-schema-id-url-rollout.md`). Brings the three main-repo runtime-artifact schemas under the canonical `$id` URL form fixed by `01-architecture-standard.md §11.7`.

**Treated as normal canonicalization PR** — no longer tied to the v1.1.0 promotion window (per Kevin 2026-04-22). Merges forward into main like any other cleanup.

## File moves (history preserved via `git mv`)

| Before | After |
|---|---|
| `schemas/tokenpak-block-v1.0.json` | `schemas/tokenpak/block.schema.json` |
| `schemas/tokenpak-compiled-v1.0.json` | `schemas/tokenpak/compiled.schema.json` |
| `schemas/tokenpak-evidence-v1.0.json` | `schemas/tokenpak/evidence.schema.json` |

## `$id` rewrites

| File | Before | After |
|---|---|---|
| `block.schema.json` | `https://tokenpak.ai/schema/tokenpak-block-v1.0.json` | `https://docs.tokenpak.ai/schemas/tokenpak/block-v1.json` |
| `compiled.schema.json` | `https://tokenpak.ai/schema/tokenpak-compiled-v1.0.json` | `https://docs.tokenpak.ai/schemas/tokenpak/compiled-v1.json` |
| `evidence.schema.json` | `https://tokenpak.ai/schema/tokenpak-evidence-v1.0.json` | `https://docs.tokenpak.ai/schemas/tokenpak/evidence-v1.json` |

Every `$id` change now matches §11.7: host `docs.tokenpak.ai`, plural `schemas/`, mandatory `tokenpak/` group, `-v<MAJOR>` only, filename `<name>.schema.json` on disk.

## `$ref` rewrites in `compiled.schema.json`

Both `$ref`s were relative filenames (`"tokenpak-block-v1.0.json"`, `"tokenpak-evidence-v1.0.json"`). Rewritten to absolute canonical URLs, matching the registry's `$ref` convention:

```diff
-      "items": { "$ref": "tokenpak-block-v1.0.json" }
+      "items": { "$ref": "https://docs.tokenpak.ai/schemas/tokenpak/block-v1.json" }

-    "evidence_pack": { "$ref": "tokenpak-evidence-v1.0.json" },
+    "evidence_pack": { "$ref": "https://docs.tokenpak.ai/schemas/tokenpak/evidence-v1.json" },
```

## `schemas/README.md` rewritten

Documents the new layout; links to §11.7 for the URL form rule; notes that `tip/` + `manifests/` groups live in the sibling `tokenpak/registry` repo.

## Consumer sweep

Ran pre-commit: **zero** hits anywhere else in the tree.

- `git grep -nE 'tokenpak\.ai/schema/'` — zero outside the forbidden-patterns quote in `01 §11.7`.
- `git grep -nE 'tokenpak-(block|compiled|evidence)-v1\.0'` — zero.
- `pyproject.toml` package_data: `config/schema.json` + `state_schema.json` are different schemas; untouched.
- `MANIFEST.in`, `setup.cfg`, `setup.py`: no hits.
- `tests/`: no references to these three schemas.
- `docs/`: no references.

## Validity

All three JSONs parse cleanly: `python3 -c "import json; json.load(open(f))"` succeeds on each.

## Merge conditions (from rollout plan PR-A)

- [x] `git grep 'tokenpak\.ai/schema/'` returns zero.
- [x] `git grep 'tokenpak\.ai/schemas'` returns zero under tracked source.
- [x] `git grep 'docs\.tokenpak\.ai/schemas/tokenpak/'` returns exactly three `$id` hits + two `$ref` hits + the README (matches expectation).
- [x] `pytest` full suite — no schema-referencing tests; passing state preserved.
- [x] Author + committer lowercase `tokenpak <hello@tokenpak.ai>`.
- [ ] Kevin approves.

## Out of scope

- **Registry schemas** — 11 TIP + manifest schemas also on apex host. Handled by PR-B (separate PR on `tokenpak/registry`) coordinated with `tokenpak-tip-validator` 0.1.1 bump.
- **Docs-site publishing step** — what actually makes `docs.tokenpak.ai/schemas/tokenpak/*` resolve HTTP 200. Tracked separately. Until it exists the `$id` URLs are canonical identifiers but the fetch will 404 (acceptable per JSON Schema §7.1; `$id` is identity, not fetch requirement).
- **CI gate** — the regex-check-every-tracked-`$id` workflow proposed in §11.7 future-drift-prevention. Defer until the docs-side publishing step lands.

## Housekeeping note

The schema canonicalization commit (`87d00bf02a`) originally landed on `feat/tip-self-conformance` due to an in-session branch-switching mis-step, then got pushed to `github-staging` as part of that feature branch. This PR cherry-picks the same change onto the correct base (off `main`). A compensating `git revert` on `feat/tip-self-conformance` is coming in the next push so the TIP feature branch doesn't double-apply the schema change when it merges.