### PR TITLE
schemas(vendored): resync _tip_schemas/ with canonical $id URLs (Architecture §11.7)

### DIFF
--- a/tokenpak/_tip_schemas/schemas/manifests/adapter.schema.json
+++ b/tokenpak/_tip_schemas/schemas/manifests/adapter.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/manifests/adapter-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/manifests/adapter-v1.json",
   "title": "TIP-1.0 Adapter Manifest",
-  "description": "Declares a per-client integration (Claude Code, Cursor, Aider, Cline, Continue, Codex) OR a framework bridge (LangChain, LlamaIndex, CrewAI, AutoGen, Langfuse). See https://tokenpak.ai/protocol/manifest-spec.",
+  "description": "Declares a per-client integration (Claude Code, Cursor, Aider, Cline, Continue, Codex) OR a framework bridge (LangChain, LlamaIndex, CrewAI, AutoGen, Langfuse). See https://docs.tokenpak.ai/protocol/manifest-spec.",
   "type": "object",
   "required": [
     "tip_version",
@@ -73,7 +73,7 @@
       "description": "Capability labels this adapter publishes. MUST include 'tip.adapter.client-integration' or 'tip.adapter.framework-bridge' depending on adapter_kind."
     },
     "compatibility": {
-      "$ref": "https://tokenpak.ai/schemas/tip/compatibility-v1.json"
+      "$ref": "https://docs.tokenpak.ai/schemas/tip/compatibility-v1.json"
     },
     "trust": {
       "type": "object",

--- a/tokenpak/_tip_schemas/schemas/manifests/client-profile.schema.json
+++ b/tokenpak/_tip_schemas/schemas/manifests/client-profile.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/manifests/client-profile-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/manifests/client-profile-v1.json",
   "title": "TIP-1.0 Client Profile",
-  "description": "Per-client inbound profile (CLI, TUI, API, IDE, cron, batch). Describes how requests from this client kind should be routed and whether the companion should attach. See https://tokenpak.ai/protocol/manifest-spec.",
+  "description": "Per-client inbound profile (CLI, TUI, API, IDE, cron, batch). Describes how requests from this client kind should be routed and whether the companion should attach. See https://docs.tokenpak.ai/protocol/manifest-spec.",
   "type": "object",
   "required": [
     "tip_version",
@@ -41,7 +41,7 @@
       }
     },
     "compatibility": {
-      "$ref": "https://tokenpak.ai/schemas/tip/compatibility-v1.json"
+      "$ref": "https://docs.tokenpak.ai/schemas/tip/compatibility-v1.json"
     },
     "client": {
       "type": "object",

--- a/tokenpak/_tip_schemas/schemas/manifests/plugin.schema.json
+++ b/tokenpak/_tip_schemas/schemas/manifests/plugin.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/manifests/plugin-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/manifests/plugin-v1.json",
   "title": "TIP-1.0 Plugin Manifest",
-  "description": "Declares an optional TokenPak plugin that installs at documented hook points. See https://tokenpak.ai/protocol/manifest-spec.",
+  "description": "Declares an optional TokenPak plugin that installs at documented hook points. See https://docs.tokenpak.ai/protocol/manifest-spec.",
   "type": "object",
   "required": [
     "tip_version",
@@ -42,7 +42,7 @@
       "description": "MUST include tip.plugin.hook-point."
     },
     "compatibility": {
-      "$ref": "https://tokenpak.ai/schemas/tip/compatibility-v1.json"
+      "$ref": "https://docs.tokenpak.ai/schemas/tip/compatibility-v1.json"
     },
     "hooks": {
       "type": "array",

--- a/tokenpak/_tip_schemas/schemas/manifests/provider-profile.schema.json
+++ b/tokenpak/_tip_schemas/schemas/manifests/provider-profile.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/manifests/provider-profile-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/manifests/provider-profile-v1.json",
   "title": "TIP-1.0 Provider Profile",
-  "description": "Per-provider outbound profile (Anthropic, OpenAI, Google, Ollama, custom-local). Describes how services.routing_service invokes this provider. See https://tokenpak.ai/protocol/manifest-spec.",
+  "description": "Per-provider outbound profile (Anthropic, OpenAI, Google, Ollama, custom-local). Describes how services.routing_service invokes this provider. See https://docs.tokenpak.ai/protocol/manifest-spec.",
   "type": "object",
   "required": [
     "tip_version",
@@ -41,7 +41,7 @@
       }
     },
     "compatibility": {
-      "$ref": "https://tokenpak.ai/schemas/tip/compatibility-v1.json"
+      "$ref": "https://docs.tokenpak.ai/schemas/tip/compatibility-v1.json"
     },
     "provider": {
       "type": "object",

--- a/tokenpak/_tip_schemas/schemas/tip/capabilities.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/capabilities.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/capabilities-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/capabilities-v1.json",
   "title": "TIP-1.0 Capability Catalog",
-  "description": "Authoritative catalog of capability labels a TokenPak-compatible component MAY publish during MCP capability negotiation or in an X-TokenPak-Capability header. TIP-reserved labels start with 'tip.'; extension labels start with 'ext.<namespace>.'. Anything else is invalid. See https://tokenpak.ai/protocol/tip-capabilities.",
+  "description": "Authoritative catalog of capability labels a TokenPak-compatible component MAY publish during MCP capability negotiation or in an X-TokenPak-Capability header. TIP-reserved labels start with 'tip.'; extension labels start with 'ext.<namespace>.'. Anything else is invalid. See https://docs.tokenpak.ai/protocol/tip-capabilities.",
   "type": "object",
   "required": ["tip_version", "labels"],
   "properties": {

--- a/tokenpak/_tip_schemas/schemas/tip/companion-journal-row.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/companion-journal-row.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/companion-journal-row-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/companion-journal-row-v1.json",
   "title": "TIP-1.0 Companion Journal Row",
-  "description": "One row in the companion-local session journal (~/.tokenpak/companion/journal.db). Companion-side UX state per Constitution §5.2-C; NEVER a source of truth for billing or cache. Rows complement (not replace) the wire-side telemetry rows written by services.telemetry_service. See https://tokenpak.ai/protocol/telemetry-semantics.",
+  "description": "One row in the companion-local session journal (~/.tokenpak/companion/journal.db). Companion-side UX state per Constitution §5.2-C; NEVER a source of truth for billing or cache. Rows complement (not replace) the wire-side telemetry rows written by services.telemetry_service. See https://docs.tokenpak.ai/protocol/telemetry-semantics.",
   "type": "object",
   "required": ["session_id", "timestamp", "entry_type", "tip_version"],
   "additionalProperties": false,

--- a/tokenpak/_tip_schemas/schemas/tip/compatibility.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/compatibility.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/compatibility-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/compatibility-v1.json",
   "title": "TIP-1.0 Compatibility Declaration",
-  "description": "How a component declares its TIP version range and peer capability requirements. Included by every TIP manifest. Evaluated by core/contracts/compatibility.py during connection negotiation. See https://tokenpak.ai/protocol/compatibility.",
+  "description": "How a component declares its TIP version range and peer capability requirements. Included by every TIP manifest. Evaluated by core/contracts/compatibility.py during connection negotiation. See https://docs.tokenpak.ai/protocol/compatibility.",
   "type": "object",
   "required": ["tip_version_range"],
   "additionalProperties": false,

--- a/tokenpak/_tip_schemas/schemas/tip/error.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/error.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/error-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/error-v1.json",
   "title": "TIP-1.0 Error Envelope",
   "description": "Canonical error shape emitted by any TIP-compatible surface. Bare HTML errors are forbidden (see project_openclaw_cali_auth_failure_mode incident). Every error response on the data plane and every error frame on the control plane conforms to this shape.",
   "type": "object",

--- a/tokenpak/_tip_schemas/schemas/tip/headers.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/headers.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/headers-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/headers-v1.json",
   "title": "TIP-1.0 Wire Headers",
-  "description": "Canonical X-TokenPak-* headers carried on data-plane requests and responses. See https://tokenpak.ai/protocol/transport-bindings for normative text. TIP-1.0 headers are informational metadata; they never alter the request body (Architecture §5.1 byte-fidelity rule).",
+  "description": "Canonical X-TokenPak-* headers carried on data-plane requests and responses. See https://docs.tokenpak.ai/protocol/transport-bindings for normative text. TIP-1.0 headers are informational metadata; they never alter the request body (Architecture §5.1 byte-fidelity rule).",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/tokenpak/_tip_schemas/schemas/tip/metadata.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/metadata.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/metadata-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/metadata-v1.json",
   "title": "TIP-1.0 Request/Response Metadata",
-  "description": "Runtime metadata attached to services.Request.metadata and services.Response.metadata. See https://tokenpak.ai/protocol/scope for what TIP-1.0 does and does not cover.",
+  "description": "Runtime metadata attached to services.Request.metadata and services.Response.metadata. See https://docs.tokenpak.ai/protocol/scope for what TIP-1.0 does and does not cover.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/tokenpak/_tip_schemas/schemas/tip/telemetry-event.schema.json
+++ b/tokenpak/_tip_schemas/schemas/tip/telemetry-event.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://tokenpak.ai/schemas/tip/telemetry-event-v1.json",
+  "$id": "https://docs.tokenpak.ai/schemas/tip/telemetry-event-v1.json",
   "title": "TIP-1.0 Telemetry Event",
-  "description": "One row per request in the telemetry store (~/.tokenpak/telemetry.db). Written only by services.telemetry_service per Architecture §7.1. Normative field set for TIP-1.0; additive MINOR bumps may extend it, MAJOR bumps may break it. See https://tokenpak.ai/protocol/telemetry-semantics.",
+  "description": "One row per request in the telemetry store (~/.tokenpak/telemetry.db). Written only by services.telemetry_service per Architecture §7.1. Normative field set for TIP-1.0; additive MINOR bumps may extend it, MAJOR bumps may break it. See https://docs.tokenpak.ai/protocol/telemetry-semantics.",
   "type": "object",
   "required": ["request_id", "timestamp", "cache_origin", "tip_version"],
   "additionalProperties": false,


### PR DESCRIPTION
## Summary

The vendored TIP + manifest schema mirror at `tokenpak/_tip_schemas/` (added in SC-07) predated PR-A (tokenpak#10) and PR-B (tokenpak/registry#1) and was still shipping **apex-form `$id` URLs inside the wheel**. This PR runs the documented sync procedure in `tokenpak/_tip_schemas/README.md` to bring the vendored tree into alignment with the canonical form fixed by `01-architecture-standard.md §11.7`.

## Scope

Pure URL host swap — **11 `$id` + 4 `$ref` rewrites across 11 schema files.** No schema content changes.

```diff
-"$id": "https://tokenpak.ai/schemas/<group>/<name>-v1.json"
+"$id": "https://docs.tokenpak.ai/schemas/<group>/<name>-v1.json"
```

Files: 7 under `tokenpak/_tip_schemas/schemas/tip/` + 4 under `tokenpak/_tip_schemas/schemas/manifests/`.

## How it was generated

Verbatim from the README's "Sync command":

```bash
rm -f tokenpak/_tip_schemas/schemas/tip/*.json \
      tokenpak/_tip_schemas/schemas/manifests/*.json
cp ../registry/schemas/tip/*.json        tokenpak/_tip_schemas/schemas/tip/
cp ../registry/schemas/manifests/*.json  tokenpak/_tip_schemas/schemas/manifests/
```

`~/registry` is at registry main post-PR-B, `951e08164cba8`.

## Verification (both README-documented steps)

| Step | Result |
|---|---|
| `pytest tests/conformance/ -m conformance` | **28/28 passed in 6.59s** |
| `tokenpak doctor --conformance` | **9 pass, 0 warn, 0 fail, exit 0** |

Post-sync drift grep:

```
$ git grep 'https://tokenpak\.ai/(schema|schemas)' -- tokenpak/_tip_schemas/
(no output)
```

## Version-bump question flagged for Kevin

`tokenpak/_tip_schemas/README.md` §3 says *"Bump `tokenpak.__version__`"* is part of the sync checklist. That instruction is scoped to TIP-MINOR schema-content changes — this sync is a **pure URL host swap with identical schema content**, not a TIP-MINOR change. I've deliberately **not** bumped the version here; letting you decide whether to fold a patch bump into the next release commit or leave it for the normal release cycle.

## Merge conditions

- [x] Matches the README's documented sync procedure verbatim.
- [x] Both verification steps in the README green.
- [x] Post-sync drift grep returns zero.
- [x] Author + committer lowercase `tokenpak <hello@tokenpak.ai>`.
- [ ] Kevin approves.

## Refs

- PR-A (main-repo schema canonicalization): `tokenpak#10` @ `8b916f1180`
- PR-B (registry + validator host swap + 0.1.1): `tokenpak/registry#1` @ `951e08164cba8`
- PR#11 (validator dev-pin bump): `tokenpak#11` @ `b7650504204c`
- Vendor source README: `tokenpak/_tip_schemas/README.md`
- Rule: `01-architecture-standard.md §11.7`