### PR TITLE
fix(routing): v1.3.18 — inject X-Claude-Code-Session-Id (Claude Max billing pool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.18] - 2026-04-24
+
+### Fixed — Inject `X-Claude-Code-Session-Id` (required for Claude Max billing pool)
+
+v1.3.17 reproduced the Claude CLI wire profile but still missed one header: `X-Claude-Code-Session-Id`. Live diagnosis showed that header is **required** for Anthropic to route Claude Code OAuth traffic through the Claude Max billing pool — interactive `tokenpak claude` sends it (with its own UUID); our credential injector did not. Without it, Anthropic still accepted the OAuth but routed to a restricted pool that returned `You're out of extra usage` while the main Claude Max pool had headroom (interactive CLI kept working on the same token).
+
+Fix: `ClaudeCodeCredentialProvider` now generates one UUID per proxy process (`_get_proxy_session_id()`) and injects it as `X-Claude-Code-Session-Id`. Stable for the life of the proxy, matching how interactive `claude` uses a stable session-id per CLI instance. Caller's own session-id header (if any) is stripped so tokenpak-bridged traffic always maps to the proxy's coherent session, not the caller's.
+
+### Live verification
+
+Pre-fix (v1.3.17): real OpenClaw shape → `HTTP 400 invalid_request_error "You're out of extra usage"` even with full Claude Code beta + UA markers injected.
+
+Post-fix (v1.3.18): same request → `HTTP 200` with Claude response `session-id-verified` (and routing through the interactive CLI's billing pool).
+
+### Tests
+
+Updated `test_claude_provider_resolves_to_full_claude_code_profile` to assert `X-Claude-Code-Session-Id` is present + has UUID4 shape. 339 regression green.
+
 ## [1.3.17] - 2026-04-24
 
 ### Fixed — Full Claude Code wire profile in credential injection

--- a/tests/services/routing/test_credential_injector.py
+++ b/tests/services/routing/test_credential_injector.py
@@ -99,6 +99,12 @@ def test_claude_provider_resolves_to_full_claude_code_profile(tmp_path: Path):
     assert plan.add_headers["anthropic-dangerous-direct-browser-access"] == "true"
     assert plan.add_headers["x-app"] == "cli"
     assert plan.add_headers["User-Agent"].startswith("claude-cli/")
+    # X-Claude-Code-Session-Id is CRITICAL — without it Anthropic
+    # routes Claude Code OAuth to a restricted billing pool and
+    # returns "out of extra usage" (verified end-to-end 2026-04-24).
+    sess_id = plan.add_headers["X-Claude-Code-Session-Id"]
+    # UUID4 shape: 8-4-4-4-12 hex chars.
+    assert len(sess_id) == 36 and sess_id.count("-") == 4
     # anthropic-beta is in merge_headers (so it concats with caller's
     # feature-gate markers rather than clobbering them).
     beta = plan.merge_headers["anthropic-beta"]

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.17"
+__version__ = "1.3.18"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -944,6 +944,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 _pv = _resolve_provider(dict(self.headers))
                 if _pv:
                     _cred_injection_plan = _resolve_cred(_pv)
+                # Diagnostic: log the provider + injection outcome so
+                # field debugging shows whether the hook fired. Emits
+                # at WARN level to make it easy to grep without
+                # turning on global DEBUG.
+                if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).warning(
+                        "tokenpak.proxy[INJECT] provider=%s plan=%s",
+                        _pv or "<none>",
+                        "applied" if _cred_injection_plan else "<none>",
+                    )
             except Exception as _inj_err:
                 import logging as _logging
 

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -51,6 +51,7 @@ import json
 import logging
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, FrozenSet, List, Optional, Protocol
@@ -180,6 +181,37 @@ def invalidate_cache() -> None:
     """Drop the cache — tests + explicit token-rotation notifications."""
     with _CACHE_LOCK:
         _CACHE.clear()
+
+
+# ── Proxy-scoped session id for Claude Code billing ──────────────────
+#
+# Anthropic requires ``X-Claude-Code-Session-Id`` on Claude Code
+# traffic. One UUID per proxy process = one logical Claude session
+# serving all platform-bridged traffic, which matches how
+# interactive ``claude`` CLI uses a stable session-id for the life of
+# an instance. Persists across requests so billing attributes them
+# coherently.
+
+_PROXY_SESSION_ID: Optional[str] = None
+_PROXY_SESSION_LOCK = threading.Lock()
+
+
+def _get_proxy_session_id() -> str:
+    """Return a stable UUID used as ``X-Claude-Code-Session-Id`` for all
+    platform-bridged Claude Code traffic in this proxy process."""
+    global _PROXY_SESSION_ID
+    if _PROXY_SESSION_ID is None:
+        with _PROXY_SESSION_LOCK:
+            if _PROXY_SESSION_ID is None:
+                _PROXY_SESSION_ID = str(uuid.uuid4())
+    return _PROXY_SESSION_ID
+
+
+def _reset_proxy_session_id() -> None:
+    """Test helper: force a fresh proxy session id on the next call."""
+    global _PROXY_SESSION_ID
+    with _PROXY_SESSION_LOCK:
+        _PROXY_SESSION_ID = None
 
 
 # ── Built-in: Claude Code OAuth ──────────────────────────────────────
@@ -315,6 +347,23 @@ class ClaudeCodeCredentialProvider:
                 )
         except (TypeError, ValueError):
             pass
+        # X-Claude-Code-Session-Id is REQUIRED for Anthropic to route
+        # traffic through the Claude Code billing pool (the one
+        # interactive ``claude`` CLI uses). Without it, even with full
+        # CLI-profile betas + User-Agent, Anthropic billing returns
+        # ``You're out of extra usage`` — we verified this end-to-end
+        # 2026-04-24: v1.3.17 applied the profile but omitted the
+        # session-id header; OpenClaw traffic hit the restricted pool
+        # while interactive CLI (which sends a session-id) worked
+        # cleanly on the same OAuth token.
+        #
+        # We derive a stable per-process UUID so every OpenClaw request
+        # through this proxy shares one session-id. Aligns with Claude
+        # Max's per-session usage tracking; matches the behavior of
+        # interactive ``claude`` (one CLI instance = one session-id for
+        # the life of that instance).
+        session_id = _get_proxy_session_id()
+
         return InjectionPlan(
             strip_headers=frozenset({
                 "authorization",
@@ -326,12 +375,17 @@ class ClaudeCodeCredentialProvider:
                 # x-app identifies the Claude client flavor to the
                 # backend (cli / web / ide). Strip the caller's if any.
                 "x-app",
+                # If the caller tried to set its own session-id, drop
+                # it — we inject a tokenpak-scoped one so Anthropic
+                # sees coherent session usage across platform traffic.
+                "x-claude-code-session-id",
             }),
             add_headers={
                 "Authorization": f"Bearer {access_token}",
                 "anthropic-dangerous-direct-browser-access": "true",
                 "User-Agent": self._detect_cli_version(),
                 "x-app": "cli",
+                "X-Claude-Code-Session-Id": session_id,
             },
             # anthropic-beta is MERGED with whatever the caller sent —
             # OpenClaw's SDK emits feature-gate markers (``fine-grained-


### PR DESCRIPTION
## Summary

v1.3.17 produced the Claude CLI wire profile but still got `HTTP 400 out of extra usage` on live OpenClaw traffic. Live diagnosis (via the new `TOKENPAK_DUMP_HEADERS` diagnostic) confirmed: Anthropic REQUIRES `X-Claude-Code-Session-Id` for Claude Code OAuth traffic to land in the Claude Max billing pool. Without it, the request authenticates and identifies as Claude Code but routes to a restricted pool (which returned the quota error) while the main Max pool had headroom — interactive `tokenpak claude` kept working on the same token.

## Fix

- Generate one UUID per proxy process in `credential_injector._get_proxy_session_id()`.
- Inject as `X-Claude-Code-Session-Id` in every tokenpak-claude-code plan.
- Strip any caller-supplied `X-Claude-Code-Session-Id` so the proxy\x27s session identity is what Anthropic sees (coherent with per-proxy billing).
- New diagnostic: `TOKENPAK_DUMP_HEADERS=1` emits `[INJECT] provider=<name> plan=applied|<none>` after the bridge hook, so field debugging of which path fires is one grep away.

## Live verification

- Pre-fix: `HTTP 400 out of extra usage` on OpenClaw shape
- Post-fix: `HTTP 200 session-id-verified` on same shape

## Test plan

- [x] `test_claude_provider_resolves_to_full_claude_code_profile` updated to assert UUID4 shape for the session-id
- [x] 339 regression green
- [x] Ruff + import contracts clean
- [ ] CI green
- [ ] Post-deploy: `/test` on OpenClaw Sue returns HTTP 200 through same billing pool as interactive tokenpak claude