### PR TITLE
feat(routing): v1.3.22 — dynamic per-model context registry + fail-fast 413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.22] - 2026-04-24
+
+### Added — Dynamic per-model context registry + fail-fast 413 at the bridge boundary
+
+Per-model context windows are now sourced from each provider's own `/v1/models` API instead of being hand-maintained in tokenpak. Self-maintaining + provider-agnostic: any future provider (OpenAI, Google, etc.) plugs in with one `register_provider()` call.
+
+**New module** `tokenpak/services/routing_service/model_context.py`:
+
+- `ModelRegistryProvider` Protocol — each provider implements `fetch() -> Iterable[ModelLimits]` against its own model-listing API.
+- `ModelContextRegistry` — federation across registered providers; lazy load on first use; 24h TTL cache at `~/.tokenpak/model_context_cache.json`; thread-safe; fail-open semantics (unreachable provider or unknown model → returns `None`, caller skips validation).
+- `AnthropicModelRegistryProvider` — built-in. Hits `GET https://api.anthropic.com/v1/models`, returns `max_input_tokens` + `max_tokens` per model. Reuses Claude CLI OAuth from `~/.claude/.credentials.json`.
+- Lookup is normalization-aware: callers can pass either versioned (`claude-haiku-4-5-20251001`) or unversioned (`claude-opus-4-7`) forms; both resolve to the same record.
+
+**OAuth backend dispatch** now does a fast input-token estimate before spawning the subprocess. If the estimate exceeds the model's context window minus a 4096-token safety margin, returns `HTTP 413` with a structured `context_overflow` error including `model`, `context_window`, `estimated_input_tokens`, `safety_margin`. No wasted round-trip to Anthropic, no reactive compaction, no ugly fail-then-retry latency. Disable via `TOKENPAK_BRIDGE_CONTEXT_CHECK=0`.
+
+### Live verification (2026-04-24)
+
+| Scenario | Result |
+|---|---|
+| Tiny payload to `claude-haiku-4-5` | HTTP 200 (passthrough) |
+| 222k tokens to `claude-haiku-4-5` (200k cap) | **HTTP 413** with `context_overflow` payload, served in milliseconds |
+| Unknown model id (`claude-opus-3-old`, `gpt-5.4`) | Registry returns `None`; backend fails-open |
+| Cache age > 24h | Lazy refresh on next access |
+| `/v1/models` unreachable | Cache stays as-is; new lookups fail-open |
+
+Initial fetch produced 9 Anthropic model records (Opus 4.6/4.7 + Sonnet 4.x at 1M, Haiku 4.5 + older Opus/Sonnet at 200k).
+
+### Provider-agnostic by design
+
+The registry has no Anthropic-specific assumptions in the federation layer — that's the registered Anthropic provider's job. Adding OpenAI/Codex would be:
+
+```python
+class OpenAIModelRegistryProvider:
+    name = "openai"
+    def fetch(self) -> Iterable[ModelLimits]:
+        # GET /v1/models with the user's OpenAI key, parse, yield ModelLimits
+        ...
+
+register_provider(OpenAIModelRegistryProvider())
+```
+
+No changes to `ModelContextRegistry`, `AnthropicOAuthBackend`, or the proxy hot path. Honors `feedback_always_dynamic` (2026-04-16) + Kevin 2026-04-24 ("provider/model/platform agnostic, self-maintaining, dynamic — users never edit a hand-written model list").
+
+### Tests
+
+191 services + proxy tests green. Ruff + import contracts clean. Live curl verification covers passthrough, 413 fail-fast, cache behavior, and unknown-model fail-open.
+
 ## [1.3.21] - 2026-04-24
 
 ### Fixed — Platform-slim subprocess context (stop auto-compaction + restore cache)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.21] - 2026-04-24
+
+### Fixed — Platform-slim subprocess context (stop auto-compaction + restore cache)
+
+v1.3.20 restored the subprocess bridge but each turn loaded ~147k tokens of full tokenpak-companion context (MCP schemas, companion-prompt.md, CLAUDE.md auto-discovery), triggering Claude Code's auto-compaction after nearly every message. Compaction rewrites the conversation history → invalidates Anthropic's prompt-cache → every turn billed as fresh (`cache_creation_input_tokens` rather than `cache_read_input_tokens`).
+
+Additionally, v1.3.20 subprocess used `--continue` by default for all platform-bridged calls with no session header, which resumed whatever the *last* CLI session on the machine had been — accumulating unrelated prior state across turns and hitting 300k+ tokens.
+
+### Changed — platform-bridge subprocess context policy
+
+**Ratified by Kevin 2026-04-24:**
+
+1. **Default: platform-slim.** For platform-bridged subprocess (OpenClaw, Codex-via-Claude, future adapters), load *only* the platform workspace's `.md` files (MEMORY.md, IDENTITY.md, AGENTS.md, TOOLS.md, etc. at the workspace root). Skip tokenpak-companion's MCP + system prompt + settings layer. Platform callers already carry their own system prompt + memory in `messages[]`; adding the companion layer is duplicative.
+2. **Opt-in full companion** via `TOKENPAK_BRIDGE_COMPANION=1` — loads the `~/.tokenpak/companion/run/` profile on top of platform context. Intended for callers that want the full `tokenpak claude` experience over the bridge.
+3. **Fresh session per request** for platform-bridged calls (`--no-session-persistence` + no `--resume` unless the session mapper has a match). Platform replays full conversation in `messages[]` each turn, so CLI-side session continuity is redundant + harmful. Auto-compaction no longer fires because the context envelope is stable across turns.
+4. **1M context window** — Claude CLI emits `context-1m-2025-08-07` beta by default; nothing in tokenpak caps it.
+
+### Implementation details
+
+- New `_platform_prompt_flags(workspace)` concatenates every `*.md` at the workspace root into a single cached tempfile at `/tmp/tokenpak-bridge-prompts/<content-hash>.md` and emits `--append-system-prompt-file <path>`. Cache key is file list + mtimes, so edits to any workspace .md invalidate cleanly.
+- New `_build_context_flags(workspace)` assembles the full flag set: platform flags by default, companion flags appended when `TOKENPAK_BRIDGE_COMPANION=1`.
+- New `_has_platform_headers(headers)` detects bridged traffic via `X-TokenPak-Backend` / `X-TokenPak-Provider` / `X-OpenClaw-*` / `X-Codex-*` so fresh-session mode kicks in even when the platform bridge doesn't detect via User-Agent.
+
+### Live verification
+
+Same curl shape as v1.3.20:
+
+| Metric | v1.3.20 | v1.3.21 |
+|---|---|---|
+| `input_tokens` | 147k-309k (stale `--continue` accumulation) | 52k (fresh session, workspace .md only) |
+| Cold-start latency | ~13s first turn, then compaction every turn | ~9s every turn, no compaction |
+| Session ID | reused across requests (context accumulates) | fresh UUID per request |
+| `msg_claude_<uuid>` response ID | same across requests | new per request (expected) |
+
+Response content still carries the Sue persona from workspace `IDENTITY.md` / `MEMORY.md` / `AGENTS.md` / `TOOLS.md` / `SOUL.md`, confirming the platform's own context loaded correctly:
+
+```
+🔥 Fresh session loaded.
+Context active:
+- Sue (Strategist) — architecture, strategy, direct Kevin partner
+- MEMORY.md curated — 19 years of standing orders and lessons
+- AGENTS.md + SOUL.md + USER.md + TOOLS.md compiled
+```
+
+### Tests
+
+191 services + proxy tests green. Ruff + import contracts clean.
+
+### Also fixed: prompt-cache re-enabled on subprocess path
+
+Removed `DISABLE_PROMPT_CACHING=1` from the subprocess env. That flag was copied from the Apr 15-18 monolith, where it prevented interference between the proxy's compression pipeline and Claude CLI's cache_control markers. In the v1.3.20+ architecture the subprocess hits `api.anthropic.com` directly (we strip `ANTHROPIC_BASE_URL`), so Anthropic's server-side prompt cache is free to fire. Opt-out via `TOKENPAK_BRIDGE_DISABLE_PROMPT_CACHE=1` (debugging only).
+
+### Also added: conversation-fingerprint session mapping (multi-turn cache accumulation)
+
+The first v1.3.21 iteration extracted only the last user message from the body for the subprocess prompt — which meant Claude CLI never saw the conversation history, so Anthropic's cache couldn't accumulate across turns within a single OpenClaw conversation. Each turn paid cache_creation on the same ~52k workspace prefix; no cache_read beyond the initial workspace block.
+
+Fixed by mapping each platform-bridged conversation to a persistent Claude CLI session via a content-addressed fingerprint (SHA256 of `model + first_user_message_text`, truncated to 16 hex chars):
+
+- **Turn 1** of a conversation: no mapping yet → run fresh, Claude CLI picks a UUID, tokenpak persists `(bridge-fp, <fingerprint>, provider) → <claude_uuid>` in the session mapper.
+- **Turn 2+** of the SAME conversation: OpenClaw replays the same first user message on every turn → same fingerprint → session_mapper returns the Claude UUID → subprocess invokes `claude --resume <uuid>`. Claude CLI has the prior-turn state locally; Anthropic's cache hits the accumulated prefix.
+- **New conversation** (e.g. OpenClaw `/new` → different first user message) → different fingerprint → no mapping → fresh session. Cache cleanly breaks on conversation boundary.
+
+Empirical verification (2026-04-24):
+
+| Turn | Conversation | `input_tokens` | `cache_creation` | `cache_read` |
+|---|---|---|---|---|
+| 1 | A (new) | 10 | 27,289 | 25,039 |
+| 2 | A (continued, same fingerprint) | 10 | **325** | **52,328** |
+| 3 | B (new `/new`, different fingerprint) | 10 | 27,284 | 25,039 |
+
+Turn 2 → 99.4% cache hit (325 creation vs 52,328 read). Conversation B correctly isolated — A's cache untouched. Session map shows one `bridge-fp` row per conversation, each mapped to its own Claude CLI session UUID.
+
+This matches the interactive `claude` chat-window behavior Kevin asked to replicate:
+- Same OpenClaw conversation multi-turn → cache accumulates like a single CLI session
+- New OpenClaw session → cache breaks only on that boundary
+
+Opt-out via `TOKENPAK_SESSION_MAPPER=0` (disables all session mapping, falls back to fresh session every turn).
+
 ## [1.3.20] - 2026-04-24
 
 ### Fixed — Restore the Apr 15-18 subprocess companion bridge as the default

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,55 @@
+# OpenClaw integration scripts
+
+Canonical install + uninstall scripts for routing OpenClaw's gateway through
+TokenPak's compression + caching pipeline (Claude Code companion bridge,
+Codex Path 1, etc.).
+
+Full reference: <https://docs.tokenpak.ai/integrations/openclaw>
+
+## Files
+
+- `tokenpak-inject.sh` — idempotent installer that mutates
+  `~/.openclaw/openclaw.json` to add `tokenpak-*` providers, mirror auth
+  profiles, stamp the `X-TokenPak-Backend` header, sync the Codex JWT,
+  and write a one-time `.pre-tokenpak-backup` for clean revert. Designed
+  to run as `ExecStartPre=` on `openclaw-gateway.service`, so the
+  TokenPak entries self-heal on every gateway restart.
+- `tokenpak-uninstall.sh` — companion that restores the pre-install
+  config from the backup (or strips `tokenpak-*` entries in place when no
+  backup exists), removes the systemd drop-in, optionally stops the
+  TokenPak proxy and purges caches. Always writes
+  `*.uninstall-rollback` files so the post-install state can be recovered.
+
+## Quick install
+
+```bash
+install -m 0755 tokenpak-inject.sh tokenpak-uninstall.sh ~/.local/bin/
+
+mkdir -p ~/.config/systemd/user/openclaw-gateway.service.d
+cat > ~/.config/systemd/user/openclaw-gateway.service.d/tokenpak-inject.conf <<'EOF'
+[Service]
+ExecStartPre=%h/.local/bin/tokenpak-inject.sh
+EOF
+
+systemctl --user daemon-reload
+# Then restart the gateway by killing its main PID:
+kill $(systemctl --user show openclaw-gateway.service -p MainPID --value)
+```
+
+## Quick uninstall
+
+```bash
+~/.local/bin/tokenpak-uninstall.sh --dry-run    # preview
+~/.local/bin/tokenpak-uninstall.sh               # do it
+~/.local/bin/tokenpak-uninstall.sh --stop-proxy --purge-caches --yes
+                                                 # full teardown
+```
+
+## Doctor compatibility
+
+`openclaw doctor` and `doctor --repair` are safe to run alongside this
+integration. The TokenPak entries (providers, auth profiles, the
+`X-TokenPak-Backend` header) are preserved. If `doctor --repair`
+normalises per-model `contextWindow` values, the next gateway restart
+re-runs `tokenpak-inject.sh` and restores them automatically. See the
+docs for the full compatibility matrix.

--- a/integrations/openclaw/tokenpak-inject.sh
+++ b/integrations/openclaw/tokenpak-inject.sh
@@ -1,0 +1,518 @@
+#!/usr/bin/env bash
+# tokenpak-inject.sh — Auto-inject TokenPak provider routing into OpenClaw config
+#
+# What it does:
+#   1. Mirrors every provider as tokenpak-* with baseUrl → proxy
+#   2. Interleaves model chains: [tp-primary, primary, tp-fb, fb, ...]
+#   3. Updates allowlist, copies auth profiles
+#   4. Processes both openclaw.json and agent models.json files
+#   5. Idempotent — safe to run repeatedly
+#
+# Runs as ExecStartPre before openclaw-gateway starts.
+#
+# DOCS:
+#   Full integration reference (install, doctor compatibility, troubleshooting):
+#     https://docs.tokenpak.ai/integrations/openclaw
+#     source: tokenpak-docs/docs/integrations/openclaw.md
+#
+# DOCTOR COMPATIBILITY (summary):
+#   `openclaw doctor` and `doctor --repair` are SAFE to run alongside this
+#   integration. Provider entries, auth profiles, and the X-TokenPak-Backend
+#   header are preserved. If `doctor --repair` normalises per-model
+#   contextWindow values, the next gateway restart re-runs this script and
+#   restores them automatically. Don't try to use `$include` indirection to
+#   isolate TokenPak settings — OpenClaw's config writer expands and
+#   inlines includes on every write-back; the ExecStartPre re-injection
+#   pattern is the only resilient strategy on current OpenClaw releases.
+
+set -euo pipefail
+
+PROXY_URL="${TOKENPAK_URL:-http://localhost:8766}"
+
+python3 << 'PYEOF'
+import json, os, shutil
+from pathlib import Path
+from glob import glob
+
+PROXY_URL = os.environ.get("TOKENPAK_URL", "http://localhost:8766")
+PREFIX = "tokenpak"
+
+# Honor the OpenClaw-native env var that systemd units set per service
+# (governor → ~/.openclaw-governor, gateway → ~/.openclaw, etc.). Falls
+# back to ~/.openclaw for single-instance hosts.
+_OC_CONFIG_ENV = os.environ.get("OPENCLAW_CONFIG_PATH", "").strip()
+if _OC_CONFIG_ENV:
+    MAIN_CONFIG = Path(_OC_CONFIG_ENV).expanduser()
+    OPENCLAW_DIR = MAIN_CONFIG.parent
+else:
+    OPENCLAW_DIR = Path.home() / ".openclaw"
+    MAIN_CONFIG = OPENCLAW_DIR / "openclaw.json"
+
+def log(msg): print(f"[tokenpak-inject] {msg}")
+def load_json(p): return json.loads(p.read_text()) if p.exists() else {}
+def save_json(p, d):
+    # Two backup files:
+    #   .tokenpak-backup       — most recent pre-mutation snapshot, rotated
+    #                            on every run. Useful for "what did the last
+    #                            run change?" diffing.
+    #   .pre-tokenpak-backup   — created ONCE on the very first run. This is
+    #                            the user's clean pre-tokenpak state, which
+    #                            tokenpak-uninstall.sh restores. Never
+    #                            overwritten so the original config is
+    #                            always recoverable.
+    shutil.copy2(p, str(p) + ".tokenpak-backup")
+    pre_path = Path(str(p) + ".pre-tokenpak-backup")
+    if not pre_path.exists():
+        shutil.copy2(p, str(pre_path))
+        log(f"Saved first-install backup: {pre_path}")
+    p.write_text(json.dumps(d, indent=2))
+
+def is_tp(name): return name.startswith(f"{PREFIX}-") or name == PREFIX
+def tp_name(name): return f"{PREFIX}-{name}"
+
+def tp_ref(ref, pm):
+    """Get tokenpak version of a model ref, or None"""
+    if not ref or "/" not in ref: return None
+    prov, model = ref.split("/", 1)
+    if is_tp(prov) or prov not in pm: return None
+    return f"{pm[prov]}/{model}"
+
+# ── 1. Mirror providers ──────────────────────────────────────────────
+
+def mirror_providers(providers):
+    changed, pm = False, {}
+    for orig, cfg in list(providers.items()):
+        if is_tp(orig) or not cfg.get("models"): continue
+        tpn = tp_name(orig)
+        pm[orig] = tpn
+        for m in cfg.get("models", []):
+            m.setdefault("cost", {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0})
+        # Copy api format from original if set; omit if not (let OpenClaw infer)
+        is_anthropic = (cfg.get("api") == "anthropic-messages") or orig.startswith("anthropic")
+        target_base = PROXY_URL  # ALL tokenpak providers route through proxy
+        new = {"baseUrl": target_base, "models": cfg["models"].copy()}
+        if cfg.get("api"):
+            new["api"] = cfg["api"]
+        if cfg.get("apiKey"): new["apiKey"] = cfg["apiKey"]
+        for k in ["headers", "authHeader"]:
+            if k in cfg: new[k] = cfg[k]
+        if providers.get(tpn, {}).get("baseUrl") != target_base or len(providers.get(tpn, {}).get("models", [])) != len(cfg["models"]):
+            providers[tpn] = new; changed = True
+            route = "proxy" if is_anthropic else "direct"
+            log(f"Mirrored: {orig} -> {tpn} ({len(cfg['models'])} models, {route})")
+    return changed, pm
+
+# ── 2. Interleave model chains ───────────────────────────────────────
+
+def interleave(model_cfg, pm):
+    """
+    Promote primary to tokenpak version. NO fallbacks.
+    
+    Input:  primary=opus4.6, fallbacks=[anything]
+    Output: primary=tp-opus4.6, fallbacks=[]
+    
+    Direct provider refs are kept in config for emergency use but never
+    auto-routed. Kevin can manually switch to anthropic/* if proxy is down.
+    """
+    # Normalize to dict
+    if isinstance(model_cfg, str):
+        model_cfg = {"primary": model_cfg, "fallbacks": []}
+    if not isinstance(model_cfg, dict):
+        return model_cfg, False
+
+    primary = model_cfg.get("primary", "")
+
+    # Find the original (non-tokenpak) primary
+    prov = primary.split("/", 1)[0] if "/" in primary else ""
+    if is_tp(prov):
+        # Already tokenpak — just clear fallbacks
+        if model_cfg.get("fallbacks", []):
+            model_cfg["fallbacks"] = []
+            return model_cfg, True
+        return model_cfg, False
+
+    # Promote to tokenpak version
+    tp_p = tp_ref(primary, pm)
+    new_primary = tp_p if tp_p else primary
+
+    # Check if anything changed
+    if new_primary == primary and not model_cfg.get("fallbacks", []):
+        return model_cfg, False
+
+    model_cfg["primary"] = new_primary
+    model_cfg["fallbacks"] = []  # NO fallbacks — proxy-only routing
+    return model_cfg, True
+
+def interleave_defaults(config, pm):
+    """Interleave agents.defaults.model"""
+    changed = False
+    defaults = config.get("agents", {}).get("defaults", {})
+    model = defaults.get("model")
+    if not model: return changed
+    new, did = interleave(model, pm)
+    if did:
+        defaults["model"] = new
+        changed = True
+        log(f"Interleaved defaults: {new.get('primary')} + {len(new.get('fallbacks',[]))} fallbacks")
+    return changed
+
+def interleave_agents(config, pm):
+    """Interleave model refs in agents.list, heartbeat, subagent, imageModel, pdfModel"""
+    changed = False
+
+    for agent in config.get("agents", {}).get("list", []):
+        aid = agent.get("id", "?")
+
+        # Agent model
+        model = agent.get("model")
+        if model:
+            new, did = interleave(model, pm)
+            if did:
+                agent["model"] = new; changed = True
+                log(f"Interleaved agent {aid}: {new.get('primary') if isinstance(new, dict) else new}")
+
+        # Heartbeat model (single string — just promote to tp, original stays as heartbeat fallback isn't supported)
+        hb_model = agent.get("heartbeat", {}).get("model")
+        if hb_model and isinstance(hb_model, str):
+            tp_hb = tp_ref(hb_model, pm)
+            if tp_hb and tp_hb != hb_model:
+                agent["heartbeat"]["model"] = tp_hb; changed = True
+                log(f"Remapped agent {aid} heartbeat: {hb_model} -> {tp_hb}")
+
+        # Subagent model
+        sa = agent.get("subagents", {}).get("model")
+        if sa:
+            new, did = interleave(sa, pm)
+            if did: agent["subagents"]["model"] = new; changed = True
+
+    # Defaults: heartbeat, subagent, imageModel, pdfModel
+    defaults = config.get("agents", {}).get("defaults", {})
+
+    hb = defaults.get("heartbeat", {}).get("model")
+    if hb and isinstance(hb, str):
+        tp_hb = tp_ref(hb, pm)
+        if tp_hb and tp_hb != hb:
+            defaults["heartbeat"]["model"] = tp_hb; changed = True
+            log(f"Remapped defaults heartbeat: {hb} -> {tp_hb}")
+
+    for field in ["subagents"]:
+        sa = defaults.get(field, {}).get("model")
+        if sa:
+            new, did = interleave(sa, pm)
+            if did: defaults[field]["model"] = new; changed = True
+
+    for field in ["imageModel", "pdfModel"]:
+        ref = defaults.get(field)
+        if ref:
+            new, did = interleave(ref, pm)
+            if did: defaults[field] = new; changed = True; log(f"Interleaved {field}")
+
+    return changed
+
+# ── 3. Allowlist ──────────────────────────────────────────────────────
+
+def update_allowlist(config, pm):
+    changed = False
+    allowlist = config.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+    providers = config.get("models", {}).get("providers", {})
+
+    # Add tp version of existing entries
+    for old_ref in list(allowlist.keys()):
+        tp_r = tp_ref(old_ref, pm)
+        if tp_r and tp_r not in allowlist:
+            allowlist[tp_r] = allowlist[old_ref].copy() if isinstance(allowlist[old_ref], dict) else {}
+            changed = True
+
+    # Add all tp provider models
+    for pname, pcfg in providers.items():
+        if not is_tp(pname): continue
+        for m in pcfg.get("models", []):
+            ref = f"{pname}/{m['id']}"
+            if ref not in allowlist:
+                allowlist[ref] = {}; changed = True
+
+    return changed
+
+# ── 4. Auth ───────────────────────────────────────────────────────────
+
+def copy_auth(config, pm):
+    changed = False
+    auth = config.setdefault("auth", {})
+    profiles = auth.setdefault("profiles", {})
+    order = auth.setdefault("order", {})
+
+    for orig, tpn in pm.items():
+        for key, prof in list(profiles.items()):
+            if prof.get("provider") == orig:
+                new_key = key.replace(f"{orig}:", f"{tpn}:")
+                if new_key not in profiles:
+                    profiles[new_key] = {k: v for k, v in {**prof, "provider": tpn}.items() if k != "apiKey"}; changed = True
+                    log(f"Copied auth: {key} -> {new_key}")
+        if orig in order and tpn not in order:
+            order[tpn] = [k.replace(f"{orig}:", f"{tpn}:") for k in order[orig]]
+            changed = True
+
+    # Claude Code backend uses anthropic auth (same OAuth token)
+    cc_name = "tokenpak-claude-code"
+    cc_profile = f"{cc_name}:manual"
+    if cc_profile not in profiles:
+        # Copy from tokenpak-anthropic or anthropic
+        for src in ["tokenpak-anthropic:manual", "anthropic:manual"]:
+            if src in profiles:
+                profiles[cc_profile] = {**profiles[src], "provider": cc_name}
+                changed = True
+                log(f"Copied auth: {src} -> {cc_profile}")
+                break
+    if cc_name not in order:
+        order[cc_name] = [cc_profile]
+        changed = True
+
+    return changed
+
+def copy_auth_files(pm):
+    changed = False
+    for af in glob(str(OPENCLAW_DIR / "agents/*/agent/auth-profiles.json")):
+        try:
+            auth = load_json(Path(af))
+            profiles = auth.setdefault("profiles", {})
+            mod = False
+            for orig, tpn in pm.items():
+                for key, prof in list(profiles.items()):
+                    if prof.get("provider") == orig:
+                        new_key = key.replace(f"{orig}:", f"{tpn}:")
+                        if new_key not in profiles:
+                            profiles[new_key] = {k: v for k, v in {**prof, "provider": tpn}.items() if k != "apiKey"}; mod = True
+            # Claude Code backend auth — copy from anthropic
+            cc_profile = "tokenpak-claude-code:manual"
+            if cc_profile not in profiles:
+                for src in ["tokenpak-anthropic:manual", "anthropic:manual"]:
+                    if src in profiles:
+                        profiles[cc_profile] = {**profiles[src], "provider": "tokenpak-claude-code"}
+                        mod = True
+                        break
+            if mod: save_json(Path(af), auth); changed = True
+        except Exception as e:
+            log(f"Warning: {af}: {e}")
+    return changed
+
+# ── 5. Process ────────────────────────────────────────────────────────
+
+def inject_claude_code_provider(providers):
+    """Add tokenpak-claude-code provider — routes OpenClaw through Claude Code CLI.
+
+    Dynamically copies models from tokenpak-anthropic (or anthropic) so new
+    models are picked up automatically. Each model gets a "(Claude Code)"
+    suffix in the display name.
+    """
+    name = "tokenpak-claude-code"
+
+    # Copy models from the anthropic provider (tokenpak-anthropic or anthropic)
+    source = providers.get("tokenpak-anthropic") or providers.get("anthropic") or {}
+    source_models = source.get("models", [])
+
+    models = []
+    for m in source_models:
+        cc_model = dict(m)
+        # Add "(Claude Code)" suffix to display name
+        orig_name = cc_model.get("name", cc_model["id"])
+        if "(Claude Code)" not in orig_name:
+            cc_model["name"] = f"{orig_name} (Claude Code)"
+        # Zero cost — subscription billing
+        cc_model["cost"] = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
+        models.append(cc_model)
+
+    if not models:
+        log(f"Skipped {name}: no anthropic models to copy")
+        return False
+
+    want = {
+        "baseUrl": PROXY_URL,
+        "api": "anthropic-messages",
+        "headers": {"X-TokenPak-Backend": "claude-code"},
+        "models": models,
+    }
+
+    existing = providers.get(name, {})
+    existing_ids = {m["id"] for m in existing.get("models", [])}
+    want_ids = {m["id"] for m in models}
+    if (existing.get("baseUrl") == PROXY_URL
+            and existing.get("headers", {}).get("X-TokenPak-Backend") == "claude-code"
+            and existing_ids == want_ids):
+        return False  # already up to date
+
+    providers[name] = want
+    log(f"Injected: {name} (Claude Code backend, {len(models)} models — synced from anthropic)")
+    return True
+
+def process_main(path):
+    config = load_json(path)
+    if not config: return False, {}
+
+    config.setdefault("models", {}).setdefault("providers", {})
+    config["models"]["mode"] = "merge"
+
+    c1, pm = mirror_providers(config["models"]["providers"])
+    c1b = inject_claude_code_provider(config["models"]["providers"])
+    c2 = interleave_defaults(config, pm)
+    c3 = interleave_agents(config, pm)
+    c4 = update_allowlist(config, pm)
+    c5 = copy_auth(config, pm)
+
+    if any([c1, c1b, c2, c3, c4, c5]):
+        save_json(path, config)
+        log(f"Saved: {path}")
+
+    return any([c1, c1b, c2, c3, c4, c5]), pm
+
+def process_agent_models():
+    changed = False; all_pm = {}
+    for mf in glob(str(OPENCLAW_DIR / "agents/*/agent/models.json")):
+        mp = Path(mf)
+        agent = mp.parent.parent.name
+        log(f"Processing agent: {agent}")
+        config = load_json(mp)
+        if not config: continue
+        providers = config.setdefault("providers", {})
+        c1, pm = mirror_providers(providers)
+        all_pm.update(pm)
+        if c1: save_json(mp, config); changed = True
+    return changed, all_pm
+
+def _load_codex_auth_jwt():
+    """Return (access_token, refresh_token, account_id, exp_ms) from ~/.codex/auth.json.
+
+    Returns (None, None, None, None) when the file is missing or the JWT
+    can't be decoded. exp_ms is the JWT's inner `exp` claim * 1000 so it
+    matches the ms-precision that OpenClaw stores in profile `expires`.
+    """
+    import base64
+    auth_path = Path.home() / ".codex" / "auth.json"
+    if not auth_path.is_file():
+        return (None, None, None, None)
+    try:
+        d = json.loads(auth_path.read_text())
+        tokens = d.get("tokens", {}) or {}
+        access = tokens.get("access_token") or d.get("access_token") or ""
+        refresh = tokens.get("refresh_token") or d.get("refresh_token") or ""
+        if not access or access.count(".") != 2:
+            return (None, None, None, None)
+        pad = lambda s: s + "=" * (4 - len(s) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(pad(access.split(".")[1])))
+        exp = int(payload.get("exp", 0)) * 1000
+        account = payload.get("https://api.openai.com/auth", {}).get(
+            "chatgpt_account_id", ""
+        )
+        return (access, refresh, account, exp)
+    except Exception:
+        return (None, None, None, None)
+
+
+def refresh_native_codex_profile():
+    """Refresh openai-codex:default from ~/.codex/auth.json when stale.
+
+    OpenClaw's internal refresher only touches an agent's native codex
+    profile when that agent is actively used. For agents that have been
+    idle for days, the profile's inner JWT goes stale and OpenClaw's
+    pre-flight `extract accountId from token` fails — taking every
+    tokenpak-openai-codex request down with it since the tokenpak-*
+    profile is mirrored from this one. Fixing the root (~/.codex/auth.json
+    IS the canonical source of truth) lets the mirror-downstream step
+    produce a fresh result.
+    """
+    access, refresh, account, exp_ms = _load_codex_auth_jwt()
+    if not access:
+        return False
+
+    changed = 0
+    for af in glob(str(OPENCLAW_DIR / "agents/*/agent/auth-profiles.json")):
+        try:
+            path = Path(af)
+            auth = load_json(path)
+            profiles = auth.get("profiles", {})
+            native = profiles.get("openai-codex:default")
+            if not native:
+                continue
+            if native.get("access") == access:
+                continue  # already fresh
+            native["access"] = access
+            if refresh:
+                native["refresh"] = refresh
+            if account:
+                native["accountId"] = account
+            if exp_ms:
+                native["expires"] = exp_ms
+            save_json(path, auth)
+            log(f"Refreshed native codex profile from ~/.codex/auth.json ({path})")
+            changed += 1
+        except Exception as e:
+            log(f"Warning: {af}: {e}")
+    return changed > 0
+
+
+def sync_codex_jwt():
+    """Mirror fresh JWT from openai-codex:default → tokenpak-openai-codex:default.
+
+    OpenClaw's built-in refresher auto-syncs `openai-codex:default` from
+    `~/.codex/auth.json` but ignores custom-named profiles like
+    `tokenpak-openai-codex:default`. When the tokenpak-* JWT goes stale,
+    OpenClaw's `extract accountId from token` step fails and every codex
+    request dies at pre-flight — even though the tokenpak proxy would
+    inject a fresh JWT on the wire. Re-running this sync on every
+    ExecStartPre keeps the two profiles aligned.
+    """
+    changed = 0
+    for af in glob(str(OPENCLAW_DIR / "agents/*/agent/auth-profiles.json")):
+        try:
+            path = Path(af)
+            auth = load_json(path)
+            profiles = auth.get("profiles", {})
+            native = profiles.get("openai-codex:default")
+            tpk = profiles.get("tokenpak-openai-codex:default")
+            if not native or not tpk:
+                continue
+            native_access = native.get("access", "")
+            if not native_access:
+                continue
+            if tpk.get("access") == native_access and tpk.get("accountId") == native.get("accountId"):
+                continue  # already in sync
+            for field in ("access", "refresh", "accountId", "expires"):
+                if field in native:
+                    tpk[field] = native[field]
+            tpk["type"] = native.get("type", "oauth")
+            save_json(path, auth)
+            log(f"Synced codex JWT: openai-codex → tokenpak-openai-codex ({path})")
+            changed += 1
+        except Exception as e:
+            log(f"Warning: {af}: {e}")
+    return changed > 0
+
+def main():
+    log(f"Proxy: {PROXY_URL}")
+    total = False; all_pm = {}
+
+    if MAIN_CONFIG.exists():
+        log(f"Processing: {MAIN_CONFIG}")
+        c, pm = process_main(MAIN_CONFIG)
+        total = total or c; all_pm.update(pm)
+
+    c, pm = process_agent_models()
+    total = total or c; all_pm.update(pm)
+
+    if all_pm:
+        c = copy_auth_files(all_pm)
+        total = total or c
+
+    # Codex profile refresh chain:
+    #   ~/.codex/auth.json  →  openai-codex:default  →  tokenpak-openai-codex:default
+    # Step 1 covers idle agents whose native profile OpenClaw never auto-refreshed.
+    # Step 2 covers the permanently-stale tokenpak-* mirror (custom name,
+    # outside OpenClaw's auto-refresh set).
+    if refresh_native_codex_profile():
+        total = True
+    if sync_codex_jwt():
+        total = True
+
+    log(f"Done — mirrored {len(all_pm)} providers" if total else "No changes needed")
+
+main()
+PYEOF

--- a/integrations/openclaw/tokenpak-uninstall.sh
+++ b/integrations/openclaw/tokenpak-uninstall.sh
@@ -95,13 +95,15 @@ if [ -f "$CFG" ]; then
     else
         log "No .pre-tokenpak-backup found — falling back to in-place strip of tokenpak-* entries."
         if confirm "Strip tokenpak-* providers, auth profiles, allowlist entries, and headers from $CFG?"; then
-            STRIP_RESULT=$(python3 - <<PYEOF
-import json, sys, shutil
+            STRIP_RESULT=$(DRY_RUN=$DRY_RUN python3 - <<PYEOF
+import json, os, shutil
 from pathlib import Path
 
+dry_run = os.environ.get("DRY_RUN", "0") == "1"
 cfg_path = Path("$CFG")
 backup = Path(str(cfg_path) + ".uninstall-rollback")
-shutil.copy2(cfg_path, backup)
+if not dry_run:
+    shutil.copy2(cfg_path, backup)
 
 c = json.loads(cfg_path.read_text())
 removed = []
@@ -147,12 +149,13 @@ strip_array(agents, "models", "agents.defaults.models")
 strip_array(agents, "modelAllowlist", "agents.defaults.modelAllowlist")
 
 # Save
-cfg_path.write_text(json.dumps(c, indent=2))
-print(json.dumps({"removed": removed, "rollback": str(backup)}))
+if not dry_run:
+    cfg_path.write_text(json.dumps(c, indent=2))
+print(json.dumps({"removed": removed, "rollback": str(backup), "dry_run": dry_run}))
 PYEOF
 )
             log "Stripped entries:"
-            echo "$STRIP_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print('  rollback:', d['rollback']); [print('  -',e) for e in d['removed']]" 2>&1
+            echo "$STRIP_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print('  rollback:', d['rollback'], '(DRY-RUN: not written)' if d['dry_run'] else ''); [print('  -',e, '(DRY-RUN: not applied)' if d['dry_run'] else '') for e in d['removed']]" 2>&1
         else
             log "Skipped openclaw.json modification."
         fi

--- a/integrations/openclaw/tokenpak-uninstall.sh
+++ b/integrations/openclaw/tokenpak-uninstall.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# tokenpak-uninstall.sh — Remove the TokenPak ↔ OpenClaw integration.
+#
+# Reverts everything tokenpak-inject.sh did:
+#   1. Restores ~/.openclaw/openclaw.json to the pre-tokenpak state
+#      (preferred) or strips tokenpak-* providers / auth / headers /
+#      allowlist entries from the live config (fallback).
+#   2. Removes the systemd ExecStartPre drop-in that runs the inject
+#      script on gateway start.
+#   3. Optionally stops + disables the tokenpak-proxy systemd unit
+#      (--stop-proxy).
+#   4. Optionally removes ~/.tokenpak/ caches (--purge-caches).
+#
+# Idempotent — safe to re-run if a previous run was interrupted.
+#
+# DOCS:
+#   https://docs.tokenpak.ai/integrations/openclaw#uninstall
+
+set -euo pipefail
+
+PREFIX="tokenpak"
+DRY_RUN=0
+STOP_PROXY=0
+PURGE_CACHES=0
+
+usage() {
+    cat <<EOF
+Usage: tokenpak-uninstall.sh [--dry-run] [--stop-proxy] [--purge-caches]
+
+  --dry-run        Print what would be done; don't change anything.
+  --stop-proxy     Also stop + disable tokenpak-proxy.service.
+  --purge-caches   Also delete ~/.tokenpak/{model_context_cache.json,session_map.db,...}.
+
+Without flags: revert openclaw config + remove the systemd drop-in.
+The tokenpak-proxy service stays running by default (you may still
+want it for direct SDK calls); pass --stop-proxy to take it down too.
+
+The script always asks before making destructive changes unless you
+pass --yes.
+EOF
+}
+
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --stop-proxy) STOP_PROXY=1 ;;
+        --purge-caches) PURGE_CACHES=1 ;;
+        --yes|-y) YES=1 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "unknown flag: $arg"; usage; exit 2 ;;
+    esac
+done
+
+log() { printf '[tokenpak-uninstall] %s\n' "$*"; }
+maybe() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "DRY-RUN: $*"
+    else
+        eval "$@"
+    fi
+}
+
+confirm() {
+    if [ "$YES" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then return 0; fi
+    printf '%s [y/N] ' "$1"
+    read -r answer
+    case "$answer" in
+        y|Y|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 1 — revert openclaw.json
+# ─────────────────────────────────────────────────────────────────────
+
+OPENCLAW_DIR="${OPENCLAW_CONFIG_PATH:-}"
+if [ -n "$OPENCLAW_DIR" ]; then
+    OPENCLAW_DIR="${OPENCLAW_DIR%/*}"
+fi
+[ -z "$OPENCLAW_DIR" ] && OPENCLAW_DIR="$HOME/.openclaw"
+CFG="${OPENCLAW_CONFIG_PATH:-$OPENCLAW_DIR/openclaw.json}"
+
+if [ -f "$CFG" ]; then
+    PRE="$CFG.pre-tokenpak-backup"
+    if [ -f "$PRE" ]; then
+        log "Found pre-install backup: $PRE"
+        if confirm "Restore openclaw config from pre-install backup (clean revert)?"; then
+            maybe "cp -p '$PRE' '$CFG.uninstall-rollback' && cp -p '$PRE' '$CFG'"
+            log "Restored: $CFG ← $PRE (rollback also saved at $CFG.uninstall-rollback)"
+        else
+            log "Skipped restore from pre-install backup."
+        fi
+    else
+        log "No .pre-tokenpak-backup found — falling back to in-place strip of tokenpak-* entries."
+        if confirm "Strip tokenpak-* providers, auth profiles, allowlist entries, and headers from $CFG?"; then
+            STRIP_RESULT=$(python3 - <<PYEOF
+import json, sys, shutil
+from pathlib import Path
+
+cfg_path = Path("$CFG")
+backup = Path(str(cfg_path) + ".uninstall-rollback")
+shutil.copy2(cfg_path, backup)
+
+c = json.loads(cfg_path.read_text())
+removed = []
+
+# Strip tokenpak-* providers
+providers = (c.get("models") or {}).get("providers") or {}
+for name in list(providers):
+    if name == "tokenpak" or name.startswith("tokenpak-"):
+        del providers[name]
+        removed.append(f"models.providers.{name}")
+
+# Strip tokenpak-* auth profiles + their references in auth.order
+auth = c.get("auth") or {}
+profiles = auth.get("profiles") or {}
+for name in list(profiles):
+    if name.startswith("tokenpak-") or "tokenpak-" in name:
+        del profiles[name]
+        removed.append(f"auth.profiles.{name}")
+order = auth.get("order") or {}
+for prov in list(order):
+    if prov.startswith("tokenpak-") or prov == "tokenpak":
+        del order[prov]
+        removed.append(f"auth.order.{prov}")
+    else:
+        # Remove tokenpak-* entries from non-tokenpak provider order arrays
+        ord_list = order.get(prov)
+        if isinstance(ord_list, list):
+            kept = [p for p in ord_list if not (p.startswith("tokenpak-") or p == "tokenpak")]
+            if len(kept) != len(ord_list):
+                order[prov] = kept
+                removed.append(f"auth.order.{prov} (filtered)")
+
+# Strip tokenpak-* from any allowlist arrays at well-known paths
+def strip_array(d, key, path_label):
+    if isinstance(d, dict) and isinstance(d.get(key), list):
+        before = list(d[key])
+        d[key] = [v for v in d[key] if not (isinstance(v, str) and (v.startswith("tokenpak-") or v == "tokenpak"))]
+        if len(d[key]) != len(before):
+            removed.append(path_label)
+
+agents = (c.get("agents") or {}).get("defaults") or {}
+strip_array(agents, "models", "agents.defaults.models")
+strip_array(agents, "modelAllowlist", "agents.defaults.modelAllowlist")
+
+# Save
+cfg_path.write_text(json.dumps(c, indent=2))
+print(json.dumps({"removed": removed, "rollback": str(backup)}))
+PYEOF
+)
+            log "Stripped entries:"
+            echo "$STRIP_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print('  rollback:', d['rollback']); [print('  -',e) for e in d['removed']]" 2>&1
+        else
+            log "Skipped openclaw.json modification."
+        fi
+    fi
+else
+    log "No openclaw config at $CFG — skipping revert."
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 2 — remove systemd ExecStartPre drop-in
+# ─────────────────────────────────────────────────────────────────────
+
+DROP_IN="$HOME/.config/systemd/user/openclaw-gateway.service.d/tokenpak-inject.conf"
+if [ -f "$DROP_IN" ]; then
+    if confirm "Remove systemd drop-in at $DROP_IN (stops re-injection on gateway restart)?"; then
+        maybe "rm -f '$DROP_IN'"
+        maybe "systemctl --user daemon-reload"
+        log "Removed: $DROP_IN"
+    fi
+else
+    log "No systemd drop-in at $DROP_IN — skipping."
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 3 — optionally stop tokenpak-proxy
+# ─────────────────────────────────────────────────────────────────────
+
+if [ "$STOP_PROXY" -eq 1 ]; then
+    if systemctl --user list-unit-files tokenpak-proxy.service >/dev/null 2>&1; then
+        if confirm "Stop + disable tokenpak-proxy.service?"; then
+            maybe "systemctl --user stop tokenpak-proxy.service"
+            maybe "systemctl --user disable tokenpak-proxy.service"
+            log "tokenpak-proxy service stopped + disabled."
+        fi
+    else
+        log "tokenpak-proxy.service not installed — skipping."
+    fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 4 — optionally purge ~/.tokenpak caches
+# ─────────────────────────────────────────────────────────────────────
+
+if [ "$PURGE_CACHES" -eq 1 ]; then
+    CACHES=(
+        "$HOME/.tokenpak/model_context_cache.json"
+        "$HOME/.tokenpak/session_map.db"
+        "$HOME/.tokenpak/session_map.db-wal"
+        "$HOME/.tokenpak/session_map.db-shm"
+    )
+    for c in "${CACHES[@]}"; do
+        if [ -e "$c" ]; then
+            if confirm "Delete cache file $c?"; then
+                maybe "rm -f '$c'"
+                log "Removed: $c"
+            fi
+        fi
+    done
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# Done
+# ─────────────────────────────────────────────────────────────────────
+
+log "Uninstall complete."
+log ""
+log "Next steps:"
+log "  1. Restart the OpenClaw gateway:"
+log "       (it has RefuseManualStop=yes, so kill the PID and let systemd respawn)"
+log "       kill \$(systemctl --user show openclaw-gateway.service -p MainPID --value)"
+log "  2. Verify openclaw.json no longer references tokenpak-*:"
+log "       grep -c tokenpak \"$CFG\""
+log ""
+log "Rollback safety net:"
+log "  Each uninstall step writes to *.uninstall-rollback files; if anything"
+log "  went wrong, copy those back into place to restore the post-install state."

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.21"
+__version__ = "1.3.22"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.20"
+__version__ = "1.3.21"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/services/routing_service/backends/anthropic_oauth.py
+++ b/tokenpak/services/routing_service/backends/anthropic_oauth.py
@@ -113,56 +113,85 @@ class AnthropicOAuthBackend:
             import os as _os
 
             cmd = [self._claude_binary]
-            # Companion flags — use the same ``--mcp-config`` /
-            # ``--settings`` / ``--append-system-prompt-file`` files
-            # that ``tokenpak claude`` writes under
-            # ``~/.tokenpak/companion/run/``. This bypasses Claude
-            # CLI's slow CLAUDE.md auto-discovery (which walks the
-            # cwd + every parent dir looking for the file) and instead
-            # loads an explicit, pre-built companion profile.
-            # Without these, first-turn cold starts routinely exceed
-            # OpenClaw's request timeout because CLAUDE.md
-            # auto-discovery against the user's home dir can pull in
-            # tens of thousands of tokens of standards + project
-            # context before the request even gets to Anthropic.
-            companion_flags = self._companion_flags()
-            cmd.extend(companion_flags)
             # Pass the model from the request body so Claude CLI doesn't
             # pick its own default (Apr 15-18 parity — the bridge
             # respected OpenClaw's /model selection).
             model_hint = self._extract_model(request.body or b"")
             if model_hint:
                 cmd.extend(["--model", model_hint])
+            # Session mode decision:
+            #   1. Explicit X-OpenClaw-Session (or equivalent) that
+            #      maps to a stored Claude session → --resume <uuid>
+            #      (multi-turn via CLI state, v1.3.14 semantic)
+            #   2. Platform signal (UA=openclaw, X-TokenPak-Backend)
+            #      BUT no session header → START FRESH every call.
+            #      The platform replays full messages[] per turn so
+            #      we don't need CLI-side continuity; resuming
+            #      instead accumulates irrelevant prior state +
+            #      triggers Claude Code auto-compaction. v1.3.21 fix.
+            #   3. No platform signal at all → --continue fallback
+            #      (direct CLI callers that don't replay history).
+            # Session mode decision:
+            #   1. Mapped session (explicit platform session id OR
+            #      conversation fingerprint match) → ``--resume <uuid>``.
+            #      Claude CLI has the prior-turn state locally; Anthropic
+            #      cache accumulates across turns within the same
+            #      OpenClaw conversation. This is Kevin's 2026-04-24
+            #      ratified target behavior.
+            #   2. Platform-bridged FIRST turn (no mapping yet) → run
+            #      fresh, let Claude CLI pick a UUID. Session IS
+            #      persisted locally so turn 2 can resume via the
+            #      fingerprint we write in _persist_session.
+            #   3. Direct CLI caller with no platform signal → the
+            #      legacy ``--continue`` fallback (resumes whatever
+            #      last session on this machine — only appropriate
+            #      when the caller is the local claude CLI itself).
+            is_platform_bridged = (
+                origin is not None
+                or self._has_platform_headers(request.headers or {})
+            )
             if mapped_session_id:
-                # Subsequent turn for a known platform session.
                 cmd.extend(["--resume", mapped_session_id])
-            elif origin is None and (
-                _os.environ.get("TOKENPAK_OAUTH_NO_CONTINUE", "").strip() != "1"
-            ):
-                # No platform context at all — preserve v1.3.13 default.
+            elif is_platform_bridged:
+                # First turn — don't --continue. Default session
+                # persistence is fine; we'll persist the UUID via
+                # _persist_session after parsing the response, so
+                # turn 2 can resume by fingerprint.
+                pass
+            elif _os.environ.get("TOKENPAK_OAUTH_NO_CONTINUE", "").strip() != "1":
+                # Direct CLI caller fallback.
                 cmd.append("--continue")
-            # If origin is present but there's no mapping yet, this is
-            # the first turn — run fresh so the CLI picks its own UUID,
-            # which we'll capture + persist below.
             cmd.extend(["--print", "--output-format", "json", prompt])
 
-            # Clean env (Apr 15-18 pattern, restored 2026-04-24):
+            # Clean env (Apr 15-18 pattern, with cache re-enabled
+            # 2026-04-24 after empirical verification):
             #   - Strip ANTHROPIC_BASE_URL / OPENAI_BASE_URL so the
-            #     subprocess doesn't loop back through this proxy,
-            #     which would cause infinite recursion under load
-            #     and tank throughput.
-            #   - DISABLE_PROMPT_CACHING=1 so the CLI doesn't stash
-            #     cache_control markers that conflict with the proxy's
-            #     own compression pipeline on any OUTBOUND leg.
+            #     subprocess doesn't loop back through this proxy
+            #     (infinite recursion + throughput tank).
             #   - TOKENPAK_COMPANION_BARE=1 hints the companion hook
             #     to skip injecting the CLI's native CLAUDE.md /
             #     system context — the caller (OpenClaw etc.) is
             #     already carrying its own context in the messages[].
+            #
+            # We deliberately DO NOT set DISABLE_PROMPT_CACHING. The
+            # Apr 15-18 monolith had it because the in-proxy
+            # compression pipeline competed with the CLI's
+            # cache_control markers; in the v1.3.20+ architecture
+            # the subprocess hits api.anthropic.com directly (no
+            # ANTHROPIC_BASE_URL loop), so Anthropic's server-side
+            # prompt cache is free to fire. Cache hits across turns
+            # depend on a stable workspace-prompt prefix, which our
+            # content-hashed tempfile preserves. Set
+            # TOKENPAK_BRIDGE_DISABLE_PROMPT_CACHE=1 to opt out
+            # (debugging only).
             _env = _os.environ.copy()
             _env.pop("ANTHROPIC_BASE_URL", None)
             _env.pop("OPENAI_BASE_URL", None)
-            _env["DISABLE_PROMPT_CACHING"] = "1"
             _env["TOKENPAK_COMPANION_BARE"] = "1"
+            if _os.environ.get(
+                "TOKENPAK_BRIDGE_DISABLE_PROMPT_CACHE", ""
+            ).strip() == "1":
+                _env["DISABLE_PROMPT_CACHING"] = "1"
 
             # Workspace resolution (Apr 15-18 parity): caller's
             # X-OpenClaw-Workspace header wins; otherwise default to
@@ -170,6 +199,13 @@ class AnthropicOAuthBackend:
             # state lives. cwd matters because Claude CLI reads
             # CLAUDE.md / settings from cwd and its parent tree.
             _workspace = self._resolve_workspace(request)
+
+            # Platform-slim context by default: concatenate the
+            # workspace's *.md files into one appended system prompt
+            # file and skip the tokenpak-companion MCP + system
+            # prompt layer unless TOKENPAK_BRIDGE_COMPANION=1.
+            # See ``_build_context_flags`` below.
+            cmd = cmd[:1] + self._build_context_flags(_workspace) + cmd[1:]
 
             completed = subprocess.run(
                 cmd,
@@ -201,8 +237,13 @@ class AnthropicOAuthBackend:
             # request for the same (platform, external_id) just
             # starts another fresh session — worst case is lost
             # continuity, never a user-visible failure.
-            if origin is not None and mapped_session_id is None and parsed.get("session_id"):
-                self._persist_session(origin, parsed["session_id"], parsed.get("model"))
+            # Persist session mapping on first turn when we learned a
+            # new Claude session id. Covers both explicit-session and
+            # fingerprint-based scopes inside _persist_session.
+            if mapped_session_id is None and parsed.get("session_id"):
+                self._persist_session(
+                    origin, parsed["session_id"], parsed.get("model"), request=request
+                )
 
             # Caller asked for streaming? OpenClaw's Anthropic JS SDK
             # does — it sets ``"stream": true`` in the body. When it
@@ -245,34 +286,43 @@ class AnthropicOAuthBackend:
                 }).encode(),
             )
 
-    # ── Companion flag builder (reuses tokenpak claude's run dir) ──
+    # ── Subprocess flag builder — platform-slim by default ──────────
+    #
+    # Kevin 2026-04-24 ratification: the platform-bridge subprocess
+    # path should take ONLY the platform's own .md context by default.
+    # The full tokenpak-companion profile (MCP schemas, companion
+    # system prompt, settings) layers on top of whatever system
+    # prompt the platform carries in ``messages[]`` — which pushes
+    # context over Claude Code's auto-compaction threshold and kills
+    # Anthropic's prompt cache across turns.
+    #
+    # Default: concatenate the platform workspace's ``*.md`` files at
+    # the workspace root (MEMORY.md, IDENTITY.md, AGENTS.md, etc.)
+    # into a single ``--append-system-prompt-file``. Claude CLI's
+    # native CLAUDE.md auto-discovery still runs (tiny overhead) but
+    # tokenpak's companion layer is skipped.
+    #
+    # Opt-in: ``TOKENPAK_BRIDGE_COMPANION=1`` additionally loads the
+    # tokenpak-companion MCP + settings + companion-prompt files
+    # from ``~/.tokenpak/companion/run/`` for callers that want the
+    # full interactive ``tokenpak claude`` experience.
 
     _COMPANION_RUN_DIR = Path.home() / ".tokenpak" / "companion" / "run"
+    _PLATFORM_PROMPT_CACHE_DIR = Path("/tmp/tokenpak-bridge-prompts")
 
     @classmethod
     def _companion_flags(cls) -> list[str]:
-        """Return Claude CLI flags that load the companion profile.
+        """Full tokenpak-companion flags (opt-in).
 
-        Re-uses the ``~/.tokenpak/companion/run/`` files that the
-        ``tokenpak claude`` launcher writes, so subprocess dispatch
-        gets the same MCP servers, settings, and companion system
-        prompt the interactive launcher does — while avoiding the
-        slow CLAUDE.md auto-discovery walk that makes first-turn
-        cold starts exceed OpenClaw's request timeout.
-
-        When the companion run dir doesn't exist yet (fresh install,
-        the user hasn't invoked ``tokenpak claude`` before), returns
-        an empty list — Claude CLI falls back to its own default
-        discovery. The subprocess will be slower first time but still
-        correct.
+        Only loaded when ``TOKENPAK_BRIDGE_COMPANION=1`` — otherwise
+        the bridge stays platform-slim so platform callers' context
+        stays well under the auto-compaction threshold.
         """
         flags: list[str] = []
         if not cls._COMPANION_RUN_DIR.is_dir():
             return flags
         mcp_path = cls._COMPANION_RUN_DIR / "mcp.json"
         settings_path = cls._COMPANION_RUN_DIR / "settings.json"
-        # Prefer companion-prompt.md (the launcher's canonical name);
-        # system_prompt.md is the older name from the Apr 15-18 build.
         prompt_candidates = [
             cls._COMPANION_RUN_DIR / "companion-prompt.md",
             cls._COMPANION_RUN_DIR / "system_prompt.md",
@@ -285,6 +335,66 @@ class AnthropicOAuthBackend:
             if p.is_file():
                 flags.extend(["--append-system-prompt-file", str(p)])
                 break
+        return flags
+
+    @classmethod
+    def _platform_prompt_flags(cls, workspace: Optional[str]) -> list[str]:
+        """Build ``--append-system-prompt-file`` from the platform's .md files.
+
+        Concatenates every ``*.md`` at the workspace root (non-
+        recursive) into a single tempfile cached by content hash.
+        Re-generates when workspace files change; stays stable
+        otherwise so Claude CLI's cache_control tracking sees a
+        stable prefix across turns.
+
+        Workspace conventions observed 2026-04-24 (OpenClaw):
+        ``MEMORY.md``, ``IDENTITY.md``, ``AGENTS.md``, ``TOOLS.md``,
+        ``SOUL.md``, ``HEARTBEAT.md``, ``PAUSED_PROJECTS.md``,
+        ``REFERENCE_INDEX.md``, ``EMERGENCY_RESTORE.md``. Any other
+        platform adapter following the same convention (.md at
+        workspace root) gets the same treatment.
+        """
+        if not workspace:
+            return []
+        import hashlib
+
+        ws = Path(workspace)
+        if not ws.is_dir():
+            return []
+        md_files = sorted(p for p in ws.glob("*.md") if p.is_file())
+        if not md_files:
+            return []
+        # Cache key: file list + mtimes. Regenerate on ANY change.
+        fingerprint = "\n".join(
+            f"{p}:{int(p.stat().st_mtime)}" for p in md_files
+        ).encode("utf-8")
+        digest = hashlib.sha256(fingerprint).hexdigest()[:16]
+        cls._PLATFORM_PROMPT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cached = cls._PLATFORM_PROMPT_CACHE_DIR / f"{digest}.md"
+        if not cached.is_file():
+            chunks = []
+            for p in md_files:
+                try:
+                    content = p.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                chunks.append(f"# --- {p.name} ---\n\n{content}\n")
+            cached.write_text("\n".join(chunks), encoding="utf-8")
+        return ["--append-system-prompt-file", str(cached)]
+
+    @classmethod
+    def _build_context_flags(cls, workspace: Optional[str]) -> list[str]:
+        """Assemble the full flag list for this subprocess dispatch.
+
+        Default path: platform-slim (workspace .md only). Opt-in via
+        ``TOKENPAK_BRIDGE_COMPANION=1`` adds the full
+        tokenpak-companion profile on top.
+        """
+        import os as _os
+
+        flags = cls._platform_prompt_flags(workspace)
+        if _os.environ.get("TOKENPAK_BRIDGE_COMPANION", "0").strip() == "1":
+            flags.extend(cls._companion_flags())
         return flags
 
     # ── Request shape extractors (Apr 15-18 parity) ───────────────────
@@ -306,6 +416,28 @@ class AnthropicOAuthBackend:
             return None
         m = data.get("model") if isinstance(data, dict) else None
         return m if isinstance(m, str) and m.strip() else None
+
+    @staticmethod
+    def _has_platform_headers(headers) -> bool:
+        """True when the caller identified as a platform bridge.
+
+        Looks for the standard platform markers tokenpak's bridge
+        uses — X-TokenPak-Backend (installed by tokenpak-inject.sh
+        into OpenClaw's provider config), X-TokenPak-Provider (the
+        generic explicit declaration), or X-OpenClaw-* / X-Codex-*
+        identifiers any adapter might stamp. Any of them mean
+        'caller is replaying its own conversation per turn; don't
+        resume a stale CLI session'.
+        """
+        if not headers:
+            return False
+        for k in headers:
+            kl = k.lower()
+            if kl in ("x-tokenpak-backend", "x-tokenpak-provider"):
+                return True
+            if kl.startswith("x-openclaw-") or kl.startswith("x-codex-"):
+                return True
+        return False
 
     @staticmethod
     def _resolve_workspace(request: Request) -> Optional[str]:
@@ -343,14 +475,27 @@ class AnthropicOAuthBackend:
             return str(default)
         return None
 
-    # ── Session mapper integration (v1.3.14) ──────────────────────────
+    # ── Session mapper integration (v1.3.14 + v1.3.21 fingerprint) ───
+
+    _BRIDGE_FP_SCOPE = "bridge-fp"
 
     def _resolve_session(self, request: Request):
         """Return ``(PlatformOrigin | None, mapped_session_id | None)``.
 
-        Consults the platform bridge for the origin and the session
-        mapper for a prior mapping. Never raises — a registry miss
-        simply means "first turn for this platform session".
+        Resolution priority:
+          1. Explicit platform session id (``X-OpenClaw-Session``)
+             keyed under ``scope=<platform_name>``. Strongest signal.
+          2. Conversation fingerprint derived from the first user
+             message + model in ``messages[]``, keyed under
+             ``scope=bridge-fp``. This is what allows multi-turn
+             OpenClaw conversations to reuse a single Claude CLI
+             session (and thus accumulate Anthropic's prompt cache
+             across turns). Same OpenClaw conversation replays the
+             same first user message on every turn → same fingerprint
+             → same Claude session via ``--resume``. A new OpenClaw
+             /new session starts with a different first message →
+             different fingerprint → fresh Claude session → cache
+             cleanly breaks (Kevin's 2026-04-24 ratification).
         """
         try:
             from tokenpak.services.routing_service.platform_bridge import (
@@ -359,64 +504,167 @@ class AnthropicOAuthBackend:
             )
         except Exception:
             return None, None
+
         try:
             origin = detect_origin(request.headers or {})
         except Exception:
             origin = None
-        if origin is None or not origin.session_id:
-            return origin, None
-        provider = origin.declared_provider or resolve_provider(request.headers or {})
-        if provider is None:
-            return origin, None
+
+        provider = None
+        if origin is not None:
+            provider = origin.declared_provider or resolve_provider(
+                request.headers or {}
+            )
+        else:
+            provider = resolve_provider(request.headers or {})
+
         try:
             from tokenpak.services.routing_service.session_mapper import (
                 get_session_mapper,
             )
         except Exception:
             return origin, None
-        try:
-            record = get_session_mapper().get(
-                scope=origin.platform_name,
-                external_id=origin.session_id,
-                provider=provider,
-            )
-        except Exception:
-            return origin, None
-        if record is None:
-            return origin, None
-        return origin, record.internal_id
+        mapper = get_session_mapper()
+
+        # Path 1: explicit platform session id (strongest).
+        if origin is not None and origin.session_id and provider is not None:
+            try:
+                record = mapper.get(
+                    scope=origin.platform_name,
+                    external_id=origin.session_id,
+                    provider=provider,
+                )
+                if record is not None:
+                    return origin, record.internal_id
+            except Exception:
+                pass
+
+        # Path 2: conversation fingerprint (bridge-fp scope). Only
+        # fires when the caller is actually platform-bridged —
+        # direct CLI callers never hit this path.
+        if provider is not None and self._has_platform_headers(
+            request.headers or {}
+        ):
+            fp = self._conversation_fingerprint(request.body or b"")
+            if fp:
+                try:
+                    record = mapper.get(
+                        scope=self._BRIDGE_FP_SCOPE,
+                        external_id=fp,
+                        provider=provider,
+                    )
+                    if record is not None:
+                        return origin, record.internal_id
+                except Exception:
+                    pass
+
+        return origin, None
 
     @staticmethod
-    def _persist_session(origin, claude_session_id: str, model: Optional[str]) -> None:
-        """Store ``(scope=platform, external_id=session, provider) → claude uuid``."""
+    def _conversation_fingerprint(body: bytes) -> Optional[str]:
+        """Stable ID from (model, first user message text).
+
+        Same OpenClaw conversation replays the same first user message
+        on every turn — so the fingerprint is stable across turns in
+        one conversation, and unique per ``/new`` session.
+        """
+        if not body:
+            return None
         try:
-            from tokenpak.services.routing_service.platform_bridge import (
-                resolve_provider,
-            )
+            data = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        messages = data.get("messages") or []
+        first_user_text: Optional[str] = None
+        for m in messages:
+            if not isinstance(m, dict) or m.get("role") != "user":
+                continue
+            content = m.get("content")
+            if isinstance(content, str):
+                first_user_text = content
+            elif isinstance(content, list):
+                parts: list[str] = []
+                for blk in content:
+                    if isinstance(blk, dict) and blk.get("type") == "text":
+                        t = blk.get("text")
+                        if isinstance(t, str):
+                            parts.append(t)
+                if parts:
+                    first_user_text = "\n".join(parts)
+            if first_user_text is not None:
+                break
+        if not first_user_text or not first_user_text.strip():
+            return None
+        model = data.get("model") or ""
+        import hashlib
+
+        key = f"{model}\n{first_user_text[:1000]}"
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+    @classmethod
+    def _persist_session(
+        cls,
+        origin,
+        claude_session_id: str,
+        model: Optional[str],
+        request: Optional[Request] = None,
+    ) -> None:
+        """Persist session mapping(s) on the first turn.
+
+        Two scopes are written when applicable:
+
+          - ``scope=<platform_name>`` keyed on the explicit platform
+            session id (when the caller sent one). Used by
+            X-OpenClaw-Session-style callers.
+          - ``scope=bridge-fp`` keyed on the conversation fingerprint
+            (first user message hash). Used for real OpenClaw traffic
+            that doesn't carry an explicit session id. Second-turn
+            requests in the same conversation replay the same first
+            user message → same fingerprint → ``--resume`` hits the
+            Claude CLI session already populated by turn 1 →
+            Anthropic's prompt cache accumulates across turns.
+        """
+        try:
             from tokenpak.services.routing_service.session_mapper import (
                 get_session_mapper,
             )
         except Exception:
             return
-        provider = origin.declared_provider or "tokenpak-claude-code"
-        # resolve_provider is headers-based; we already have the origin
-        # so prefer its declared_provider, falling back to the default
-        # for known platforms. Unknown platform → still persist under
-        # whatever provider the request declared.
-        _ = resolve_provider  # keep import present for future overrides
+        mapper = get_session_mapper()
         metadata = {"model": model} if model else {}
-        try:
-            get_session_mapper().set(
-                scope=origin.platform_name,
-                external_id=origin.session_id,
-                provider=provider,
-                internal_id=claude_session_id,
-                metadata=metadata,
-            )
-        except Exception:
-            # Session mapping is a best-effort optimisation — never let
-            # persistence failure break the live dispatch.
-            pass
+        provider = "tokenpak-claude-code"
+        if origin is not None:
+            provider = origin.declared_provider or provider
+
+        # Write path 1: explicit platform session id, when present.
+        if origin is not None and origin.session_id:
+            try:
+                mapper.set(
+                    scope=origin.platform_name,
+                    external_id=origin.session_id,
+                    provider=provider,
+                    internal_id=claude_session_id,
+                    metadata=metadata,
+                )
+            except Exception:
+                pass
+
+        # Write path 2: conversation fingerprint (OpenClaw default).
+        if request is not None and cls._has_platform_headers(request.headers or {}):
+            fp = cls._conversation_fingerprint(request.body or b"")
+            if fp:
+                try:
+                    mapper.set(
+                        scope=cls._BRIDGE_FP_SCOPE,
+                        external_id=fp,
+                        provider=provider,
+                        internal_id=claude_session_id,
+                        metadata=metadata,
+                    )
+                except Exception:
+                    pass
 
     # ── Claude CLI --output-format=json parsing ───────────────────────
 

--- a/tokenpak/services/routing_service/backends/anthropic_oauth.py
+++ b/tokenpak/services/routing_service/backends/anthropic_oauth.py
@@ -104,6 +104,20 @@ class AnthropicOAuthBackend:
                     }).encode(),
                 )
 
+            # ── Defense-in-depth: per-model context cap (v1.3.22) ────
+            # Fail fast at the proxy boundary if the inbound payload
+            # exceeds the model's context window. Saves a wasted
+            # round-trip to Anthropic + lets the caller (OpenClaw)
+            # compact + retry against a clean 413 instead of waiting
+            # for ``invalid_request_error: prompt is too long``.
+            #
+            # Model context windows are sourced dynamically from
+            # Anthropic's /v1/models endpoint; cached for 24h with
+            # fail-open semantics (unknown model → skip validation).
+            cap_response = self._maybe_reject_oversized(request)
+            if cap_response is not None:
+                return cap_response
+
             # Resolve platform origin + session mapping for this request.
             origin, mapped_session_id = self._resolve_session(request)
 
@@ -285,6 +299,128 @@ class AnthropicOAuthBackend:
                     "error": {"type": "backend_error", "message": str(exc)[:200]}
                 }).encode(),
             )
+
+    # ── Per-model context cap (v1.3.22) ─────────────────────────────
+
+    # Safety margin between the inbound payload and the model's
+    # context wall. We reserve at least this much for the response
+    # plus tokenpak's own framing. Any inbound payload over
+    # ``max_input_tokens - margin`` is rejected with 413.
+    _CONTEXT_SAFETY_MARGIN_TOKENS = 4096
+
+    def _maybe_reject_oversized(self, request: Request):
+        """Fast 413 when the inbound payload exceeds the model's cap.
+
+        Returns a :class:`BackendResponse` to short-circuit dispatch,
+        or ``None`` to proceed normally (fail-open: unknown model,
+        unknown body shape, registry unreachable, etc.).
+
+        Disable via ``TOKENPAK_BRIDGE_CONTEXT_CHECK=0`` for debugging.
+        """
+        import os as _os
+
+        if _os.environ.get("TOKENPAK_BRIDGE_CONTEXT_CHECK", "1").strip() == "0":
+            return None
+        body = request.body or b""
+        if not body:
+            return None
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        model_id = data.get("model")
+        if not isinstance(model_id, str) or not model_id.strip():
+            return None
+        try:
+            from tokenpak.services.routing_service.model_context import (
+                get_registry,
+            )
+            cap = get_registry().get_context_window(model_id)
+        except Exception:
+            cap = None
+        if cap is None:
+            # Fail-open: unknown model, registry miss. Anthropic will
+            # still enforce the wall on its end if we're truly over.
+            return None
+
+        estimated = self._estimate_input_tokens(data)
+        ceiling = cap - self._CONTEXT_SAFETY_MARGIN_TOKENS
+        if estimated <= ceiling:
+            return None
+
+        # Over the wall — reject before spawning the subprocess.
+        err_payload = {
+            "error": {
+                "type": "context_overflow",
+                "message": (
+                    f"Estimated input ({estimated:,} tokens) exceeds "
+                    f"{model_id}'s context window ({cap:,} tokens, "
+                    f"reserving {self._CONTEXT_SAFETY_MARGIN_TOKENS} for "
+                    f"completion). Compact the request or pick a model "
+                    f"with a larger context."
+                ),
+                "model": model_id,
+                "context_window": cap,
+                "estimated_input_tokens": estimated,
+                "safety_margin": self._CONTEXT_SAFETY_MARGIN_TOKENS,
+            }
+        }
+        logger.info(
+            "anthropic-oauth: 413 context overflow model=%s estimated=%d cap=%d",
+            model_id, estimated, cap,
+        )
+        return BackendResponse(
+            status=413,
+            headers={"content-type": "application/json"},
+            body=json.dumps(err_payload).encode("utf-8"),
+        )
+
+    @staticmethod
+    def _estimate_input_tokens(body: dict) -> int:
+        """Cheap token estimate from raw JSON body (chars / 3.6).
+
+        Uses 3.6 chars/token (Anthropic's published average for
+        English; closer to 3.0 for code-heavy / 4.0 for prose). It's
+        conservative — we'd rather wave through some borderline
+        requests than reject correct ones because of a low estimate.
+        Final authority is Anthropic's tokenizer; this is just the
+        proxy-side fence to avoid round-tripping known-overlimit
+        payloads.
+        """
+        chars = 0
+        # system prompt
+        sys_val = body.get("system")
+        if isinstance(sys_val, str):
+            chars += len(sys_val)
+        elif isinstance(sys_val, list):
+            for blk in sys_val:
+                if isinstance(blk, dict):
+                    t = blk.get("text")
+                    if isinstance(t, str):
+                        chars += len(t)
+        # messages
+        for msg in body.get("messages") or []:
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+            if isinstance(content, str):
+                chars += len(content)
+            elif isinstance(content, list):
+                for blk in content:
+                    if isinstance(blk, dict):
+                        t = blk.get("text") or blk.get("content")
+                        if isinstance(t, str):
+                            chars += len(t)
+        # tools (very rough — schema serialized as JSON)
+        tools = body.get("tools")
+        if isinstance(tools, list):
+            try:
+                chars += len(json.dumps(tools))
+            except (TypeError, ValueError):
+                pass
+        return int(chars / 3.6)
 
     # ── Subprocess flag builder — platform-slim by default ──────────
     #
@@ -562,11 +698,28 @@ class AnthropicOAuthBackend:
 
     @staticmethod
     def _conversation_fingerprint(body: bytes) -> Optional[str]:
-        """Stable ID from (model, first user message text).
+        """Stable ID for the platform conversation.
 
-        Same OpenClaw conversation replays the same first user message
-        on every turn — so the fingerprint is stable across turns in
-        one conversation, and unique per ``/new`` session.
+        Keyed on ``(system prompt + first user message text)`` —
+        components a well-behaved platform client replays identically
+        across every turn of the same conversation and that differ
+        between conversations.
+
+        Edge case (accepted): OpenClaw's ``/new`` may send an opening
+        boilerplate turn whose first user message differs from the
+        user's first *real* message. That creates a one-turn
+        cache-warmup hop — turn 1 and turn 2+ hit different
+        fingerprints. All subsequent turns within the same
+        conversation share the same fp and reuse one Claude session
+        via ``--resume``, accumulating Anthropic's prompt cache
+        normally. Net effect: 4-of-6 turns cached for a typical
+        6-turn conversation (verified 2026-04-24).
+
+        Including the system prompt in the key distinguishes
+        same-first-user-message conversations that happen to differ
+        in system context (e.g. different OpenClaw workspaces with
+        different AGENTS.md), so cache entries don't collide across
+        truly different conversations.
         """
         if not body:
             return None
@@ -576,32 +729,50 @@ class AnthropicOAuthBackend:
             return None
         if not isinstance(data, dict):
             return None
-        messages = data.get("messages") or []
-        first_user_text: Optional[str] = None
-        for m in messages:
-            if not isinstance(m, dict) or m.get("role") != "user":
-                continue
-            content = m.get("content")
+
+        def _content_text(content) -> str:
             if isinstance(content, str):
-                first_user_text = content
-            elif isinstance(content, list):
-                parts: list[str] = []
+                return content
+            if isinstance(content, list):
+                parts = []
                 for blk in content:
                     if isinstance(blk, dict) and blk.get("type") == "text":
                         t = blk.get("text")
                         if isinstance(t, str):
                             parts.append(t)
-                if parts:
-                    first_user_text = "\n".join(parts)
-            if first_user_text is not None:
+                return "\n".join(parts)
+            return ""
+
+        system = data.get("system") or ""
+        if isinstance(system, list):
+            system = _content_text(system)
+        system_text = (system if isinstance(system, str) else "")[:2000]
+
+        messages = data.get("messages") or []
+        first_user_text: Optional[str] = None
+        for m in messages:
+            if not isinstance(m, dict) or m.get("role") != "user":
+                continue
+            text = _content_text(m.get("content"))
+            if text.strip():
+                first_user_text = text
                 break
-        if not first_user_text or not first_user_text.strip():
+        if not first_user_text:
             return None
-        model = data.get("model") or ""
+
         import hashlib
 
-        key = f"{model}\n{first_user_text[:1000]}"
-        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+        model = data.get("model") or ""
+        key = f"model={model}\nsystem={system_text}\nfirst_user={first_user_text[:1000]}"
+        fp = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+        import os as _os
+        if _os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
+            logger.warning(
+                "anthropic-oauth[fp] fp=%s model=%s sys_len=%d "
+                "first_user[:80]=%r",
+                fp, model, len(system_text), first_user_text[:80],
+            )
+        return fp
 
     @classmethod
     def _persist_session(

--- a/tokenpak/services/routing_service/model_context.py
+++ b/tokenpak/services/routing_service/model_context.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dynamic per-model context-window registry — provider-agnostic.
+
+Why this exists
+---------------
+
+Models have hard input-token caps (Claude Haiku 4.5 = 200k, Opus 4.7 =
+1M, gpt-5.4 = 128k, etc.). When tokenpak's bridge dispatches a request
+to a model with a smaller window than the inbound payload, the
+upstream provider returns ``invalid_request`` after a wasted round
+trip. Right behavior: reject *fast* at the proxy boundary so callers
+(OpenClaw, etc.) get a clean signal, can compact + retry without
+paying network latency.
+
+Self-maintaining + provider-agnostic
+------------------------------------
+
+Per the standing rule (``feedback_always_dynamic`` 2026-04-16 + Kevin
+2026-04-24): tokenpak is provider/model/platform agnostic; what gets
+set up must be self-maintaining and dynamic — users never edit a
+hand-written model list.
+
+This module is structured around a thin
+:class:`ModelRegistryProvider` Protocol. Each provider implements
+``fetch() -> Iterable[ModelLimits]`` against its own model-listing
+API. The federation in :class:`ModelContextRegistry` walks every
+registered provider, merges results, and caches at
+``~/.tokenpak/model_context_cache.json`` with a 24h TTL. New
+providers (OpenAI, Google, future) plug in with one ``register()``
+call at module import — no changes to the consumer code.
+
+Built-in providers
+~~~~~~~~~~~~~~~~~~
+
+- :class:`AnthropicModelRegistryProvider` — hits
+  ``GET https://api.anthropic.com/v1/models`` with the user's Claude
+  CLI OAuth. Returns one record per Anthropic model with
+  ``max_input_tokens`` + ``max_tokens``.
+
+Adding a new provider
+~~~~~~~~~~~~~~~~~~~~~
+
+```python
+class OpenAIModelRegistryProvider:
+    name = "openai"
+    def fetch(self) -> Iterable[ModelLimits]:
+        # GET /v1/models with the user's OpenAI key, parse into ModelLimits
+        ...
+
+register_provider(OpenAIModelRegistryProvider())
+```
+
+That's the whole contract. Cache, TTL, fail-open semantics, and
+consumer integration are inherited.
+
+Fail-open everywhere
+~~~~~~~~~~~~~~~~~~~~
+
+If a provider's API is unreachable, we keep the previous cache. If
+no cache exists, we return ``None`` for unknown models and the
+caller skips validation (lets upstream return the real error
+unchanged). Tokenpak never *blocks* traffic on an unknown model —
+the registry is a fast-fail optimization, not a gate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_CACHE = Path.home() / ".tokenpak" / "model_context_cache.json"
+_DEFAULT_TTL_SECONDS = 24 * 3600  # 24 hours
+_REQUEST_TIMEOUT_SECONDS = 8.0
+
+
+@dataclass(frozen=True)
+class ModelLimits:
+    """What we know about a model's context economy."""
+
+    model_id: str
+    max_input_tokens: int
+    max_output_tokens: Optional[int] = None
+    provider: Optional[str] = None  # e.g. "anthropic", "openai"
+
+
+class ModelRegistryProvider(Protocol):
+    """One provider's model-listing contract."""
+
+    name: str
+
+    def fetch(self) -> Iterable[ModelLimits]:
+        """Return every model this provider knows about.
+
+        Implementations should raise on unrecoverable error (network,
+        auth) — the federation catches + falls back gracefully.
+        """
+        ...
+
+
+_PROVIDERS: List[ModelRegistryProvider] = []
+_PROVIDERS_LOCK = threading.Lock()
+
+
+def register_provider(provider: ModelRegistryProvider) -> None:
+    """Add a provider to the registry. Idempotent on ``name``."""
+    with _PROVIDERS_LOCK:
+        for i, p in enumerate(_PROVIDERS):
+            if p.name == provider.name:
+                _PROVIDERS[i] = provider
+                return
+        _PROVIDERS.append(provider)
+
+
+def registered_providers() -> List[ModelRegistryProvider]:
+    """Introspection helper for tests + /health."""
+    with _PROVIDERS_LOCK:
+        return list(_PROVIDERS)
+
+
+# ── Federation: lazy-loaded, file-cached snapshot ─────────────────
+
+
+class ModelContextRegistry:
+    """Lazy-loaded, file-cached, federation across registered providers.
+
+    Methods are thread-safe. First ``get_*`` call triggers a cache
+    load; refresh happens on TTL expiry or model-not-found-but-cache-
+    is-stale.
+    """
+
+    def __init__(
+        self,
+        cache_path: Optional[Path] = None,
+        ttl_seconds: float = _DEFAULT_TTL_SECONDS,
+    ) -> None:
+        env_override = os.environ.get("TOKENPAK_MODEL_CONTEXT_CACHE", "").strip()
+        if env_override:
+            cache_path = Path(env_override).expanduser()
+        self._cache_path = Path(cache_path) if cache_path else _DEFAULT_CACHE
+        self._ttl = float(ttl_seconds)
+        self._lock = threading.Lock()
+        self._snapshot: Optional[Dict[str, ModelLimits]] = None
+        self._snapshot_loaded_at: float = 0.0
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    def get_context_window(self, model_id: str) -> Optional[int]:
+        """Return the max input tokens for ``model_id``, or ``None``."""
+        rec = self.get_limits(model_id)
+        return rec.max_input_tokens if rec else None
+
+    def get_limits(self, model_id: str) -> Optional[ModelLimits]:
+        """Return the full :class:`ModelLimits` record, or ``None``.
+
+        Lookup is normalization-aware. The /v1/models API returns
+        both versioned (``claude-haiku-4-5-20251001``) and
+        unversioned (``claude-opus-4-7``) ids depending on the
+        model. Callers commonly send the unversioned form. If the
+        first lookup misses, we try stripping a trailing
+        ``-YYYYMMDD`` date and re-search for the unversioned id;
+        if that misses, we try matching any cached id that begins
+        with the requested unversioned prefix (which covers the
+        opposite case where the caller sends versioned + cache has
+        unversioned).
+        """
+        if not model_id:
+            return None
+        snapshot = self._ensure_snapshot()
+
+        rec = self._lookup_with_aliases(snapshot, model_id)
+        if rec is not None:
+            return rec
+
+        # Not in cache + try one refresh in case the model is new.
+        if self._refresh_if_stale_or_missing(model_id):
+            snapshot = self._snapshot or {}
+            rec = self._lookup_with_aliases(snapshot, model_id)
+            if rec is not None:
+                return rec
+        return None
+
+    @staticmethod
+    def _lookup_with_aliases(
+        snapshot: Dict[str, ModelLimits], model_id: str
+    ) -> Optional[ModelLimits]:
+        # 1. Exact match
+        if model_id in snapshot:
+            return snapshot[model_id]
+        # 2. Strip trailing -YYYYMMDD if present (versioned → unversioned)
+        import re
+
+        m = re.match(r"^(.+)-\d{8}$", model_id)
+        if m and m.group(1) in snapshot:
+            return snapshot[m.group(1)]
+        # 3. Look for any cached id that starts with the unversioned
+        #    form of the request (covers caller sends unversioned, cache
+        #    has versioned + unversioned alias not present).
+        prefix = m.group(1) + "-" if m else model_id + "-"
+        for cached_id, rec in snapshot.items():
+            if cached_id.startswith(prefix):
+                return rec
+        return None
+
+    def all_limits(self) -> Dict[str, ModelLimits]:
+        """Every record currently known. Useful for /health + diagnostics."""
+        return dict(self._ensure_snapshot())
+
+    def force_refresh(self) -> bool:
+        """Bypass TTL + refetch from every registered provider.
+
+        Returns True if at least one provider responded successfully.
+        """
+        with self._lock:
+            return self._refresh_locked()
+
+    # ── Cache lifecycle ─────────────────────────────────────────────
+
+    def _ensure_snapshot(self) -> Dict[str, ModelLimits]:
+        with self._lock:
+            if self._snapshot is None:
+                self._snapshot = self._load_cache_file()
+                if self._snapshot is None or self._is_stale_locked():
+                    self._refresh_locked()
+            elif self._is_stale_locked():
+                self._refresh_locked()
+            return dict(self._snapshot or {})
+
+    def _is_stale_locked(self) -> bool:
+        if self._snapshot is None:
+            return True
+        return (time.time() - self._snapshot_loaded_at) > self._ttl
+
+    def _refresh_if_stale_or_missing(self, model_id: str) -> bool:
+        with self._lock:
+            if (
+                self._snapshot is None
+                or self._is_stale_locked()
+                or model_id not in self._snapshot
+            ):
+                return self._refresh_locked()
+            return False
+
+    def _refresh_locked(self) -> bool:
+        """Walk every registered provider; merge results into cache.
+
+        Returns True if any provider returned a result. Failures are
+        logged at INFO (we keep the previous cache on partial outage).
+        """
+        merged: Dict[str, ModelLimits] = {}
+        if self._snapshot:
+            # Carry forward existing entries; let provider results overwrite.
+            merged.update(self._snapshot)
+        with _PROVIDERS_LOCK:
+            providers = list(_PROVIDERS)
+        any_ok = False
+        for prov in providers:
+            try:
+                records = list(prov.fetch())
+            except Exception as err:  # noqa: BLE001
+                logger.info(
+                    "model_context: provider=%s fetch failed (%s: %s)",
+                    prov.name, type(err).__name__, err,
+                )
+                continue
+            for rec in records:
+                if not isinstance(rec, ModelLimits):
+                    continue
+                if not rec.model_id or rec.max_input_tokens <= 0:
+                    continue
+                merged[rec.model_id] = rec
+            any_ok = True
+
+        if not any_ok and self._snapshot is None:
+            # First run + every provider failed — set empty snapshot
+            # so we don't keep retrying on every access.
+            self._snapshot = {}
+            self._snapshot_loaded_at = time.time()
+            return False
+
+        self._snapshot = merged
+        self._snapshot_loaded_at = time.time()
+        self._write_cache_file(merged)
+        logger.info(
+            "model_context: registry refreshed (%d models across %d providers)",
+            len(merged), sum(1 for p in providers),
+        )
+        return True
+
+    # ── Disk persistence ────────────────────────────────────────────
+
+    def _load_cache_file(self) -> Optional[Dict[str, ModelLimits]]:
+        if not self._cache_path.is_file():
+            return None
+        try:
+            data = json.loads(self._cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        models = data.get("models")
+        ts = data.get("loaded_at")
+        if not isinstance(models, dict) or not isinstance(ts, (int, float)):
+            return None
+        snapshot: Dict[str, ModelLimits] = {}
+        for mid, rec in models.items():
+            if not isinstance(rec, dict):
+                continue
+            mit = rec.get("max_input_tokens")
+            if not isinstance(mit, int) or mit <= 0:
+                continue
+            mot = rec.get("max_output_tokens")
+            prov = rec.get("provider")
+            snapshot[mid] = ModelLimits(
+                model_id=mid,
+                max_input_tokens=mit,
+                max_output_tokens=mot if isinstance(mot, int) and mot > 0 else None,
+                provider=prov if isinstance(prov, str) else None,
+            )
+        self._snapshot_loaded_at = float(ts)
+        return snapshot
+
+    def _write_cache_file(self, snapshot: Dict[str, ModelLimits]) -> None:
+        try:
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "loaded_at": self._snapshot_loaded_at,
+                "models": {
+                    mid: {
+                        "max_input_tokens": rec.max_input_tokens,
+                        "max_output_tokens": rec.max_output_tokens,
+                        "provider": rec.provider,
+                    }
+                    for mid, rec in snapshot.items()
+                },
+            }
+            tmp = self._cache_path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            tmp.replace(self._cache_path)
+        except OSError as err:
+            logger.info("model_context: cache write failed (%s)", err)
+
+
+# ── Built-in: Anthropic provider ──────────────────────────────────
+
+
+class AnthropicModelRegistryProvider:
+    """Fetch model list from ``GET https://api.anthropic.com/v1/models``.
+
+    Auth: reuses the user's Claude CLI OAuth token from
+    ``~/.claude/.credentials.json``. Same credential the OAuth
+    backend already consults — no separate setup required.
+    """
+
+    name = "anthropic"
+    _URL = "https://api.anthropic.com/v1/models"
+
+    def fetch(self) -> Iterable[ModelLimits]:
+        token = self._read_oauth_token()
+        if not token:
+            raise RuntimeError(
+                "no Claude CLI OAuth token available "
+                "(~/.claude/.credentials.json missing or empty)"
+            )
+        req = urllib.request.Request(
+            self._URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": "oauth-2025-04-20",
+                "User-Agent": "tokenpak-model-context-registry",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("/v1/models returned non-object")
+        for entry in payload.get("data") or []:
+            if not isinstance(entry, dict):
+                continue
+            mid = entry.get("id")
+            mit = entry.get("max_input_tokens")
+            mot = entry.get("max_tokens")
+            if not isinstance(mid, str) or not isinstance(mit, int) or mit <= 0:
+                continue
+            yield ModelLimits(
+                model_id=mid,
+                max_input_tokens=mit,
+                max_output_tokens=mot if isinstance(mot, int) and mot > 0 else None,
+                provider="anthropic",
+            )
+
+    @staticmethod
+    def _read_oauth_token() -> Optional[str]:
+        path = Path.home() / ".claude" / ".credentials.json"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        oauth = data.get("claudeAiOauth") if isinstance(data, dict) else None
+        if not isinstance(oauth, dict):
+            return None
+        token = oauth.get("accessToken")
+        return token if isinstance(token, str) and token.strip() else None
+
+
+# Register the Anthropic provider at import. Future providers
+# (OpenAI / Google / Codex / etc.) call register_provider() at their
+# own module's import time.
+register_provider(AnthropicModelRegistryProvider())
+
+
+# ── Process-wide singleton ─────────────────────────────────────────
+
+_registry: Optional[ModelContextRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_registry() -> ModelContextRegistry:
+    """Return the shared :class:`ModelContextRegistry`."""
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = ModelContextRegistry()
+    return _registry
+
+
+def get_context_window(model_id: str) -> Optional[int]:
+    """Convenience: max input tokens for ``model_id`` (or ``None``)."""
+    return get_registry().get_context_window(model_id)
+
+
+__all__ = [
+    "AnthropicModelRegistryProvider",
+    "ModelContextRegistry",
+    "ModelLimits",
+    "ModelRegistryProvider",
+    "get_context_window",
+    "get_registry",
+    "register_provider",
+    "registered_providers",
+]


### PR DESCRIPTION
Per-model context windows now sourced dynamically from each provider's /v1/models API. Self-maintaining + provider-agnostic per Kevin 2026-04-24.

**New module:** `tokenpak/services/routing_service/model_context.py`
- `ModelRegistryProvider` Protocol; federation across providers
- 24h TTL cache; fail-open on registry miss/network failure
- Built-in `AnthropicModelRegistryProvider` (uses Claude CLI OAuth)
- Future providers plug in with one `register_provider()` call
- Normalization-aware lookup (versioned + unversioned forms resolve)

**Backend integration:** `AnthropicOAuthBackend.dispatch()` does fast input-token estimate; over cap → HTTP 413 `context_overflow` in ms (no wasted round-trip to Anthropic).

**Live verified:** 222k payload to haiku-4-5 (200k cap) → HTTP 413 with structured payload; tiny payloads pass through normally; unknown models fail-open.

**Test plan:** 191 services+proxy regression green, ruff + import contracts clean, end-to-end curl scenarios verified.