### PR TITLE
feat(proxy): v1.3.23 — restore OpenAICodexResponsesAdapter for direct Codex CLI traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.23] - 2026-04-24
+
+### Added — `OpenAICodexResponsesAdapter` (Codex format adapter restored)
+
+Restores the `OpenAICodexResponsesAdapter` deleted in the Apr-16 wave-4 cleanup, ported as a functional reiteration against the current modular tree (not a verbatim copy of the Apr-12 file).
+
+**New module** `tokenpak/proxy/adapters/openai_codex_responses_adapter.py`:
+
+- Extends `OpenAIResponsesAdapter`. Wire format is identical to `/v1/responses`; only the upstream, path, and a few payload constraints differ.
+- **Detection (priority 270)**: matches `/v1/responses` requests whose `Authorization` header carries a ChatGPT OAuth JWT (`Bearer eyJ…`). The standard `OpenAIResponsesAdapter` (priority 260) still matches the API-key (`sk-…`) case, so existing direct-OpenAI traffic is untouched.
+- **Upstream rewrite**: `get_default_upstream() → https://chatgpt.com/backend-api`, `get_upstream_path() → /codex/responses`. SSE format reuses `openai-responses-sse`.
+- **Payload constraints** enforced in `denormalize()` (the ChatGPT Codex backend rejects requests that don't conform):
+  - `stream: true` (always)
+  - `store: false` (no server-side conversation persistence)
+  - `max_output_tokens` is dropped (the backend computes its own cap)
+  - `input` is promoted to a list of message objects when the parent emits a string
+
+**Relationship to `credential_injector` (v1.3.15):** the existing `CodexCredentialProvider` handles the *platform-bridged* path — when OpenClaw stamps `X-TokenPak-Backend` / `X-TokenPak-Provider: tokenpak-openai-codex`, the proxy's pre-forward hook reads `~/.codex/auth.json`, injects headers, rewrites the URL, and normalises the body. That runs **before** adapter selection. This adapter handles the *direct* path — when a Codex CLI client (or any caller carrying a JWT directly) hits the proxy at `/v1/responses`. No double injection because the bridge path returns its own response before the adapter registry runs.
+
+**Registered** in `build_default_registry()` at priority 270, between `AnthropicAdapter` (300) and `OpenAIResponsesAdapter` (260).
+
+**Tests** (`tests/test_openai_codex_responses_adapter.py`, 22 cases):
+
+- JWT detection: `eyJ` + `.` shape, `Bearer ` prefix stripping (case-insensitive), `sk-` rejection, empty-header rejection
+- Adapter `detect()`: path filter, auth-header casing, missing-auth rejection
+- Upstream + path + SSE format overrides
+- `denormalize()`: forces `stream=true` + `store=false`, drops `max_output_tokens`, promotes string input to structured list, preserves existing list/dict input via deep-copy
+- Registry integration: JWT routes to Codex adapter, `sk-` falls through to standard `OpenAIResponsesAdapter`
+
 ## [1.3.22] - 2026-04-24
 
 ### Added — Dynamic per-model context registry + fail-fast 413 at the bridge boundary

--- a/tests/test_openai_codex_responses_adapter.py
+++ b/tests/test_openai_codex_responses_adapter.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OpenAICodexResponsesAdapter."""
+
+from __future__ import annotations
+
+import json
+
+from tokenpak.proxy.adapters import build_default_registry
+from tokenpak.proxy.adapters.canonical import CanonicalRequest
+from tokenpak.proxy.adapters.openai_codex_responses_adapter import (
+    OpenAICodexResponsesAdapter,
+    _is_chatgpt_oauth_token,
+)
+
+JWT_SAMPLE = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ4In0.signature"
+
+
+class TestJWTDetection:
+    def test_eyJ_with_dot_is_jwt(self):
+        assert _is_chatgpt_oauth_token(JWT_SAMPLE) is True
+
+    def test_bearer_prefix_stripped(self):
+        assert _is_chatgpt_oauth_token(f"Bearer {JWT_SAMPLE}") is True
+
+    def test_lowercase_bearer_prefix_stripped(self):
+        assert _is_chatgpt_oauth_token(f"bearer {JWT_SAMPLE}") is True
+
+    def test_sk_api_key_is_not_jwt(self):
+        assert _is_chatgpt_oauth_token("Bearer sk-abc123") is False
+
+    def test_empty_header_is_not_jwt(self):
+        assert _is_chatgpt_oauth_token("") is False
+
+    def test_eyJ_without_dot_is_not_jwt(self):
+        assert _is_chatgpt_oauth_token("eyJabcdefg") is False
+
+
+class TestDetect:
+    def test_v1_responses_with_jwt_matches(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert (
+            adapter.detect(
+                "/v1/responses",
+                {"Authorization": f"Bearer {JWT_SAMPLE}"},
+                None,
+            )
+            is True
+        )
+
+    def test_v1_responses_with_lowercase_authorization_matches(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert (
+            adapter.detect(
+                "/v1/responses",
+                {"authorization": f"Bearer {JWT_SAMPLE}"},
+                None,
+            )
+            is True
+        )
+
+    def test_v1_responses_with_sk_key_does_not_match(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert (
+            adapter.detect(
+                "/v1/responses",
+                {"Authorization": "Bearer sk-abc123"},
+                None,
+            )
+            is False
+        )
+
+    def test_other_path_does_not_match(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert (
+            adapter.detect(
+                "/v1/chat/completions",
+                {"Authorization": f"Bearer {JWT_SAMPLE}"},
+                None,
+            )
+            is False
+        )
+
+    def test_missing_auth_does_not_match(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert adapter.detect("/v1/responses", {}, None) is False
+
+
+class TestUpstreamAndPath:
+    def test_default_upstream_is_chatgpt_backend(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert adapter.get_default_upstream() == "https://chatgpt.com/backend-api"
+
+    def test_upstream_path_is_codex_responses(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert adapter.get_upstream_path() == "/codex/responses"
+
+    def test_sse_format_inherited(self):
+        adapter = OpenAICodexResponsesAdapter()
+        assert adapter.get_sse_format() == "openai-responses-sse"
+
+
+class TestDenormalize:
+    def _canonical(self, **overrides) -> CanonicalRequest:
+        defaults = dict(
+            model="gpt-5-codex",
+            system="",
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=None,
+            generation={},
+            stream=False,
+            raw_extra={"_input_format": "string"},
+            source_format="openai-codex-responses",
+        )
+        defaults.update(overrides)
+        return CanonicalRequest(**defaults)
+
+    def test_forces_stream_true(self):
+        adapter = OpenAICodexResponsesAdapter()
+        payload = json.loads(adapter.denormalize(self._canonical(stream=False)))
+        assert payload["stream"] is True
+
+    def test_forces_store_false(self):
+        adapter = OpenAICodexResponsesAdapter()
+        payload = json.loads(adapter.denormalize(self._canonical()))
+        assert payload["store"] is False
+
+    def test_drops_max_output_tokens(self):
+        adapter = OpenAICodexResponsesAdapter()
+        canonical = self._canonical(generation={"max_output_tokens": 1024})
+        payload = json.loads(adapter.denormalize(canonical))
+        assert "max_output_tokens" not in payload
+
+    def test_promotes_string_input_to_message_list(self):
+        adapter = OpenAICodexResponsesAdapter()
+        payload = json.loads(adapter.denormalize(self._canonical()))
+        assert isinstance(payload["input"], list)
+        assert payload["input"][0]["role"] == "user"
+        assert payload["input"][0]["content"][0]["type"] == "input_text"
+        assert payload["input"][0]["content"][0]["text"] == "Hello"
+
+    def test_empty_string_input_becomes_empty_list(self):
+        adapter = OpenAICodexResponsesAdapter()
+        canonical = self._canonical(messages=[{"role": "user", "content": ""}])
+        payload = json.loads(adapter.denormalize(canonical))
+        assert payload["input"] == []
+
+    def test_existing_list_input_preserved(self):
+        adapter = OpenAICodexResponsesAdapter()
+        canonical = self._canonical(
+            messages=[
+                {"role": "system", "content": "ctx"},
+                {"role": "user", "content": "Hi"},
+            ],
+            raw_extra={"_input_format": "message_array"},
+        )
+        payload = json.loads(adapter.denormalize(canonical))
+        assert isinstance(payload["input"], list)
+        assert len(payload["input"]) == 2
+        assert payload["input"][0]["role"] == "system"
+        assert payload["input"][1]["role"] == "user"
+
+
+class TestRegistryRegistration:
+    def test_codex_adapter_registered_above_standard_responses(self):
+        registry = build_default_registry()
+        # JWT bearer to /v1/responses must select the Codex adapter,
+        # not the standard OpenAIResponsesAdapter at priority 260.
+        adapter = registry.detect(
+            "/v1/responses",
+            {"Authorization": f"Bearer {JWT_SAMPLE}"},
+            None,
+        )
+        assert isinstance(adapter, OpenAICodexResponsesAdapter)
+
+    def test_sk_key_falls_through_to_standard_responses(self):
+        registry = build_default_registry()
+        adapter = registry.detect(
+            "/v1/responses",
+            {"Authorization": "Bearer sk-test"},
+            None,
+        )
+        assert not isinstance(adapter, OpenAICodexResponsesAdapter)
+        assert adapter.source_format == "openai-responses"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.3.22"
+__version__ = "1.3.23"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"

--- a/tokenpak/proxy/adapters/__init__.py
+++ b/tokenpak/proxy/adapters/__init__.py
@@ -5,6 +5,7 @@ from .base import FormatAdapter
 from .canonical import CanonicalRequest, CanonicalResponse
 from .google_adapter import GoogleGenerativeAIAdapter
 from .openai_chat_adapter import OpenAIChatAdapter
+from .openai_codex_responses_adapter import OpenAICodexResponsesAdapter
 from .openai_responses_adapter import OpenAIResponsesAdapter
 from .passthrough_adapter import PassthroughAdapter
 from .registry import AdapterRegistry
@@ -13,6 +14,7 @@ from .registry import AdapterRegistry
 def build_default_registry() -> AdapterRegistry:
     registry = AdapterRegistry()
     registry.register(AnthropicAdapter(), priority=300)
+    registry.register(OpenAICodexResponsesAdapter(), priority=270)
     registry.register(OpenAIResponsesAdapter(), priority=260)
     registry.register(OpenAIChatAdapter(), priority=250)
     registry.register(GoogleGenerativeAIAdapter(), priority=240)
@@ -28,6 +30,7 @@ __all__ = [
     "FormatAdapter",
     "GoogleGenerativeAIAdapter",
     "OpenAIChatAdapter",
+    "OpenAICodexResponsesAdapter",
     "OpenAIResponsesAdapter",
     "PassthroughAdapter",
     "build_default_registry",

--- a/tokenpak/proxy/adapters/openai_codex_responses_adapter.py
+++ b/tokenpak/proxy/adapters/openai_codex_responses_adapter.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI Codex Responses adapter — routes ``/v1/responses`` + JWT to ChatGPT.
+
+Restored 2026-04-24 from the Apr-12 build (deleted in the Apr-16
+wave-4 cleanup). Ported as a functional reiteration against the
+current modular tree, not a verbatim copy.
+
+Why this exists
+---------------
+
+The standard :class:`OpenAIResponsesAdapter` routes ``/v1/responses``
+traffic to ``api.openai.com`` and authenticates with an OpenAI
+``sk-`` API key. ChatGPT's Codex offering uses the same Responses
+API wire format but a *different upstream* (``chatgpt.com/backend-api``)
+and a *different auth shape* (JWT OAuth from the Codex CLI's
+``~/.codex/auth.json``). Calling ``api.openai.com`` with a ChatGPT
+JWT returns 401 every time.
+
+This adapter sits at priority 270 (above generic OpenAIResponses at
+260) and matches ``/v1/responses`` requests whose ``Authorization``
+header carries a JWT (``Bearer eyJ…``). The standard adapter still
+matches the API-key case at priority 260, so direct OpenAI traffic
+keeps working unchanged.
+
+Relationship to ``credential_injector``
+---------------------------------------
+
+The v1.3.15 ``CodexCredentialProvider`` in
+``services/routing_service/credential_injector.py`` handles the
+*platform-bridged* path — when OpenClaw or another adapter sets
+``X-TokenPak-Backend`` / ``X-TokenPak-Provider: tokenpak-openai-codex``,
+the proxy's pre-forward hook reads ``~/.codex/auth.json``, injects
+the right headers, rewrites the URL, and normalises the body. That
+runs *before* adapter selection.
+
+This adapter handles the *direct* path — when a Codex CLI client (or
+any caller carrying a JWT directly) hits the proxy at
+``/v1/responses``, the adapter selects itself by token shape and
+applies the same upstream / path / payload-shape transforms via the
+adapter registry's normal denormalize→forward flow. No double
+injection because the bridge path returns its own response before the
+adapter registry runs.
+
+Payload constraints
+-------------------
+
+The ChatGPT Codex backend rejects requests that don't conform to:
+
+- ``stream: true`` always
+- ``store: false`` always (no server-side conversation persistence)
+- no ``max_output_tokens`` parameter (the backend computes its own cap)
+- ``input`` as a list (string form is auto-promoted to a single
+  ``user``-role text block)
+
+These are enforced in :meth:`denormalize`. Tokenpak's compression
+pipeline runs against the *canonical* form before denormalize, so
+the constraints don't interfere with capsule injection / compaction.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Mapping, Optional
+
+from .canonical import CanonicalRequest
+from .openai_responses_adapter import OpenAIResponsesAdapter
+
+# JWT detection: ChatGPT OAuth tokens are RFC-7519 JWTs that always
+# start with ``eyJ`` (base64url of ``{"``). OpenAI API keys start
+# with ``sk-``. No overlap, so a single prefix check is sufficient.
+_JWT_PREFIX = "eyJ"
+
+
+def _is_chatgpt_oauth_token(auth_header: str) -> bool:
+    """True when ``Authorization`` carries a ChatGPT OAuth JWT."""
+    if not auth_header:
+        return False
+    token = auth_header
+    if auth_header[:7].lower() == "bearer ":
+        token = auth_header[7:].strip()
+    if not token:
+        return False
+    return token.startswith(_JWT_PREFIX) and "." in token
+
+
+class OpenAICodexResponsesAdapter(OpenAIResponsesAdapter):
+    """Codex Responses adapter — same wire format, different upstream."""
+
+    source_format = "openai-codex-responses"
+
+    # ChatGPT's Codex backend path. Used when the request's URL is
+    # rewritten on the way out.
+    CODEX_PATH = "/codex/responses"
+
+    # ChatGPT backend host. Inherits ``/codex/responses`` to form the
+    # full upstream URL.
+    CODEX_UPSTREAM = "https://chatgpt.com/backend-api"
+
+    def detect(
+        self,
+        path: str,
+        headers: Mapping[str, str],
+        body: Optional[bytes],
+    ) -> bool:
+        """Match ``/v1/responses`` traffic carrying a ChatGPT OAuth JWT.
+
+        Selected at priority 270 — checked before
+        :class:`OpenAIResponsesAdapter` (priority 260). API-key
+        traffic falls through to the standard adapter unchanged.
+        """
+        if "/v1/responses" not in path:
+            return False
+        # Header lookup is case-insensitive at the HTTP layer; we check
+        # both common cases without converting the entire mapping.
+        auth = headers.get("Authorization") or headers.get("authorization") or ""
+        return _is_chatgpt_oauth_token(auth)
+
+    def get_default_upstream(self) -> str:
+        return self.CODEX_UPSTREAM
+
+    def get_sse_format(self) -> str:
+        # ChatGPT's Codex backend streams in the same format as the
+        # OpenAI Responses API SSE feed.
+        return "openai-responses-sse"
+
+    def get_upstream_path(self) -> str:
+        """Path rewrite: ``/v1/responses`` → ``/codex/responses``."""
+        return self.CODEX_PATH
+
+    def denormalize(self, canonical: CanonicalRequest) -> bytes:
+        """Apply the ChatGPT Codex backend's payload constraints.
+
+        Required by the upstream:
+          - ``stream: true``
+          - ``store: false``
+          - no ``max_output_tokens`` field
+          - ``input`` is a list, not a string
+
+        We delegate the wire-format work to the parent
+        :meth:`OpenAIResponsesAdapter.denormalize` and then patch the
+        result so the ChatGPT backend accepts it.
+        """
+        base_bytes = super().denormalize(canonical)
+        try:
+            payload = json.loads(base_bytes)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # Parent gave us non-JSON for some reason — pass through;
+            # the upstream will reject and the caller sees the error.
+            return base_bytes
+
+        if not isinstance(payload, dict):
+            return base_bytes
+
+        payload["stream"] = True
+        payload["store"] = False
+        payload.pop("max_output_tokens", None)
+
+        # The ChatGPT backend wants ``input`` as a list of message
+        # objects, not a raw string. The parent class may emit a
+        # string when the canonical input is a single user turn; we
+        # promote that into the structured form here.
+        input_value = payload.get("input")
+        if isinstance(input_value, str):
+            text = input_value
+            if text:
+                payload["input"] = [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": text}],
+                    }
+                ]
+            else:
+                payload["input"] = []
+        elif input_value is None:
+            payload["input"] = []
+        else:
+            # Already a list / dict — pass through but defensively
+            # deep-copy so any downstream mutation can't poison our
+            # canonical state.
+            payload["input"] = copy.deepcopy(input_value)
+
+        return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+__all__ = ["OpenAICodexResponsesAdapter"]


### PR DESCRIPTION
## Summary

- Restores the `OpenAICodexResponsesAdapter` deleted in the Apr-16 wave-4 cleanup, ported as a functional reiteration against the current modular tree (not a verbatim copy of the Apr-12 file)
- Routes `/v1/responses` + JWT `Bearer eyJ…` to `chatgpt.com/backend-api/codex/responses` at priority 270 — `sk-` API-key traffic keeps falling through to the standard `OpenAIResponsesAdapter` at priority 260
- Complementary to (not a duplicate of) the v1.3.15 `CodexCredentialProvider` in `services/routing_service/credential_injector.py`: that path handles platform-bridged traffic (OpenClaw stamping `X-TokenPak-Backend`); this adapter handles the *direct* CLI path

## Why

Direct Codex CLI traffic carries a ChatGPT OAuth JWT (`~/.codex/auth.json`), not an OpenAI `sk-` API key. The standard adapter routes to `api.openai.com`, which 401s every JWT request. Without a Codex-aware format adapter, the only way to reach ChatGPT's Codex backend is the OpenClaw platform bridge — which doesn't help when a Codex CLI client points directly at the proxy.

## Payload constraints

The ChatGPT Codex backend rejects requests that don't conform to:

- `stream: true` (always)
- `store: false` (no server-side conversation persistence)
- no `max_output_tokens` (the backend computes its own cap)
- `input` as a list of message objects, not a string

These are enforced in `denormalize()`. Tokenpak's compression pipeline runs against the canonical form *before* denormalize, so the constraints don't interfere with capsule injection / compaction.

## Files

- **NEW** \`tokenpak/proxy/adapters/openai_codex_responses_adapter.py\` — adapter (extends \`OpenAIResponsesAdapter\`)
- **NEW** \`tests/test_openai_codex_responses_adapter.py\` — 22 unit tests
- \`tokenpak/proxy/adapters/__init__.py\` — register at priority 270 + export
- \`tokenpak/__init__.py\` — \`__version__ = "1.3.23"\`
- \`CHANGELOG.md\` — \`[1.3.23]\` entry

## Test plan

- [x] \`python3 -m pytest tests/test_openai_codex_responses_adapter.py\` — 22 passed
- [x] \`python3 -m ruff check tokenpak/proxy/adapters/ tests/test_openai_codex_responses_adapter.py\` — clean
- [x] \`python3 -m ruff format --check\` on touched files — clean
- [x] \`make test\` — pre-existing 4-failure baseline (test_first_request / test_ingest, 404 environmental on main) unchanged
- [ ] Live: hit proxy \`/v1/responses\` with a JWT bearer token, verify routes to ChatGPT Codex backend
- [ ] Live: hit proxy \`/v1/responses\` with an \`sk-\` key, verify still routes to api.openai.com