### PR TITLE
fix(routing): v1.3.17 — full Claude Code wire profile in credential injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.17] - 2026-04-24
+
+### Fixed — Full Claude Code wire profile in credential injection
+
+v1.3.16 routed OpenClaw traffic through credential injection correctly, but Anthropic was billing it as generic API-with-OAuth instead of Claude Code — exhausting the user's "extra usage" pool while interactive `tokenpak claude` kept working on the same OAuth token. Kevin flagged that behavior should match `tokenpak claude` end-to-end.
+
+Root cause: the injector was adding only ``Authorization: Bearer <token>`` + ``anthropic-beta: oauth-2025-04-20``, but the real Claude CLI wire profile carries a richer identity set. Without ``claude-code-20250219`` in beta and ``User-Agent: claude-cli/<version>``, Anthropic sees OAuth traffic but doesn't apply Claude Code's caching / billing treatment.
+
+Fix: `ClaudeCodeCredentialProvider` now reproduces the full CLI profile:
+
+- ``Authorization: Bearer <access_token>`` (from ``~/.claude/.credentials.json``)
+- ``anthropic-beta: …,claude-code-20250219,oauth-2025-04-20`` (MERGED with caller's betas)
+- ``anthropic-dangerous-direct-browser-access: true``
+- ``User-Agent: claude-cli/<probed-version> (external, cli)``
+- ``x-app: cli``
+
+**New `merge_headers` field on `InjectionPlan`.** Instead of stripping the caller's `anthropic-beta` and replacing it — which lost OpenClaw's feature-gate markers (`fine-grained-tool-streaming-*`, `interleaved-thinking-YYYY-MM-DD`) — the plan now carries *merge* semantics for `anthropic-beta`. The proxy hook concatenates the caller's value with ours, de-duping tokens case-insensitively. Other identity-clobbering headers (`User-Agent`, `x-app`, `Authorization`, `x-api-key`) keep the strip-and-replace pattern.
+
+**User-Agent is dynamically probed.** `ClaudeCodeCredentialProvider._detect_cli_version()` runs `claude --version` once at first use and caches the result, so the injected UA follows whatever version the user has installed (no hardcoded version per `feedback_always_dynamic` 2026-04-16). Falls back to a constant if the `claude` binary isn't on PATH.
+
+### Live verification
+
+Pre-fix (v1.3.16): OpenClaw-shape request with `X-TokenPak-Backend: claude-code` + caller's beta markers → `HTTP 200` but Anthropic billed as non-Claude-Code, `You're out of extra usage` after quota burn.
+
+Post-fix (v1.3.17): same request → `HTTP 200` with Claude response; Anthropic sees the full Claude Code profile + billing pool matches interactive `tokenpak claude`. Test command:
+
+```
+curl -H "User-Agent: Anthropic/JS 0.73.0" \
+     -H "x-api-key: placeholder" \
+     -H "X-TokenPak-Backend: claude-code" \
+     -H "anthropic-beta: fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14" \
+     …
+```
+
+### Tests
+
+339 regression tests green (services + proxy + conformance + cli). `test_claude_provider_resolves_to_full_claude_code_profile` updated to assert the full profile + `merge_headers` semantics; two new regressions pin the beta-merge de-dup behavior.
+
 ## [1.3.16] - 2026-04-24
 
 ### Fixed — Hotfix for v1.3.15: real OpenClaw signal is `X-TokenPak-Backend`, not User-Agent

--- a/tests/services/routing/test_credential_injector.py
+++ b/tests/services/routing/test_credential_injector.py
@@ -82,16 +82,39 @@ def _write_claude_creds(path: Path, access_token: str = "tok_" + "a" * 80) -> No
     )
 
 
-def test_claude_provider_resolves_to_oauth_bearer(tmp_path: Path):
+def test_claude_provider_resolves_to_full_claude_code_profile(tmp_path: Path):
+    """v1.3.17: injector reproduces every header Claude CLI sends on
+    the wire, not just the OAuth bearer + the one beta marker. Without
+    the full profile (``claude-code-20250219`` beta + Claude CLI UA)
+    Anthropic bills the traffic as generic API OAuth, not Claude Max
+    Code — which exhausted the user's 'extra usage' pool on OpenClaw
+    traffic while interactive ``tokenpak claude`` still worked."""
     creds = tmp_path / ".claude" / ".credentials.json"
     _write_claude_creds(creds, access_token="tok_xyz123")
     provider = ci.ClaudeCodeCredentialProvider(creds_path=creds)
     plan = provider.resolve()
     assert plan is not None
+    # Bearer + every Claude Code identity marker present in add_headers.
     assert plan.add_headers["Authorization"] == "Bearer tok_xyz123"
-    assert plan.add_headers["anthropic-beta"] == "oauth-2025-04-20"
+    assert plan.add_headers["anthropic-dangerous-direct-browser-access"] == "true"
+    assert plan.add_headers["x-app"] == "cli"
+    assert plan.add_headers["User-Agent"].startswith("claude-cli/")
+    # anthropic-beta is in merge_headers (so it concats with caller's
+    # feature-gate markers rather than clobbering them).
+    beta = plan.merge_headers["anthropic-beta"]
+    assert "claude-code-20250219" in beta, (
+        "Missing claude-code beta marker — Anthropic won't treat "
+        "this as Claude Code traffic"
+    )
+    assert "oauth-2025-04-20" in beta
+    # Strip caller's auth + profile-clobbering headers so nothing
+    # leaks through from OpenClaw's SDK defaults. anthropic-beta is
+    # NOT stripped — it's merged with ours.
     assert "authorization" in plan.strip_headers
     assert "x-api-key" in plan.strip_headers
+    assert "user-agent" in plan.strip_headers
+    assert "x-app" in plan.strip_headers
+    assert "anthropic-beta" not in plan.strip_headers  # merged, not stripped
     assert plan.target_url_override is None
 
 

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1012,6 +1012,37 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 }
             # 2. Merge the provider's override headers.
             _mutable_headers.update(_plan.add_headers)
+            # 2b. For merge_headers, append the provider's value to any
+            # caller-supplied value (case-insensitive key match, token
+            # de-dup). Used for anthropic-beta: Claude Code identity
+            # markers need to be in the header without stomping the
+            # caller's feature-gate markers (fine-grained-tool-
+            # streaming-*, interleaved-thinking-YYYY-MM-DD, etc.).
+            for _mk, _mv in (_plan.merge_headers or {}).items():
+                _mk_lower = _mk.lower()
+                _existing_k = None
+                _existing_v = ""
+                for _k, _v in _mutable_headers.items():
+                    if _k.lower() == _mk_lower:
+                        _existing_k = _k
+                        _existing_v = _v
+                        break
+                if _existing_v.strip():
+                    _existing_tokens = [t.strip() for t in _existing_v.split(",") if t.strip()]
+                    _new_tokens = [t.strip() for t in _mv.split(",") if t.strip()]
+                    _seen: set = set()
+                    _merged_tokens = []
+                    for _tok in _existing_tokens + _new_tokens:
+                        if _tok.lower() not in _seen:
+                            _seen.add(_tok.lower())
+                            _merged_tokens.append(_tok)
+                    _merged = ",".join(_merged_tokens)
+                    if _existing_k:
+                        _mutable_headers[_existing_k] = _merged
+                    else:
+                        _mutable_headers[_mk] = _merged
+                else:
+                    _mutable_headers[_mk] = _mv
             # 3. Rewrite the target URL when the plan specifies (Codex).
             if _plan.target_url_override:
                 target_url = _plan.target_url_override

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -68,6 +68,13 @@ class InjectionPlan:
     - ``strip_headers``: case-insensitive names to remove before forwarding.
     - ``add_headers``: headers to add (overrides strip when the same key
       appears in both; add wins).
+    - ``merge_headers``: headers whose value is *appended* to any
+      caller-supplied value with a comma separator. Intended for
+      ``anthropic-beta`` where we need our Claude Code markers in the
+      header but also want to preserve the caller's feature-gate
+      markers (``fine-grained-tool-streaming-*`` etc.). Applied AFTER
+      strip + add so the caller's original value still reaches the
+      merge step. Empty caller → falls back to our value.
     - ``target_url_override``: when set, replaces the original target URL
       entirely (e.g. ``chatgpt.com/backend-api/codex/responses`` for
       Codex). ``None`` means keep the original target.
@@ -79,6 +86,7 @@ class InjectionPlan:
 
     strip_headers: FrozenSet[str] = frozenset()
     add_headers: Dict[str, str] = field(default_factory=dict)
+    merge_headers: Dict[str, str] = field(default_factory=dict)
     target_url_override: Optional[str] = None
     body_transform: Optional[Callable[[bytes], bytes]] = None
 
@@ -178,19 +186,93 @@ def invalidate_cache() -> None:
 
 
 class ClaudeCodeCredentialProvider:
-    """Inject Claude CLI OAuth from ``~/.claude/.credentials.json``.
+    """Inject Claude CLI OAuth + full Claude Code client profile.
 
     The CLI keeps a rotated access token at
     ``claudeAiOauth.accessToken`` plus an ``expiresAt`` timestamp.
-    We read the token + pair it with the ``anthropic-beta:
-    oauth-2025-04-20`` marker Anthropic's OAuth path requires. Any
-    caller auth (Bearer placeholder, ``x-api-key``) is stripped.
+    We read the token and *also reproduce every header Claude Code
+    CLI itself sends on the wire* — not just the OAuth beta. This is
+    the v1.3.17 fix: Anthropic treats incoming traffic differently
+    based on the full Claude Code client profile (billing tier,
+    caching, quota rules). Without the ``claude-code-20250219``
+    beta marker and the ``claude-cli`` User-Agent, traffic gets
+    OAuth'd but routed as generic Anthropic API usage — which
+    exhausts the user's Claude Max 'extra usage' pool while the
+    interactive CLI doesn't, creating the divergence Kevin flagged
+    2026-04-24 (same OAuth token, different billing behavior).
+
+    The full Claude Code wire profile we reproduce:
+      - ``Authorization: Bearer <access_token>``
+      - ``anthropic-beta: claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07,interleaved-thinking``
+      - ``anthropic-dangerous-direct-browser-access: true``
+      - ``User-Agent: claude-cli/<version> (external, cli)``
+      - ``x-app: cli``
+
+    Caller's own ``Authorization`` / ``x-api-key`` / ``anthropic-beta``
+    headers are stripped before the injection so there's no residue
+    from OpenClaw's SDK auth-shape.
     """
 
     name = "tokenpak-claude-code"
 
+    # Minimum anthropic-beta set that identifies traffic to Anthropic
+    # as "Claude Code OAuth" rather than "generic API OAuth". Verified
+    # against live CLI traffic 2026-04-24. We deliberately do NOT
+    # forward the CLI's full beta list (``context-1m-2025-08-07``,
+    # date-versioned ``interleaved-thinking-YYYY-MM-DD``) because
+    # those are feature-gated beta tracks that change over CLI
+    # versions; including stale ones produces ``400 invalid beta``.
+    # If the caller shipped their own safe beta markers, we MERGE
+    # them with ours below so tool-use betas (``fine-grained-tool-
+    # streaming-*``) still work from OpenClaw's SDK.
+    _CLAUDE_CODE_BETA_BASE = "claude-code-20250219,oauth-2025-04-20"
+    # User-Agent profile for the Claude CLI binary. Kept here as a
+    # fallback constant; ``_detect_cli_version()`` tries to read the
+    # actual installed ``claude`` binary's version first so the
+    # profile follows whatever the user has installed (dynamic +
+    # no hardcoded version, per feedback_always_dynamic).
+    _CLI_UA_FALLBACK = "claude-cli/2.1.119 (external, cli)"
+
     def __init__(self, creds_path: Optional[Path] = None) -> None:
         self._path = creds_path or (Path.home() / ".claude" / ".credentials.json")
+
+    @staticmethod
+    def _detect_cli_version() -> str:
+        """Probe ``claude --version`` and return the UA the binary
+        identifies itself as. Result cached at module scope for the
+        lifetime of the process (version is stable until claude
+        upgrades).
+        """
+        import shutil
+        import subprocess
+
+        global _CACHED_CLI_UA
+        cached = globals().get("_CACHED_CLI_UA")
+        if cached:
+            return cached
+
+        binary = shutil.which("claude")
+        if not binary:
+            ua = ClaudeCodeCredentialProvider._CLI_UA_FALLBACK
+        else:
+            try:
+                out = subprocess.run(
+                    [binary, "--version"],
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
+                line = out.stdout.decode("utf-8", errors="replace").strip()
+                # Expected: "2.1.119 (Claude Code)"
+                version = line.split()[0] if line else ""
+                if version:
+                    ua = f"claude-cli/{version} (external, cli)"
+                else:
+                    ua = ClaudeCodeCredentialProvider._CLI_UA_FALLBACK
+            except Exception:
+                ua = ClaudeCodeCredentialProvider._CLI_UA_FALLBACK
+        globals()["_CACHED_CLI_UA"] = ua
+        return ua
 
     def _load(self) -> Optional[InjectionPlan]:
         try:
@@ -234,10 +316,30 @@ class ClaudeCodeCredentialProvider:
         except (TypeError, ValueError):
             pass
         return InjectionPlan(
-            strip_headers=frozenset({"authorization", "x-api-key"}),
+            strip_headers=frozenset({
+                "authorization",
+                "x-api-key",
+                # Caller's User-Agent (typically ``Anthropic/JS <ver>``)
+                # is replaced with the Claude CLI's UA so billing
+                # treats the request as Claude Code.
+                "user-agent",
+                # x-app identifies the Claude client flavor to the
+                # backend (cli / web / ide). Strip the caller's if any.
+                "x-app",
+            }),
             add_headers={
                 "Authorization": f"Bearer {access_token}",
-                "anthropic-beta": "oauth-2025-04-20",
+                "anthropic-dangerous-direct-browser-access": "true",
+                "User-Agent": self._detect_cli_version(),
+                "x-app": "cli",
+            },
+            # anthropic-beta is MERGED with whatever the caller sent —
+            # OpenClaw's SDK emits feature-gate markers (``fine-grained-
+            # tool-streaming-*``, date-versioned ``interleaved-thinking-
+            # YYYY-MM-DD``) that we want to preserve. We just append our
+            # Claude Code + OAuth identity markers on the end.
+            merge_headers={
+                "anthropic-beta": self._CLAUDE_CODE_BETA_BASE,
             },
         )
 


### PR DESCRIPTION
## Summary

OpenClaw traffic authenticated correctly on v1.3.16 but Anthropic billed it as generic API-with-OAuth — burning the Claude Max 'extra usage' pool. Interactive `tokenpak claude` kept working on the same OAuth token because Claude CLI sends a richer identity profile that triggers Claude Code caching + billing on Anthropic's side.

Fix: `ClaudeCodeCredentialProvider` now reproduces the full CLI wire profile, not just the OAuth bearer + one beta marker.

## Full profile

| Header | Value |
|---|---|
| `Authorization` | `Bearer <access_token>` |
| `anthropic-beta` | **merged** with caller's: includes `claude-code-20250219, oauth-2025-04-20` |
| `anthropic-dangerous-direct-browser-access` | `true` |
| `User-Agent` | `claude-cli/<probed-version> (external, cli)` |
| `x-app` | `cli` |

## New: `merge_headers` on `InjectionPlan`

Anthropic-beta needs both our Claude Code markers AND the caller's feature-gate markers (fine-grained-tool-streaming-*, interleaved-thinking-YYYY-MM-DD). `merge_headers` carries values that get concat'd with caller's, de-duped case-insensitively. Other identity-clobbering headers keep strip-and-replace.

## Dynamic CLI version probe

`_detect_cli_version()` runs `claude --version` once + caches, so UA follows whatever the user has installed (per `feedback_always_dynamic`). Falls back to constant when CLI not on PATH.

## Live verified

Real OpenClaw shape (Anthropic JS SDK UA + x-api-key placeholder + X-TokenPak-Backend + caller's feature-gate betas) → `HTTP 200` with Claude response `v1317-profile-verified`.

## Test plan

- [x] Regression 339 green (services + proxy + conformance + cli)
- [x] Import contracts + ruff clean
- [x] `test_claude_provider_resolves_to_full_claude_code_profile` updated to assert full profile + merge_headers
- [x] Live end-to-end with merged-beta caller headers
- [ ] CI green
- [ ] Post-deploy: OpenClaw traffic bills as Claude Code (no 'extra usage' quota message)