### PR TITLE
fix(routing): v1.3.16 hotfix — real OpenClaw signal is X-TokenPak-Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.16] - 2026-04-24
+
+### Fixed — Hotfix for v1.3.15: real OpenClaw signal is `X-TokenPak-Backend`, not User-Agent
+
+v1.3.15 shipped User-Agent-based OpenClaw detection based on a static grep of `openclaw/dist/*.js`. But the UA=`openclaw` strings found in that grep are used by OpenClaw's **internal** modules (audit log, a2ui host identification, gateway self-reporting) — not by its outbound LLM HTTP client, which uses the embedded Anthropic JS SDK and sends `User-Agent: Anthropic/JS <ver>`. Live `TOKENPAK_DUMP_HEADERS` on the running proxy confirmed the mismatch.
+
+The actual signal OpenClaw carries is the `X-TokenPak-Backend: claude-code` header, installed into every `tokenpak-*` provider entry in `~/.openclaw/openclaw.json` by `tokenpak-inject.sh`. The platform bridge now reads this header and maps it:
+
+- `X-TokenPak-Backend: claude-code` → `tokenpak-claude-code`
+- `X-TokenPak-Backend: oauth` (alias) → `tokenpak-claude-code`
+- `X-TokenPak-Backend: api` → `tokenpak-anthropic`
+
+Live end-to-end verified post-fix:
+- Pre-fix (v1.3.15): OpenClaw-shape request (Anthropic JS SDK UA + `x-api-key` placeholder + `X-TokenPak-Backend`) → `HTTP 401 invalid x-api-key` (bridge didn't fire, byte-preserve forward).
+- Post-fix (v1.3.16): same request → `HTTP 200` with a real Claude response. Credential injection strips the placeholder `x-api-key`, injects Claude CLI OAuth, forwards to Anthropic which accepts.
+
+### Tests
+
+8 new regression tests pinning the `X-TokenPak-Backend` header path, case-insensitivity, precedence (explicit `X-TokenPak-Provider` still wins), unknown-value fall-through, and a "real OpenClaw shape" fixture that would have caught this bug pre-v1.3.15.
+
 ## [1.3.15] - 2026-04-24
 
 ### Fixed — OpenClaw routing pivot + Codex Path 1 restoration

--- a/tests/services/routing/test_platform_bridge_xtokenpak_backend.py
+++ b/tests/services/routing/test_platform_bridge_xtokenpak_backend.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform bridge — X-TokenPak-Backend header routing (v1.3.16, 2026-04-24).
+
+v1.3.15 shipped User-Agent detection for OpenClaw, but live HDR-DUMP
+proved OpenClaw actually uses the Anthropic JS SDK (``User-Agent:
+Anthropic/JS <ver>``) — not a distinctive UA. The real signal OpenClaw
+carries is the ``X-TokenPak-Backend`` header, installed by
+``tokenpak-inject.sh`` into every ``tokenpak-*`` provider entry in
+``~/.openclaw/openclaw.json``. These tests pin the bridge reading that
+header and mapping it to the correct provider.
+"""
+
+from __future__ import annotations
+
+from tokenpak.services.routing_service import platform_bridge as pb
+
+
+def test_x_tokenpak_backend_claude_code_maps_to_claude_provider():
+    assert (
+        pb.resolve_provider({"X-TokenPak-Backend": "claude-code"})
+        == "tokenpak-claude-code"
+    )
+
+
+def test_x_tokenpak_backend_oauth_alias_also_maps_to_claude():
+    assert (
+        pb.resolve_provider({"X-TokenPak-Backend": "oauth"})
+        == "tokenpak-claude-code"
+    )
+
+
+def test_x_tokenpak_backend_api_maps_to_anthropic_provider():
+    assert (
+        pb.resolve_provider({"X-TokenPak-Backend": "api"})
+        == "tokenpak-anthropic"
+    )
+
+
+def test_x_tokenpak_backend_is_case_insensitive():
+    for val in ("claude-code", "CLAUDE-CODE", "Claude-Code", " claude-code "):
+        assert (
+            pb.resolve_provider({"X-TokenPak-Backend": val}) == "tokenpak-claude-code"
+        ), f"failed for {val!r}"
+
+
+def test_header_name_is_case_insensitive():
+    for key in ("X-TokenPak-Backend", "x-tokenpak-backend", "X-TOKENPAK-BACKEND"):
+        assert (
+            pb.resolve_provider({key: "claude-code"}) == "tokenpak-claude-code"
+        ), f"failed for header {key!r}"
+
+
+def test_unknown_backend_value_falls_through_to_signals():
+    # Unknown value must NOT short-circuit; should fall through and
+    # return None (no signal will match).
+    assert pb.resolve_provider({"X-TokenPak-Backend": "something-else"}) is None
+
+
+def test_x_tokenpak_provider_still_wins_over_backend_header():
+    """Explicit X-TokenPak-Provider has highest precedence."""
+    assert (
+        pb.resolve_provider(
+            {
+                "X-TokenPak-Backend": "claude-code",
+                "X-TokenPak-Provider": "tokenpak-anthropic",
+            }
+        )
+        == "tokenpak-anthropic"
+    )
+
+
+def test_real_openclaw_shape_resolves_to_claude_code():
+    """The actual headers OpenClaw sends: Anthropic JS SDK UA + x-api-key
+    placeholder + X-TokenPak-Backend. Pre-fix: UA doesn't match openclaw
+    pattern → falls through → None → proxy uses byte-preserve, which
+    sends the fake x-api-key to Anthropic → 401. Post-fix: backend
+    header → tokenpak-claude-code → credential injection fires."""
+    headers = {
+        "User-Agent": "Anthropic/JS 0.73.0",
+        "anthropic-version": "2023-06-01",
+        "x-api-key": "placeholder-key",
+        "X-TokenPak-Backend": "claude-code",
+        "anthropic-beta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
+    }
+    assert pb.resolve_provider(headers) == "tokenpak-claude-code"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/services/routing_service/platform_bridge.py
+++ b/tokenpak/services/routing_service/platform_bridge.py
@@ -241,13 +241,25 @@ def resolve_provider(headers: HeaderMap) -> Optional[str]:
 
     Precedence:
       1. Explicit ``X-TokenPak-Provider`` header (wins).
-      2. The first registered platform signal's default_provider.
-      3. ``None`` — selector falls back to its legacy RouteClass default.
+      2. Legacy ``X-TokenPak-Backend`` header: ``claude-code`` / ``oauth``
+         → ``tokenpak-claude-code``, ``api`` → ``tokenpak-anthropic``.
+         This is what ``tokenpak-inject.sh`` actually installs in
+         ``~/.openclaw/openclaw.json``, so real OpenClaw traffic routes
+         through this header — not via User-Agent, which OpenClaw's
+         embedded Anthropic JS SDK sets to ``Anthropic/JS <ver>`` and
+         doesn't mention OpenClaw at all (HDR-DUMP confirmed 2026-04-24).
+      3. The first registered platform signal's default_provider.
+      4. ``None`` — caller falls back to its default behavior.
     """
     lheaders = _lower(headers)
     explicit = read_declared_provider(lheaders)
     if explicit:
         return explicit
+    backend_hdr = lheaders.get("x-tokenpak-backend", "").strip().lower()
+    if backend_hdr in ("claude-code", "oauth"):
+        return "tokenpak-claude-code"
+    if backend_hdr == "api":
+        return "tokenpak-anthropic"
     for sig in _REGISTRY:
         origin = sig.extract(lheaders)
         if origin is not None:


### PR DESCRIPTION
## Summary

v1.3.15 keyed OpenClaw detection on `User-Agent=openclaw`, based on static grep of `openclaw/dist/*.js`. Live `TOKENPAK_DUMP_HEADERS` proved that UA is set only by OpenClaw's internal modules (audit log, a2ui host, gateway self-id) — **not** by its outbound LLM client, which embeds the Anthropic JS SDK and sends `User-Agent: Anthropic/JS <ver>`. So v1.3.15 fired on curl tests but not on the actual OpenClaw traffic Kevin + Sue workers were generating.

The real signal: `X-TokenPak-Backend` header, installed by `tokenpak-inject.sh` into every `tokenpak-*` provider entry in `~/.openclaw/openclaw.json`. Bridge now maps:

| Header | Provider |
|---|---|
| `X-TokenPak-Backend: claude-code` | `tokenpak-claude-code` |
| `X-TokenPak-Backend: oauth` (alias) | `tokenpak-claude-code` |
| `X-TokenPak-Backend: api` | `tokenpak-anthropic` |

## Live verification

- Pre-fix (Anthropic JS SDK UA + `x-api-key` placeholder + `X-TokenPak-Backend: claude-code`): `HTTP 401 invalid x-api-key`
- Post-fix (same request): `HTTP 200` with real Claude response (`"v1315fixed"`)

## Tests

- [x] 8 new regression tests in `test_platform_bridge_xtokenpak_backend.py` pinning the header path, case-insensitivity, precedence, unknown-value fall-through, and a 'real OpenClaw shape' fixture that would have caught this
- [x] 123/123 routing+backends tests green
- [ ] CI green
- [ ] Post-deploy: OpenClaw workers stop 401-ing