### PR TITLE
fix(proxy): route OpenClaw → companion subprocess via platform bridge (v1.3.13)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -239,6 +239,15 @@ ignore_imports =
     tokenpak.proxy.server -> tokenpak.services.request_pipeline.classify_stage
     tokenpak.proxy.server -> tokenpak.services.request_pipeline.stages
     ;
+    ; === v1.3.13: OpenClaw → companion subprocess routing (2026-04-24) ===
+    ; proxy/ consumes the platform bridge + OAuth backend to decide when
+    ; to intercept Messages traffic for companion-path dispatch (claude
+    ; CLI --continue with Claude CLI OAuth) instead of the byte-preserved
+    ; forward. Same intended direction as the 1.3.0-α block above —
+    ; proxy-as-transport-shell over services-as-execution-backbone.
+    tokenpak.proxy.server -> tokenpak.services.routing_service.platform_bridge
+    tokenpak.proxy.server -> tokenpak.services.routing_service.backends.anthropic_oauth
+    ;
     ; === TIP-SC / SC-02 + SC2-02: conformance observer cross-cutting (§5.2-C) ===
     ; `services.diagnostics.conformance` is the single shared contract
     ; proxy + companion both emit through for the TIP-1.0 self-conformance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.13] - 2026-04-24
+
+### Fixed — OpenClaw → TokenPak → Claude Code companion routing
+
+Ratified by Kevin 2026-04-24 after confirming OpenClaw traffic was hitting api.anthropic.com with `x-api-key`/bearer-token 401s (`provider=tokenpak-claude-code error=HTTP 401 authentication_error: invalid x-api-key`). The underlying issue: the `OpenClawAdapter` scaffolded in commit `60c33e87d3` detected OpenClaw traffic but its output was never consumed by the classifier, selector, or proxy forward path — so OpenClaw requests fell through to the api-key backend that rejected them.
+
+**New — `tokenpak/services/routing_service/platform_bridge.py`.** Reusable platform-bridge mechanism that any agent-orchestration adapter (OpenClaw, Codex, future) uses to declare its origin and preferred provider via request headers:
+
+- `X-OpenClaw-Session: <id>` — OpenClaw session marker (built-in handler, default provider `tokenpak-claude-code`).
+- `X-TokenPak-Provider: <name>` — explicit provider declaration, wins over any platform default. Accepted: `tokenpak-claude-code`, `tokenpak-anthropic`, or any future provider name.
+
+Adding a new platform is one `register(PlatformSignal(...))` call. No call-site enumeration (`feedback_always_dynamic` 2026-04-16).
+
+**Classifier + Selector — provider-aware routing.**
+
+- `RouteClassifier` now upgrades requests to `RouteClass.CLAUDE_CODE_CLI` when the bridge resolves the provider to `tokenpak-claude-code`, so downstream policy sees Claude-Code-family traffic.
+- `BackendSelector` routes per Kevin's 2026-04-24 ratification:
+  - `tokenpak-claude-code` → always OAuth backend (companion subprocess path), regardless of caller auth shape.
+  - `tokenpak-anthropic` + `x-api-key` → api backend (caller's key).
+  - `tokenpak-anthropic` + `Authorization: Bearer …` → OAuth backend (caller's OAuth).
+  - Explicit `X-TokenPak-Backend` header still wins over provider.
+
+**Proxy companion-path dispatch.** `ProxyServer.do_POST` now intercepts Messages traffic that the bridge resolves to `tokenpak-claude-code` and dispatches it via `AnthropicOAuthBackend` (Claude CLI subprocess) instead of the byte-preserved forward to api.anthropic.com. The caller's auth is stripped and the Claude CLI OAuth from `~/.claude/.credentials.json` is used — restoring the pre-D1 "inject Claude CLI tokens for OpenClaw" behavior. Opt-out via `TOKENPAK_COMPANION_DISPATCH=0`.
+
+**Part 2b — `claude --continue` for session continuity.** `AnthropicOAuthBackend` now passes `--continue` to the CLI subprocess so every OpenClaw / companion-path request resumes the last session on this machine rather than opening a fresh conversation per request. Single-agent semantics accepted by Kevin's ratification. Opt-out via `TOKENPAK_OAUTH_NO_CONTINUE=1`.
+
+### Tests
+
+31 new tests (platform bridge + classifier integration + selector × provider × auth-shape × `X-TokenPak-Backend` precedence matrix + OAuth backend `--continue` flag). Regression: 280 services/conformance/CLI tests green, 12/12 proxy tests green. Live end-to-end verified on running proxy + OpenClaw header shape — returns HTTP 200 via companion subprocess where pre-fix returned 401.
+
 ## [1.3.12] - 2026-04-24
 
 ### Added — L-8 (Launch Readiness): IDE integration in `tokenpak setup`

--- a/tests/services/backends/test_anthropic_oauth_continue.py
+++ b/tests/services/backends/test_anthropic_oauth_continue.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AnthropicOAuthBackend — `claude --continue` session continuity (Part 2b).
+
+Kevin's 2026-04-24 ratification: the OAuth backend passes `--continue`
+to the `claude` CLI so every OpenClaw / companion-path request resumes
+the last session on this machine instead of opening a fresh one per
+request. Single-agent semantics were explicitly accepted.
+
+Tests use a fake `claude` binary (bash stub) that echoes its argv so we
+can assert `--continue` made it into the subprocess call.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tokenpak.services.request import Request
+from tokenpak.services.routing_service.backends.anthropic_oauth import (
+    AnthropicOAuthBackend,
+)
+
+
+def _write_fake_claude(bin_dir: Path) -> Path:
+    """Write a bash stub that prints its argv then exits 0."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    path = bin_dir / "claude"
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf "ARGV: %s\\n" "$@"\n'
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _body() -> bytes:
+    return json.dumps(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    ).encode()
+
+
+@pytest.fixture(autouse=True)
+def _clear_opt_out(monkeypatch):
+    # Baseline: opt-out flag not set — backend should pass --continue.
+    monkeypatch.delenv("TOKENPAK_OAUTH_NO_CONTINUE", raising=False)
+
+
+def test_oauth_backend_passes_continue_flag(tmp_path: Path):
+    claude = _write_fake_claude(tmp_path)
+    be = AnthropicOAuthBackend(claude_binary=str(claude))
+    resp = be.dispatch(Request(body=_body(), headers={}))
+    assert resp.status == 200
+    stdout = resp.body.decode()
+    # Body is JSON-wrapped; the CLI's ARGV echo appears inside content[0].text.
+    data = json.loads(stdout)
+    cli_output = data["content"][0]["text"]
+    assert "--continue" in cli_output
+    assert "--print" in cli_output
+    assert "ping" in cli_output
+
+
+def test_oauth_backend_opt_out_env_drops_continue(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_OAUTH_NO_CONTINUE", "1")
+    claude = _write_fake_claude(tmp_path)
+    be = AnthropicOAuthBackend(claude_binary=str(claude))
+    resp = be.dispatch(Request(body=_body(), headers={}))
+    assert resp.status == 200
+    data = json.loads(resp.body.decode())
+    cli_output = data["content"][0]["text"]
+    assert "--continue" not in cli_output
+    assert "--print" in cli_output
+
+
+def test_oauth_backend_missing_binary_returns_502():
+    be = AnthropicOAuthBackend(claude_binary="/nonexistent/path/to/claude")
+    resp = be.dispatch(Request(body=_body(), headers={}))
+    assert resp.status == 502
+    assert b"backend_unavailable" in resp.body

--- a/tests/services/backends/test_backend_selector_openclaw.py
+++ b/tests/services/backends/test_backend_selector_openclaw.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BackendSelector — platform-bridge routing (2026-04-24).
+
+Pins Kevin's 2026-04-24 ratification for OpenClaw + future platform traffic:
+
+  - ``tokenpak-claude-code`` → always OAuth (companion subprocess path)
+  - ``tokenpak-anthropic`` + ``x-api-key`` → api backend
+  - ``tokenpak-anthropic`` + ``Authorization: Bearer …`` → OAuth backend
+  - ``X-OpenClaw-Session`` alone (no explicit provider) → OAuth
+    (openclaw's default_provider)
+  - Explicit ``X-TokenPak-Provider`` always wins over platform default
+  - Explicit ``X-TokenPak-Backend`` still wins over provider (preserved)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tokenpak.core.routing.route_class import RouteClass
+from tokenpak.services.request import Request
+from tokenpak.services.routing_service.backend_selector import BackendSelector
+from tokenpak.services.routing_service.backends.base import BackendResponse
+
+
+@dataclass
+class _StubBackend:
+    name: str
+
+    def dispatch(self, request: Request) -> BackendResponse:
+        return BackendResponse(status=200, headers={}, body=self.name.encode())
+
+
+def _selector() -> BackendSelector:
+    return BackendSelector(
+        api_backend=_StubBackend(name="api-stub"),
+        oauth_backend=_StubBackend(name="oauth-stub"),
+    )
+
+
+# ── tokenpak-claude-code provider ────────────────────────────────────────────
+
+
+def test_openclaw_session_alone_selects_oauth():
+    sel = _selector()
+    req = Request(headers={"X-OpenClaw-Session": "sess-1"})
+    # Route class is GENERIC — the bridge must upgrade routing anyway.
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "oauth-stub"
+
+
+def test_explicit_provider_claude_code_selects_oauth():
+    sel = _selector()
+    req = Request(headers={"X-TokenPak-Provider": "tokenpak-claude-code"})
+    b = sel.select(req, RouteClass.ANTHROPIC_SDK)
+    assert b.name == "oauth-stub"
+
+
+def test_claude_code_provider_beats_api_key_header():
+    """tokenpak-claude-code always rides the companion path, even when
+    the caller shipped an x-api-key. Auth is stripped + Claude CLI OAuth
+    is used instead."""
+    sel = _selector()
+    req = Request(
+        headers={
+            "X-TokenPak-Provider": "tokenpak-claude-code",
+            "x-api-key": "sk-ant-stray-key",
+        }
+    )
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "oauth-stub"
+
+
+# ── tokenpak-anthropic provider (auth-shape dispatch) ────────────────────────
+
+
+def test_anthropic_provider_with_api_key_selects_api():
+    sel = _selector()
+    req = Request(
+        headers={
+            "X-TokenPak-Provider": "tokenpak-anthropic",
+            "x-api-key": "sk-ant-x",
+        }
+    )
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "api-stub"
+
+
+def test_anthropic_provider_with_bearer_selects_oauth():
+    sel = _selector()
+    req = Request(
+        headers={
+            "X-TokenPak-Provider": "tokenpak-anthropic",
+            "Authorization": "Bearer ocw_oauth_token",
+        }
+    )
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "oauth-stub"
+
+
+def test_anthropic_provider_no_auth_selects_api_by_default():
+    sel = _selector()
+    req = Request(headers={"X-TokenPak-Provider": "tokenpak-anthropic"})
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "api-stub"
+
+
+# ── Precedence: header > provider > route class ──────────────────────────────
+
+
+def test_explicit_backend_header_still_wins():
+    sel = _selector()
+    req = Request(
+        headers={
+            "X-TokenPak-Backend": "api",
+            "X-OpenClaw-Session": "sess-override-me",
+        }
+    )
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "api-stub"
+
+
+def test_explicit_provider_beats_openclaw_default():
+    sel = _selector()
+    req = Request(
+        headers={
+            "X-OpenClaw-Session": "sess-1",
+            "X-TokenPak-Provider": "tokenpak-anthropic",
+            "x-api-key": "sk-ant-x",
+        }
+    )
+    b = sel.select(req, RouteClass.GENERIC)
+    assert b.name == "api-stub"

--- a/tests/services/routing/test_classifier_platform_bridge.py
+++ b/tests/services/routing/test_classifier_platform_bridge.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""RouteClassifier — platform-bridge integration (2026-04-24).
+
+Pins the classifier's new precedence rule: when the platform bridge
+resolves a provider to ``tokenpak-claude-code``, the request is
+classified as the Claude Code family regardless of what User-Agent /
+auth headers the caller shipped. This closes the OpenClaw 401 loop
+where bearer-token traffic was previously classified as ANTHROPIC_SDK
+and routed to the api-key backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenpak.core.routing.route_class import RouteClass
+from tokenpak.services.request import Request
+from tokenpak.services.routing_service.classifier import RouteClassifier
+
+
+@pytest.fixture
+def clf() -> RouteClassifier:
+    return RouteClassifier()
+
+
+def _req(headers=None, body=b"") -> Request:
+    return Request(body=body, headers=headers or {})
+
+
+def test_openclaw_session_header_classifies_as_claude_code(clf):
+    rc = clf.classify(_req(headers={"X-OpenClaw-Session": "sess-1"}))
+    assert rc.is_claude_code
+
+
+def test_explicit_provider_claude_code_classifies_as_claude_code(clf):
+    rc = clf.classify(_req(headers={"X-TokenPak-Provider": "tokenpak-claude-code"}))
+    assert rc.is_claude_code
+
+
+def test_openclaw_with_bearer_token_classifies_as_claude_code(clf):
+    """Prior behavior: Authorization: Bearer + ``"messages"`` body → ANTHROPIC_SDK.
+    New behavior: X-OpenClaw-Session wins over the body fingerprint.
+    """
+    rc = clf.classify(
+        _req(
+            headers={
+                "X-OpenClaw-Session": "sess-1",
+                "Authorization": "Bearer ocw_oauth_token",
+                "Content-Type": "application/json",
+            },
+            body=b'{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}',
+        )
+    )
+    assert rc.is_claude_code
+
+
+def test_anthropic_provider_header_does_not_force_claude_code(clf):
+    """Explicit tokenpak-anthropic provider should NOT reclassify as
+    Claude Code; the classifier leaves it to the selector to choose
+    api vs oauth based on auth shape."""
+    rc = clf.classify(
+        _req(
+            headers={"X-TokenPak-Provider": "tokenpak-anthropic"},
+            body=b'{"messages":[{"role":"user","content":"hi"}]}',
+        )
+    )
+    # Body contains `"messages":` → should classify as ANTHROPIC_SDK.
+    assert rc == RouteClass.ANTHROPIC_SDK
+
+
+def test_no_platform_signal_preserves_prior_behavior(clf):
+    """Regression: absent any platform markers, the classifier behaves
+    exactly as before (body-fingerprint Anthropic SDK)."""
+    rc = clf.classify(
+        _req(body=b'{"anthropic_version":"bedrock-2023-05-31","messages":[]}')
+    )
+    assert rc == RouteClass.ANTHROPIC_SDK

--- a/tests/services/routing/test_platform_bridge.py
+++ b/tests/services/routing/test_platform_bridge.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform bridge — unit + contract tests.
+
+The bridge is the shared mechanism any agent platform (OpenClaw, Codex,
+future) uses to tell tokenpak *"I am platform X, my session id is Y, and
+I want provider Z"*. These tests pin:
+
+  1. Registration is idempotent on name (no duplicate signals).
+  2. Built-in OpenClaw signal fires on ``X-OpenClaw-Session``.
+  3. Explicit ``X-TokenPak-Provider`` header beats the signal's default.
+  4. ``resolve_provider`` returns the right provider name for common shapes.
+  5. Third-party signals register cleanly and participate in detection.
+  6. No OpenClaw marker + no explicit provider → ``None`` (legacy fallthrough).
+"""
+
+from __future__ import annotations
+
+from tokenpak.services.routing_service import platform_bridge as pb
+
+
+def _fresh_signal(name: str, marker_header: str, provider: str) -> pb.PlatformSignal:
+    def _extract(headers):
+        v = headers.get(marker_header.lower(), "").strip()
+        if not v:
+            return None
+        return pb.PlatformOrigin(
+            platform_name=name, session_id=v, declared_provider=None
+        )
+
+    return pb.PlatformSignal(name=name, default_provider=provider, extract=_extract)
+
+
+# ── Registry basics ──────────────────────────────────────────────────────────
+
+
+def test_openclaw_signal_is_built_in():
+    names = {s.name for s in pb.registered()}
+    assert "openclaw" in names
+
+
+def test_register_is_idempotent_on_name():
+    before = len(pb.registered())
+    # Re-registering openclaw with a noop extract should not grow the list.
+    pb.register(
+        pb.PlatformSignal(
+            name="openclaw",
+            default_provider="tokenpak-claude-code",
+            extract=lambda h: None,
+        )
+    )
+    after = len(pb.registered())
+    assert after == before
+
+
+def test_register_then_detect_new_platform():
+    # Restore openclaw at end so other tests keep working.
+    from tokenpak.services.routing_service.platform_bridge import (
+        _openclaw_signal as _real,
+    )
+
+    sig = _fresh_signal("fakeadapter", "X-Fake-Session", "tokenpak-fake")
+    pb.register(sig)
+    try:
+        origin = pb.detect_origin({"X-Fake-Session": "abc-123"})
+        assert origin is not None
+        assert origin.platform_name == "fakeadapter"
+        assert origin.session_id == "abc-123"
+    finally:
+        # Remove test signal by overwriting with a dead one.
+        pb.register(
+            pb.PlatformSignal(
+                name="fakeadapter",
+                default_provider="none",
+                extract=lambda h: None,
+            )
+        )
+        # Re-assert openclaw built-in is intact
+        pb.register(_real)
+
+
+# ── OpenClaw detection ───────────────────────────────────────────────────────
+
+
+def test_detect_origin_openclaw_via_session_header():
+    origin = pb.detect_origin({"X-OpenClaw-Session": "sess-777"})
+    assert origin is not None
+    assert origin.platform_name == "openclaw"
+    assert origin.session_id == "sess-777"
+
+
+def test_detect_origin_returns_none_for_unknown_traffic():
+    origin = pb.detect_origin(
+        {"User-Agent": "python-requests/2.31", "Content-Type": "application/json"}
+    )
+    assert origin is None
+
+
+# ── Explicit provider header ─────────────────────────────────────────────────
+
+
+def test_explicit_provider_header_overrides_signal_default():
+    origin = pb.detect_origin(
+        {
+            "X-OpenClaw-Session": "sess-1",
+            "X-TokenPak-Provider": "tokenpak-anthropic",
+        }
+    )
+    assert origin is not None
+    assert origin.declared_provider == "tokenpak-anthropic"
+
+
+def test_read_declared_provider_returns_none_when_absent():
+    assert pb.read_declared_provider({}) is None
+
+
+def test_read_declared_provider_strips_whitespace():
+    assert (
+        pb.read_declared_provider({"X-TokenPak-Provider": "  tokenpak-claude-code  "})
+        == "tokenpak-claude-code"
+    )
+
+
+# ── resolve_provider — end-to-end selector input ─────────────────────────────
+
+
+def test_resolve_provider_explicit_header_wins():
+    assert (
+        pb.resolve_provider({"X-TokenPak-Provider": "tokenpak-anthropic"})
+        == "tokenpak-anthropic"
+    )
+
+
+def test_resolve_provider_openclaw_default_is_claude_code():
+    assert (
+        pb.resolve_provider({"X-OpenClaw-Session": "x"}) == "tokenpak-claude-code"
+    )
+
+
+def test_resolve_provider_explicit_header_beats_openclaw_default():
+    assert (
+        pb.resolve_provider(
+            {
+                "X-OpenClaw-Session": "x",
+                "X-TokenPak-Provider": "tokenpak-anthropic",
+            }
+        )
+        == "tokenpak-anthropic"
+    )
+
+
+def test_resolve_provider_no_signal_returns_none():
+    assert pb.resolve_provider({"User-Agent": "curl/8"}) is None
+
+
+# ── Case-insensitivity ───────────────────────────────────────────────────────
+
+
+def test_header_lookup_is_case_insensitive():
+    a = pb.detect_origin({"x-openclaw-session": "aa"})
+    b = pb.detect_origin({"X-OPENCLAW-SESSION": "aa"})
+    c = pb.detect_origin({"X-OpenClaw-Session": "aa"})
+    assert a and b and c
+    assert a.session_id == b.session_id == c.session_id == "aa"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.12"
+__version__ = "1.3.13"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -884,6 +884,61 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         else:
             passthrough_cfg = PassthroughConfig(require_auth=False)
 
+        # ── Companion-path dispatch (OpenClaw / tokenpak-claude-code) ─────
+        #
+        # 2026-04-24 fix: when the platform bridge resolves the request to
+        # the ``tokenpak-claude-code`` provider (OpenClaw default, or any
+        # caller that sets ``X-TokenPak-Provider: tokenpak-claude-code``),
+        # route via the AnthropicOAuthBackend subprocess (claude CLI with
+        # ``--continue``) instead of the byte-preserved forward to
+        # api.anthropic.com. The caller's auth is stripped and the Claude
+        # CLI's OAuth from ``~/.claude/.credentials.json`` is used,
+        # restoring the pre-D1 "proxy injects Claude CLI tokens for
+        # OpenClaw" behavior. Opt-out via TOKENPAK_COMPANION_DISPATCH=0
+        # for ops debugging; default is on for Messages traffic.
+        if (
+            should_log
+            and is_messages
+            and os.environ.get("TOKENPAK_COMPANION_DISPATCH", "1") != "0"
+        ):
+            try:
+                from tokenpak.services.routing_service.platform_bridge import (
+                    resolve_provider as _resolve_provider,
+                )
+
+                _pv = _resolve_provider(dict(self.headers))
+            except Exception:
+                _pv = None
+            if _pv == "tokenpak-claude-code":
+                try:
+                    from tokenpak.services.request import Request as _Req
+                    from tokenpak.services.routing_service.backends.anthropic_oauth import (
+                        AnthropicOAuthBackend,
+                    )
+
+                    _be = AnthropicOAuthBackend()
+                    _resp = _be.dispatch(
+                        _Req(body=body or b"", headers=dict(self.headers))
+                    )
+                    self.send_response(_resp.status)
+                    for _hk, _hv in (_resp.headers or {}).items():
+                        self.send_header(_hk, _hv)
+                    self.send_header("Content-Length", str(len(_resp.body or b"")))
+                    self.end_headers()
+                    if _resp.body:
+                        self.wfile.write(_resp.body)
+                    return
+                except Exception as _be_err:
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).warning(
+                        "tokenpak.proxy: companion-path dispatch failed, "
+                        "falling back to byte-preserved forward: %s: %s",
+                        type(_be_err).__name__,
+                        _be_err,
+                    )
+                    # Fall through to normal forward path.
+
         # Build forwarding headers (client-supplied auth forwarded unchanged)
         fwd_headers = forward_headers(dict(self.headers), passthrough_cfg)
         fwd_headers["Host"] = parsed.netloc

--- a/tokenpak/services/routing_service/backend_selector.py
+++ b/tokenpak/services/routing_service/backend_selector.py
@@ -87,10 +87,43 @@ class BackendSelector:
                 hdr_val,
             )
 
+        # 2. Platform bridge — provider-name routing for adapter traffic
+        # (OpenClaw, Codex, future). Ratified 2026-04-24:
+        #   - tokenpak-claude-code  → companion path (OAuth backend) always
+        #   - tokenpak-anthropic    → api or OAuth based on caller auth shape
+        #   - tokenpak-openai-codex → (reserved; falls through for now)
+        provider = self._resolve_provider(request.headers or {})
+        if provider == "tokenpak-claude-code":
+            return self._oauth
+        if provider == "tokenpak-anthropic":
+            lh = {k.lower(): v for k, v in (request.headers or {}).items()}
+            if lh.get("x-api-key"):
+                return self._api
+            if lh.get("authorization", "").lower().startswith("bearer "):
+                return self._oauth
+            # Caller declared the provider but shipped no auth — preserve
+            # prior behavior (api backend) rather than guess.
+            return self._api
+
         # 3. RouteClass default.
         if route_class and route_class.is_claude_code:
             return self._oauth
         return self._api
+
+    @staticmethod
+    def _resolve_provider(headers: dict) -> Optional[str]:
+        # Lazy import to avoid a circular dep at module load: the
+        # platform_bridge module lives in the same package.
+        try:
+            from tokenpak.services.routing_service.platform_bridge import (
+                resolve_provider,
+            )
+        except Exception:
+            return None
+        try:
+            return resolve_provider(headers)
+        except Exception:
+            return None
 
     @staticmethod
     def _get_header(headers: dict, name: str) -> str:

--- a/tokenpak/services/routing_service/backends/anthropic_oauth.py
+++ b/tokenpak/services/routing_service/backends/anthropic_oauth.py
@@ -98,8 +98,22 @@ class AnthropicOAuthBackend:
                 )
 
             # Synchronous invocation for γ; streaming driver lands later.
+            #
+            # Session continuity (Part 2b, 2026-04-24): pass ``--continue``
+            # so the CLI picks up the last session on this machine instead
+            # of opening a fresh conversation per request. Single-agent
+            # semantics accepted by Kevin's ratification — multi-session
+            # isolation is a later item if concurrency actually breaks.
+            # The flag is opt-out via TOKENPAK_OAUTH_NO_CONTINUE=1 for
+            # tests + rare debugging.
+            import os as _os
+
+            cmd = [self._claude_binary]
+            if _os.environ.get("TOKENPAK_OAUTH_NO_CONTINUE", "").strip() != "1":
+                cmd.append("--continue")
+            cmd.extend(["--print", prompt])
             completed = subprocess.run(
-                [self._claude_binary, "--print", prompt],
+                cmd,
                 capture_output=True,
                 timeout=120,
                 check=False,

--- a/tokenpak/services/routing_service/classifier.py
+++ b/tokenpak/services/routing_service/classifier.py
@@ -66,7 +66,22 @@ class RouteClassifier:
         """
         headers = _lower_headers(request.headers or {})
 
-        # Signal 2 first (strongest): Claude Code session id header.
+        # Signal 0 (highest): platform bridge — a registered non-Claude
+        # platform (OpenClaw, Codex, future) carrying its own session
+        # marker. When the platform's default_provider resolves to the
+        # Claude Code family, we classify it as Claude Code so that the
+        # BackendSelector picks the OAuth backend (companion subprocess
+        # with `--continue`). This is the 2026-04-24 fix for OpenClaw
+        # traffic hitting the api-key backend with 401s.
+        from tokenpak.services.routing_service.platform_bridge import (
+            resolve_provider as _resolve_provider,
+        )
+
+        _provider = _resolve_provider(headers)
+        if _provider == "tokenpak-claude-code":
+            return self._claude_code_mode(headers, request)
+
+        # Signal 2 (strongest inside Claude Code): Claude Code session id header.
         if headers.get("x-claude-code-session-id"):
             return self._claude_code_mode(headers, request)
 

--- a/tokenpak/services/routing_service/platform_bridge.py
+++ b/tokenpak/services/routing_service/platform_bridge.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform bridge — translate external-platform request signals into tokenpak routing decisions.
+
+Problem it solves
+-----------------
+
+Agent platforms like OpenClaw + Codex route their Anthropic / OpenAI traffic
+through the tokenpak proxy at ``http://127.0.0.1:8766``. They each carry their
+own platform-specific session / identity markers (``X-OpenClaw-Session``, etc.)
+and pick one of tokenpak's "providers" — ``tokenpak-claude-code``,
+``tokenpak-anthropic``, ``tokenpak-openai-codex`` — to declare billing /
+backend intent.
+
+Without this module, tokenpak's ``RouteClassifier`` looks for Claude Code's
+own markers (``claude-cli`` User-Agent, ``x-claude-code-session-id``) and
+treats anything else as ``ANTHROPIC_SDK`` or ``GENERIC`` — which the
+``BackendSelector`` routes to the api-key backend. OpenClaw (which has no
+Anthropic api-key) gets 401s.
+
+What it does
+------------
+
+Two things:
+
+1. **Defines the bridge contract** — a ``PlatformOrigin`` record
+   (``platform_name``, ``session_id``, ``declared_provider``, optional
+   ``extra`` dict) plus a thin ``PlatformSignal`` Protocol that any adapter
+   implements to extract a ``PlatformOrigin`` from an incoming request.
+2. **Maintains a registry** — new platforms register a ``PlatformSignal``
+   instance; ``detect_origin(headers)`` walks the registry and returns the
+   first match. No hardcoded enumeration of platforms at the call site
+   (``feedback_always_dynamic`` 2026-04-16).
+
+How callers use it
+------------------
+
+``RouteClassifier`` peeks the registry before falling through to its
+historic (Claude-Code-specific) signal list — an OpenClaw session id is
+enough to classify the request as Claude-Code-family. ``BackendSelector``
+reads the ``declared_provider`` on the origin record plus the request's
+auth shape to pick between the api-key backend and the OAuth (companion)
+backend.
+
+Kevin's ratification 2026-04-24:
+    - ``tokenpak-claude-code`` provider → always companion path (OAuth
+      backend) regardless of caller auth shape. Caller auth is stripped,
+      Claude CLI OAuth from ``~/.claude/.credentials.json`` is injected
+      via ``claude --continue`` subprocess (Part 2b).
+    - ``tokenpak-anthropic`` provider → caller's credentials. api-key
+      → api backend; Bearer / OAuth → companion backend.
+    - OpenClaw default (no explicit ``X-TokenPak-Provider`` header) →
+      ``tokenpak-claude-code`` (the failure mode users are hitting is
+      api-key; routing to the companion unblocks them).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Mapping, Optional
+
+HeaderMap = Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class PlatformOrigin:
+    """What tokenpak learned about the caller.
+
+    ``session_id`` is the caller's own identifier — *not* a Claude Code
+    session id. ``declared_provider`` is the tokenpak provider name the
+    caller claims (``tokenpak-claude-code`` / ``tokenpak-anthropic`` /
+    ``tokenpak-openai-codex`` / etc.); when absent, the selector falls
+    back to the platform's default_provider.
+    """
+
+    platform_name: str
+    session_id: Optional[str] = None
+    declared_provider: Optional[str] = None
+    extra: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PlatformSignal:
+    """Signal extractor for one platform.
+
+    ``extract(headers)`` returns a :class:`PlatformOrigin` if this
+    platform's markers are present, else ``None``. The first matching
+    signal in registration order wins.
+    """
+
+    name: str
+    default_provider: str
+    extract: Callable[[HeaderMap], Optional[PlatformOrigin]]
+
+
+_REGISTRY: List[PlatformSignal] = []
+
+
+def register(signal: PlatformSignal) -> None:
+    """Add a signal to the registry. Idempotent on ``name``."""
+    for i, existing in enumerate(_REGISTRY):
+        if existing.name == signal.name:
+            _REGISTRY[i] = signal
+            return
+    _REGISTRY.append(signal)
+
+
+def registered() -> List[PlatformSignal]:
+    """Return all registered signals (for tests + introspection)."""
+    return list(_REGISTRY)
+
+
+def _lower(headers: HeaderMap) -> Dict[str, str]:
+    return {k.lower(): v for k, v in headers.items()}
+
+
+# ── Well-known header that any platform adapter can set ───────────────────────
+
+TOKENPAK_PROVIDER_HEADER = "x-tokenpak-provider"
+"""Explicit provider declaration — when set, overrides the adapter's default.
+
+Platform adapters (OpenClaw, Codex, future) can set this to pin which
+tokenpak backend class the request should hit. Accepted values: any
+provider name defined in the caller's config (we never validate the
+string; the selector routes based on prefix / known values and falls
+through gracefully).
+"""
+
+
+def read_declared_provider(headers: HeaderMap) -> Optional[str]:
+    """Return the explicit provider name from ``X-TokenPak-Provider``, if any."""
+    v = _lower(headers).get(TOKENPAK_PROVIDER_HEADER, "").strip()
+    return v or None
+
+
+def detect_origin(headers: HeaderMap) -> Optional[PlatformOrigin]:
+    """Walk the registry and return the first platform that matches.
+
+    Stateless. Returns ``None`` when no registered platform recognises
+    the request, which is the common case for direct SDK traffic.
+    """
+    lheaders = _lower(headers)
+    explicit_provider = read_declared_provider(lheaders)
+    for sig in _REGISTRY:
+        origin = sig.extract(lheaders)
+        if origin is None:
+            continue
+        # Let the explicit header override the signal's default.
+        if explicit_provider and origin.declared_provider is None:
+            origin = PlatformOrigin(
+                platform_name=origin.platform_name,
+                session_id=origin.session_id,
+                declared_provider=explicit_provider,
+                extra=origin.extra,
+            )
+        return origin
+    return None
+
+
+# ── Built-in signals ──────────────────────────────────────────────────────────
+#
+# Kept here for first-class platforms; third-party adapters call register()
+# at import time. Follow the feedback_always_dynamic rule: no enumeration at
+# the call site.
+
+
+def _openclaw_extract(headers: HeaderMap) -> Optional[PlatformOrigin]:
+    session_id = headers.get("x-openclaw-session", "").strip()
+    if not session_id:
+        return None
+    return PlatformOrigin(
+        platform_name="openclaw",
+        session_id=session_id,
+        declared_provider=None,  # default_provider supplied by caller
+    )
+
+
+_openclaw_signal = PlatformSignal(
+    name="openclaw",
+    default_provider="tokenpak-claude-code",
+    extract=_openclaw_extract,
+)
+
+register(_openclaw_signal)
+
+
+# ── Helpers consumed by BackendSelector ───────────────────────────────────────
+
+
+def resolve_provider(headers: HeaderMap) -> Optional[str]:
+    """Best effort: return the tokenpak provider name for this request.
+
+    Precedence:
+      1. Explicit ``X-TokenPak-Provider`` header (wins).
+      2. The first registered platform signal's default_provider.
+      3. ``None`` — selector falls back to its legacy RouteClass default.
+    """
+    lheaders = _lower(headers)
+    explicit = read_declared_provider(lheaders)
+    if explicit:
+        return explicit
+    for sig in _REGISTRY:
+        origin = sig.extract(lheaders)
+        if origin is not None:
+            return origin.declared_provider or sig.default_provider
+    return None
+
+
+__all__ = [
+    "HeaderMap",
+    "PlatformOrigin",
+    "PlatformSignal",
+    "TOKENPAK_PROVIDER_HEADER",
+    "detect_origin",
+    "read_declared_provider",
+    "register",
+    "registered",
+    "resolve_provider",
+]


### PR DESCRIPTION
## Summary

Restores the pre-D1 *proxy injects Claude CLI tokens for OpenClaw* behavior lost in the modular-tree refactor. OpenClaw traffic was routed to the tokenpak proxy by config, but the proxy classified it as ANTHROPIC_SDK and forwarded bearer-token traffic to api.anthropic.com, which returned `401 invalid x-api-key` on every call (live log confirmed: `provider=tokenpak-claude-code error=HTTP 401`).

Ratified by Kevin 2026-04-24:

- `tokenpak-claude-code` provider → always companion subprocess path (`claude --continue`, OAuth from `~/.claude/.credentials.json`).
- `tokenpak-anthropic` provider → api or OAuth backend per caller auth shape.
- Reusable platform-bridge module any future adapter (Codex, etc.) can plug into.
- Part 2b: subprocess uses `--continue` for session continuity; opt-out via `TOKENPAK_OAUTH_NO_CONTINUE=1`.

## New module

`tokenpak/services/routing_service/platform_bridge.py` — `PlatformOrigin` + `PlatformSignal` + `register()` registry. Built-in OpenClaw signal on `X-OpenClaw-Session` → default `tokenpak-claude-code`. `X-TokenPak-Provider` header overrides.

## Proxy hook

`ProxyServer.do_POST` intercepts Messages traffic resolved to `tokenpak-claude-code` and dispatches via `AnthropicOAuthBackend` (subprocess) instead of byte-preserved forward. Opt-out via `TOKENPAK_COMPANION_DISPATCH=0`.

## Test plan

- [x] 31 new tests: platform bridge registry, OpenClaw detection, classifier precedence, selector × provider × auth-shape matrix, OAuth backend `--continue` flag
- [x] Full regression: 280 services / conformance / CLI tests green; 12/12 proxy
- [x] Live end-to-end: pre-fix OpenClaw curl → HTTP 401; post-fix → HTTP 200 via `claude` subprocess
- [ ] CI green
- [ ] Post-deploy: Cali/Trix workers resume producing 200s (currently burning 401s)

Closes the OpenClaw routing gap Kevin reported 2026-04-24.