### PR TITLE
fix(proxy): v1.3.19 — add ?beta=true URL param for injected Claude Code traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.19] - 2026-04-24
+
+### Fixed — Add `?beta=true` URL param for injected Claude Code traffic
+
+Final delta between interactive `tokenpak claude` outbound and OpenClaw-bridged outbound (confirmed by live `POST-INJECT` header dump 2026-04-24):
+
+- Claude CLI: `https://api.anthropic.com/v1/messages?beta=true`
+- OpenClaw post-injection: `https://api.anthropic.com/v1/messages` (no param)
+
+Without the `?beta=true` query param, Anthropic's beta-feature gating doesn't honor the `anthropic-beta: claude-code-20250219` header we inject. The request authenticates + identifies as Claude Code but lands in the restricted billing pool that returned `"You're out of extra usage"` — while interactive CLI on the same OAuth token kept working because it always sets the param.
+
+Fix: when the credential injector applies a Claude Code plan (anything with `X-Claude-Code-Session-Id`), the proxy appends `?beta=true` to the forward URL if not already present. Codex path is unaffected — it uses a `target_url_override` that already carries the correct query.
+
+### Live verification
+
+Post-fix outbound URL: `https://api.anthropic.com/v1/messages?beta=true` — matches interactive CLI bit-for-bit. Synthetic curl with OpenClaw shape returns `HTTP 200`.
+
 ## [1.3.18] - 2026-04-24
 
 ### Fixed — Inject `X-Claude-Code-Session-Id` (required for Claude Max billing pool)

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.18"
+__version__ = "1.3.19"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1059,6 +1059,24 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             if _plan.target_url_override:
                 target_url = _plan.target_url_override
                 parsed = urlparse(target_url)
+            # 3b. Claude Code identity: ensure ``?beta=true`` is on the
+            # URL when we're injecting the Claude Code profile. Without
+            # this param Anthropic's beta-feature gating doesn't honor
+            # the ``anthropic-beta: claude-code-20250219`` header we
+            # inject — traffic authenticates as Claude Code but lands
+            # in the restricted pool. Claude CLI always sets this param;
+            # OpenClaw's JS SDK doesn't. Verified 2026-04-24 live HDR
+            # dumps: CLI URL="...?beta=true", OpenClaw URL="..." (no
+            # param) → different billing pool.
+            if (
+                _plan.target_url_override is None
+                and _plan.add_headers
+                and "X-Claude-Code-Session-Id" in _plan.add_headers
+                and "beta=true" not in (parsed.query or "")
+            ):
+                _new_query = (parsed.query + "&beta=true") if parsed.query else "beta=true"
+                target_url = parsed._replace(query=_new_query).geturl()
+                parsed = urlparse(target_url)
             # 4. Normalize the body when the plan specifies (Codex).
             if _plan.body_transform is not None and body is not None:
                 try:
@@ -1076,6 +1094,28 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             fwd_headers["Host"] = parsed.netloc
             if body is not None:
                 fwd_headers["Content-Length"] = str(len(body))
+            # Diagnostic: dump the final outbound header names (+ values
+            # for identity markers, auth redacted) so field debugging
+            # shows exactly what Anthropic receives post-injection.
+            if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
+                import logging as _logging
+
+                _safe = ("x-claude-code-", "anthropic-", "user-agent", "x-app", "x-tokenpak-")
+                _out = []
+                for _k, _v in fwd_headers.items():
+                    _kl = _k.lower()
+                    if any(_kl.startswith(p) or _kl == p for p in _safe):
+                        _out.append(f"{_k}={_v[:100]}")
+                    elif _kl in ("authorization", "x-api-key"):
+                        _out.append(f"{_k}=<redacted:{len(_v)}>")
+                    else:
+                        _out.append(_kl)
+                _logging.getLogger(__name__).warning(
+                    "tokenpak.proxy[POST-INJECT] url=%s body_bytes=%d headers=%s",
+                    target_url[:80],
+                    len(body or b""),
+                    " | ".join(_out),
+                )
         else:
             # Default byte-preserved pass-through (unchanged).
             fwd_headers = forward_headers(dict(self.headers), passthrough_cfg)


### PR DESCRIPTION
## Summary

Live POST-INJECT diff between interactive `tokenpak claude` and OpenClaw-bridged outbound:

- CLI: `https://api.anthropic.com/v1/messages?beta=true`
- OpenClaw post-v1.3.18: `https://api.anthropic.com/v1/messages` (no param)

Without `?beta=true`, Anthropic does not honor the `anthropic-beta: claude-code-20250219` header we inject → request identifies as Claude Code but lands in the restricted billing pool → `out of extra usage`.

Fix: append `?beta=true` to the forward URL when the credential injector applies a Claude Code plan (detected via `X-Claude-Code-Session-Id` in `add_headers`). Codex path unaffected.

## Live verified

Synthetic OpenClaw-shape curl now hits `?beta=true` URL → HTTP 200 with Claude response.

## Test plan

- [x] 339 regression green
- [x] Ruff + import contracts clean
- [x] Live end-to-end outbound URL matches CLI
- [ ] CI green
- [ ] Post-deploy: OpenClaw /test on Sue returns HTTP 200 through same billing pool as interactive tokenpak claude