### PR TITLE
feat(routing): v1.3.14 — multi-turn session continuity via platform-agnostic mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.14] - 2026-04-24
+
+### Added — Multi-turn session continuity for platform-bridged traffic
+
+Ratified by Kevin 2026-04-24 as the functional reiteration (not code copy) of the Apr 18-19 working implementation that was lost in the Apr 20 TIP-1.0 protocol rehaul. The v1.3.13 platform-bridge was the plumbing; this release makes it multi-turn-coherent.
+
+**New — `tokenpak/services/routing_service/session_mapper.py`.** Platform-agnostic `(scope, external_id, provider) → internal_id` persistent store. SQLite-backed at `~/.tokenpak/session_map.db` in WAL mode so parallel OpenClaw workers (Cali / Trix / future) can read + write concurrently without serialization. Primary key is the triple — two platforms can reuse the same external session-id string without collision. Corrupt-db recovery quarantines the broken file and initialises a fresh one; `TOKENPAK_SESSION_MAPPER=0` disables the mapper process-wide as a debug escape hatch.
+
+**`AnthropicOAuthBackend` — session-aware dispatch.**
+
+- Now invokes `claude --print --output-format json` so the CLI emits a parseable result record (`session_id`, `usage`, `result`, `modelUsage`, `total_cost_usd`).
+- Per-request flow: `platform_bridge.detect_origin()` extracts `(platform, external_session_id)` from headers; `session_mapper.get()` returns the Claude CLI UUID if a prior turn persisted one. If found → `claude --resume <uuid>`. If not found (first turn) → fresh invocation, capture UUID from CLI output, persist via `session_mapper.set()`.
+- Requests with no platform origin keep the v1.3.13 `--continue` (resume-last-session) default — no behavior change for direct callers.
+- **Real usage tokens are now forwarded.** Previous response stub was `usage: {input_tokens: 0, output_tokens: 0}`; the new JSON-parsed path forwards `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` from the CLI result directly, so `tokenpak cost` / `tokenpak savings` for OpenClaw traffic stop being a blind spot.
+
+**Live verification on running proxy**:
+- Turn 1 with `X-OpenClaw-Session: live-test-sess-A` → Claude session UUID `33a39508-…` captured + persisted.
+- Turn 2 with same external session → `--resume <uuid>` dispatched, Claude recalled context ("Your name is Bob."), cache-read tokens confirm session reuse.
+
+### Tests
+
+26 new tests: 13 for `session_mapper` (roundtrip, triple-key discrimination, upsert, delete, prune, corrupt-db recovery, env opt-out, singleton) + 10 for `AnthropicOAuthBackend` session integration (first-turn persist, subsequent-turn resume, no-platform fallback, mapper-opt-out semantics, usage forwarding, non-JSON graceful degradation) + 3 pre-existing `--continue` tests updated. Regression: 303 services / conformance / proxy / CLI tests green. Import contracts clean.
+
 ## [1.3.13] - 2026-04-24
 
 ### Fixed — OpenClaw → TokenPak → Claude Code companion routing

--- a/tests/services/backends/test_anthropic_oauth_session.py
+++ b/tests/services/backends/test_anthropic_oauth_session.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AnthropicOAuthBackend — session-mapper integration (v1.3.14, 2026-04-24).
+
+The backend now:
+
+  1. Invokes ``claude --output-format json`` to get a parseable result.
+  2. Persists ``session_id`` from the CLI output to the session mapper
+     keyed by ``(platform, external_session_id, provider)`` when the
+     request carries a platform signal.
+  3. On subsequent turns with the same ``(platform, external_id)``,
+     invokes ``claude --resume <uuid>`` so multi-turn conversations
+     share one Claude session.
+  4. Falls back to ``--continue`` when no platform signal is present
+     (preserves v1.3.13 behavior for direct callers).
+
+Tests use a bash stub that emits the real CLI's JSON schema so we can
+assert the argv + persist behavior without needing a live Claude
+install. The session mapper uses a per-test SQLite file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tokenpak.services.request import Request
+from tokenpak.services.routing_service.backends.anthropic_oauth import (
+    AnthropicOAuthBackend,
+)
+from tokenpak.services.routing_service.session_mapper import SessionMap
+
+
+def _write_claude_stub(
+    bin_dir: Path, session_id: str = "cli-uuid-001", argv_log: Path = None
+) -> Path:
+    """Emit JSON like the real CLI. Log argv to ``argv_log`` for assertions.
+
+    ``argv_log`` must be on the filesystem because subprocess.run captures
+    stderr into ``completed.stderr`` (the parent process doesn't see it).
+    Pytest's ``capfd`` can't reach through that barrier, so we use a
+    side-channel file the test can read back.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    path = bin_dir / "claude"
+    log_path = str(argv_log or (bin_dir / "argv.log"))
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" >> "{log_path}"\n'
+        f'cat <<JSON\n'
+        f'{{"type":"result","subtype":"success","is_error":false,'
+        f'"session_id":"{session_id}","result":"OK","stop_reason":"end_turn",'
+        f'"usage":{{"input_tokens":12,"output_tokens":3,'
+        f'"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},'
+        f'"modelUsage":{{"claude-sonnet-4-6":{{"inputTokens":12,"outputTokens":3}}}},'
+        f'"total_cost_usd":0.0001}}\n'
+        f'JSON\n'
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _read_argv(bin_dir: Path) -> str:
+    argv_log = bin_dir / "argv.log"
+    return argv_log.read_text() if argv_log.exists() else ""
+
+
+def _req(headers=None, body=None) -> Request:
+    body = body or json.dumps(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    ).encode()
+    return Request(body=body, headers=headers or {})
+
+
+@pytest.fixture
+def isolated_mapper(tmp_path: Path, monkeypatch):
+    """Swap the singleton mapper with a test-local one so db state is per-test."""
+    mapper = SessionMap(db_path=tmp_path / "session_map.db")
+    monkeypatch.setattr(
+        "tokenpak.services.routing_service.session_mapper._singleton",
+        mapper,
+    )
+    return mapper
+
+
+@pytest.fixture(autouse=True)
+def _clear_no_continue(monkeypatch):
+    monkeypatch.delenv("TOKENPAK_OAUTH_NO_CONTINUE", raising=False)
+    monkeypatch.delenv("TOKENPAK_SESSION_MAPPER", raising=False)
+
+
+# ── First-turn persistence ─────────────────────────────────────────────
+
+
+def test_first_turn_persists_session_id(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path, session_id="cli-uuid-AAA")
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+
+    resp = backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    assert resp.status == 200
+
+    rec = isolated_mapper.get(
+        scope="openclaw",
+        external_id="oc-sess-1",
+        provider="tokenpak-claude-code",
+    )
+    assert rec is not None
+    assert rec.internal_id == "cli-uuid-AAA"
+
+
+def test_first_turn_runs_without_resume_flag(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    argv = _read_argv(tmp_path)
+    assert "--resume" not in argv
+    assert "--continue" not in argv
+    assert "--output-format" in argv and "json" in argv
+
+
+# ── Subsequent-turn resume ────────────────────────────────────────────
+
+
+def test_subsequent_turn_uses_resume(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path, session_id="cli-uuid-BBB")
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+
+    # Pre-seed the mapping as if turn 1 already happened.
+    isolated_mapper.set(
+        scope="openclaw",
+        external_id="oc-sess-9",
+        provider="tokenpak-claude-code",
+        internal_id="cli-uuid-BBB",
+    )
+
+    backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-9"}))
+    argv = _read_argv(tmp_path)
+    assert "--resume" in argv
+    assert "cli-uuid-BBB" in argv
+    # --continue must NOT be set simultaneously.
+    assert "--continue" not in argv
+
+
+# ── No-platform fallback to --continue ────────────────────────────────
+
+
+def test_no_platform_signal_uses_continue_default(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    backend.dispatch(_req(headers={}))  # no X-OpenClaw-Session
+    argv = _read_argv(tmp_path)
+    assert "--continue" in argv
+    assert "--resume" not in argv
+
+
+def test_no_platform_signal_with_opt_out_drops_continue(
+    tmp_path: Path, isolated_mapper, monkeypatch
+):
+    monkeypatch.setenv("TOKENPAK_OAUTH_NO_CONTINUE", "1")
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    backend.dispatch(_req(headers={}))
+    argv = _read_argv(tmp_path)
+    assert "--continue" not in argv
+    assert "--resume" not in argv
+
+
+# ── Session mapper opt-out preserves first-turn semantic ──────────────
+
+
+def test_session_mapper_disabled_treats_as_first_turn(
+    tmp_path: Path, isolated_mapper, monkeypatch
+):
+    monkeypatch.setenv("TOKENPAK_SESSION_MAPPER", "0")
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    argv = _read_argv(tmp_path)
+    # Origin is detected but mapper returns None, so first-turn path —
+    # no --resume, no --continue.
+    assert "--resume" not in argv
+
+
+# ── Usage tokens are forwarded ────────────────────────────────────────
+
+
+def test_response_forwards_real_usage_tokens(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    resp = backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    data = json.loads(resp.body)
+    # Stub emits input_tokens=12, output_tokens=3.
+    assert data["usage"]["input_tokens"] == 12
+    assert data["usage"]["output_tokens"] == 3
+
+
+def test_response_returns_result_text(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    resp = backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    data = json.loads(resp.body)
+    assert data["content"][0]["text"] == "OK"
+    assert data["content"][0]["type"] == "text"
+
+
+def test_response_model_from_cli_modelusage(tmp_path: Path, isolated_mapper):
+    claude = _write_claude_stub(tmp_path)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude))
+    resp = backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    data = json.loads(resp.body)
+    assert data["model"] == "claude-sonnet-4-6"
+
+
+# ── Graceful degradation: non-JSON stdout ─────────────────────────────
+
+
+def test_non_json_stdout_falls_back_to_text(tmp_path: Path, isolated_mapper):
+    """If the CLI emits plain text (old version / unexpected path), the
+    backend still wraps it as a Messages response — just with zero
+    tokens + no session persistence."""
+    claude_path = tmp_path / "claude"
+    claude_path.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "plain text response"\n'
+    )
+    claude_path.chmod(0o755)
+    backend = AnthropicOAuthBackend(claude_binary=str(claude_path))
+    resp = backend.dispatch(_req(headers={"X-OpenClaw-Session": "oc-sess-1"}))
+    assert resp.status == 200
+    data = json.loads(resp.body)
+    assert "plain text response" in data["content"][0]["text"]
+    # No session persisted (no session_id in stdout).
+    rec = isolated_mapper.get(
+        "openclaw", "oc-sess-1", "tokenpak-claude-code"
+    )
+    assert rec is None

--- a/tests/services/routing/test_session_mapper.py
+++ b/tests/services/routing/test_session_mapper.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session mapper — unit tests (v1.3.14, 2026-04-24).
+
+The mapper is the shared ``(scope, external_id, provider) → internal_id``
+store consumed by every backend that cares about session continuity
+across platforms (OpenClaw today, Codex and future adapters next).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenpak.services.routing_service.session_mapper import (
+    SessionMap,
+    SessionRecord,
+)
+
+
+@pytest.fixture
+def mapper(tmp_path: Path) -> SessionMap:
+    return SessionMap(db_path=tmp_path / "session_map.db")
+
+
+# ── Roundtrip ───────────────────────────────────────────────────────────────
+
+
+def test_get_returns_none_for_unknown_triple(mapper):
+    assert mapper.get("openclaw", "sess-1", "tokenpak-claude-code") is None
+
+
+def test_set_then_get_roundtrip(mapper):
+    ok = mapper.set(
+        scope="openclaw",
+        external_id="sess-1",
+        provider="tokenpak-claude-code",
+        internal_id="claude-uuid-xyz",
+        metadata={"model": "claude-sonnet-4-6"},
+    )
+    assert ok is True
+    rec = mapper.get("openclaw", "sess-1", "tokenpak-claude-code")
+    assert isinstance(rec, SessionRecord)
+    assert rec.scope == "openclaw"
+    assert rec.external_id == "sess-1"
+    assert rec.provider == "tokenpak-claude-code"
+    assert rec.internal_id == "claude-uuid-xyz"
+    assert rec.metadata == {"model": "claude-sonnet-4-6"}
+
+
+def test_primary_key_is_triple_not_external_id_alone(mapper):
+    mapper.set("openclaw", "sess-1", "tokenpak-claude-code", "uuid-a")
+    mapper.set("openclaw", "sess-1", "tokenpak-anthropic", "uuid-b")
+    assert mapper.get("openclaw", "sess-1", "tokenpak-claude-code").internal_id == "uuid-a"
+    assert mapper.get("openclaw", "sess-1", "tokenpak-anthropic").internal_id == "uuid-b"
+
+
+def test_set_is_upsert(mapper):
+    mapper.set("openclaw", "sess-1", "tokenpak-claude-code", "uuid-old")
+    mapper.set("openclaw", "sess-1", "tokenpak-claude-code", "uuid-new")
+    rec = mapper.get("openclaw", "sess-1", "tokenpak-claude-code")
+    assert rec.internal_id == "uuid-new"
+
+
+def test_delete_removes_mapping(mapper):
+    mapper.set("openclaw", "sess-1", "tokenpak-claude-code", "uuid")
+    assert mapper.delete("openclaw", "sess-1", "tokenpak-claude-code") is True
+    assert mapper.get("openclaw", "sess-1", "tokenpak-claude-code") is None
+
+
+def test_delete_returns_false_for_missing(mapper):
+    assert mapper.delete("openclaw", "nonexistent", "provider") is False
+
+
+def test_count_reflects_actual_rows(mapper):
+    assert mapper.count() == 0
+    mapper.set("openclaw", "s1", "p1", "i1")
+    mapper.set("openclaw", "s2", "p1", "i2")
+    mapper.set("codex", "s1", "p1", "i3")
+    assert mapper.count() == 3
+
+
+# ── Liveness (last_used_at) ─────────────────────────────────────────────────
+
+
+def test_get_touches_last_used_at(mapper):
+    mapper.set("openclaw", "sess-1", "tokenpak-claude-code", "uuid")
+    rec1 = mapper.get("openclaw", "sess-1", "tokenpak-claude-code")
+    # Artificially age the row by sleeping briefly then reading.
+    import time as _time
+
+    _time.sleep(0.05)
+    rec2 = mapper.get("openclaw", "sess-1", "tokenpak-claude-code")
+    assert rec2.last_used_at >= rec1.last_used_at
+
+
+def test_prune_older_than_removes_stale(mapper):
+    mapper.set("openclaw", "old", "p", "i-old")
+    mapper.set("openclaw", "new", "p", "i-new")
+    # Force old row to look stale by setting last_used_at far in the past.
+    import sqlite3 as _sqlite3
+
+    with _sqlite3.connect(str(mapper._db_path)) as c:
+        c.execute(
+            "UPDATE session_map SET last_used_at=0 WHERE external_id=?", ("old",)
+        )
+    # Prune anything older than 1 second — only the zeroed row qualifies.
+    removed = mapper.prune_older_than(1.0)
+    assert removed == 1
+    assert mapper.get("openclaw", "old", "p") is None
+    assert mapper.get("openclaw", "new", "p") is not None
+
+
+# ── Corrupt-db recovery ─────────────────────────────────────────────────────
+
+
+def test_constructor_recovers_from_corrupt_db(tmp_path: Path):
+    # Plant a non-SQLite file at the target path.
+    db_path = tmp_path / "session_map.db"
+    db_path.write_bytes(b"not a database, just garbage")
+    # Construction must NOT raise; a fresh db replaces the corrupt file.
+    mapper = SessionMap(db_path=db_path)
+    mapper.set("openclaw", "sess-1", "provider", "uuid")
+    assert mapper.get("openclaw", "sess-1", "provider").internal_id == "uuid"
+    # Corrupt file got quarantined (renamed with .corrupt-<ts>.db suffix).
+    corrupted = list(tmp_path.glob("session_map.corrupt-*.db"))
+    assert len(corrupted) == 1
+
+
+# ── Opt-out env ─────────────────────────────────────────────────────────────
+
+
+def test_env_disables_all_operations(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_SESSION_MAPPER", "0")
+    m = SessionMap(db_path=tmp_path / "session_map.db")
+    assert m.set("openclaw", "s", "p", "i") is False
+    assert m.get("openclaw", "s", "p") is None
+    assert m.delete("openclaw", "s", "p") is False
+    assert m.prune_older_than(0) == 0
+    assert m.count() == 0
+
+
+def test_env_enabled_by_default(mapper, monkeypatch):
+    monkeypatch.delenv("TOKENPAK_SESSION_MAPPER", raising=False)
+    assert mapper.set("openclaw", "s", "p", "i") is True
+    assert mapper.get("openclaw", "s", "p") is not None
+
+
+# ── Singleton ───────────────────────────────────────────────────────────────
+
+
+def test_singleton_returns_same_instance():
+    from tokenpak.services.routing_service.session_mapper import get_session_mapper
+
+    a = get_session_mapper()
+    b = get_session_mapper()
+    assert a is b

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/services/routing_service/backends/anthropic_oauth.py
+++ b/tokenpak/services/routing_service/backends/anthropic_oauth.py
@@ -60,11 +60,19 @@ class AnthropicOAuthBackend:
         )
 
     def dispatch(self, request: Request) -> BackendResponse:
-        """Invoke ``claude --print`` with the request body on stdin.
+        """Invoke ``claude --print --output-format json`` with the request prompt.
 
-        Current state: executes the CLI synchronously + captures
-        stdout. Streaming mode lands alongside the proxy pipeline
-        rewrite. Returns a JSON-shaped Anthropic Messages response.
+        Session continuity (v1.3.14, 2026-04-24): if the request carries
+        a platform signal (``X-OpenClaw-Session`` or similar), consult
+        the session mapper to find the Claude CLI session UUID for this
+        ``(platform, external_id, provider)`` triple. Pass ``--resume
+        <uuid>`` on subsequent turns so multi-turn conversations stay
+        coherent. First turn runs without ``--resume``; we parse the
+        UUID out of the CLI's JSON output and persist it.
+
+        When the mapper is disabled or there's no platform signal, fall
+        back to the v1.3.13 ``--continue`` (resume-last-session)
+        behavior so direct callers keep working.
         """
         if not self._is_available():
             return BackendResponse(
@@ -82,8 +90,6 @@ class AnthropicOAuthBackend:
             )
 
         try:
-            # Extract the user message from the request body — the CLI
-            # expects a prompt, not a wire-format JSON payload.
             prompt = self._extract_prompt(request.body or b"")
             if prompt is None:
                 return BackendResponse(
@@ -97,21 +103,28 @@ class AnthropicOAuthBackend:
                     }).encode(),
                 )
 
-            # Synchronous invocation for γ; streaming driver lands later.
-            #
-            # Session continuity (Part 2b, 2026-04-24): pass ``--continue``
-            # so the CLI picks up the last session on this machine instead
-            # of opening a fresh conversation per request. Single-agent
-            # semantics accepted by Kevin's ratification — multi-session
-            # isolation is a later item if concurrency actually breaks.
-            # The flag is opt-out via TOKENPAK_OAUTH_NO_CONTINUE=1 for
-            # tests + rare debugging.
+            # Resolve platform origin + session mapping for this request.
+            origin, mapped_session_id = self._resolve_session(request)
+
+            # Build argv. --output-format json makes the CLI emit a
+            # parseable record with session_id + usage + result; we
+            # always ask for it so telemetry forwarding is accurate.
             import os as _os
 
             cmd = [self._claude_binary]
-            if _os.environ.get("TOKENPAK_OAUTH_NO_CONTINUE", "").strip() != "1":
+            if mapped_session_id:
+                # Subsequent turn for a known platform session.
+                cmd.extend(["--resume", mapped_session_id])
+            elif origin is None and (
+                _os.environ.get("TOKENPAK_OAUTH_NO_CONTINUE", "").strip() != "1"
+            ):
+                # No platform context at all — preserve v1.3.13 default.
                 cmd.append("--continue")
-            cmd.extend(["--print", prompt])
+            # If origin is present but there's no mapping yet, this is
+            # the first turn — run fresh so the CLI picks its own UUID,
+            # which we'll capture + persist below.
+            cmd.extend(["--print", "--output-format", "json", prompt])
+
             completed = subprocess.run(
                 cmd,
                 capture_output=True,
@@ -131,21 +144,22 @@ class AnthropicOAuthBackend:
                     }).encode(),
                 )
 
-            # Wrap the CLI's text output in Anthropic Messages response shape
-            # so clients can consume it uniformly.
-            assistant_text = completed.stdout.decode("utf-8", errors="replace")
+            # Parse the CLI's JSON output — session_id + usage + result text.
+            parsed = self._parse_cli_output(completed.stdout)
+
+            # Persist the session mapping on the first turn (when
+            # we had an origin but no prior mapping). If the parse
+            # failed we still return a valid response; the next
+            # request for the same (platform, external_id) just
+            # starts another fresh session — worst case is lost
+            # continuity, never a user-visible failure.
+            if origin is not None and mapped_session_id is None and parsed.get("session_id"):
+                self._persist_session(origin, parsed["session_id"], parsed.get("model"))
+
             return BackendResponse(
                 status=200,
                 headers={"content-type": "application/json"},
-                body=json.dumps({
-                    "id": "msg_claude_cli",
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": assistant_text}],
-                    "model": "claude-via-oauth",
-                    "stop_reason": "end_turn",
-                    "usage": {"input_tokens": 0, "output_tokens": 0},
-                }).encode(),
+                body=json.dumps(self._as_messages_response(parsed)).encode(),
             )
         except subprocess.TimeoutExpired:
             return BackendResponse(
@@ -164,6 +178,149 @@ class AnthropicOAuthBackend:
                     "error": {"type": "backend_error", "message": str(exc)[:200]}
                 }).encode(),
             )
+
+    # ── Session mapper integration (v1.3.14) ──────────────────────────
+
+    def _resolve_session(self, request: Request):
+        """Return ``(PlatformOrigin | None, mapped_session_id | None)``.
+
+        Consults the platform bridge for the origin and the session
+        mapper for a prior mapping. Never raises — a registry miss
+        simply means "first turn for this platform session".
+        """
+        try:
+            from tokenpak.services.routing_service.platform_bridge import (
+                detect_origin,
+                resolve_provider,
+            )
+        except Exception:
+            return None, None
+        try:
+            origin = detect_origin(request.headers or {})
+        except Exception:
+            origin = None
+        if origin is None or not origin.session_id:
+            return origin, None
+        provider = origin.declared_provider or resolve_provider(request.headers or {})
+        if provider is None:
+            return origin, None
+        try:
+            from tokenpak.services.routing_service.session_mapper import (
+                get_session_mapper,
+            )
+        except Exception:
+            return origin, None
+        try:
+            record = get_session_mapper().get(
+                scope=origin.platform_name,
+                external_id=origin.session_id,
+                provider=provider,
+            )
+        except Exception:
+            return origin, None
+        if record is None:
+            return origin, None
+        return origin, record.internal_id
+
+    @staticmethod
+    def _persist_session(origin, claude_session_id: str, model: Optional[str]) -> None:
+        """Store ``(scope=platform, external_id=session, provider) → claude uuid``."""
+        try:
+            from tokenpak.services.routing_service.platform_bridge import (
+                resolve_provider,
+            )
+            from tokenpak.services.routing_service.session_mapper import (
+                get_session_mapper,
+            )
+        except Exception:
+            return
+        provider = origin.declared_provider or "tokenpak-claude-code"
+        # resolve_provider is headers-based; we already have the origin
+        # so prefer its declared_provider, falling back to the default
+        # for known platforms. Unknown platform → still persist under
+        # whatever provider the request declared.
+        _ = resolve_provider  # keep import present for future overrides
+        metadata = {"model": model} if model else {}
+        try:
+            get_session_mapper().set(
+                scope=origin.platform_name,
+                external_id=origin.session_id,
+                provider=provider,
+                internal_id=claude_session_id,
+                metadata=metadata,
+            )
+        except Exception:
+            # Session mapping is a best-effort optimisation — never let
+            # persistence failure break the live dispatch.
+            pass
+
+    # ── Claude CLI --output-format=json parsing ───────────────────────
+
+    @staticmethod
+    def _parse_cli_output(stdout: bytes) -> dict:
+        """Decode ``claude --output-format json`` stdout.
+
+        Expected schema (claude-cli 2.1.x):
+          {"type":"result","session_id":"<uuid>","result":"<text>",
+           "usage":{"input_tokens":N,"output_tokens":N,...},
+           "modelUsage":{...},"total_cost_usd":F}
+
+        Falls back to a best-effort text extraction when the CLI didn't
+        emit JSON (e.g. old CLI version or an unexpected error path).
+        """
+        try:
+            data = json.loads(stdout.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return {
+                "result": stdout.decode("utf-8", errors="replace"),
+                "session_id": None,
+                "model": None,
+                "usage": {},
+            }
+        if not isinstance(data, dict):
+            return {
+                "result": str(data),
+                "session_id": None,
+                "model": None,
+                "usage": {},
+            }
+        model = None
+        model_usage = data.get("modelUsage")
+        if isinstance(model_usage, dict) and model_usage:
+            model = next(iter(model_usage.keys()), None)
+        return {
+            "result": data.get("result", ""),
+            "session_id": data.get("session_id"),
+            "model": model,
+            "usage": data.get("usage") or {},
+            "total_cost_usd": data.get("total_cost_usd"),
+            "stop_reason": data.get("stop_reason") or "end_turn",
+        }
+
+    @staticmethod
+    def _as_messages_response(parsed: dict) -> dict:
+        """Re-shape the CLI's parsed output into an Anthropic Messages envelope."""
+        usage = parsed.get("usage") or {}
+        input_tokens = int(usage.get("input_tokens") or 0)
+        output_tokens = int(usage.get("output_tokens") or 0)
+        return {
+            "id": f"msg_claude_{parsed.get('session_id') or 'cli'}",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": parsed.get("result", "")}],
+            "model": parsed.get("model") or "claude-via-oauth",
+            "stop_reason": parsed.get("stop_reason", "end_turn"),
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": int(
+                    usage.get("cache_creation_input_tokens") or 0
+                ),
+                "cache_read_input_tokens": int(
+                    usage.get("cache_read_input_tokens") or 0
+                ),
+            },
+        }
 
     @staticmethod
     def _extract_prompt(body: bytes) -> Optional[str]:

--- a/tokenpak/services/routing_service/session_mapper.py
+++ b/tokenpak/services/routing_service/session_mapper.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session mapper — platform-agnostic external→internal session id persistence.
+
+Why this exists
+---------------
+
+When an agent-orchestration platform (OpenClaw, Codex, future adapters)
+routes traffic through tokenpak, each of its own sessions needs a stable
+mapping onto the provider's native session id so multi-turn conversations
+stay coherent. For the Claude Code companion path, the "internal" id is
+the UUID that ``claude --output-format json`` emits on every turn; future
+providers expose their own equivalents.
+
+Design
+------
+
+- **Scope-keyed**: every record is keyed by
+  ``(scope, external_id, provider)`` where ``scope`` is the platform
+  name ("openclaw" / "codex" / …) and ``provider`` is the tokenpak
+  provider slug the caller targeted ("tokenpak-claude-code" / …). The
+  triple is the primary key so two platforms can reuse the same external
+  session-id string without collision.
+- **SQLite-backed** at ``~/.tokenpak/session_map.db`` in WAL mode so
+  parallel OpenClaw workers / Cali / Trix writing concurrently don't
+  serialize around a single JSON file. A corrupt database file is
+  renamed and a fresh one is initialised — we never let a stale map
+  break live routing.
+- **Single-writer, many-reader semantics** within a process via
+  ``threading.Lock``; cross-process coherence comes from SQLite's WAL
+  journal.
+- **No PII / no secrets.** Records hold only ids + timestamps + an
+  optional ``metadata`` JSON blob (intended for model name / route
+  class — never tokens or prompt content).
+
+Public surface
+--------------
+
+- :class:`SessionMap` — the store (construct with path override for tests).
+- :func:`get_session_mapper()` — process-wide singleton.
+- :class:`SessionRecord` — what callers get back from a lookup.
+
+Opt-out
+-------
+
+``TOKENPAK_SESSION_MAPPER=0`` disables the mapper process-wide —
+callers (backends) see ``None`` on every lookup and skip persistence.
+The oauth backend then falls back to its v1.3.13 ``--continue``
+behavior. This is the only escape hatch; no partial disablement.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_DB_PATH = Path.home() / ".tokenpak" / "session_map.db"
+
+
+def _enabled() -> bool:
+    """Process-wide opt-out via ``TOKENPAK_SESSION_MAPPER=0``."""
+    return os.environ.get("TOKENPAK_SESSION_MAPPER", "1").strip() != "0"
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    """Result of a successful :meth:`SessionMap.get` lookup."""
+
+    scope: str
+    external_id: str
+    provider: str
+    internal_id: str
+    created_at: float
+    last_used_at: float
+    metadata: Dict[str, str]
+
+
+class SessionMap:
+    """SQLite-backed external→internal session id mapping.
+
+    Constructed with a path override (tests) or the default
+    ``~/.tokenpak/session_map.db``. Thread-safe; multi-process safe via
+    SQLite WAL.
+    """
+
+    _SCHEMA = """
+    CREATE TABLE IF NOT EXISTS session_map (
+        scope       TEXT NOT NULL,
+        external_id TEXT NOT NULL,
+        provider    TEXT NOT NULL,
+        internal_id TEXT NOT NULL,
+        created_at  REAL NOT NULL,
+        last_used_at REAL NOT NULL,
+        metadata    TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY (scope, external_id, provider)
+    );
+    """
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._lock = threading.Lock()
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        """Create the parent dir + schema. Recover from a corrupt db file."""
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with self._connect() as conn:
+                conn.executescript(self._SCHEMA)
+                conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.DatabaseError as err:
+            # File exists but isn't a valid SQLite db — quarantine + retry once.
+            logger.warning(
+                "session_mapper: corrupt db at %s (%s); quarantining and recreating",
+                self._db_path,
+                err,
+            )
+            quarantine = self._db_path.with_suffix(
+                f".corrupt-{int(time.time())}.db"
+            )
+            try:
+                shutil.move(str(self._db_path), str(quarantine))
+            except OSError:
+                try:
+                    self._db_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            with self._connect() as conn:
+                conn.executescript(self._SCHEMA)
+                conn.execute("PRAGMA journal_mode=WAL")
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self._db_path),
+            timeout=5.0,
+            isolation_level=None,  # autocommit; we manage transactions explicitly.
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def get(
+        self, scope: str, external_id: str, provider: str
+    ) -> Optional[SessionRecord]:
+        """Return the stored record, or ``None`` when absent.
+
+        Touches ``last_used_at`` on every hit — read is write, by design,
+        so TTL-based pruning gets accurate liveness signals.
+        """
+        if not _enabled():
+            return None
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    row = conn.execute(
+                        "SELECT * FROM session_map "
+                        "WHERE scope=? AND external_id=? AND provider=?",
+                        (scope, external_id, provider),
+                    ).fetchone()
+                    if row is None:
+                        return None
+                    now = time.time()
+                    conn.execute(
+                        "UPDATE session_map SET last_used_at=? "
+                        "WHERE scope=? AND external_id=? AND provider=?",
+                        (now, scope, external_id, provider),
+                    )
+                    metadata: Dict[str, str] = {}
+                    try:
+                        raw = row["metadata"]
+                        if raw:
+                            parsed = json.loads(raw)
+                            if isinstance(parsed, dict):
+                                metadata = {str(k): str(v) for k, v in parsed.items()}
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                    return SessionRecord(
+                        scope=row["scope"],
+                        external_id=row["external_id"],
+                        provider=row["provider"],
+                        internal_id=row["internal_id"],
+                        created_at=row["created_at"],
+                        last_used_at=now,
+                        metadata=metadata,
+                    )
+            except sqlite3.Error as err:
+                logger.warning("session_mapper: get() failed: %s", err)
+                return None
+
+    def set(
+        self,
+        scope: str,
+        external_id: str,
+        provider: str,
+        internal_id: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> bool:
+        """Persist a mapping. Returns True on success, False on db error.
+
+        Upserts: a second call with a different ``internal_id`` replaces
+        the stored id. That happens when the provider rotates its own
+        session id (e.g. a Claude conversation forks).
+        """
+        if not _enabled():
+            return False
+        meta_json = json.dumps(metadata or {})
+        now = time.time()
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    conn.execute(
+                        "INSERT INTO session_map "
+                        "(scope, external_id, provider, internal_id, created_at, last_used_at, metadata) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                        "ON CONFLICT(scope, external_id, provider) DO UPDATE SET "
+                        "internal_id=excluded.internal_id, "
+                        "last_used_at=excluded.last_used_at, "
+                        "metadata=excluded.metadata",
+                        (scope, external_id, provider, internal_id, now, now, meta_json),
+                    )
+                return True
+            except sqlite3.Error as err:
+                logger.warning("session_mapper: set() failed: %s", err)
+                return False
+
+    def delete(self, scope: str, external_id: str, provider: str) -> bool:
+        """Remove a mapping. Used on explicit session invalidation."""
+        if not _enabled():
+            return False
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    cursor = conn.execute(
+                        "DELETE FROM session_map "
+                        "WHERE scope=? AND external_id=? AND provider=?",
+                        (scope, external_id, provider),
+                    )
+                    return cursor.rowcount > 0
+            except sqlite3.Error as err:
+                logger.warning("session_mapper: delete() failed: %s", err)
+                return False
+
+    def prune_older_than(self, max_age_seconds: float) -> int:
+        """Delete records whose ``last_used_at`` is older than cutoff.
+
+        Returns the number of rows removed. Callers schedule this (cron /
+        startup hook); the mapper itself never auto-prunes so a long-idle
+        session isn't silently dropped.
+        """
+        if not _enabled():
+            return 0
+        cutoff = time.time() - max_age_seconds
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    cursor = conn.execute(
+                        "DELETE FROM session_map WHERE last_used_at < ?", (cutoff,)
+                    )
+                    return cursor.rowcount
+            except sqlite3.Error as err:
+                logger.warning("session_mapper: prune failed: %s", err)
+                return 0
+
+    def count(self) -> int:
+        """Number of active mappings (diagnostics / tests)."""
+        if not _enabled():
+            return 0
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    row = conn.execute(
+                        "SELECT COUNT(*) AS n FROM session_map"
+                    ).fetchone()
+                    return int(row["n"]) if row else 0
+            except sqlite3.Error:
+                return 0
+
+
+# ── Process-wide singleton ─────────────────────────────────────────────
+
+_singleton: Optional[SessionMap] = None
+_singleton_lock = threading.Lock()
+
+
+def get_session_mapper() -> SessionMap:
+    """Return the process-wide :class:`SessionMap`, creating it lazily.
+
+    A fresh :class:`SessionMap` can still be constructed directly with a
+    path override — tests use that to get per-test isolation.
+    """
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = SessionMap()
+    return _singleton
+
+
+__all__ = [
+    "SessionMap",
+    "SessionRecord",
+    "get_session_mapper",
+]


### PR DESCRIPTION
## Summary

Closes the multi-turn gap from v1.3.13: OpenClaw companion path was coherent within a single HTTP request, but each request spawned a fresh Claude conversation. This PR restores the Apr 18-19 behavior (session id persistence + `claude --resume`) via a **platform-agnostic** session mapper — Codex and any future adapter plug into the same store without touching this code.

## New — `tokenpak/services/routing_service/session_mapper.py`

- SQLite-backed store at `~/.tokenpak/session_map.db` (WAL mode for parallel OpenClaw workers)
- Primary key: `(scope, external_id, provider)` — platforms can reuse external session strings without collision
- Corrupt-db recovery quarantines bad files + initialises fresh
- `TOKENPAK_SESSION_MAPPER=0` disables process-wide

## AnthropicOAuthBackend updates

- `claude --print --output-format json` for parseable results
- Per-request: bridge extracts `(platform, external_session)`; mapper lookup → `--resume <uuid>` if known, fresh spawn + persist if not
- **Real usage tokens forwarded** (input/output/cache) — previous stub was zeroed

## Live verified

Turn 1 with `X-OpenClaw-Session: live-test-sess-A` → Claude UUID `33a39508-…` captured + persisted.
Turn 2 with same external session → `--resume <uuid>`, Claude recalled `Your name is Bob` from turn 1 context.

## Test plan

- [x] 26 new tests (13 session_mapper + 10 oauth backend session integration + 3 pre-existing `--continue` preserved)
- [x] 303 services/conformance/proxy/cli tests green
- [x] Import contracts clean
- [x] Ruff clean
- [x] Live end-to-end multi-turn on running proxy
- [ ] CI green
- [ ] Post-deploy: OpenClaw workers see improved multi-turn coherence