### PR TITLE
dev(deps): bump tokenpak-tip-validator 0.1.0 → 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,11 @@ dev = [
     "import-linter>=2.0",
     # TIP-1.0 Phase 4: conformance validator. Published to PyPI
     # 2026-04-20 (DECISION-P4-PUBLISH). Pinned exact for CI stability.
-    "tokenpak-tip-validator==0.1.0",
+    # Bumped to 0.1.1 on 2026-04-22 for the schema $id URL
+    # canonicalization (01 §11.7); also unlocks companion-journal-row
+    # schema (scripts/tip_conformance_check.py emission:journal goes
+    # WARN -> PASS).
+    "tokenpak-tip-validator==0.1.1",
 ]
 tokens = [
     "tiktoken>=0.5.0",


### PR DESCRIPTION
## Summary

Follow-up to **PR-B** on the schema `$id` URL rollout (`tokenpak/registry#1`, merged 2026-04-22 at `951e08164cba8`). Bumps the `[dev]` extras pin from `tokenpak-tip-validator==0.1.0` → `==0.1.1` now that 0.1.1 is live on PyPI.

## What 0.1.1 brings

1. **Schema `$id` URL canonicalization** — all 11 registry-hosted schemas (7 TIP + 4 manifests) now use `docs.tokenpak.ai/schemas/<group>/<name>-v1.json` per `01-architecture-standard.md §11.7`. No field-set changes.
2. **Embedded `companion-journal-row` schema** — shipped in SC-01 on the registry side (2026-04-22); 0.1.0 predated it. This unblocks `emission:journal` in this repo's conformance check.
3. **Dangling `registry.json` `$schema` reference removed** — tracked as a parked follow-up proposal; unrelated to this repo.

## Local verification (in this repo's `.venv`)

```
$ source .venv/bin/activate
$ pip install -U tokenpak-tip-validator==0.1.1
$ python scripts/tip_conformance_check.py
```

| Validator | Result |
|---|---|
| `0.1.0` | 8 pass, 1 warn, 0 fail — WARN: `emission:journal — validator predates companion-journal-row schema` |
| `0.1.1` | **9 pass, 0 warn, 0 fail** |

Net: strict improvement — every pass-state preserved, the one WARN flips to PASS. No regressions.

## What this PR changes

Single line in `pyproject.toml` `[dev]` extras:

```diff
     # TIP-1.0 Phase 4: conformance validator. Published to PyPI
     # 2026-04-20 (DECISION-P4-PUBLISH). Pinned exact for CI stability.
-    "tokenpak-tip-validator==0.1.0",
+    # Bumped to 0.1.1 on 2026-04-22 for the schema $id URL
+    # canonicalization (01 §11.7); also unlocks companion-journal-row
+    # schema (scripts/tip_conformance_check.py emission:journal goes
+    # WARN -> PASS).
+    "tokenpak-tip-validator==0.1.1",
```

Strict pin retained per the existing "Pinned exact for CI stability" comment convention.

## Merge conditions

- [x] Validator 0.1.1 live on PyPI: `https://pypi.org/project/tokenpak-tip-validator/0.1.1/`.
- [x] Registry tag pushed: `tokenpak/registry@tip-validator-v0.1.1`.
- [x] Local `scripts/tip_conformance_check.py` green (9/9) with 0.1.1.
- [x] Author + committer lowercase `tokenpak <hello@tokenpak.ai>`.
- [ ] Kevin approves.

## Refs

- PR-B (registry + validator host swap): `https://github.com/tokenpak/registry/pull/1`
- PR-A (main-repo canonicalization): `https://github.com/tokenpak/tokenpak/pull/10` (merged `8b916f1180`)
- Rule: `01-architecture-standard.md §11.7`
- Rollout plan: `~/vault/02_COMMAND_CENTER/proposals/2026-04-22-schema-id-url-rollout.md`