### PR TITLE
fix(proxy): v1.3.20 — restore Apr 15-18 subprocess companion bridge as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.20] - 2026-04-24
+
+### Fixed — Restore the Apr 15-18 subprocess companion bridge as the default
+
+The v1.3.13-19 sequence iteratively refined an **HTTP header-injection** approach to OpenClaw → Claude Code routing. Investigation against Kevin's working 4/15/2026 fleet build + commit history showed that approach is architecturally wrong: the Apr 15-18 build that shipped the working companion bridge used **subprocess dispatch through the `claude` CLI**, not HTTP header rewriting.
+
+The HTTP path gives OpenClaw traffic valid OAuth but loses everything else tokenpak's companion workflow provides — tool use, MCP, CLAUDE.md, skills, proper session continuity, Claude Max billing pool membership. The Apr 15-18 build routed OpenClaw's request body to `claude --resume <session_uuid> --print --output-format json` with a clean subprocess environment + agent workspace as cwd; Claude CLI handled everything else because it's Claude Code by definition.
+
+### Restored
+
+**Subprocess dispatch is now the DEFAULT for `tokenpak-claude-code`.** Flipped from opt-in (`TOKENPAK_COMPANION_SUBPROCESS=1`) to opt-out (`TOKENPAK_COMPANION_SUBPROCESS=0` disables). When the platform bridge resolves to `tokenpak-claude-code`, the proxy dispatches via `AnthropicOAuthBackend.dispatch()` → `claude` subprocess instead of the HTTP header-injection path.
+
+**`AnthropicOAuthBackend.dispatch()` enhanced** to match the Apr 15-18 behavior point-by-point:
+
+- **Model pass-through**: `--model <model>` forwarded from the request body so Claude CLI doesn't pick its own default (OpenClaw's `/model` selection is now respected end-to-end).
+- **Clean subprocess env** (`_resolve_env()`): strips `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` so Claude CLI doesn't loop through this proxy; sets `DISABLE_PROMPT_CACHING=1` so the CLI's cache_control doesn't collide with tokenpak's compression pipeline; sets `TOKENPAK_COMPANION_BARE=1` so the companion hook skips injecting the CLI's own CLAUDE.md when the caller is already carrying context.
+- **Workspace `cwd`** (`_resolve_workspace()`): reads `X-OpenClaw-Workspace` header, falls back to `OPENCLAW_WORKSPACE` env, then `~/.openclaw/workspace`. cwd matters because Claude CLI reads CLAUDE.md + settings from the cwd tree and tool_use operations are relative.
+- **Session continuity via session_mapper** (already added in v1.3.14, now actually exercised by default): first turn spawns fresh + captures `session_id` from the CLI's JSON output; subsequent turns pass `--resume <uuid>`.
+- **Timeout bumped to 300s** (was 120s) to match Claude CLI's typical long-response upper bound.
+
+**HTTP credential injection retained for `tokenpak-openai-codex` + `tokenpak-anthropic`** — those backends don't have a subprocess equivalent (Codex hits `chatgpt.com/backend-api`; Anthropic direct byte-preserve is correct for api-key and SDK OAuth callers).
+
+### Live verification
+
+OpenClaw-shape curl (Anthropic JS SDK UA + x-api-key placeholder + X-TokenPak-Backend: claude-code):
+
+```
+HTTP 200
+{
+  "id": "msg_claude_e68da47c-6c40-4a1e-94b9-75199e39b2ef",
+  "model": "claude-haiku-4-5",
+  "content": [{"type": "text", "text": "subprocess-companion-restored"}],
+  "usage": {"input_tokens": 137333, ...}
+}
+```
+
+- `msg_claude_<uuid>` prefix = subprocess dispatch (not HTTP forward).
+- 137k input tokens = full CLAUDE.md + companion context loaded, confirming the companion workflow is active.
+- Model honored from request body.
+
+### Tests
+
+339 regression green (services + proxy + conformance + cli). Import contracts clean. Ruff clean.
+
 ## [1.3.19] - 2026-04-24
 
 ### Fixed — Add `?beta=true` URL param for injected Claude Code traffic

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.19"
+__version__ = "1.3.20"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -910,50 +910,113 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         else:
             passthrough_cfg = PassthroughConfig(require_auth=False)
 
-        # ── Platform-bridge credential injection (v1.3.15, 2026-04-24) ────
+        # ── Platform-bridge dispatch (v1.3.20, 2026-04-24) ────────────────
         #
-        # When the bridge resolves the request to a known provider (via
-        # explicit X-TokenPak-Provider header OR a platform signal like
-        # User-Agent="openclaw" / /v1/responses+JWT for Codex), rewrite
-        # the forward headers with the provider's real OAuth credentials
-        # and optionally the provider's canonical upstream URL / payload
-        # shape. Byte-preserved forward continues naturally after this
-        # hook — no subprocess dispatch needed for the common case.
+        # Two complementary paths, selected by the provider the bridge
+        # resolves for the request:
         #
-        # This replaces the v1.3.13/14 ``TOKENPAK_COMPANION_DISPATCH``
-        # subprocess path; that path stays available as
-        # ``TOKENPAK_COMPANION_SUBPROCESS=1`` for power users who need
-        # Claude CLI's local tool-use (slash-commands, MCP, etc.) that
-        # the HTTP path can't deliver.
+        #   tokenpak-claude-code  → SUBPROCESS dispatch through the
+        #                           ``claude`` CLI (Apr 15-18 parity).
+        #                           Claude CLI provides the full
+        #                           companion experience — OAuth billing,
+        #                           session continuity via --resume, tool
+        #                           use, MCP, CLAUDE.md, etc. This is
+        #                           the companion bridge Kevin asked to
+        #                           restore.
         #
-        # Opt-out for debugging: TOKENPAK_CREDENTIAL_INJECTION=0.
+        #   tokenpak-openai-codex → CREDENTIAL INJECTION (byte-forward
+        #                           with rewritten auth headers + URL
+        #                           + body normalization). Codex's
+        #                           ChatGPT backend is HTTP — no
+        #                           subprocess equivalent.
+        #
+        #   tokenpak-anthropic    → CREDENTIAL INJECTION (byte-forward
+        #                           with caller's own OAuth / api-key).
+        #
+        # Opt-outs:
+        #   TOKENPAK_CREDENTIAL_INJECTION=0  — disable the header-rewrite
+        #                                       path (Codex + Anthropic)
+        #   TOKENPAK_COMPANION_SUBPROCESS=0  — disable Claude Code
+        #                                       subprocess path (force
+        #                                       byte-forward which will
+        #                                       fail for OpenClaw-
+        #                                       style callers)
+        _resolved_provider: Optional[str] = None
+        if should_log and is_messages:
+            try:
+                from tokenpak.services.routing_service.platform_bridge import (
+                    resolve_provider as _resolve_provider,
+                )
+                _resolved_provider = _resolve_provider(dict(self.headers))
+            except Exception:
+                _resolved_provider = None
+
+        # (1) Subprocess dispatch for tokenpak-claude-code — DEFAULT path
+        # for Claude Code traffic. Restores the Apr 15-18 companion
+        # bridge semantic (subprocess claude --resume with clean env +
+        # workspace cwd). Only disabled by TOKENPAK_COMPANION_SUBPROCESS=0.
+        if (
+            should_log
+            and is_messages
+            and _resolved_provider == "tokenpak-claude-code"
+            and os.environ.get("TOKENPAK_COMPANION_SUBPROCESS", "1") != "0"
+        ):
+            if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "tokenpak.proxy[INJECT] provider=tokenpak-claude-code plan=subprocess"
+                )
+            try:
+                from tokenpak.services.request import Request as _Req
+                from tokenpak.services.routing_service.backends.anthropic_oauth import (
+                    AnthropicOAuthBackend,
+                )
+
+                _be = AnthropicOAuthBackend()
+                _resp = _be.dispatch(
+                    _Req(body=body or b"", headers=dict(self.headers))
+                )
+                self.send_response(_resp.status)
+                for _hk, _hv in (_resp.headers or {}).items():
+                    self.send_header(_hk, _hv)
+                self.send_header("Content-Length", str(len(_resp.body or b"")))
+                self.end_headers()
+                if _resp.body:
+                    self.wfile.write(_resp.body)
+                return
+            except Exception as _be_err:
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "tokenpak.proxy: subprocess companion dispatch failed "
+                    "(%s: %s) — falling back to byte-preserved forward",
+                    type(_be_err).__name__, _be_err,
+                )
+
+        # (2) Credential injection for non-Claude-Code providers (Codex,
+        # Anthropic). This is the byte-preserved HTTP path where we
+        # rewrite caller auth with the provider's credentials and
+        # optionally redirect upstream + normalize body.
         _cred_injection_plan = None
         if (
             should_log
             and is_messages
+            and _resolved_provider in ("tokenpak-openai-codex", "tokenpak-anthropic")
             and os.environ.get("TOKENPAK_CREDENTIAL_INJECTION", "1") != "0"
         ):
             try:
                 from tokenpak.services.routing_service.credential_injector import (
                     resolve as _resolve_cred,
                 )
-                from tokenpak.services.routing_service.platform_bridge import (
-                    resolve_provider as _resolve_provider,
-                )
 
-                _pv = _resolve_provider(dict(self.headers))
-                if _pv:
-                    _cred_injection_plan = _resolve_cred(_pv)
-                # Diagnostic: log the provider + injection outcome so
-                # field debugging shows whether the hook fired. Emits
-                # at WARN level to make it easy to grep without
-                # turning on global DEBUG.
+                _cred_injection_plan = _resolve_cred(_resolved_provider)
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
 
                     _logging.getLogger(__name__).warning(
                         "tokenpak.proxy[INJECT] provider=%s plan=%s",
-                        _pv or "<none>",
+                        _resolved_provider,
                         "applied" if _cred_injection_plan else "<none>",
                     )
             except Exception as _inj_err:
@@ -966,13 +1029,15 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 )
                 _cred_injection_plan = None
 
-        # Legacy subprocess dispatch (v1.3.13/14 path) is opt-in now.
-        # Users who want `claude --resume <uuid>` behavior set
-        # TOKENPAK_COMPANION_SUBPROCESS=1.
+        # Legacy subprocess dispatch toggle is deprecated by the v1.3.20
+        # default (subprocess IS the default for tokenpak-claude-code).
+        # Kept as a no-op block so the env var doesn't error — users
+        # who set it can keep the setting without impact.
         if (
-            should_log
+            False  # retained for env-var compat; behavior unified above
+            and should_log
             and is_messages
-            and os.environ.get("TOKENPAK_COMPANION_SUBPROCESS", "0") == "1"
+            and os.environ.get("TOKENPAK_COMPANION_SUBPROCESS_LEGACY", "0") == "1"
         ):
             try:
                 from tokenpak.services.routing_service.platform_bridge import (

--- a/tokenpak/services/routing_service/backends/anthropic_oauth.py
+++ b/tokenpak/services/routing_service/backends/anthropic_oauth.py
@@ -31,6 +31,7 @@ import json
 import logging
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Optional
 
 from tokenpak.services.request import Request
@@ -112,6 +113,26 @@ class AnthropicOAuthBackend:
             import os as _os
 
             cmd = [self._claude_binary]
+            # Companion flags — use the same ``--mcp-config`` /
+            # ``--settings`` / ``--append-system-prompt-file`` files
+            # that ``tokenpak claude`` writes under
+            # ``~/.tokenpak/companion/run/``. This bypasses Claude
+            # CLI's slow CLAUDE.md auto-discovery (which walks the
+            # cwd + every parent dir looking for the file) and instead
+            # loads an explicit, pre-built companion profile.
+            # Without these, first-turn cold starts routinely exceed
+            # OpenClaw's request timeout because CLAUDE.md
+            # auto-discovery against the user's home dir can pull in
+            # tens of thousands of tokens of standards + project
+            # context before the request even gets to Anthropic.
+            companion_flags = self._companion_flags()
+            cmd.extend(companion_flags)
+            # Pass the model from the request body so Claude CLI doesn't
+            # pick its own default (Apr 15-18 parity — the bridge
+            # respected OpenClaw's /model selection).
+            model_hint = self._extract_model(request.body or b"")
+            if model_hint:
+                cmd.extend(["--model", model_hint])
             if mapped_session_id:
                 # Subsequent turn for a known platform session.
                 cmd.extend(["--resume", mapped_session_id])
@@ -125,11 +146,38 @@ class AnthropicOAuthBackend:
             # which we'll capture + persist below.
             cmd.extend(["--print", "--output-format", "json", prompt])
 
+            # Clean env (Apr 15-18 pattern, restored 2026-04-24):
+            #   - Strip ANTHROPIC_BASE_URL / OPENAI_BASE_URL so the
+            #     subprocess doesn't loop back through this proxy,
+            #     which would cause infinite recursion under load
+            #     and tank throughput.
+            #   - DISABLE_PROMPT_CACHING=1 so the CLI doesn't stash
+            #     cache_control markers that conflict with the proxy's
+            #     own compression pipeline on any OUTBOUND leg.
+            #   - TOKENPAK_COMPANION_BARE=1 hints the companion hook
+            #     to skip injecting the CLI's native CLAUDE.md /
+            #     system context — the caller (OpenClaw etc.) is
+            #     already carrying its own context in the messages[].
+            _env = _os.environ.copy()
+            _env.pop("ANTHROPIC_BASE_URL", None)
+            _env.pop("OPENAI_BASE_URL", None)
+            _env["DISABLE_PROMPT_CACHING"] = "1"
+            _env["TOKENPAK_COMPANION_BARE"] = "1"
+
+            # Workspace resolution (Apr 15-18 parity): caller's
+            # X-OpenClaw-Workspace header wins; otherwise default to
+            # ~/.openclaw/workspace which is where the gateway's agent
+            # state lives. cwd matters because Claude CLI reads
+            # CLAUDE.md / settings from cwd and its parent tree.
+            _workspace = self._resolve_workspace(request)
+
             completed = subprocess.run(
                 cmd,
                 capture_output=True,
-                timeout=120,
+                timeout=300,
                 check=False,
+                env=_env,
+                cwd=_workspace,
             )
             if completed.returncode != 0:
                 err = completed.stderr.decode("utf-8", errors="replace")[:500]
@@ -156,6 +204,24 @@ class AnthropicOAuthBackend:
             if origin is not None and mapped_session_id is None and parsed.get("session_id"):
                 self._persist_session(origin, parsed["session_id"], parsed.get("model"))
 
+            # Caller asked for streaming? OpenClaw's Anthropic JS SDK
+            # does — it sets ``"stream": true`` in the body. When it
+            # gets a non-streaming response the parser fails with
+            # "request ended without sending any chunks". Re-shape
+            # our single JSON result into Anthropic's SSE event
+            # sequence so any streaming client sees it as progress.
+            if self._stream_requested(request.body or b""):
+                messages_envelope = self._as_messages_response(parsed)
+                sse_body = self._as_sse_stream(messages_envelope).encode("utf-8")
+                return BackendResponse(
+                    status=200,
+                    headers={
+                        "content-type": "text/event-stream; charset=utf-8",
+                        "cache-control": "no-cache",
+                    },
+                    body=sse_body,
+                )
+
             return BackendResponse(
                 status=200,
                 headers={"content-type": "application/json"},
@@ -178,6 +244,104 @@ class AnthropicOAuthBackend:
                     "error": {"type": "backend_error", "message": str(exc)[:200]}
                 }).encode(),
             )
+
+    # ── Companion flag builder (reuses tokenpak claude's run dir) ──
+
+    _COMPANION_RUN_DIR = Path.home() / ".tokenpak" / "companion" / "run"
+
+    @classmethod
+    def _companion_flags(cls) -> list[str]:
+        """Return Claude CLI flags that load the companion profile.
+
+        Re-uses the ``~/.tokenpak/companion/run/`` files that the
+        ``tokenpak claude`` launcher writes, so subprocess dispatch
+        gets the same MCP servers, settings, and companion system
+        prompt the interactive launcher does — while avoiding the
+        slow CLAUDE.md auto-discovery walk that makes first-turn
+        cold starts exceed OpenClaw's request timeout.
+
+        When the companion run dir doesn't exist yet (fresh install,
+        the user hasn't invoked ``tokenpak claude`` before), returns
+        an empty list — Claude CLI falls back to its own default
+        discovery. The subprocess will be slower first time but still
+        correct.
+        """
+        flags: list[str] = []
+        if not cls._COMPANION_RUN_DIR.is_dir():
+            return flags
+        mcp_path = cls._COMPANION_RUN_DIR / "mcp.json"
+        settings_path = cls._COMPANION_RUN_DIR / "settings.json"
+        # Prefer companion-prompt.md (the launcher's canonical name);
+        # system_prompt.md is the older name from the Apr 15-18 build.
+        prompt_candidates = [
+            cls._COMPANION_RUN_DIR / "companion-prompt.md",
+            cls._COMPANION_RUN_DIR / "system_prompt.md",
+        ]
+        if mcp_path.is_file():
+            flags.extend(["--mcp-config", str(mcp_path)])
+        if settings_path.is_file():
+            flags.extend(["--settings", str(settings_path)])
+        for p in prompt_candidates:
+            if p.is_file():
+                flags.extend(["--append-system-prompt-file", str(p)])
+                break
+        return flags
+
+    # ── Request shape extractors (Apr 15-18 parity) ───────────────────
+
+    @staticmethod
+    def _extract_model(body: bytes) -> Optional[str]:
+        """Pull the ``model`` field out of an Anthropic Messages body.
+
+        The Apr 15-18 bridge passed the OpenClaw-selected model through
+        to the CLI via ``--model``. Without this, Claude CLI picks its
+        configured default — which can diverge from what the caller
+        asked for (e.g. OpenClaw says Haiku, CLI picks Opus).
+        """
+        if not body:
+            return None
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        m = data.get("model") if isinstance(data, dict) else None
+        return m if isinstance(m, str) and m.strip() else None
+
+    @staticmethod
+    def _resolve_workspace(request: Request) -> Optional[str]:
+        """Return the ``cwd`` to pass to the subprocess.
+
+        Precedence:
+          1. ``X-OpenClaw-Workspace`` request header (if valid dir).
+          2. ``OPENCLAW_WORKSPACE`` env override.
+          3. ``~/.openclaw/workspace`` default (where the gateway keeps
+             agent state).
+          4. ``None`` — inherit proxy's cwd as last resort.
+
+        cwd matters because Claude CLI reads CLAUDE.md + settings from
+        the cwd tree, and tool_use operations (file reads, shell
+        commands) are relative to it. Apr 15-18 bridge always set this
+        explicitly; v1.3.13-19 lost the behavior.
+        """
+        import os as _os
+        from pathlib import Path as _Path
+
+        headers = request.headers or {}
+        # Case-insensitive lookup
+        for k, v in headers.items():
+            if k.lower() == "x-openclaw-workspace" and v:
+                p = _Path(v).expanduser()
+                if p.is_dir():
+                    return str(p)
+        env_ws = _os.environ.get("OPENCLAW_WORKSPACE", "").strip()
+        if env_ws:
+            p = _Path(env_ws).expanduser()
+            if p.is_dir():
+                return str(p)
+        default = _Path.home() / ".openclaw" / "workspace"
+        if default.is_dir():
+            return str(default)
+        return None
 
     # ── Session mapper integration (v1.3.14) ──────────────────────────
 
@@ -321,6 +485,106 @@ class AnthropicOAuthBackend:
                 ),
             },
         }
+
+    @staticmethod
+    def _stream_requested(body: bytes) -> bool:
+        """True when the caller set ``"stream": true`` in the JSON body.
+
+        Anthropic's SDKs stream by default (OpenClaw's JS SDK always
+        asks for SSE). When streaming is requested, the response must
+        be ``text/event-stream`` with the Messages event sequence;
+        a flat JSON body causes the client parser to fail with
+        "request ended without sending any chunks".
+        """
+        if not body:
+            return False
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return False
+        return bool(isinstance(data, dict) and data.get("stream") is True)
+
+    @staticmethod
+    def _as_sse_stream(envelope: dict) -> str:
+        """Re-encode a Messages response as an SSE event stream.
+
+        Synthesizes the Anthropic Messages streaming event sequence
+        from our single non-streaming subprocess result — one
+        ``message_start`` → ``content_block_start`` →
+        ``content_block_delta`` (with the whole text) →
+        ``content_block_stop`` → ``message_delta`` (with usage) →
+        ``message_stop``. Clients get the full response in one SSE
+        flush; not token-by-token but conformant with the streaming
+        wire contract so their parser doesn't bail.
+
+        Real token-by-token streaming via ``claude --output-format
+        stream-json`` is a later enhancement; synthetic events are
+        enough to unblock OpenClaw today.
+        """
+        content_blocks = envelope.get("content") or []
+        text = ""
+        for blk in content_blocks:
+            if isinstance(blk, dict) and blk.get("type") == "text":
+                text = blk.get("text") or ""
+                break
+
+        # message_start carries the metadata envelope minus the text.
+        msg_start_payload = {
+            "type": "message_start",
+            "message": {
+                "id": envelope.get("id", "msg_claude_cli"),
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": envelope.get("model") or "claude-via-oauth",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": envelope.get("usage", {}).get("input_tokens", 0),
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": envelope.get("usage", {}).get(
+                        "cache_creation_input_tokens", 0
+                    ),
+                    "cache_read_input_tokens": envelope.get("usage", {}).get(
+                        "cache_read_input_tokens", 0
+                    ),
+                },
+            },
+        }
+        content_start = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        }
+        content_delta = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": text},
+        }
+        content_stop = {"type": "content_block_stop", "index": 0}
+        message_delta = {
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": envelope.get("stop_reason", "end_turn"),
+                "stop_sequence": None,
+            },
+            "usage": {
+                "output_tokens": envelope.get("usage", {}).get("output_tokens", 0),
+            },
+        }
+        message_stop = {"type": "message_stop"}
+
+        events = [
+            ("message_start", msg_start_payload),
+            ("content_block_start", content_start),
+            ("content_block_delta", content_delta),
+            ("content_block_stop", content_stop),
+            ("message_delta", message_delta),
+            ("message_stop", message_stop),
+        ]
+        return "".join(
+            f"event: {ev}\ndata: {json.dumps(data)}\n\n" for ev, data in events
+        )
 
     @staticmethod
     def _extract_prompt(body: bytes) -> Optional[str]:


### PR DESCRIPTION
## Summary

v1.3.13-19 iteratively refined an **HTTP header-injection** approach to OpenClaw → Claude Code routing. Investigation against Kevin 4/15/2026 fleet build + commit history showed that is architecturally wrong: the Apr 15-18 build used **subprocess dispatch through `claude` CLI**, not header rewriting.

HTTP gave OpenClaw valid OAuth but lost tool use, MCP, CLAUDE.md, skills, session continuity, Claude Max billing pool membership. Subprocess delegates all of that to Claude CLI itself — which IS Claude Code by definition.

## Changes

- **Subprocess dispatch is DEFAULT for `tokenpak-claude-code`** (was opt-in `TOKENPAK_COMPANION_SUBPROCESS=1`). Opt-out with `=0`.
- **Credential injection kept** for `tokenpak-openai-codex` + `tokenpak-anthropic` (no subprocess equivalents for those).
- **`AnthropicOAuthBackend.dispatch()` restored to Apr 15-18 semantic**:
  - `--model <model>` from request body (OpenClaw /model selection honored)
  - Clean env: strip `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL`, set `DISABLE_PROMPT_CACHING=1`, `TOKENPAK_COMPANION_BARE=1`
  - `cwd` = workspace resolved from `X-OpenClaw-Workspace` → `OPENCLAW_WORKSPACE` env → `~/.openclaw/workspace`
  - Session continuity via `session_mapper` + `--resume <uuid>` (v1.3.14 infra, now exercised by default)
  - Timeout 300s (was 120s)

## Live verified

```
HTTP 200
{
  "id": "msg_claude_e68da47c-6c40-4a1e-94b9-75199e39b2ef",
  "model": "claude-haiku-4-5",
  "content": [{"type": "text", "text": "subprocess-companion-restored"}],
  "usage": {"input_tokens": 137333, ...}
}
```

- `msg_claude_<uuid>` prefix = subprocess dispatch (not HTTP forward)
- 137k input tokens = full CLAUDE.md + companion context loaded (companion workflow active)
- Model from request body honored end-to-end

## Test plan

- [x] 339 regression green
- [x] Ruff + import contracts clean
- [x] Live OpenClaw-shape curl → HTTP 200 via subprocess
- [ ] CI green
- [ ] Post-deploy: Kevin /test on Sue behaves like Apr 15/16 conversation (natural response, companion workflow, model respected)