### PR TITLE
feat(cli): L-8 IDE integration in tokenpak setup (v1.3.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.12] - 2026-04-24
+
+### Added — L-8 (Launch Readiness): IDE integration in `tokenpak setup`
+
+Ratified by Kevin 2026-04-24 as the sole launch-blocker-adjacent gap surfaced by the adapter dynamic-passivity audit (`02-ADAPTER-AUDIT.md`). The wizard now detects IDE hosts via environment signals and offers to wire `ANTHROPIC_BASE_URL` into the user's shell profile so IDE-launched Claude Code / Anthropic SDK calls route through the local proxy without manual configuration.
+
+**Design.** Per-IDE handlers live in `tokenpak/cli/ide.py::_REGISTRY`. Registering a new IDE is one `register(IDEHandler(...))` call; detection is signal-based and the call-site does not enumerate IDEs (`feedback_always_dynamic`, 2026-04-16). Built-in handlers: Cursor (`CURSOR_*` env, `TERM_PROGRAM=cursor`), VSCode (`VSCODE_PID`, `VSCODE_IPC_HOOK`, `TERM_PROGRAM=vscode`).
+
+**Flow.** After the proxy starts, the wizard:
+1. Detects the user's IDE host by env signals.
+2. Locates the first existing shell profile (zsh / bash / fish) honoring `$SHELL`.
+3. Prompts (default yes) to append an `ANTHROPIC_BASE_URL` export in the target shell's syntax.
+4. Prints a manual copy-paste fallback if no profile exists or the user declines.
+
+Idempotent: re-running `tokenpak setup` with the same port does not duplicate the export line. No-op when no IDE signals are present — the wizard stays single-screen for CLI-only users. Setup never fails because of the IDE step; any error is caught and surfaced as a one-line notice.
+
+### Tests
+
+18 new tests covering registry idempotency, per-IDE signal detection, shell-profile resolution, shell-specific export syntax (bash/zsh/fish), idempotent append semantics, decline / accept / auto-yes paths, and the no-profile fallback. Regression coverage: 46/46 CLI tests green.
+
 ## [1.3.11] - 2026-04-24
 
 ### Added — Phase B of MVP Gap Closure (Working Product Readiness)

--- a/tests/cli/test_ide_integration.py
+++ b/tests/cli/test_ide_integration.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""L-8 (Launch Readiness, 2026-04-24): IDE integration step in `tokenpak setup`.
+
+The wizard learned to detect Cursor / VSCode / related IDE hosts via
+environment signals and offer to write `ANTHROPIC_BASE_URL` to the user's
+shell profile. These tests pin:
+
+  1. The registry pattern honors `feedback_always_dynamic` — adding a
+     handler via `register()` is enough; no call-site enumeration.
+  2. Detection is env-driven and returns the right handlers per signal.
+  3. Shell-profile writer is idempotent and picks the right syntax per shell.
+  4. `run_setup_step` is a no-op when no IDE signals are present.
+  5. `run_setup_step` does not write when the user declines.
+  6. `auto_yes=True` writes without prompting (for scripted setup).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenpak.cli import ide
+
+# ── 1. Registry ──────────────────────────────────────────────────────────────
+
+
+def test_registry_has_cursor_and_vscode():
+    names = {h.name for h in ide.registered()}
+    assert "cursor" in names
+    assert "vscode" in names
+
+
+def test_register_is_idempotent_on_name():
+    before = len(ide.registered())
+    ide.register(ide.IDEHandler(name="cursor", label="Cursor", detect=lambda e: False))
+    after = len(ide.registered())
+    assert after == before
+    # Restore real detector so subsequent tests keep working.
+    ide.register(
+        ide.IDEHandler(
+            name="cursor",
+            label="Cursor",
+            detect=lambda env: any(k.startswith("CURSOR_") for k in env.keys())
+            or env.get("TERM_PROGRAM") == "cursor",
+        )
+    )
+
+
+def test_register_custom_handler_is_detected():
+    ide.register(ide.IDEHandler(name="fakeide", label="Fake", detect=lambda e: "FAKE_IDE" in e))
+    try:
+        hits = ide.detect({"FAKE_IDE": "1"})
+        assert any(h.name == "fakeide" for h in hits)
+    finally:
+        # Remove the test handler by re-registering with a permanent-false detector
+        # is sufficient for isolation; the registry is module-global.
+        ide.register(ide.IDEHandler(name="fakeide", label="Fake", detect=lambda e: False))
+
+
+# ── 2. Detection ─────────────────────────────────────────────────────────────
+
+
+def test_detect_cursor_via_cursor_env_prefix():
+    hits = {h.name for h in ide.detect({"CURSOR_TRACE_ID": "abc"})}
+    assert "cursor" in hits
+
+
+def test_detect_vscode_via_vscode_pid():
+    hits = {h.name for h in ide.detect({"VSCODE_PID": "12345"})}
+    assert "vscode" in hits
+
+
+def test_detect_vscode_via_term_program():
+    hits = {h.name for h in ide.detect({"TERM_PROGRAM": "vscode"})}
+    assert "vscode" in hits
+
+
+def test_detect_returns_empty_on_plain_shell():
+    hits = ide.detect({"SHELL": "/bin/bash", "HOME": "/home/x"})
+    assert hits == []
+
+
+# ── 3. Shell-profile writer ──────────────────────────────────────────────────
+
+
+def test_resolve_profile_prefers_existing_zshrc_when_zsh(tmp_path: Path):
+    (tmp_path / ".zshrc").write_text("")
+    (tmp_path / ".bashrc").write_text("")
+    assert ide.resolve_profile(home=tmp_path, shell="/usr/bin/zsh") == tmp_path / ".zshrc"
+
+
+def test_resolve_profile_prefers_bashrc_when_bash(tmp_path: Path):
+    (tmp_path / ".bashrc").write_text("")
+    (tmp_path / ".zshrc").write_text("")
+    assert ide.resolve_profile(home=tmp_path, shell="/bin/bash") == tmp_path / ".bashrc"
+
+
+def test_resolve_profile_returns_none_when_no_profile_exists(tmp_path: Path):
+    assert ide.resolve_profile(home=tmp_path, shell="/bin/bash") is None
+
+
+def test_write_export_appends_when_missing(tmp_path: Path):
+    profile = tmp_path / ".zshrc"
+    profile.write_text("# existing content\n")
+    modified = ide.write_export(profile, "http://127.0.0.1:8766")
+    assert modified is True
+    text = profile.read_text()
+    assert 'export ANTHROPIC_BASE_URL="http://127.0.0.1:8766"' in text
+    assert "existing content" in text  # preserved
+
+
+def test_write_export_is_idempotent(tmp_path: Path):
+    profile = tmp_path / ".zshrc"
+    profile.write_text("")
+    ide.write_export(profile, "http://127.0.0.1:8766")
+    modified_second = ide.write_export(profile, "http://127.0.0.1:8766")
+    assert modified_second is False
+    # Only one export line should be present.
+    assert profile.read_text().count("ANTHROPIC_BASE_URL=") == 1
+
+
+def test_write_export_uses_fish_syntax(tmp_path: Path):
+    profile = tmp_path / ".config" / "fish" / "config.fish"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("")
+    ide.write_export(profile, "http://127.0.0.1:8766")
+    assert "set -gx ANTHROPIC_BASE_URL" in profile.read_text()
+
+
+# ── 4. run_setup_step end-to-end ─────────────────────────────────────────────
+
+
+def test_run_setup_step_noop_without_ide_signals(tmp_path: Path, capsys):
+    result = ide.run_setup_step(
+        port=8766,
+        env={"HOME": str(tmp_path)},
+        home=tmp_path,
+        shell="/bin/bash",
+        prompt=lambda _msg: pytest.fail("should not prompt when no IDE detected"),
+    )
+    assert result["detected"] == []
+    assert result["wrote"] is None
+
+
+def test_run_setup_step_skips_when_user_declines(tmp_path: Path, capsys):
+    (tmp_path / ".zshrc").write_text("")
+    result = ide.run_setup_step(
+        port=8766,
+        env={"CURSOR_TRACE_ID": "abc"},
+        home=tmp_path,
+        shell="/usr/bin/zsh",
+        prompt=lambda _msg: "no",
+    )
+    assert "cursor" in result["detected"]
+    assert result["wrote"] is False
+    assert "ANTHROPIC_BASE_URL" not in (tmp_path / ".zshrc").read_text()
+
+
+def test_run_setup_step_writes_when_user_accepts(tmp_path: Path, capsys):
+    (tmp_path / ".zshrc").write_text("")
+    result = ide.run_setup_step(
+        port=8766,
+        env={"CURSOR_TRACE_ID": "abc"},
+        home=tmp_path,
+        shell="/usr/bin/zsh",
+        prompt=lambda _msg: "yes",
+    )
+    assert "cursor" in result["detected"]
+    assert result["wrote"] is True
+    assert 'ANTHROPIC_BASE_URL="http://127.0.0.1:8766"' in (tmp_path / ".zshrc").read_text()
+
+
+def test_run_setup_step_auto_yes_writes_without_prompt(tmp_path: Path):
+    (tmp_path / ".zshrc").write_text("")
+    result = ide.run_setup_step(
+        port=8766,
+        env={"VSCODE_PID": "12345"},
+        home=tmp_path,
+        shell="/usr/bin/zsh",
+        prompt=lambda _msg: pytest.fail("auto_yes=True should skip the prompt"),
+        auto_yes=True,
+    )
+    assert "vscode" in result["detected"]
+    assert result["wrote"] is True
+
+
+def test_run_setup_step_prints_manual_export_when_no_profile(tmp_path: Path, capsys):
+    # No .zshrc / .bashrc / config.fish in tmp_path
+    result = ide.run_setup_step(
+        port=8766,
+        env={"CURSOR_TRACE_ID": "abc"},
+        home=tmp_path,
+        shell="/bin/bash",
+        prompt=lambda _msg: pytest.fail("should not prompt when no profile exists"),
+    )
+    assert "cursor" in result["detected"]
+    assert result["profile"] is None
+    captured = capsys.readouterr().out
+    assert 'export ANTHROPIC_BASE_URL="http://127.0.0.1:8766"' in captured

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -329,6 +329,18 @@ def cmd_setup(args):
     # user had no discovery path to the local dashboard until this was
     # added — README mentioned `tokenpak dashboard` but the wizard's
     # "Next steps" block did not.
+    # L-8 (Launch Readiness, 2026-04-24): if an IDE host is detected, offer
+    # to wire ANTHROPIC_BASE_URL into the user's shell profile so
+    # IDE-launched Claude Code / Anthropic SDK calls route through the
+    # proxy. No-op when no IDE signals are present — keeps the wizard
+    # single-screen for CLI-only users.
+    try:
+        from tokenpak.cli.ide import run_setup_step as _run_ide_step
+
+        _run_ide_step(port)
+    except Exception as _ide_err:  # never block setup on the IDE step
+        print(f"(IDE integration step skipped: {_ide_err})")
+
     print("\nNext steps:")
     print(f"  1. Set your LLM client's base URL to http://127.0.0.1:{port}")
     print(f"  2. Open the dashboard: http://127.0.0.1:{port}/dashboard")

--- a/tokenpak/cli/ide.py
+++ b/tokenpak/cli/ide.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""IDE integration helpers for `tokenpak setup`.
+
+Detects common IDE hosts (Cursor, VSCode, and variants) via environment signals
+and offers to write `ANTHROPIC_BASE_URL` to the user's shell profile so that
+IDE-launched Claude Code / Anthropic SDK calls route through the local proxy.
+
+Design: per-IDE handlers live in a registry keyed by `name`. Handlers expose
+a `detect(env)` predicate and a static label. The registry is the single
+source of truth; adding a new IDE is `register(Handler())`. There is no
+hardcoded enumeration of IDEs at the call site (`feedback_always_dynamic`,
+2026-04-16) — detection is signal-based and unknowns are a graceful no-op.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Mapping, Optional
+
+ExportLine = str
+EnvLike = Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class IDEHandler:
+    """A detector for one IDE host.
+
+    `name` is the slug used in messages. `detect` returns True if the given
+    environment indicates this IDE is currently running. `label` is the
+    human-facing name.
+    """
+
+    name: str
+    label: str
+    detect: Callable[[EnvLike], bool]
+
+
+_REGISTRY: List[IDEHandler] = []
+
+
+def register(handler: IDEHandler) -> None:
+    """Add a handler to the detection registry. Idempotent on `name`."""
+    for i, existing in enumerate(_REGISTRY):
+        if existing.name == handler.name:
+            _REGISTRY[i] = handler
+            return
+    _REGISTRY.append(handler)
+
+
+def registered() -> List[IDEHandler]:
+    """Return all registered handlers (for tests + introspection)."""
+    return list(_REGISTRY)
+
+
+def detect(env: Optional[EnvLike] = None) -> List[IDEHandler]:
+    """Return every registered handler whose `detect` fires for `env`.
+
+    Multiple matches are possible (e.g. Cursor runs with VSCODE_PID set).
+    Call-sites de-duplicate by `name` if they need to."""
+    env = env if env is not None else os.environ
+    return [h for h in _REGISTRY if h.detect(env)]
+
+
+# ── Built-in handlers ────────────────────────────────────────────────────────
+#
+# Each handler reads ONLY from the env dict passed in. No global state.
+
+
+def _cursor_detect(env: EnvLike) -> bool:
+    # Cursor exports CURSOR_* env vars. It also sets VSCODE_* because it
+    # forks VSCode, so we bias Cursor over VSCode when both fire.
+    if any(k.startswith("CURSOR_") for k in env.keys()):
+        return True
+    return env.get("TERM_PROGRAM") == "cursor"
+
+
+def _vscode_detect(env: EnvLike) -> bool:
+    if env.get("TERM_PROGRAM") == "vscode":
+        return True
+    if env.get("VSCODE_PID") or env.get("VSCODE_IPC_HOOK") or env.get("VSCODE_IPC_HOOK_CLI"):
+        return True
+    return False
+
+
+register(IDEHandler(name="cursor", label="Cursor", detect=_cursor_detect))
+register(IDEHandler(name="vscode", label="VSCode", detect=_vscode_detect))
+
+
+# ── Shell-profile writer ─────────────────────────────────────────────────────
+
+
+_EXPORT_MARKER = "# Added by `tokenpak setup` — route Anthropic SDK traffic through the local proxy"
+
+
+def _candidate_profile_paths(home: Path, shell: Optional[str]) -> List[Path]:
+    """Return likely shell profile paths for this user, in preference order.
+
+    Preference: match the detected shell if possible, else fall back to
+    whatever profile file already exists on disk. We never create a new
+    shell config file silently; if none exists the caller prints the
+    manual export instead.
+    """
+    shell = (shell or "").lower()
+    if "zsh" in shell:
+        order = [".zshrc", ".bashrc", ".bash_profile"]
+    elif "fish" in shell:
+        order = [".config/fish/config.fish", ".zshrc", ".bashrc"]
+    elif "bash" in shell:
+        order = [".bashrc", ".bash_profile", ".zshrc"]
+    else:
+        order = [".zshrc", ".bashrc", ".bash_profile", ".config/fish/config.fish"]
+    return [home / rel for rel in order]
+
+
+def _format_export(shell_path: Path, base_url: str) -> ExportLine:
+    """Format the export line in the syntax the target shell uses."""
+    if shell_path.name == "config.fish" or "fish" in shell_path.parts:
+        return f'set -gx ANTHROPIC_BASE_URL "{base_url}"\n'
+    return f'export ANTHROPIC_BASE_URL="{base_url}"\n'
+
+
+def resolve_profile(home: Optional[Path] = None, shell: Optional[str] = None) -> Optional[Path]:
+    """Pick the shell profile to write to, or None if none exists."""
+    home = home or Path.home()
+    shell = shell if shell is not None else os.environ.get("SHELL", "")
+    for candidate in _candidate_profile_paths(home, shell):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def write_export(
+    profile_path: Path,
+    base_url: str,
+) -> bool:
+    """Append an ANTHROPIC_BASE_URL export to `profile_path`. Idempotent.
+
+    Returns True if the file was modified, False if the export already
+    points at this URL. Existing exports with a different URL are replaced
+    by appending a fresh (commented) stanza — we do not mutate the user's
+    original line.
+    """
+    existing = profile_path.read_text() if profile_path.exists() else ""
+    desired = _format_export(profile_path, base_url).strip()
+    if desired in existing:
+        return False
+
+    stanza = f"\n{_EXPORT_MARKER}\n{_format_export(profile_path, base_url)}"
+    with open(profile_path, "a", encoding="utf-8") as f:
+        f.write(stanza)
+    return True
+
+
+# ── Orchestration used by cmd_setup ──────────────────────────────────────────
+
+
+def run_setup_step(
+    port: int,
+    *,
+    env: Optional[EnvLike] = None,
+    home: Optional[Path] = None,
+    shell: Optional[str] = None,
+    prompt: Optional[Callable[[str], str]] = None,
+    printer: Callable[[str], None] = print,
+    auto_yes: bool = False,
+) -> dict:
+    """The IDE integration step invoked from `cmd_setup`.
+
+    Returns a small dict describing what happened — used by tests. Writes
+    nothing if no IDE is detected OR if the user declines the prompt.
+    """
+    env = env if env is not None else os.environ
+    prompt = prompt or input
+    base_url = f"http://127.0.0.1:{port}"
+
+    detected: List[IDEHandler] = detect(env)
+    # Dedup by name (Cursor handler also fires vscode_detect since Cursor
+    # inherits VSCode env). Prefer the first match per name.
+    seen: set = set()
+    unique: List[IDEHandler] = []
+    for h in detected:
+        if h.name not in seen:
+            seen.add(h.name)
+            unique.append(h)
+
+    if not unique:
+        return {"detected": [], "wrote": None, "profile": None, "base_url": base_url}
+
+    labels = ", ".join(h.label for h in unique)
+    printer("")
+    printer(f"IDE integration: detected {labels}.")
+    printer("  To route IDE-launched Claude Code / Anthropic SDK calls through tokenpak,")
+    printer(f"  set ANTHROPIC_BASE_URL={base_url} in your shell.")
+
+    profile = resolve_profile(home=home, shell=shell)
+    if profile is None:
+        printer("")
+        printer("  No shell profile found (.zshrc / .bashrc / fish config).")
+        printer("  Run this manually to route IDE traffic through tokenpak:")
+        printer(f'    export ANTHROPIC_BASE_URL="{base_url}"')
+        return {
+            "detected": [h.name for h in unique],
+            "wrote": None,
+            "profile": None,
+            "base_url": base_url,
+        }
+
+    if auto_yes:
+        answer = "yes"
+    else:
+        answer = prompt(f"  Append export to {profile}? (yes/no) [yes]: ").strip().lower()
+        if answer == "":
+            answer = "yes"
+
+    if answer not in ("yes", "y"):
+        printer("  Skipped. Run this manually to enable:")
+        printer(f'    export ANTHROPIC_BASE_URL="{base_url}"')
+        return {
+            "detected": [h.name for h in unique],
+            "wrote": False,
+            "profile": str(profile),
+            "base_url": base_url,
+        }
+
+    modified = write_export(profile, base_url)
+    if modified:
+        printer(f"  ✅ Appended to {profile}.")
+        printer(f"     Start a new shell (or `source {profile}`) and relaunch your IDE.")
+    else:
+        printer(f"  ✅ Already present in {profile}. No change.")
+    return {
+        "detected": [h.name for h in unique],
+        "wrote": modified,
+        "profile": str(profile),
+        "base_url": base_url,
+    }
+
+
+__all__ = [
+    "IDEHandler",
+    "detect",
+    "register",
+    "registered",
+    "resolve_profile",
+    "run_setup_step",
+    "write_export",
+]


### PR DESCRIPTION
## Summary

- Closes L-8 from the launch-readiness proposal (`02-ADAPTER-AUDIT.md` 2026-04-24) — the sole launch-blocker-adjacent gap the adapter audit surfaced.
- Adds `tokenpak/cli/ide.py` with a per-IDE handler registry (signal-based, no call-site enumeration per `feedback_always_dynamic`) + built-in Cursor + VSCode handlers.
- `cmd_setup` gains a post-proxy step that detects IDE hosts, locates the user shell profile honoring `$SHELL`, and prompts (default yes) to append `ANTHROPIC_BASE_URL` in the right syntax (bash/zsh/fish). Idempotent. No-op when no IDE signals present.

## Test plan

- [x] 18 new tests in `tests/cli/test_ide_integration.py` (registry, detection, profile resolution, shell-specific syntax, idempotency, accept/decline/auto-yes, no-profile fallback)
- [x] Full `tests/cli/` green (46/46)
- [x] Ruff clean
- [ ] CI green
- [ ] Post-merge smoke: `python -m tokenpak setup --help` exits 0