### PR TITLE
feat(proxy): Phase 2b — AWS Bedrock for Claude (SigV4 + envelope)

### DIFF
--- a/tests/test_adapter_capabilities.py
+++ b/tests/test_adapter_capabilities.py
@@ -20,7 +20,10 @@ from tokenpak.proxy.adapters.google_adapter import GoogleGenerativeAIAdapter
 from tokenpak.proxy.adapters.openai_chat_adapter import OpenAIChatAdapter
 from tokenpak.proxy.adapters.openai_responses_adapter import OpenAIResponsesAdapter
 from tokenpak.proxy.adapters.passthrough_adapter import PassthroughAdapter
-from tokenpak.proxy.server import _extract_tokens_via_adapters
+from tokenpak.proxy.server import (
+    _extract_tokens_via_adapters,
+    _resolve_adapter_for_request,
+)
 
 # TIP capability label format: ``tip.<group>.<feature>`` or ``ext.<vendor>.<feature>``.
 _TIP_LABEL_RE = re.compile(r"^(tip|ext)\.[a-z0-9._-]+$")
@@ -218,3 +221,76 @@ class TestProxyHotPathFormatAgnostic:
         # PassthroughAdapter accepts any body; it'll normalise to a
         # canonical with no messages → 0 tokens. Critical: no exception.
         assert tokens == 0
+
+
+class TestCapabilityGatedMiddleware:
+    """``_resolve_adapter_for_request`` returns the adapter so middleware
+    can read ``adapter.capabilities`` and decide whether to apply.
+    """
+
+    def test_anthropic_request_resolves_to_anthropic_adapter_with_compression(self):
+        body = json.dumps({
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        adapter = _resolve_adapter_for_request(
+            body, {"x-api-key": "sk-test"}, "/v1/messages"
+        )
+        assert adapter is not None
+        assert isinstance(adapter, AnthropicAdapter)
+        # Anthropic opts in to compression — gate evaluates True.
+        assert "tip.compression.v1" in adapter.capabilities
+
+    def test_codex_request_resolves_with_compression_capability(self):
+        body = json.dumps({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                }
+            ],
+        }).encode()
+        long_jwt = "eyJ" + "x" * 300 + ".y.z"
+        adapter = _resolve_adapter_for_request(
+            body,
+            {"Authorization": f"Bearer {long_jwt}"},
+            "/v1/responses",
+        )
+        assert adapter is not None
+        # Whichever Responses-family adapter wins, both declare compression.
+        assert "tip.compression.v1" in adapter.capabilities
+
+    def test_unknown_format_falls_through_to_passthrough_no_compression(self):
+        # An opaque body (no recognisable shape) lands on PassthroughAdapter
+        # via the catch-all detect=True. Passthrough does NOT declare
+        # tip.compression.v1 → middleware gates evaluate False → no
+        # phantom telemetry rows + no body mutation.
+        body = json.dumps({"weird_format": True, "data": "..."}).encode()
+        adapter = _resolve_adapter_for_request(body, {}, "/some/random/path")
+        assert adapter is not None
+        assert isinstance(adapter, PassthroughAdapter)
+        assert "tip.compression.v1" not in adapter.capabilities
+
+    def test_empty_body_resolves_to_none(self):
+        # Defensive: no body → no adapter → middleware gates default to "skip".
+        assert _resolve_adapter_for_request(b"", {}, "/v1/messages") is None
+
+    def test_capability_gate_pattern_works_per_adapter(self):
+        # Demonstrates the gating pattern callers should use:
+        #   adapter = _resolve_adapter_for_request(body, headers, path)
+        #   if adapter and "tip.X" in adapter.capabilities:
+        #       run_middleware_X()
+        registry = build_default_registry()
+        compression_supporters = [
+            a
+            for a in registry.adapters()
+            if "tip.compression.v1" in a.capabilities
+        ]
+        # All four real format adapters opt in; passthrough does not.
+        formats_with_compression = {a.source_format for a in compression_supporters}
+        assert "anthropic-messages" in formats_with_compression
+        assert "openai-responses" in formats_with_compression
+        assert "openai-chat" in formats_with_compression
+        assert "google-generative-ai" in formats_with_compression
+        assert "passthrough" not in formats_with_compression

--- a/tests/test_adapter_capabilities.py
+++ b/tests/test_adapter_capabilities.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TIP capability declarations on FormatAdapter classes.
+
+Verifies the consolidation pass: each adapter declares its TIP-1.0
+capability set, the proxy hot path uses the registry to count tokens
+correctly across formats (codex, google, etc.), and the capability
+labels conform to the canonical TIP vocabulary.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from tokenpak.core.contracts.capabilities import SELF_CAPABILITIES_PROXY
+from tokenpak.proxy.adapters import build_default_registry
+from tokenpak.proxy.adapters.anthropic_adapter import AnthropicAdapter
+from tokenpak.proxy.adapters.base import FormatAdapter
+from tokenpak.proxy.adapters.google_adapter import GoogleGenerativeAIAdapter
+from tokenpak.proxy.adapters.openai_chat_adapter import OpenAIChatAdapter
+from tokenpak.proxy.adapters.openai_responses_adapter import OpenAIResponsesAdapter
+from tokenpak.proxy.adapters.passthrough_adapter import PassthroughAdapter
+from tokenpak.proxy.server import _extract_tokens_via_adapters
+
+# TIP capability label format: ``tip.<group>.<feature>`` or ``ext.<vendor>.<feature>``.
+_TIP_LABEL_RE = re.compile(r"^(tip|ext)\.[a-z0-9._-]+$")
+
+
+class TestCapabilityFieldShape:
+    """Each adapter declares a frozenset of TIP-vocabulary labels."""
+
+    def test_base_class_default_is_empty_frozenset(self):
+        assert FormatAdapter.capabilities == frozenset()
+
+    def test_anthropic_declares_byte_preserved_and_ttl_ordering(self):
+        # Anthropic Messages: cache_control routing depends on byte
+        # fidelity, so byte-preserved is mandatory; ttl-ordering applies
+        # to the 1h-block-must-precede-default-ttl rule.
+        caps = AnthropicAdapter.capabilities
+        assert "tip.compression.v1" in caps
+        assert "tip.byte-preserved-passthrough" in caps
+        assert "tip.cache.proxy-managed" in caps
+        assert "tip.cache.ttl-ordering" in caps
+
+    def test_openai_responses_declares_compression_and_cache(self):
+        caps = OpenAIResponsesAdapter.capabilities
+        assert "tip.compression.v1" in caps
+        assert "tip.cache.proxy-managed" in caps
+        # Responses API is re-serialised on denormalize → not byte-preserved.
+        assert "tip.byte-preserved-passthrough" not in caps
+
+    def test_openai_chat_declares_compression_and_cache(self):
+        caps = OpenAIChatAdapter.capabilities
+        assert "tip.compression.v1" in caps
+        assert "tip.cache.proxy-managed" in caps
+
+    def test_google_declares_compression_and_cache(self):
+        caps = GoogleGenerativeAIAdapter.capabilities
+        assert "tip.compression.v1" in caps
+        assert "tip.cache.proxy-managed" in caps
+
+    def test_passthrough_declares_byte_preserved_only(self):
+        # The catch-all fallback can only forward bytes — no opt-in to
+        # compression / cache (we don't know the format).
+        caps = PassthroughAdapter.capabilities
+        assert "tip.byte-preserved-passthrough" in caps
+        assert "tip.compression.v1" not in caps
+        assert "tip.cache.proxy-managed" not in caps
+
+
+class TestCapabilityLabelsAreValid:
+    """Every declared label conforms to the TIP vocabulary pattern."""
+
+    def test_all_adapter_labels_match_tip_pattern(self):
+        for cls in (
+            AnthropicAdapter,
+            OpenAIResponsesAdapter,
+            OpenAIChatAdapter,
+            GoogleGenerativeAIAdapter,
+            PassthroughAdapter,
+        ):
+            for label in cls.capabilities:
+                assert _TIP_LABEL_RE.match(label), (
+                    f"{cls.__name__}.capabilities contains non-TIP-shaped "
+                    f"label {label!r}"
+                )
+
+    def test_adapter_capabilities_subset_of_proxy_self_published(self):
+        # The proxy publishes a SELF_CAPABILITIES_PROXY set at boot.
+        # Every per-adapter capability must be in that set (otherwise
+        # we'd be claiming features the proxy doesn't actually
+        # implement).
+        union = set()
+        for cls in (
+            AnthropicAdapter,
+            OpenAIResponsesAdapter,
+            OpenAIChatAdapter,
+            GoogleGenerativeAIAdapter,
+            PassthroughAdapter,
+        ):
+            union |= cls.capabilities
+        missing = union - SELF_CAPABILITIES_PROXY
+        assert not missing, (
+            f"Adapters declare {missing} but the proxy doesn't publish "
+            f"those in SELF_CAPABILITIES_PROXY — either implement them "
+            f"or drop them from the adapter."
+        )
+
+
+class TestDescribeIntrospection:
+    """``describe()`` exposes adapter metadata for docs/discovery."""
+
+    def test_describe_is_jsonable(self):
+        for cls in (AnthropicAdapter, OpenAIResponsesAdapter, GoogleGenerativeAIAdapter):
+            d = cls.describe()
+            json.dumps(d)  # must not raise
+            assert d["source_format"] == cls.source_format
+            assert d["class_name"] == cls.__name__
+            assert isinstance(d["capabilities"], list)
+            assert d["capabilities"] == sorted(cls.capabilities)
+
+    def test_registry_can_emit_full_adapter_inventory(self):
+        # Used by ``tokenpak doctor`` / docs generator to enumerate
+        # every registered adapter + its capabilities in one shot.
+        registry = build_default_registry()
+        inventory = [a.describe() for a in registry.adapters()]
+        assert len(inventory) >= 5
+        formats = {entry["source_format"] for entry in inventory}
+        assert "anthropic-messages" in formats
+        assert "openai-responses" in formats
+        assert "google-generative-ai" in formats
+        assert "passthrough" in formats
+
+
+class TestProxyHotPathFormatAgnostic:
+    """``_extract_tokens_via_adapters`` counts tokens per format correctly."""
+
+    def test_anthropic_messages_body_counts_via_adapter(self):
+        body = json.dumps({
+            "model": "claude-haiku-4-5",
+            "messages": [
+                {"role": "user", "content": "hello world this is anthropic"},
+            ],
+        }).encode()
+        model, tokens = _extract_tokens_via_adapters(
+            body, {"x-api-key": "sk-test"}, "/v1/messages"
+        )
+        assert tokens > 0
+        assert model == "claude-haiku-4-5"
+
+    def test_openai_responses_body_counts_via_adapter(self):
+        # The historical ``_estimate_tokens_from_body`` returned 0 for
+        # this shape — that was the codex regression. After
+        # consolidation, the adapter handles ``input`` and counts
+        # correctly.
+        body = json.dumps({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello world this is codex"}],
+                }
+            ],
+        }).encode()
+        model, tokens = _extract_tokens_via_adapters(body, {}, "/v1/responses")
+        assert tokens > 0
+        assert model == "gpt-5.4"
+
+    def test_codex_responses_path_also_counts(self):
+        # OpenClaw's pi-ai connector posts to /codex/responses — the
+        # OpenAICodexResponsesAdapter (priority 270) detects + counts.
+        body = json.dumps({
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "another codex prompt"}],
+                }
+            ],
+        }).encode()
+        # JWT-shape Authorization header to match the codex adapter's
+        # detect() on /v1/responses; for /codex/responses path we just
+        # need any registered adapter to recognise the body shape.
+        long_jwt = "eyJ" + "x" * 300 + ".y.z"
+        _model, tokens = _extract_tokens_via_adapters(
+            body,
+            {"Authorization": f"Bearer {long_jwt}"},
+            "/v1/responses",
+        )
+        assert tokens > 0
+
+    def test_google_generative_ai_body_counts(self):
+        body = json.dumps({
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": "hello world this is gemini"}],
+                }
+            ],
+        }).encode()
+        # Google adapter's detect requires ``/v1beta/`` in path or
+        # ``x-goog-api-key`` header. Either selects the adapter so
+        # extract_request_tokens reads ``contents`` correctly.
+        _model, tokens = _extract_tokens_via_adapters(
+            body,
+            {"x-goog-api-key": "AIza-test"},
+            "/v1beta/models/gemini-pro:generateContent",
+        )
+        assert tokens > 0
+
+    def test_empty_body_returns_zero(self):
+        model, tokens = _extract_tokens_via_adapters(b"", {}, "/v1/messages")
+        assert tokens == 0
+        assert model == "unknown"
+
+    def test_malformed_body_does_not_raise(self):
+        model, tokens = _extract_tokens_via_adapters(b"not json", {}, "/v1/messages")
+        # PassthroughAdapter accepts any body; it'll normalise to a
+        # canonical with no messages → 0 tokens. Critical: no exception.
+        assert tokens == 0

--- a/tests/test_adapter_capabilities.py
+++ b/tests/test_adapter_capabilities.py
@@ -237,7 +237,13 @@ class TestCapabilityGatedMiddleware:
             body, {"x-api-key": "sk-test"}, "/v1/messages"
         )
         assert adapter is not None
-        assert isinstance(adapter, AnthropicAdapter)
+        # Compare by ``source_format`` rather than ``isinstance`` — the
+        # latter is fragile under module-reload tests
+        # (``tests/deprecations`` pops every ``tokenpak.proxy.*`` from
+        # ``sys.modules`` to verify shim warnings, after which the
+        # registered AnthropicAdapter class object differs by identity
+        # from the one captured at top-of-file imports here).
+        assert adapter.source_format == "anthropic-messages"
         # Anthropic opts in to compression — gate evaluates True.
         assert "tip.compression.v1" in adapter.capabilities
 
@@ -269,7 +275,8 @@ class TestCapabilityGatedMiddleware:
         body = json.dumps({"weird_format": True, "data": "..."}).encode()
         adapter = _resolve_adapter_for_request(body, {}, "/some/random/path")
         assert adapter is not None
-        assert isinstance(adapter, PassthroughAdapter)
+        # source_format check — see same rationale as the anthropic test above.
+        assert adapter.source_format == "passthrough"
         assert "tip.compression.v1" not in adapter.capabilities
 
     def test_empty_body_resolves_to_none(self):

--- a/tests/test_adapter_discovery.py
+++ b/tests/test_adapter_discovery.py
@@ -8,7 +8,6 @@ from textwrap import dedent
 
 from tokenpak.proxy.adapters import (
     build_default_registry,
-    build_registry,
     discover_filesystem_adapters,
     register_discovered,
 )
@@ -241,15 +240,19 @@ class TestRegisterDiscovered:
 
 
 class TestBuildRegistry:
-    def test_build_registry_includes_builtins_and_filesystem_adapters(
-        self, tmp_path: Path, monkeypatch
+    def test_register_discovered_with_explicit_dir_finds_plugin(
+        self, tmp_path: Path
     ):
-        # Point the dropin discovery at our tmp dir for this test.
-        monkeypatch.setattr(
-            "tokenpak.proxy.adapters.discovery._DEFAULT_DROPIN_DIR", tmp_path
-        )
+        # Use the explicit ``filesystem_dir`` parameter rather than
+        # monkeypatching the module-level ``_DEFAULT_DROPIN_DIR`` —
+        # the test-suite poisoner (tests/deprecations) can re-import
+        # the discovery module mid-suite, dropping any monkeypatched
+        # constant. Passing the dir explicitly survives that.
         (tmp_path / "p1.py").write_text(VALID_PLUGIN_SRC)
-        registry = build_registry()
+        registry = build_default_registry()
+        register_discovered(
+            registry, include_entry_points=False, filesystem_dir=tmp_path
+        )
         formats = {a.source_format for a in registry.adapters()}
         # Built-ins still present
         assert "anthropic-messages" in formats
@@ -257,14 +260,19 @@ class TestBuildRegistry:
         # Plugin discovered
         assert "my-test" in formats
 
-    def test_build_registry_with_no_plugins_matches_default(self, monkeypatch):
-        # Empty dropin dir + no entry points → identical to default.
-        monkeypatch.setattr(
-            "tokenpak.proxy.adapters.discovery._DEFAULT_DROPIN_DIR",
-            Path("/nonexistent/path/for/test"),
+    def test_build_registry_with_empty_dropin_matches_default(self, tmp_path: Path):
+        # Empty (non-existent) dropin dir → register_discovered adds 0;
+        # registry equals build_default_registry.
+        empty_dir = tmp_path / "nonexistent"
+        registry = build_default_registry()
+        added = register_discovered(
+            registry,
+            include_entry_points=False,
+            filesystem_dir=empty_dir,
         )
-        default = {a.source_format for a in build_default_registry().adapters()}
-        full = {a.source_format for a in build_registry().adapters()}
-        # Full may have entry-point plugins from the host environment;
-        # but it must contain everything default has + nothing fewer.
-        assert default <= full
+        assert added == 0
+        default_formats = {
+            a.source_format for a in build_default_registry().adapters()
+        }
+        full_formats = {a.source_format for a in registry.adapters()}
+        assert default_formats == full_formats

--- a/tests/test_adapter_discovery.py
+++ b/tests/test_adapter_discovery.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plugin discovery — entry points + filesystem drop-in for FormatAdapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from tokenpak.proxy.adapters import (
+    build_default_registry,
+    build_registry,
+    discover_filesystem_adapters,
+    register_discovered,
+)
+from tokenpak.proxy.adapters.discovery import (
+    _validate_adapter_class,
+    discovery_enabled,
+)
+
+# ── Filesystem drop-in path ──────────────────────────────────────────
+
+
+VALID_PLUGIN_SRC = dedent('''
+    """Minimal plugin adapter for testing the filesystem drop-in path."""
+    from tokenpak.proxy.adapters.base import FormatAdapter
+    from tokenpak.proxy.adapters.canonical import CanonicalRequest
+
+
+    class MyTestAdapter(FormatAdapter):
+        source_format = "my-test"
+        capabilities = frozenset({"tip.byte-preserved-passthrough"})
+
+        def detect(self, path, headers, body):
+            return "/my-test/" in path
+
+        def normalize(self, body):
+            return CanonicalRequest(
+                model="my-test-model",
+                system="",
+                messages=[],
+                tools=None,
+                generation={},
+                stream=False,
+                raw_extra={"raw": body},
+                source_format=self.source_format,
+            )
+
+        def denormalize(self, canonical):
+            return canonical.raw_extra.get("raw", b"") or b""
+
+        def get_default_upstream(self):
+            return "https://my-test.example.com"
+''').lstrip()
+
+
+class TestFilesystemDiscovery:
+    def test_loads_a_valid_plugin_file(self, tmp_path: Path):
+        (tmp_path / "my_test.py").write_text(VALID_PLUGIN_SRC)
+        found = discover_filesystem_adapters(tmp_path)
+        assert len(found) == 1
+        adapter, priority, source = found[0]
+        assert adapter.source_format == "my-test"
+        assert priority == 100  # default plugin priority
+        assert "my_test.py" in source
+
+    def test_skips_files_starting_with_underscore(self, tmp_path: Path):
+        (tmp_path / "_disabled.py").write_text(VALID_PLUGIN_SRC)
+        assert discover_filesystem_adapters(tmp_path) == []
+
+    def test_missing_directory_returns_empty(self, tmp_path: Path):
+        assert discover_filesystem_adapters(tmp_path / "no-such-dir") == []
+
+    def test_skips_non_format_adapter_classes(self, tmp_path: Path):
+        # Random class that ISN'T a FormatAdapter — should be skipped
+        # without crashing the discovery pass.
+        (tmp_path / "junk.py").write_text(
+            "class NotAnAdapter:\n    pass\n"
+        )
+        assert discover_filesystem_adapters(tmp_path) == []
+
+    def test_skips_module_with_syntax_error(self, tmp_path: Path, caplog):
+        (tmp_path / "broken.py").write_text("class :::\n")
+        # Discovery should log + skip, not crash.
+        result = discover_filesystem_adapters(tmp_path)
+        assert result == []
+
+    def test_skips_imported_FormatAdapter_itself(self, tmp_path: Path):
+        # ``from .base import FormatAdapter`` brings the abstract base
+        # class into the module's namespace. Discovery must NOT try to
+        # instantiate it (it's abstract; would fail) — only classes
+        # actually defined in the dropin module count.
+        src = (
+            "from tokenpak.proxy.adapters.base import FormatAdapter\n"
+            "# Just imports — no subclass declared in this file.\n"
+        )
+        (tmp_path / "imports_only.py").write_text(src)
+        assert discover_filesystem_adapters(tmp_path) == []
+
+    def test_skips_adapter_with_invalid_capability_label(self, tmp_path: Path):
+        bad_src = VALID_PLUGIN_SRC.replace(
+            'capabilities = frozenset({"tip.byte-preserved-passthrough"})',
+            'capabilities = frozenset({"NOT_A_TIP_LABEL"})',
+        )
+        (tmp_path / "bad_caps.py").write_text(bad_src)
+        assert discover_filesystem_adapters(tmp_path) == []
+
+    def test_loads_plugin_with_explicit_priority(self, tmp_path: Path):
+        custom_src = VALID_PLUGIN_SRC.replace(
+            '    source_format = "my-test"\n',
+            '    source_format = "my-test"\n    priority = 275\n',
+        )
+        (tmp_path / "with_pri.py").write_text(custom_src)
+        found = discover_filesystem_adapters(tmp_path)
+        assert len(found) == 1
+        _, priority, _ = found[0]
+        assert priority == 275
+
+
+# ── Validation rules ─────────────────────────────────────────────────
+
+
+class TestValidation:
+    def test_rejects_non_class(self):
+        assert _validate_adapter_class(lambda: None, "test") is False
+
+    def test_rejects_non_subclass(self):
+        class NotAdapter:
+            pass
+
+        assert _validate_adapter_class(NotAdapter, "test") is False
+
+    def test_rejects_FormatAdapter_itself(self):
+        from tokenpak.proxy.adapters.base import FormatAdapter
+
+        assert _validate_adapter_class(FormatAdapter, "test") is False
+
+    def test_rejects_empty_source_format(self):
+        from tokenpak.proxy.adapters.base import FormatAdapter
+
+        class NoFormat(FormatAdapter):
+            source_format = ""
+            def detect(self, path, headers, body): return False
+            def normalize(self, body): return None
+            def denormalize(self, canonical): return b""
+            def get_default_upstream(self): return ""
+
+        assert _validate_adapter_class(NoFormat, "test") is False
+
+    def test_rejects_default_unknown_source_format(self):
+        from tokenpak.proxy.adapters.base import FormatAdapter
+
+        class UnknownFormat(FormatAdapter):
+            # Doesn't override default ``source_format = "unknown"``.
+            def detect(self, path, headers, body): return False
+            def normalize(self, body): return None
+            def denormalize(self, canonical): return b""
+            def get_default_upstream(self): return ""
+
+        assert _validate_adapter_class(UnknownFormat, "test") is False
+
+    def test_accepts_well_formed_subclass(self):
+        from tokenpak.proxy.adapters.base import FormatAdapter
+
+        class Good(FormatAdapter):
+            source_format = "good"
+            capabilities = frozenset({"tip.compression.v1"})
+            def detect(self, path, headers, body): return False
+            def normalize(self, body): return None
+            def denormalize(self, canonical): return b""
+            def get_default_upstream(self): return ""
+
+        assert _validate_adapter_class(Good, "test") is True
+
+    def test_accepts_ext_namespace_capability(self):
+        # ``ext.<vendor>.<feature>`` is the third-party namespace per
+        # the registry schema. Should validate.
+        from tokenpak.proxy.adapters.base import FormatAdapter
+
+        class WithExt(FormatAdapter):
+            source_format = "ext-good"
+            capabilities = frozenset({"ext.acme.proprietary-feature"})
+            def detect(self, path, headers, body): return False
+            def normalize(self, body): return None
+            def denormalize(self, canonical): return b""
+            def get_default_upstream(self): return ""
+
+        assert _validate_adapter_class(WithExt, "test") is True
+
+
+# ── Registration into a registry ──────────────────────────────────────
+
+
+class TestRegisterDiscovered:
+    def test_registers_filesystem_adapter_into_registry(self, tmp_path: Path):
+        (tmp_path / "p1.py").write_text(VALID_PLUGIN_SRC)
+        registry = build_default_registry()
+        before = len(registry.adapters())
+        count = register_discovered(
+            registry,
+            include_entry_points=False,
+            filesystem_dir=tmp_path,
+        )
+        assert count == 1
+        assert len(registry.adapters()) == before + 1
+        formats = {a.source_format for a in registry.adapters()}
+        assert "my-test" in formats
+
+    def test_builtin_wins_on_format_collision(self, tmp_path: Path):
+        # A drop-in adapter declaring source_format = "anthropic-messages"
+        # should be rejected — the built-in AnthropicAdapter wins.
+        colliding = VALID_PLUGIN_SRC.replace(
+            'source_format = "my-test"',
+            'source_format = "anthropic-messages"',
+        )
+        (tmp_path / "collide.py").write_text(colliding)
+        registry = build_default_registry()
+        count = register_discovered(
+            registry,
+            include_entry_points=False,
+            filesystem_dir=tmp_path,
+        )
+        assert count == 0
+
+    def test_disable_env_short_circuits_discovery(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "p1.py").write_text(VALID_PLUGIN_SRC)
+        monkeypatch.setenv("TOKENPAK_DISABLE_ADAPTER_PLUGINS", "1")
+        registry = build_default_registry()
+        count = register_discovered(
+            registry,
+            include_entry_points=False,
+            filesystem_dir=tmp_path,
+        )
+        assert count == 0
+
+    def test_discovery_enabled_default(self, monkeypatch):
+        monkeypatch.delenv("TOKENPAK_DISABLE_ADAPTER_PLUGINS", raising=False)
+        assert discovery_enabled() is True
+
+
+# ── End-to-end via build_registry ─────────────────────────────────────
+
+
+class TestBuildRegistry:
+    def test_build_registry_includes_builtins_and_filesystem_adapters(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # Point the dropin discovery at our tmp dir for this test.
+        monkeypatch.setattr(
+            "tokenpak.proxy.adapters.discovery._DEFAULT_DROPIN_DIR", tmp_path
+        )
+        (tmp_path / "p1.py").write_text(VALID_PLUGIN_SRC)
+        registry = build_registry()
+        formats = {a.source_format for a in registry.adapters()}
+        # Built-ins still present
+        assert "anthropic-messages" in formats
+        assert "passthrough" in formats
+        # Plugin discovered
+        assert "my-test" in formats
+
+    def test_build_registry_with_no_plugins_matches_default(self, monkeypatch):
+        # Empty dropin dir + no entry points → identical to default.
+        monkeypatch.setattr(
+            "tokenpak.proxy.adapters.discovery._DEFAULT_DROPIN_DIR",
+            Path("/nonexistent/path/for/test"),
+        )
+        default = {a.source_format for a in build_default_registry().adapters()}
+        full = {a.source_format for a in build_registry().adapters()}
+        # Full may have entry-point plugins from the host environment;
+        # but it must contain everything default has + nothing fewer.
+        assert default <= full

--- a/tests/test_codex_path_routing.py
+++ b/tests/test_codex_path_routing.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /codex/responses path matcher + caller-creds precedence."""
+
+from __future__ import annotations
+
+from tokenpak.proxy.router import ProviderRouter
+from tokenpak.proxy.server import _ProxyHandler
+
+
+class TestCodexPathRouting:
+    """``/codex/responses`` (OpenClaw pi-ai shape) routes to openai-codex."""
+
+    def test_codex_responses_detected_as_openai_codex(self):
+        router = ProviderRouter()
+        result = router.route("/codex/responses", {})
+        assert result.provider == "openai-codex"
+
+    def test_v1_responses_still_detected_as_openai_codex(self):
+        router = ProviderRouter()
+        result = router.route("/v1/responses", {})
+        assert result.provider == "openai-codex"
+
+    def test_codex_responses_path_in_full_url(self):
+        router = ProviderRouter()
+        result = router.route("/codex/responses", {})
+        # The base URL for openai-codex is api.openai.com; the
+        # CodexCredentialProvider overrides this to chatgpt.com on
+        # injection. Router itself just builds base + path.
+        assert "/codex/responses" in result.full_url
+
+
+class TestCallerHasCredentials:
+    """``_caller_has_credentials`` distinguishes real auth from stale placeholders."""
+
+    def test_sk_api_key_via_x_api_key(self):
+        assert _ProxyHandler._caller_has_credentials({"x-api-key": "sk-abc123def456"}) is True
+
+    def test_sk_api_key_via_bearer(self):
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": "Bearer sk-abc123def456"}
+            )
+            is True
+        )
+
+    def test_long_jwt_via_bearer(self):
+        long_jwt = "eyJ" + "a" * 200 + ".x.y"
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": f"Bearer {long_jwt}"}
+            )
+            is True
+        )
+
+    def test_short_jwt_rejected(self):
+        # OpenClaw sometimes ships short stale OAuth-shape Bearer tokens
+        # (≤100 chars). These shouldn't count as "caller has creds".
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": "Bearer eyJabc.short.token"}
+            )
+            is False
+        )
+
+    def test_jwt_without_dot_rejected(self):
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": "Bearer eyJ" + "a" * 300}
+            )
+            is False
+        )
+
+    def test_placeholder_bearer_rejected(self):
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": "Bearer placeholder-not-real"}
+            )
+            is False
+        )
+
+    def test_no_auth_headers(self):
+        assert _ProxyHandler._caller_has_credentials({}) is False
+
+    def test_empty_headers_dict(self):
+        assert _ProxyHandler._caller_has_credentials({}) is False
+
+    def test_case_insensitive_header_lookup(self):
+        assert (
+            _ProxyHandler._caller_has_credentials({"X-Api-Key": "sk-abc123def456"})
+            is True
+        )
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"AUTHORIZATION": "Bearer sk-abc123def456"}
+            )
+            is True
+        )
+
+    def test_non_sk_non_jwt_bearer_rejected(self):
+        # Random opaque tokens (e.g. session ids) shouldn't trigger
+        # passthrough — we wouldn't know what to do with them upstream.
+        assert (
+            _ProxyHandler._caller_has_credentials(
+                {"Authorization": "Bearer opaque-session-token-12345"}
+            )
+            is False
+        )

--- a/tests/test_phase1_provider_pack.py
+++ b/tests/test_phase1_provider_pack.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 1 adapter pack: Mistral + Groq + Together + DeepSeek + OpenRouter.
+
+Five OpenAI-Chat-compatible providers wired as CredentialProviders.
+The OpenAIChatAdapter handles the wire format; what differs per
+provider is the upstream URL + the API key (read from a per-provider
+env var) + (OpenRouter only) two static headers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenpak.services.routing_service.credential_injector import (
+    DeepSeekCredentialProvider,
+    GroqCredentialProvider,
+    MistralCredentialProvider,
+    OpenRouterCredentialProvider,
+    TogetherCredentialProvider,
+    invalidate_cache,
+    registered,
+    resolve,
+)
+
+# ── Per-provider resolve() shape ──────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """The credential injector caches resolutions for 30s — reset between
+    tests so an env-var change in one test doesn't leak into the next."""
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+PROVIDERS = [
+    (MistralCredentialProvider, "MISTRAL_API_KEY", "api.mistral.ai"),
+    (GroqCredentialProvider, "GROQ_API_KEY", "api.groq.com"),
+    (TogetherCredentialProvider, "TOGETHER_API_KEY", "api.together.xyz"),
+    (DeepSeekCredentialProvider, "DEEPSEEK_API_KEY", "api.deepseek.com"),
+    (OpenRouterCredentialProvider, "OPENROUTER_API_KEY", "openrouter.ai"),
+]
+
+
+@pytest.mark.parametrize("cls,env_var,host", PROVIDERS)
+class TestEnvKeyBearerProviders:
+    def test_no_env_var_returns_none(self, cls, env_var, host, monkeypatch):
+        monkeypatch.delenv(env_var, raising=False)
+        plan = cls().resolve()
+        assert plan is None
+
+    def test_empty_env_var_returns_none(self, cls, env_var, host, monkeypatch):
+        monkeypatch.setenv(env_var, "")
+        plan = cls().resolve()
+        assert plan is None
+
+    def test_whitespace_env_var_returns_none(self, cls, env_var, host, monkeypatch):
+        monkeypatch.setenv(env_var, "   ")
+        plan = cls().resolve()
+        assert plan is None
+
+    def test_valid_key_emits_plan_with_bearer_and_url(
+        self, cls, env_var, host, monkeypatch
+    ):
+        monkeypatch.setenv(env_var, "sk-test-key-1234567890")
+        plan = cls().resolve()
+        assert plan is not None
+        assert plan.target_url_override is not None
+        assert host in plan.target_url_override
+        assert plan.add_headers["Authorization"] == "Bearer sk-test-key-1234567890"
+        # Caller's auth must be stripped before our auth lands.
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+
+    def test_target_url_override_uses_https(self, cls, env_var, host, monkeypatch):
+        monkeypatch.setenv(env_var, "sk-test")
+        plan = cls().resolve()
+        assert plan.target_url_override.startswith("https://")
+
+
+# ── OpenRouter-specific extra headers ─────────────────────────────────
+
+
+class TestOpenRouterExtraHeaders:
+    def test_emits_http_referer_and_x_title(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        plan = OpenRouterCredentialProvider().resolve()
+        assert plan is not None
+        assert plan.add_headers.get("HTTP-Referer") == "https://tokenpak.ai"
+        assert plan.add_headers.get("X-Title") == "TokenPak"
+        # Other providers don't have these.
+        assert plan.add_headers["Authorization"] == "Bearer sk-or-test"
+
+    def test_other_providers_do_not_have_referer_header(self, monkeypatch):
+        monkeypatch.setenv("MISTRAL_API_KEY", "sk-m-test")
+        plan = MistralCredentialProvider().resolve()
+        assert "HTTP-Referer" not in plan.add_headers
+        assert "X-Title" not in plan.add_headers
+
+
+# ── Registration: all 5 are auto-registered at import ─────────────────
+
+
+class TestAutoRegistration:
+    def test_all_five_providers_registered(self):
+        names = {p.name for p in registered()}
+        for slug in (
+            "tokenpak-mistral",
+            "tokenpak-groq",
+            "tokenpak-together",
+            "tokenpak-deepseek",
+            "tokenpak-openrouter",
+        ):
+            assert slug in names, f"{slug!r} not auto-registered"
+
+    def test_existing_providers_still_registered(self):
+        names = {p.name for p in registered()}
+        # Phase 1 must not have displaced the originals.
+        assert "tokenpak-claude-code" in names
+        assert "tokenpak-openai-codex" in names
+
+    @pytest.mark.parametrize(
+        "slug,env_var",
+        [
+            ("tokenpak-mistral", "MISTRAL_API_KEY"),
+            ("tokenpak-groq", "GROQ_API_KEY"),
+            ("tokenpak-together", "TOGETHER_API_KEY"),
+            ("tokenpak-deepseek", "DEEPSEEK_API_KEY"),
+            ("tokenpak-openrouter", "OPENROUTER_API_KEY"),
+        ],
+    )
+    def test_resolve_by_slug_walks_registry(self, slug, env_var, monkeypatch):
+        monkeypatch.setenv(env_var, "sk-resolve-test")
+        plan = resolve(slug)
+        assert plan is not None
+        assert plan.add_headers["Authorization"] == "Bearer sk-resolve-test"
+
+
+# ── Format-agnostic: each provider points at /v1/chat/completions ────
+
+
+class TestUpstreamShapes:
+    """All five upstreams target an OpenAI-Chat-Completions endpoint, so
+    the existing OpenAIChatAdapter handles the wire format — no new
+    format adapter required."""
+
+    def test_all_target_chat_completions_endpoint(self, monkeypatch):
+        for cls, env_var, _host in PROVIDERS:
+            monkeypatch.setenv(env_var, "sk-test")
+            plan = cls().resolve()
+            invalidate_cache()
+            assert "/chat/completions" in plan.target_url_override, (
+                f"{cls.__name__} does not target a chat-completions endpoint"
+            )

--- a/tests/test_phase2a_azure_openai.py
+++ b/tests/test_phase2a_azure_openai.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2a: Azure OpenAI adapter — body-aware URL resolution.
+
+Azure OpenAI uses the same wire format as OpenAI Chat Completions but
+routes by deployment id in the URL path
+(``<endpoint>/openai/deployments/<dep>/chat/completions``) and uses
+``api-key`` instead of ``Authorization: Bearer``. Tests verify:
+
+  - The InjectionPlan's ``target_url_resolver`` is called with the
+    request body + headers and returns a fully-qualified Azure URL.
+  - Header override (``X-Azure-Deployment``) wins over body's model field.
+  - Missing creds / endpoint / model field returns None at each layer.
+  - ``api-key`` header replaces caller's auth.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tokenpak.services.routing_service.credential_injector import (
+    AzureOpenAICredentialProvider,
+    invalidate_cache,
+    registered,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+def _set_creds(monkeypatch, key="sk-azure-test", endpoint="https://my-resource.openai.azure.com"):
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", key)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", endpoint)
+
+
+# ── resolve() returns plan only when both env vars set ────────────────
+
+
+class TestResolveGate:
+    def test_no_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_only_key_returns_none(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_only_endpoint_returns_none(self, monkeypatch):
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com")
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_both_set_returns_plan(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan is not None
+
+
+# ── Auth shape: api-key header replaces caller auth ───────────────────
+
+
+class TestAuthHeader:
+    def test_emits_api_key_header_not_bearer(self, monkeypatch):
+        _set_creds(monkeypatch, key="sk-real-azure-key")
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.add_headers == {"api-key": "sk-real-azure-key"}
+        # Must NOT inject a Bearer Authorization (Azure doesn't accept it).
+        assert "Authorization" not in plan.add_headers
+
+    def test_strips_callers_auth_headers(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+
+
+# ── URL resolution: body's model field → deployment id ────────────────
+
+
+class TestUrlResolution:
+    def test_model_field_becomes_deployment_in_url(self, monkeypatch):
+        _set_creds(monkeypatch, endpoint="https://my-resource.openai.azure.com")
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "my-gpt4-deployment", "messages": []}).encode()
+        url = plan.target_url_resolver(body, {})
+        assert url == (
+            "https://my-resource.openai.azure.com/openai/deployments/"
+            "my-gpt4-deployment/chat/completions?api-version=2024-10-21"
+        )
+
+    def test_uses_explicit_api_version_env(self, monkeypatch):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2025-03-15-preview")
+        # Recreate provider so env is reread (cache cleared by fixture).
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "x"}).encode()
+        url = plan.target_url_resolver(body, {})
+        assert "api-version=2025-03-15-preview" in url
+
+    def test_endpoint_trailing_slash_tolerated(self, monkeypatch):
+        _set_creds(monkeypatch, endpoint="https://x.openai.azure.com///")
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "d"}).encode()
+        url = plan.target_url_resolver(body, {})
+        # No double slashes after the host.
+        assert url.startswith("https://x.openai.azure.com/openai/deployments/d/")
+        assert "//openai" not in url
+
+    def test_missing_model_field_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"messages": []}).encode()
+        assert plan.target_url_resolver(body, {}) is None
+
+    def test_empty_model_field_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "", "messages": []}).encode()
+        assert plan.target_url_resolver(body, {}) is None
+
+    def test_malformed_body_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.target_url_resolver(b"not json", {}) is None
+
+    def test_empty_body_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.target_url_resolver(b"", {}) is None
+
+
+class TestHeaderOverride:
+    def test_x_azure_deployment_header_wins_over_body(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-deployment"}).encode()
+        url = plan.target_url_resolver(
+            body, {"X-Azure-Deployment": "header-deployment"}
+        )
+        assert "/deployments/header-deployment/" in url
+        assert "body-deployment" not in url
+
+    def test_lowercase_header_lookup(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-d"}).encode()
+        url = plan.target_url_resolver(
+            body, {"x-azure-deployment": "lower-d"}
+        )
+        assert "/deployments/lower-d/" in url
+
+    def test_empty_header_falls_through_to_body(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-d"}).encode()
+        url = plan.target_url_resolver(body, {"X-Azure-Deployment": "  "})
+        assert "/deployments/body-d/" in url
+
+
+# ── Auto-registration ────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_registered_with_known_slug(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-azure-openai" in names
+
+    def test_does_not_displace_existing_providers(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-claude-code" in names
+        assert "tokenpak-mistral" in names

--- a/tests/test_phase2b_bedrock_claude.py
+++ b/tests/test_phase2b_bedrock_claude.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2b: AWS Bedrock for Claude — SigV4 + Bedrock envelope.
+
+Bedrock takes the Anthropic Messages payload but routes the model via
+URL path (not body) and authenticates with AWS SigV4 over the request
+bytes. The provider:
+
+  - Strips ``model`` from the body and adds ``anthropic_version`` per
+    Bedrock's contract.
+  - Builds the URL from the body's ``model`` field — picks
+    ``/invoke`` or ``/invoke-with-response-stream`` based on the
+    body's ``stream`` flag.
+  - Signs with boto3's ``SigV4Auth`` after body transform + URL
+    resolution, so the signature reflects the exact bytes being sent.
+
+Tests use placeholder AWS creds via env vars; SigV4 produces a valid
+signature shape (we verify the headers it emits without hitting AWS).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+
+from tokenpak.services.routing_service.credential_injector import (
+    BedrockClaudeCredentialProvider,
+    invalidate_cache,
+    registered,
+)
+
+
+@pytest.fixture(autouse=True)
+def _aws_env(monkeypatch):
+    """Set placeholder AWS credentials so boto3's session can resolve."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+# ── boto3 gating ─────────────────────────────────────────────────────
+
+
+class TestBoto3Gating:
+    def test_returns_none_when_boto3_missing(self, monkeypatch):
+        # Simulate boto3 being unimportable by replacing the cached
+        # module entry. The provider catches ImportError and logs.
+        import sys
+        monkeypatch.setitem(sys.modules, "boto3", None)
+        # Force cache reload of the credential_injector module so
+        # ``import boto3`` re-runs inside _load.
+        invalidate_cache()
+        plan = BedrockClaudeCredentialProvider().resolve()
+        assert plan is None
+
+
+# ── URL resolution from body ─────────────────────────────────────────
+
+
+class TestUrlResolution:
+    def _resolver(self):
+        return BedrockClaudeCredentialProvider().resolve().target_url_resolver
+
+    def test_non_streaming_picks_invoke_suffix(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        url = self._resolver()(body, {})
+        assert url == (
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/"
+            "anthropic.claude-3-5-sonnet-20241022-v2:0/invoke"
+        )
+
+    def test_streaming_picks_response_stream_suffix(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-haiku-20240307-v1:0",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }).encode()
+        url = self._resolver()(body, {})
+        assert url.endswith(
+            "/model/anthropic.claude-3-haiku-20240307-v1:0/invoke-with-response-stream"
+        )
+
+    def test_inference_profile_arn_preserved(self):
+        # Inference profile IDs contain dots/colons; the resolver must
+        # not mangle them.
+        body = json.dumps({
+            "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [],
+        }).encode()
+        url = self._resolver()(body, {})
+        assert "us.anthropic.claude-3-5-sonnet-20241022-v2:0" in url
+
+    def test_region_env_override(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        invalidate_cache()
+        body = json.dumps({"model": "anthropic.claude-x", "messages": []}).encode()
+        url = BedrockClaudeCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "bedrock-runtime.eu-west-2.amazonaws.com" in url
+
+    def test_default_region_when_neither_env_var_set(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        invalidate_cache()
+        body = json.dumps({"model": "anthropic.claude-x", "messages": []}).encode()
+        url = BedrockClaudeCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "bedrock-runtime.us-east-1.amazonaws.com" in url
+
+    def test_missing_model_returns_none(self):
+        body = json.dumps({"messages": []}).encode()
+        assert self._resolver()(body, {}) is None
+
+    def test_empty_body_returns_none(self):
+        assert self._resolver()(b"", {}) is None
+
+    def test_malformed_body_returns_none(self):
+        assert self._resolver()(b"not json", {}) is None
+
+
+# ── Body transform: strip model + add anthropic_version ──────────────
+
+
+class TestBodyTransform:
+    def _xform(self):
+        return BedrockClaudeCredentialProvider().resolve().body_transform
+
+    def test_strips_model_field(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        }).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert "model" not in decoded
+        assert decoded["messages"] == [{"role": "user", "content": "hi"}]
+        assert decoded["max_tokens"] == 100
+
+    def test_adds_anthropic_version(self):
+        body = json.dumps({"model": "x", "messages": []}).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert decoded["anthropic_version"] == "bedrock-2023-05-31"
+
+    def test_preserves_callers_anthropic_version(self):
+        # If the caller already set their own version, don't clobber.
+        body = json.dumps({
+            "model": "x",
+            "messages": [],
+            "anthropic_version": "bedrock-2023-05-31-custom",
+        }).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert decoded["anthropic_version"] == "bedrock-2023-05-31-custom"
+
+    def test_empty_body_passes_through(self):
+        assert self._xform()(b"") == b""
+
+    def test_malformed_body_passes_through(self):
+        assert self._xform()(b"not json") == b"not json"
+
+
+# ── SigV4 header_resolver ────────────────────────────────────────────
+
+
+class TestSigV4Headers:
+    def _signer(self):
+        return BedrockClaudeCredentialProvider().resolve().header_resolver
+
+    def test_emits_canonical_sigv4_headers(self):
+        url = (
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/"
+            "anthropic.claude-x/invoke"
+        )
+        body = json.dumps({"messages": [], "anthropic_version": "x"}).encode()
+        headers = self._signer()(body, url, "POST", {})
+        # SigV4 always emits these four.
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256 Credential=")
+        assert "X-Amz-Date" in headers or "x-amz-date" in {
+            k.lower() for k in headers
+        }
+        # Host derived from URL.
+        host_key = next(k for k in headers if k.lower() == "host")
+        assert headers[host_key] == "bedrock-runtime.us-east-1.amazonaws.com"
+
+    def test_signature_changes_when_body_changes(self):
+        signer = self._signer()
+        url = "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/invoke"
+        body_a = json.dumps({"a": 1}).encode()
+        body_b = json.dumps({"a": 2}).encode()
+        # SigV4 includes a date timestamp, so two consecutive calls
+        # may produce the same Authorization for the same body if
+        # they land in the same second. We just check the two bodies
+        # produce DIFFERENT Authorization headers — the signature
+        # must reflect body bytes (it includes the SHA256 of body
+        # in the canonical request).
+        headers_a = signer(body_a, url, "POST", {})
+        headers_b = signer(body_b, url, "POST", {})
+        assert headers_a["Authorization"] != headers_b["Authorization"]
+
+
+# ── End-to-end plan composition ──────────────────────────────────────
+
+
+class TestPlanComposition:
+    def test_plan_has_all_dynamic_fields(self):
+        plan = BedrockClaudeCredentialProvider().resolve()
+        assert plan is not None
+        assert plan.target_url_resolver is not None
+        assert plan.body_transform is not None
+        assert plan.header_resolver is not None
+        # Static fields:
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+        assert plan.add_headers["Content-Type"] == "application/json"
+        # Dynamic SigV4 means no static Authorization to inject.
+        assert "Authorization" not in plan.add_headers
+
+
+class TestRegistration:
+    def test_registered_with_known_slug(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-bedrock-claude" in names
+
+    def test_does_not_displace_other_providers(self):
+        names = {p.name for p in registered()}
+        for slug in (
+            "tokenpak-claude-code",
+            "tokenpak-mistral",
+            "tokenpak-azure-openai",
+        ):
+            assert slug in names

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -546,7 +546,7 @@ def cmd_codex(args):
     ``tokenpak codex --model gpt-5.3-codex`` becomes
     ``codex --model gpt-5.3-codex`` with proxy env wired.
     """
-    from tokenpak.companion.launcher._impl import launch_codex
+    from tokenpak.companion.launcher import launch_codex
 
     extra = list(getattr(args, "extra_args", None) or [])
     launch_codex(extra_args=extra)

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -534,6 +534,24 @@ def cmd_claude(args):
     launch(config=config, extra_args=extra)
 
 
+def cmd_codex(args):
+    """Launch the ``codex`` CLI with traffic routed through the tokenpak proxy.
+
+    Mirrors ``tokenpak claude``: sets ``OPENAI_BASE_URL`` to the local
+    proxy and execs ``codex``. The proxy handles compression, caching,
+    telemetry, and credential precedence — caller's own
+    ``OPENAI_API_KEY`` / ChatGPT JWT (if any) wins over managed creds.
+
+    All tail arguments are forwarded verbatim to ``codex`` —
+    ``tokenpak codex --model gpt-5.3-codex`` becomes
+    ``codex --model gpt-5.3-codex`` with proxy env wired.
+    """
+    from tokenpak.companion.launcher._impl import launch_codex
+
+    extra = list(getattr(args, "extra_args", None) or [])
+    launch_codex(extra_args=extra)
+
+
 def cmd_logs(args):
     """Show recent proxy logs."""
     log_candidates = [
@@ -1979,6 +1997,14 @@ def build_parser():
     )
     p_claude.add_argument("extra_args", nargs=argparse.REMAINDER)
     p_claude.set_defaults(func=cmd_claude)
+
+    p_codex = sub.add_parser(
+        "codex",
+        help="Launch the codex CLI with traffic routed through the tokenpak proxy",
+        add_help=False,  # all flags after `codex` are forwarded verbatim
+    )
+    p_codex.add_argument("extra_args", nargs=argparse.REMAINDER)
+    p_codex.set_defaults(func=cmd_codex)
 
     p_logs = sub.add_parser("logs", help="Show recent proxy logs")
     p_logs.add_argument(

--- a/tokenpak/companion/launcher/__init__.py
+++ b/tokenpak/companion/launcher/__init__.py
@@ -22,7 +22,7 @@ from tokenpak.companion.launcher._impl import (
     _write_system_prompt as _write_system_prompt_impl,
 )
 
-from ._impl import launch
+from ._impl import launch, launch_codex
 
 
 def regenerate_config() -> dict:
@@ -49,4 +49,4 @@ def regenerate_config() -> dict:
     return paths
 
 
-__all__ = ["launch", "regenerate_config"]
+__all__ = ["launch", "launch_codex", "regenerate_config"]

--- a/tokenpak/companion/launcher/_impl.py
+++ b/tokenpak/companion/launcher/_impl.py
@@ -101,6 +101,51 @@ def _wire_proxy_env(env: dict) -> dict:
     return env
 
 
+def _wire_codex_env(env: dict) -> dict:
+    """Route codex CLI traffic through the local TokenPak proxy.
+
+    The codex CLI reads ``OPENAI_BASE_URL`` for ChatGPT-OAuth-mode calls
+    and falls back to the ChatGPT backend URL otherwise. Setting it to
+    the proxy lets the proxy apply compression / caching / telemetry +
+    credential precedence (caller's own ``OPENAI_API_KEY`` wins; else
+    managed creds get injected).
+
+    Same ``TOKENPAK_PROXY_BYPASS=1`` opt-out as the Claude path.
+    """
+    if env.get("TOKENPAK_PROXY_BYPASS") == "1":
+        return env
+    port = env.get("TOKENPAK_PORT", "8766")
+    proxy_url = f"http://127.0.0.1:{port}"
+    # Codex's pi-ai connector posts to ``<baseUrl>/codex/responses`` and
+    # ``<baseUrl>/v1/responses`` depending on shape. Pointing at the
+    # proxy root lets both work; the proxy's path matcher routes either.
+    env.setdefault("OPENAI_BASE_URL", proxy_url)
+    return env
+
+
+def launch_codex(extra_args: Optional[List[str]] = None) -> None:
+    """Build env-routed launch for the codex CLI.
+
+    Mirrors :func:`launch` for Claude Code: sets ``OPENAI_BASE_URL`` to
+    the local TokenPak proxy and execs ``codex`` with any forwarded
+    args. Codex's own AGENTS.md / hooks / MCP discovery from the cwd
+    keeps working — we only redirect outbound HTTP through the proxy.
+
+    The companion MCP / hook layer is *not* wired in yet for codex
+    (Kevin 2026-04-15 architecture parks that as a follow-up: native
+    MCP + hooks + AGENTS.md + skills, NOT a wrapper). For now this
+    launcher is purely env wiring.
+    """
+    env = _wire_codex_env(dict(os.environ))
+    cmd_args = ["codex"] + (extra_args or [])
+    try:
+        os.execvpe("codex", cmd_args, env)
+    except OSError:
+        import subprocess  # noqa: PLC0415
+
+        subprocess.run(cmd_args, env=env, check=False)
+
+
 def launch(
     config: Optional[CompanionConfig] = None,
     extra_args: Optional[List[str]] = None,

--- a/tokenpak/proxy/adapters/__init__.py
+++ b/tokenpak/proxy/adapters/__init__.py
@@ -3,6 +3,12 @@
 from .anthropic_adapter import AnthropicAdapter
 from .base import FormatAdapter
 from .canonical import CanonicalRequest, CanonicalResponse
+from .discovery import (
+    discover_entry_point_adapters,
+    discover_filesystem_adapters,
+    discovery_enabled,
+    register_discovered,
+)
 from .google_adapter import GoogleGenerativeAIAdapter
 from .openai_chat_adapter import OpenAIChatAdapter
 from .openai_responses_adapter import OpenAIResponsesAdapter
@@ -11,12 +17,33 @@ from .registry import AdapterRegistry
 
 
 def build_default_registry() -> AdapterRegistry:
+    """Closed-set factory: only the built-in TokenPak format adapters.
+
+    Use this when tests or callers need a deterministic registry
+    independent of the host's installed plugins or filesystem state.
+    """
     registry = AdapterRegistry()
     registry.register(AnthropicAdapter(), priority=300)
     registry.register(OpenAIResponsesAdapter(), priority=260)
     registry.register(OpenAIChatAdapter(), priority=250)
     registry.register(GoogleGenerativeAIAdapter(), priority=240)
     registry.register(PassthroughAdapter(), priority=0)
+    return registry
+
+
+def build_registry() -> AdapterRegistry:
+    """Production factory: built-ins + discovered plugin adapters.
+
+    Mirrors the MCP-style integration UX — a third party publishes a
+    ``tokenpak.format_adapters`` entry point or drops a ``.py`` file
+    into ``~/.tokenpak/adapters/`` and the proxy picks the adapter up
+    on startup. Built-ins always win on ``source_format`` collision.
+
+    Discovery is suppressed when ``TOKENPAK_DISABLE_ADAPTER_PLUGINS=1``
+    (test isolation, conformance suite, paranoid deployments).
+    """
+    registry = build_default_registry()
+    register_discovered(registry)
     return registry
 
 
@@ -31,4 +58,9 @@ __all__ = [
     "OpenAIResponsesAdapter",
     "PassthroughAdapter",
     "build_default_registry",
+    "build_registry",
+    "discover_entry_point_adapters",
+    "discover_filesystem_adapters",
+    "discovery_enabled",
+    "register_discovered",
 ]

--- a/tokenpak/proxy/adapters/anthropic_adapter.py
+++ b/tokenpak/proxy/adapters/anthropic_adapter.py
@@ -12,6 +12,15 @@ from .canonical import CanonicalRequest
 
 class AnthropicAdapter(FormatAdapter):
     source_format = "anthropic-messages"
+    # Anthropic Messages API: byte-preserved (cache_control routing
+    # depends on exact bytes), supports proxy-managed cache + the
+    # ttl-ordering rule (1h blocks before default-ttl), full compression.
+    capabilities = frozenset({
+        "tip.compression.v1",
+        "tip.byte-preserved-passthrough",
+        "tip.cache.proxy-managed",
+        "tip.cache.ttl-ordering",
+    })
 
     def detect(self, path: str, headers: Mapping[str, str], body: Optional[bytes]) -> bool:
         lower = {k.lower(): v for k, v in headers.items()}

--- a/tokenpak/proxy/adapters/base.py
+++ b/tokenpak/proxy/adapters/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Mapping, Optional, Tuple
+from typing import Any, Callable, FrozenSet, Mapping, Optional, Tuple
 
 from .canonical import CanonicalRequest
 
@@ -12,9 +12,62 @@ TokenCounter = Callable[[str], int]
 
 
 class FormatAdapter(ABC):
-    """Abstract format adapter for provider-specific payloads."""
+    """Abstract format adapter for provider-specific payloads.
+
+    TIP-1.0 capability declaration
+    ------------------------------
+
+    Each adapter declares the TIP capability labels its format supports
+    via the ``capabilities`` class attribute (default: empty). The proxy
+    reads these at runtime to decide which middleware to activate for
+    traffic of this format — compression telemetry, semantic cache,
+    capsule injection, compaction, etc. Capability vocabulary is
+    authoritative in :mod:`tokenpak.core.contracts.capabilities` and the
+    canonical catalog in the registry repo.
+
+    Adding a new platform:
+
+        class MyProviderAdapter(FormatAdapter):
+            source_format = "my-provider"
+            capabilities = frozenset({
+                "tip.compression.v1",
+                "tip.cache.proxy-managed",
+            })
+            def normalize(self, body): ...
+            def denormalize(self, canonical): ...
+            def get_default_upstream(self): ...
+
+    Drop the file in, register at priority — features the adapter opted
+    in to are automatically active for its traffic. No edits to
+    compression/cache/capsule code, no edits to the proxy core. This is
+    the MCP-analog dev UX — declare capabilities, get features.
+    """
 
     source_format: str = "unknown"
+
+    # TIP-1.0 capability labels this adapter publishes. Format:
+    # ``frozenset[str]`` of ``tip.<group>.<feature>`` labels (or
+    # ``ext.<vendor>.<feature>`` for non-TIP capability extensions).
+    # Empty default means "format-only adapter, no opt-in features" —
+    # this is what PassthroughAdapter wants. Override in subclasses.
+    capabilities: FrozenSet[str] = frozenset()
+
+    @classmethod
+    def describe(cls) -> dict:
+        """Return a self-describing dict for introspection / docs / TIP discovery.
+
+        Used by ``tokenpak doctor`` and the docs generator to enumerate
+        which capabilities each registered adapter publishes. Output is
+        intentionally JSON-serialisable so it can be ingested by an
+        external docs site or third-party tool that wants to know what
+        TokenPak's adapters support without importing Python.
+        """
+        return {
+            "source_format": cls.source_format,
+            "class_name": cls.__name__,
+            "capabilities": sorted(cls.capabilities),
+            "module": cls.__module__,
+        }
 
     @abstractmethod
     def detect(self, path: str, headers: Mapping[str, str], body: Optional[bytes]) -> bool:

--- a/tokenpak/proxy/adapters/discovery.py
+++ b/tokenpak/proxy/adapters/discovery.py
@@ -84,6 +84,31 @@ def _ep_dist(ep: EntryPoint) -> str:
     return "<unknown>"
 
 
+def _is_format_adapter_subclass(cls) -> bool:
+    """Robust subclass-of-FormatAdapter check.
+
+    Walks ``cls.__mro__`` and matches any ancestor whose ``__name__``
+    is ``"FormatAdapter"`` and whose ``__module__`` ends in
+    ``proxy.adapters.base``. This is resilient to module reloads —
+    if ``tokenpak.proxy.adapters.base`` was popped from
+    ``sys.modules`` (by the deprecation-shim test suite, for example)
+    and re-imported, the resulting class object differs by identity
+    from any captured top-level import — but the name + module path
+    are stable. Plain ``issubclass`` would falsely return False in
+    that scenario.
+    """
+    for ancestor in cls.__mro__:
+        if (
+            ancestor is cls
+            or ancestor.__name__ != "FormatAdapter"
+        ):
+            continue
+        mod = getattr(ancestor, "__module__", "") or ""
+        if mod.endswith("proxy.adapters.base"):
+            return True
+    return False
+
+
 def _validate_adapter_class(cls, source: str) -> bool:
     """Return ``True`` if ``cls`` is a registrable FormatAdapter subclass.
 
@@ -102,7 +127,7 @@ def _validate_adapter_class(cls, source: str) -> bool:
             getattr(cls, "__name__", repr(cls)), source,
         )
         return False
-    if not issubclass(cls, FormatAdapter) or cls is FormatAdapter:
+    if cls is FormatAdapter or not _is_format_adapter_subclass(cls):
         logger.warning(
             "tokenpak adapter-plugin %r (from %s) is not a FormatAdapter "
             "subclass; skipped.",

--- a/tokenpak/proxy/adapters/discovery.py
+++ b/tokenpak/proxy/adapters/discovery.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plugin discovery for FormatAdapter — entry points + filesystem drop-in.
+
+Two ways third parties extend TokenPak with new format adapters:
+
+1. **Python entry points** (the packaged path). A distribution declares::
+
+       [project.entry-points."tokenpak.format_adapters"]
+       my-provider = "my_pkg.adapters:MyProviderAdapter"
+
+   ``pip install my_pkg`` then makes the adapter available without any
+   edit to TokenPak.
+
+2. **Filesystem drop-in** (the prototyping path). A user writes a
+   ``.py`` file under ``~/.tokenpak/adapters/`` containing one or more
+   :class:`FormatAdapter` subclasses. TokenPak imports the file and
+   registers the subclasses on startup.
+
+Both paths flow through this module's :func:`register_discovered`,
+which:
+
+  - Validates each candidate (subclass check, abstract-method check,
+    TIP capability label pattern).
+  - Skips bad candidates with a logged WARNING — startup never crashes
+    from a misbehaving plugin.
+  - Honors an explicit ``priority`` class attribute (default 100) so
+    plugins slot between ``AnthropicAdapter`` (300) and
+    ``PassthroughAdapter`` (0).
+  - Skips duplicate ``source_format`` registrations — first wins, with
+    a logged WARNING on collision.
+
+Opt-out
+-------
+
+Discovery runs by default. Set ``TOKENPAK_DISABLE_ADAPTER_PLUGINS=1``
+to skip both paths (e.g. in the conformance suite or CI environments
+where third-party plugins must not affect the test surface).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+import os
+import re
+from importlib.metadata import EntryPoint, entry_points
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .base import FormatAdapter
+from .registry import AdapterRegistry
+
+logger = logging.getLogger(__name__)
+
+
+_ENTRY_POINT_GROUP = "tokenpak.format_adapters"
+_DISABLE_ENV = "TOKENPAK_DISABLE_ADAPTER_PLUGINS"
+_DEFAULT_DROPIN_DIR = Path.home() / ".tokenpak" / "adapters"
+_DEFAULT_PLUGIN_PRIORITY = 100
+
+# TIP capability label pattern (matches the registry schema rule).
+_TIP_LABEL_RE = re.compile(r"^(tip|ext)\.[a-z0-9._-]+$")
+
+
+def discovery_enabled() -> bool:
+    """``True`` when adapter-plugin discovery should run.
+
+    Default ON (drop-in adapters work without ceremony). Set
+    ``TOKENPAK_DISABLE_ADAPTER_PLUGINS=1`` to opt out.
+    """
+    return os.environ.get(_DISABLE_ENV, "").strip().lower() not in {
+        "1", "true", "yes",
+    }
+
+
+def _ep_dist(ep: EntryPoint) -> str:
+    """Best-effort distribution name for diagnostics."""
+    dist = getattr(ep, "dist", None)
+    if dist is not None:
+        name = getattr(dist, "name", None) or getattr(dist, "metadata", {}).get("Name")
+        if name:
+            return str(name)
+    return "<unknown>"
+
+
+def _validate_adapter_class(cls, source: str) -> bool:
+    """Return ``True`` if ``cls`` is a registrable FormatAdapter subclass.
+
+    Logs a WARNING with the rejection reason on failure. Validation
+    rules:
+
+      - Must be a class, must subclass FormatAdapter (and not be it).
+      - Must declare a non-empty ``source_format`` distinct from
+        ``"unknown"``.
+      - All declared capability labels must match the TIP vocabulary
+        pattern (``tip.<...>`` or ``ext.<...>``).
+    """
+    if not inspect.isclass(cls):
+        logger.warning(
+            "tokenpak adapter-plugin %r (from %s) is not a class; skipped.",
+            getattr(cls, "__name__", repr(cls)), source,
+        )
+        return False
+    if not issubclass(cls, FormatAdapter) or cls is FormatAdapter:
+        logger.warning(
+            "tokenpak adapter-plugin %r (from %s) is not a FormatAdapter "
+            "subclass; skipped.",
+            cls.__name__, source,
+        )
+        return False
+    fmt = getattr(cls, "source_format", None)
+    if not isinstance(fmt, str) or not fmt or fmt == "unknown":
+        logger.warning(
+            "tokenpak adapter-plugin %r (from %s) has no source_format; "
+            "skipped.",
+            cls.__name__, source,
+        )
+        return False
+    caps = getattr(cls, "capabilities", frozenset())
+    bad_labels = [
+        label for label in caps if not _TIP_LABEL_RE.match(str(label))
+    ]
+    if bad_labels:
+        logger.warning(
+            "tokenpak adapter-plugin %r (from %s) declares non-TIP capability "
+            "labels %r; skipped. Use ``tip.<group>.<feature>`` or "
+            "``ext.<vendor>.<feature>``.",
+            cls.__name__, source, bad_labels,
+        )
+        return False
+    return True
+
+
+def _adapter_priority(cls) -> int:
+    """Read the optional ``priority`` class attribute (default 100)."""
+    pri = getattr(cls, "priority", None)
+    if isinstance(pri, int):
+        return pri
+    return _DEFAULT_PLUGIN_PRIORITY
+
+
+def discover_entry_point_adapters() -> List[Tuple[FormatAdapter, int, str]]:
+    """Walk ``tokenpak.format_adapters`` entry points + return instances.
+
+    Returns ``[(adapter_instance, priority, source_label), ...]``. The
+    source label is human-readable (``"entry-point: <distribution>"``)
+    and used for diagnostics + collision warnings.
+    """
+    out: List[Tuple[FormatAdapter, int, str]] = []
+    try:
+        eps = entry_points(group=_ENTRY_POINT_GROUP)
+    except Exception as exc:
+        logger.warning(
+            "tokenpak adapter-plugin discovery failed at entry_points() "
+            "call: %s: %s",
+            type(exc).__name__, exc,
+        )
+        return out
+
+    for ep in eps:
+        try:
+            target = ep.load()
+        except Exception as exc:
+            logger.warning(
+                "tokenpak adapter-plugin %r (from %s) failed to load: %s: %s",
+                ep.name, _ep_dist(ep), type(exc).__name__, exc,
+            )
+            continue
+        if not _validate_adapter_class(target, f"entry-point: {_ep_dist(ep)}"):
+            continue
+        try:
+            instance = target()
+        except Exception as exc:
+            logger.warning(
+                "tokenpak adapter-plugin %r (from %s) failed to instantiate: "
+                "%s: %s",
+                ep.name, _ep_dist(ep), type(exc).__name__, exc,
+            )
+            continue
+        out.append(
+            (instance, _adapter_priority(target), f"entry-point: {_ep_dist(ep)}")
+        )
+    return out
+
+
+def discover_filesystem_adapters(
+    directory: Optional[Path] = None,
+) -> List[Tuple[FormatAdapter, int, str]]:
+    """Import ``*.py`` files in ``directory`` + return adapter instances.
+
+    Each file is imported as a sandboxed module. Every top-level class
+    that subclasses :class:`FormatAdapter` (and isn't FormatAdapter
+    itself) is validated + instantiated.
+
+    Defaults to ``~/.tokenpak/adapters``. Missing directory is a no-op.
+    Files starting with ``_`` are skipped (Python convention for
+    private / disabled).
+    """
+    out: List[Tuple[FormatAdapter, int, str]] = []
+    if directory is None:
+        directory = _DEFAULT_DROPIN_DIR
+    if not directory.is_dir():
+        return out
+
+    for path in sorted(directory.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        module_name = f"tokenpak._dropin_adapter_{path.stem}"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            logger.warning(
+                "tokenpak adapter-plugin: could not build import spec for %s; "
+                "skipped.",
+                path,
+            )
+            continue
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except Exception as exc:
+            logger.warning(
+                "tokenpak adapter-plugin %s failed to import: %s: %s",
+                path, type(exc).__name__, exc,
+            )
+            continue
+
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            # Only top-level classes defined in this module — skip
+            # imports (e.g. FormatAdapter itself, or other adapters
+            # imported for reference).
+            if obj.__module__ != module_name:
+                continue
+            source = f"file: {path}"
+            if not _validate_adapter_class(obj, source):
+                continue
+            try:
+                instance = obj()
+            except Exception as exc:
+                logger.warning(
+                    "tokenpak adapter-plugin %r (from %s) failed to "
+                    "instantiate: %s: %s",
+                    name, source, type(exc).__name__, exc,
+                )
+                continue
+            out.append((instance, _adapter_priority(obj), source))
+
+    return out
+
+
+def register_discovered(
+    registry: AdapterRegistry,
+    *,
+    include_entry_points: bool = True,
+    include_filesystem: bool = True,
+    filesystem_dir: Optional[Path] = None,
+) -> int:
+    """Discover + register plugin adapters into ``registry``.
+
+    Returns the count of newly-registered adapters. Built-in adapters
+    already registered take precedence on ``source_format`` collision
+    (the registry's ``register`` is append-only; we add a separate
+    pre-check here to log the collision before silently dropping).
+
+    Honors :func:`discovery_enabled` — short-circuits to 0 when
+    ``TOKENPAK_DISABLE_ADAPTER_PLUGINS=1``.
+    """
+    if not discovery_enabled():
+        logger.debug("tokenpak adapter-plugin discovery disabled via env")
+        return 0
+
+    candidates: List[Tuple[FormatAdapter, int, str]] = []
+    if include_entry_points:
+        candidates.extend(discover_entry_point_adapters())
+    if include_filesystem:
+        candidates.extend(discover_filesystem_adapters(filesystem_dir))
+
+    if not candidates:
+        return 0
+
+    existing_formats = {a.source_format for a in registry.adapters()}
+    seen_now: dict = {}
+    registered = 0
+
+    for instance, priority, source in candidates:
+        fmt = instance.source_format
+        if fmt in existing_formats:
+            logger.warning(
+                "tokenpak adapter-plugin %r (from %s) collides with built-in "
+                "format %r; built-in wins, plugin skipped.",
+                type(instance).__name__, source, fmt,
+            )
+            continue
+        prior = seen_now.get(fmt)
+        if prior is not None:
+            logger.warning(
+                "tokenpak adapter-plugin %r (from %s) collides with already-"
+                "discovered plugin (from %s) for format %r; first wins, "
+                "this one skipped.",
+                type(instance).__name__, source, prior, fmt,
+            )
+            continue
+        registry.register(instance, priority=priority)
+        seen_now[fmt] = source
+        registered += 1
+        logger.info(
+            "tokenpak adapter-plugin: registered %r (format=%s, priority=%d, "
+            "from %s)",
+            type(instance).__name__, fmt, priority, source,
+        )
+
+    return registered
+
+
+__all__ = [
+    "discovery_enabled",
+    "discover_entry_point_adapters",
+    "discover_filesystem_adapters",
+    "register_discovered",
+]

--- a/tokenpak/proxy/adapters/google_adapter.py
+++ b/tokenpak/proxy/adapters/google_adapter.py
@@ -12,6 +12,12 @@ from .canonical import CanonicalRequest
 
 class GoogleGenerativeAIAdapter(FormatAdapter):
     source_format = "google-generative-ai"
+    # Google Generative AI (Gemini): proxy-managed cache + compression.
+    # Re-serialised during denormalize, so not byte-preserved.
+    capabilities = frozenset({
+        "tip.compression.v1",
+        "tip.cache.proxy-managed",
+    })
 
     def validate_tools(self) -> None:
         """

--- a/tokenpak/proxy/adapters/openai_chat_adapter.py
+++ b/tokenpak/proxy/adapters/openai_chat_adapter.py
@@ -12,6 +12,12 @@ from .canonical import CanonicalRequest
 
 class OpenAIChatAdapter(FormatAdapter):
     source_format = "openai-chat"
+    # OpenAI Chat Completions: proxy-managed cache + compression. Same
+    # rationale as OpenAIResponsesAdapter — not byte-preserved.
+    capabilities = frozenset({
+        "tip.compression.v1",
+        "tip.cache.proxy-managed",
+    })
 
     def detect(self, path: str, headers: Mapping[str, str], body: Optional[bytes]) -> bool:
         return "/v1/chat/completions" in path

--- a/tokenpak/proxy/adapters/openai_responses_adapter.py
+++ b/tokenpak/proxy/adapters/openai_responses_adapter.py
@@ -12,6 +12,14 @@ from .canonical import CanonicalRequest
 
 class OpenAIResponsesAdapter(FormatAdapter):
     source_format = "openai-responses"
+    # OpenAI Responses API: proxy-managed cache + compression.
+    # Not byte-preserved (we re-serialize during denormalize) — the
+    # OpenAI prompt cache uses ``prompt_cache_key`` which we preserve
+    # in raw_extra, so byte fidelity isn't a cache prerequisite.
+    capabilities = frozenset({
+        "tip.compression.v1",
+        "tip.cache.proxy-managed",
+    })
 
     def detect(self, path: str, headers: Mapping[str, str], body: Optional[bytes]) -> bool:
         return "/v1/responses" in path

--- a/tokenpak/proxy/adapters/passthrough_adapter.py
+++ b/tokenpak/proxy/adapters/passthrough_adapter.py
@@ -12,6 +12,10 @@ from .canonical import CanonicalRequest
 
 class PassthroughAdapter(FormatAdapter):
     source_format = "passthrough"
+    # Catch-all fallback. Byte-preserved by definition (we don't know
+    # the format, so we can't safely transform anything). No opt-in
+    # capabilities — the proxy treats this as "forward only".
+    capabilities = frozenset({"tip.byte-preserved-passthrough"})
 
     def detect(self, path: str, headers: Mapping[str, str], body: Optional[bytes]) -> bool:
         return True

--- a/tokenpak/proxy/capsule_integration.py
+++ b/tokenpak/proxy/capsule_integration.py
@@ -218,22 +218,34 @@ def get_capsule_request_hook(
 
 
 def _estimate_tokens(body: bytes) -> int:
-    """Rough token estimate (chars / 4)."""
-    try:
-        import json
+    """Format-agnostic token estimate via the adapter registry.
 
-        data = json.loads(body)
-        messages = data.get("messages", [])
-        total_chars = 0
-        for msg in messages:
-            content = msg.get("content", "")
-            if isinstance(content, str):
-                total_chars += len(content)
-            elif isinstance(content, list):
-                for part in content:
-                    if isinstance(part, dict):
-                        total_chars += len(part.get("text", ""))
-        return total_chars // 4
+    Iterates registered :class:`FormatAdapter` instances and asks each
+    to count — only the adapter that actually understands the body
+    shape will return >0 (the others return 0 from a JSON parse error
+    or a missing root field). Picks the max so any adapter that
+    successfully parses wins.
+
+    Covers Anthropic Messages (``messages``), OpenAI Responses
+    (``input``), OpenAI Chat (``messages``), Google (``contents``) +
+    any future format that registers an adapter. No per-platform
+    branches in this function.
+    """
+    if not body:
+        return 0
+    try:
+        from tokenpak.proxy.adapters import build_default_registry
+
+        registry = build_default_registry()
+        best = 0
+        for adapter in registry.adapters():
+            try:
+                _model, tokens = adapter.extract_request_tokens(body)
+                if tokens > best:
+                    best = tokens
+            except Exception:
+                continue
+        return best if best > 0 else len(body) // 4
     except Exception:
         return len(body) // 4
 

--- a/tokenpak/proxy/router.py
+++ b/tokenpak/proxy/router.py
@@ -172,8 +172,10 @@ class ProviderRouter:
         # Path-based detection (highest priority)
         if "/v1/messages" in path:
             return "anthropic"
-        if "/v1/responses" in path:
-            # OpenAI Responses API — used by Codex subscription models
+        if "/v1/responses" in path or "/codex/responses" in path:
+            # OpenAI Responses API — used by Codex subscription models.
+            # ``/codex/responses`` is OpenClaw's pi-ai Codex connector
+            # endpoint shape; ``/v1/responses`` is the standard.
             return "openai-codex"
         if "/chat/completions" in path:
             return "openai"

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -29,7 +29,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Callable, Dict, Generator, List, Optional
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from tokenpak import __version__ as _tokenpak_version
@@ -772,7 +772,21 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 model = route.model
             except Exception:
                 pass
-            input_tokens = _estimate_tokens_from_body(body)
+            # Format-agnostic token estimation: route through the
+            # adapter registry so codex (``input`` field), Google
+            # (``contents`` field), and any future format counted
+            # correctly without per-platform branches in this hot path.
+            # Falls back to legacy hardcoded ``messages`` reader when
+            # no adapter matches (passthrough or unrecognised body).
+            _adapter_model, _adapter_tokens = _extract_tokens_via_adapters(
+                body, dict(self.headers), self.path
+            )
+            if _adapter_tokens > 0:
+                input_tokens = _adapter_tokens
+                if model in (None, "", "unknown") and _adapter_model:
+                    model = _adapter_model
+            else:
+                input_tokens = _estimate_tokens_from_body(body)
 
             try:
                 data = json.loads(body)
@@ -1866,7 +1880,52 @@ def _compute_stable_prefix_hash(body: Optional[bytes]) -> str:
         return ""
 
 
+# Lazy module-level adapter registry — built once on first use, then
+# reused for every request. Used by ``_extract_tokens_via_adapters`` to
+# delegate request shape parsing to the format-specific adapter.
+_ADAPTER_REGISTRY = None
+
+
+def _get_adapter_registry():
+    global _ADAPTER_REGISTRY
+    if _ADAPTER_REGISTRY is None:
+        from tokenpak.proxy.adapters import build_default_registry
+        _ADAPTER_REGISTRY = build_default_registry()
+    return _ADAPTER_REGISTRY
+
+
+def _extract_tokens_via_adapters(
+    body: bytes,
+    headers: dict,
+    path: str,
+) -> Tuple[str, int]:
+    """Look up the matching format adapter + ask it for (model, tokens).
+
+    Format-agnostic replacement for the historical hardcoded
+    ``messages`` field reader. Each registered adapter knows its own
+    request shape (Anthropic ``messages``, OpenAI Responses ``input``,
+    Google ``contents``, etc.) — we let it do the counting.
+
+    Returns ``("unknown", 0)`` when no adapter matches or counting
+    fails; the caller decides whether to fall back.
+    """
+    if not body:
+        return "unknown", 0
+    try:
+        registry = _get_adapter_registry()
+        adapter = registry.detect(path, headers, body)
+        return adapter.extract_request_tokens(body)
+    except Exception:
+        return "unknown", 0
+
+
 def _estimate_tokens_from_body(body: bytes) -> int:
+    """Legacy hardcoded ``messages``-only token estimator.
+
+    Kept as a fallback for paths where adapter detection fails (e.g.
+    passthrough adapter normalises to a single empty user message).
+    Prefer :func:`_extract_tokens_via_adapters` in new code.
+    """
     try:
         data = json.loads(body)
         messages = data.get("messages", [])

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1185,6 +1185,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     add_headers={},
                     merge_headers={},
                     target_url_override=_full_plan.target_url_override,
+                    target_url_resolver=_full_plan.target_url_resolver,
                     body_transform=_full_plan.body_transform,
                 )
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
@@ -1297,8 +1298,27 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         _mutable_headers[_mk] = _merged
                 else:
                     _mutable_headers[_mk] = _mv
-            # 3. Rewrite the target URL when the plan specifies (Codex).
-            if _plan.target_url_override:
+            # 3. Rewrite the target URL when the plan specifies. Two
+            # mechanisms, in priority order:
+            #   - ``target_url_resolver``: body-aware resolution (Azure
+            #     OpenAI routes by deployment id from the body's
+            #     ``model`` field). Returning ``None`` falls back to
+            #     the static override.
+            #   - ``target_url_override``: static rewrite (Codex points
+            #     at ChatGPT backend regardless of body).
+            _resolver = getattr(_plan, "target_url_resolver", None)
+            if _resolver is not None:
+                try:
+                    _resolved_url = _resolver(body or b"", dict(self.headers))
+                except Exception:
+                    _resolved_url = None
+                if _resolved_url:
+                    target_url = _resolved_url
+                    parsed = urlparse(target_url)
+                elif _plan.target_url_override:
+                    target_url = _plan.target_url_override
+                    parsed = urlparse(target_url)
+            elif _plan.target_url_override:
                 target_url = _plan.target_url_override
                 parsed = urlparse(target_url)
             # 3b. Claude Code identity: ensure ``?beta=true`` is on the

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1048,12 +1048,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         #
         # Caller-creds precedence (Kevin 2026-04-24):
         #   - If the caller already shipped a usable credential
-        #     (``x-api-key: sk-…`` or ``Authorization: Bearer …``),
-        #     skip injection and pass their creds through.
-        #   - Else fall back to the registered provider plan (managed
-        #     creds from ``~/.claude`` / ``~/.codex``).
-        # This lets ``tokenpak codex`` users with their own OpenAI key
-        # or ChatGPT JWT bypass the managed credentials entirely.
+        #     (``x-api-key: sk-…`` or long-form ``Authorization: Bearer
+        #     …``), preserve their auth — but still apply the plan's
+        #     ``target_url_override`` and ``body_transform``. Codex's
+        #     URL rewrite (``api.openai.com/codex/responses`` →
+        #     ``chatgpt.com/backend-api/codex/responses``) is mandatory
+        #     even when the caller's JWT is the right shape; the
+        #     OpenAI host doesn't serve the codex path.
+        #   - Else fall back to the full plan (managed creds from
+        #     ``~/.claude`` / ``~/.codex``).
+        # Override: ``TOKENPAK_INJECTION_OVERRIDE=1`` forces full
+        # injection even when caller has creds.
         _cred_injection_plan = None
         if (
             should_log
@@ -1062,41 +1067,58 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             and os.environ.get("TOKENPAK_CREDENTIAL_INJECTION", "1") != "0"
         ):
             _caller_has_creds = self._caller_has_credentials(dict(self.headers))
-            if _caller_has_creds and os.environ.get(
-                "TOKENPAK_INJECTION_OVERRIDE", "0"
-            ).strip() != "1":
+            _force_inject = (
+                os.environ.get("TOKENPAK_INJECTION_OVERRIDE", "0").strip() == "1"
+            )
+            try:
+                from tokenpak.services.routing_service.credential_injector import (
+                    resolve as _resolve_cred,
+                )
+
+                _full_plan = _resolve_cred(_resolved_provider)
+            except Exception as _inj_err:
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "tokenpak.proxy: credential-injection resolve failed (%s: %s) — "
+                    "falling back to byte-preserved forward",
+                    type(_inj_err).__name__, _inj_err,
+                )
+                _full_plan = None
+
+            if _full_plan is not None and _caller_has_creds and not _force_inject:
+                # Caller has their own creds: keep their auth, but still
+                # apply URL + body transforms from the plan (otherwise
+                # ``/codex/responses`` would 404 against api.openai.com).
+                from tokenpak.services.routing_service.credential_injector import (
+                    InjectionPlan as _InjectionPlan,
+                )
+
+                _cred_injection_plan = _InjectionPlan(
+                    strip_headers=frozenset(),
+                    add_headers={},
+                    merge_headers={},
+                    target_url_override=_full_plan.target_url_override,
+                    body_transform=_full_plan.body_transform,
+                )
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
 
                     _logging.getLogger(__name__).warning(
-                        "tokenpak.proxy[INJECT] provider=%s plan=passthrough "
-                        "(caller has own credentials)",
+                        "tokenpak.proxy[INJECT] provider=%s plan=passthrough+url "
+                        "(caller has own credentials; URL rewrite preserved)",
                         _resolved_provider,
                     )
             else:
-                try:
-                    from tokenpak.services.routing_service.credential_injector import (
-                        resolve as _resolve_cred,
-                    )
-
-                    _cred_injection_plan = _resolve_cred(_resolved_provider)
-                    if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
-                        import logging as _logging
-
-                        _logging.getLogger(__name__).warning(
-                            "tokenpak.proxy[INJECT] provider=%s plan=%s",
-                            _resolved_provider,
-                            "applied" if _cred_injection_plan else "<none>",
-                        )
-                except Exception as _inj_err:
+                _cred_injection_plan = _full_plan
+                if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
 
                     _logging.getLogger(__name__).warning(
-                        "tokenpak.proxy: credential-injection resolve failed (%s: %s) — "
-                        "falling back to byte-preserved forward",
-                        type(_inj_err).__name__, _inj_err,
+                        "tokenpak.proxy[INJECT] provider=%s plan=%s",
+                        _resolved_provider,
+                        "applied" if _cred_injection_plan else "<none>",
                     )
-                    _cred_injection_plan = None
 
         # Legacy subprocess dispatch toggle is deprecated by the v1.3.20
         # default (subprocess IS the default for tokenpak-claude-code).

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1922,8 +1922,13 @@ _ADAPTER_REGISTRY = None
 def _get_adapter_registry():
     global _ADAPTER_REGISTRY
     if _ADAPTER_REGISTRY is None:
-        from tokenpak.proxy.adapters import build_default_registry
-        _ADAPTER_REGISTRY = build_default_registry()
+        # Use ``build_registry`` (not ``build_default_registry``) so
+        # discovered plugin adapters — entry points + filesystem
+        # drop-ins under ``~/.tokenpak/adapters/`` — auto-register at
+        # startup. Built-ins always win on ``source_format`` collision;
+        # ``TOKENPAK_DISABLE_ADAPTER_PLUGINS=1`` opts out entirely.
+        from tokenpak.proxy.adapters import build_registry
+        _ADAPTER_REGISTRY = build_registry()
     return _ADAPTER_REGISTRY
 
 

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -719,6 +719,11 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         is_streaming = False
         cache_read_tokens = 0
         cache_creation_tokens = 0
+        # Resolved format adapter for this request — set by the
+        # token-extraction step and read later by capability gates
+        # (compression telemetry, capsule injection, cache lookup).
+        # ``None`` when no adapter matches; gates default to "skip".
+        request_adapter = None
 
         trace: Optional[PipelineTrace] = None
         if should_log and is_messages:
@@ -778,14 +783,22 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             # correctly without per-platform branches in this hot path.
             # Falls back to legacy hardcoded ``messages`` reader when
             # no adapter matches (passthrough or unrecognised body).
-            _adapter_model, _adapter_tokens = _extract_tokens_via_adapters(
+            request_adapter = _resolve_adapter_for_request(
                 body, dict(self.headers), self.path
             )
-            if _adapter_tokens > 0:
-                input_tokens = _adapter_tokens
-                if model in (None, "", "unknown") and _adapter_model:
-                    model = _adapter_model
-            else:
+            _adapter_tokens = 0
+            if request_adapter is not None:
+                try:
+                    _adapter_model, _adapter_tokens = (
+                        request_adapter.extract_request_tokens(body)
+                    )
+                    if _adapter_tokens > 0:
+                        input_tokens = _adapter_tokens
+                        if model in (None, "", "unknown") and _adapter_model:
+                            model = _adapter_model
+                except Exception:
+                    pass
+            if _adapter_tokens == 0:
                 input_tokens = _estimate_tokens_from_body(body)
 
             try:
@@ -841,7 +854,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 _cache_origin = "unknown"
             _body_before_hook = body
 
-            if ps.request_hook:
+            # Capability-gated request_hook (capsule injection +
+            # chained downstream hooks). Format adapters declare
+            # ``tip.compression.v1`` to opt in to canonical-shape
+            # transforms. Passthrough opts out — its body shape is
+            # unknown so we don't mutate it. ``request_adapter is None``
+            # also opts out (defensive: if detection failed, don't
+            # transform the body).
+            _hook_supported = (
+                request_adapter is not None
+                and "tip.compression.v1" in request_adapter.capabilities
+            )
+            if ps.request_hook and _hook_supported:
                 try:
                     body, sent_input_tokens, input_tokens, protected_tokens = ps.request_hook(
                         body, model, trace
@@ -1684,8 +1708,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 except Exception:
                     pass  # telemetry must never break request handling
 
+                # Capability-gated compression telemetry. Format adapters
+                # declare ``tip.compression.v1`` to opt in. Passthrough
+                # (catch-all, doesn't know the format) opts out — its
+                # traffic doesn't generate spurious compression rows.
+                _compression_supported = (
+                    request_adapter is not None
+                    and "tip.compression.v1" in request_adapter.capabilities
+                )
+
                 # Track per-request compression ratio for rolling average
-                if input_tokens > 0:
+                if input_tokens > 0 and _compression_supported:
                     ratio = round(saved / input_tokens, 4)
                     with ps._compression_lock:
                         ps._compression_ratios.append(ratio)
@@ -1894,6 +1927,30 @@ def _get_adapter_registry():
     return _ADAPTER_REGISTRY
 
 
+def _resolve_adapter_for_request(
+    body: bytes,
+    headers: dict,
+    path: str,
+):
+    """Look up the matching :class:`FormatAdapter` for this request.
+
+    Walks the registry's priority-ordered detect() chain. Returns the
+    adapter, or ``None`` when no adapter matches (rare —
+    PassthroughAdapter detect→True is the universal fallback).
+
+    Used both for token extraction and for capability-gated middleware
+    activation: callers can read ``adapter.capabilities`` to decide
+    whether to apply compression / capsule injection / cache lookup
+    for this request.
+    """
+    if not body:
+        return None
+    try:
+        return _get_adapter_registry().detect(path, headers, body)
+    except Exception:
+        return None
+
+
 def _extract_tokens_via_adapters(
     body: bytes,
     headers: dict,
@@ -1909,11 +1966,10 @@ def _extract_tokens_via_adapters(
     Returns ``("unknown", 0)`` when no adapter matches or counting
     fails; the caller decides whether to fall back.
     """
-    if not body:
+    adapter = _resolve_adapter_for_request(body, headers, path)
+    if adapter is None:
         return "unknown", 0
     try:
-        registry = _get_adapter_registry()
-        adapter = registry.detect(path, headers, body)
         return adapter.extract_request_tokens(body)
     except Exception:
         return "unknown", 0

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -550,7 +550,9 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         if not self._auth_gate():
             return
         if ps.shutdown.is_shutting_down and (
-            self.path.startswith("http") or self.path.startswith("/v1/")
+            self.path.startswith("http")
+            or self.path.startswith("/v1/")
+            or self.path.startswith("/codex/")
         ):
             self._send_503_shutdown()
             return
@@ -590,7 +592,13 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(_resp)))
             self.end_headers()
             self.wfile.write(_resp)
-        elif self.path.startswith("/v1/"):
+        elif self.path.startswith("/v1/") or self.path.startswith("/codex/"):
+            # ``/codex/responses`` is OpenClaw's pi-ai Codex connector
+            # endpoint shape (``<baseUrl>/codex/responses``). The standard
+            # OpenAI Responses API is ``/v1/responses``. Both route through
+            # the provider router; ``/codex/...`` resolves to the
+            # tokenpak-openai-codex provider, ``/v1/...`` to whatever the
+            # body / headers indicate.
             ps = self.server.proxy_server
             route = ps.router.route(self.path, dict(self.headers))
             self._proxy_to(route.full_url, "POST")
@@ -647,6 +655,40 @@ class _ProxyHandler(BaseHTTPRequestHandler):
     # Core forwarding
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _caller_has_credentials(headers: dict) -> bool:
+        """True when the caller already shipped a usable upstream credential.
+
+        Recognises:
+          - ``x-api-key: sk-…`` (OpenAI / Anthropic API keys)
+          - ``Authorization: Bearer sk-…`` (same, in Bearer shape)
+          - ``Authorization: Bearer eyJ…`` with a long token (JWT —
+            ChatGPT OAuth or Anthropic OAuth). The length filter
+            screens out short placeholder Bearers OpenClaw sometimes
+            ships from stale auth profiles.
+
+        Used by the credential-injection block to honour caller's own
+        creds (``tokenpak codex`` with ``OPENAI_API_KEY`` set, BYO Codex
+        JWT, etc.) instead of injecting managed creds.
+        """
+        if not headers:
+            return False
+        lh = {k.lower(): v for k, v in headers.items() if isinstance(v, str)}
+        api_key = lh.get("x-api-key", "").strip()
+        if api_key.startswith("sk-"):
+            return True
+        auth = lh.get("authorization", "").strip()
+        if auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+            if token.startswith("sk-"):
+                return True
+            # JWT: must be eyJ-prefixed AND long enough to be plausible
+            # (real JWTs are >1k chars; OpenClaw's stale auth-profile
+            # tokens are typically <100).
+            if token.startswith("eyJ") and len(token) >= 200 and "." in token:
+                return True
+        return False
+
     def _proxy_to(self, target_url: str, method: str) -> None:
         ps = self.server.proxy_server  # type: ignore[attr-defined]
         with ps.shutdown.track_request():
@@ -660,7 +702,12 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         parsed = urlparse(target_url)
 
         should_log = any(h in target_url for h in INTERCEPT_HOSTS)
-        is_messages = "/messages" in target_url or "/chat/completions" in target_url
+        is_messages = (
+            "/messages" in target_url
+            or "/chat/completions" in target_url
+            or "/v1/responses" in target_url
+            or "/codex/responses" in target_url
+        )
 
         content_length = int(self.headers.get("Content-Length", 0))
         body: Optional[bytes] = self.rfile.read(content_length) if content_length > 0 else None
@@ -998,6 +1045,15 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         # Anthropic). This is the byte-preserved HTTP path where we
         # rewrite caller auth with the provider's credentials and
         # optionally redirect upstream + normalize body.
+        #
+        # Caller-creds precedence (Kevin 2026-04-24):
+        #   - If the caller already shipped a usable credential
+        #     (``x-api-key: sk-…`` or ``Authorization: Bearer …``),
+        #     skip injection and pass their creds through.
+        #   - Else fall back to the registered provider plan (managed
+        #     creds from ``~/.claude`` / ``~/.codex``).
+        # This lets ``tokenpak codex`` users with their own OpenAI key
+        # or ChatGPT JWT bypass the managed credentials entirely.
         _cred_injection_plan = None
         if (
             should_log
@@ -1005,29 +1061,42 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             and _resolved_provider in ("tokenpak-openai-codex", "tokenpak-anthropic")
             and os.environ.get("TOKENPAK_CREDENTIAL_INJECTION", "1") != "0"
         ):
-            try:
-                from tokenpak.services.routing_service.credential_injector import (
-                    resolve as _resolve_cred,
-                )
-
-                _cred_injection_plan = _resolve_cred(_resolved_provider)
+            _caller_has_creds = self._caller_has_credentials(dict(self.headers))
+            if _caller_has_creds and os.environ.get(
+                "TOKENPAK_INJECTION_OVERRIDE", "0"
+            ).strip() != "1":
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
 
                     _logging.getLogger(__name__).warning(
-                        "tokenpak.proxy[INJECT] provider=%s plan=%s",
+                        "tokenpak.proxy[INJECT] provider=%s plan=passthrough "
+                        "(caller has own credentials)",
                         _resolved_provider,
-                        "applied" if _cred_injection_plan else "<none>",
                     )
-            except Exception as _inj_err:
-                import logging as _logging
+            else:
+                try:
+                    from tokenpak.services.routing_service.credential_injector import (
+                        resolve as _resolve_cred,
+                    )
 
-                _logging.getLogger(__name__).warning(
-                    "tokenpak.proxy: credential-injection resolve failed (%s: %s) — "
-                    "falling back to byte-preserved forward",
-                    type(_inj_err).__name__, _inj_err,
-                )
-                _cred_injection_plan = None
+                    _cred_injection_plan = _resolve_cred(_resolved_provider)
+                    if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
+                        import logging as _logging
+
+                        _logging.getLogger(__name__).warning(
+                            "tokenpak.proxy[INJECT] provider=%s plan=%s",
+                            _resolved_provider,
+                            "applied" if _cred_injection_plan else "<none>",
+                        )
+                except Exception as _inj_err:
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).warning(
+                        "tokenpak.proxy: credential-injection resolve failed (%s: %s) — "
+                        "falling back to byte-preserved forward",
+                        type(_inj_err).__name__, _inj_err,
+                    )
+                    _cred_injection_plan = None
 
         # Legacy subprocess dispatch toggle is deprecated by the v1.3.20
         # default (subprocess IS the default for tokenpak-claude-code).

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -941,28 +941,66 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             _cb_provider = None
             _cb_registry = None
 
-        # Validate credentials for intercepted provider requests
-        # Client-supplied key takes precedence over any environment-level key.
+        # Resolve the declared provider once, before the auth gate, so
+        # known providers can bypass the require-caller-auth check
+        # (the credential_injector will inject managed env credentials).
+        _resolved_provider: Optional[str] = None
         if should_log and is_messages:
-            passthrough_cfg = PassthroughConfig(require_auth=True)
-            auth_ok, auth_err = validate_auth(dict(self.headers), passthrough_cfg)
-            if not auth_ok:
-                import json as _json
+            try:
+                from tokenpak.services.routing_service.platform_bridge import (
+                    resolve_provider as _resolve_provider,
+                )
 
-                err_body = _json.dumps(
-                    {
-                        "error": {
-                            "type": "authentication_error",
-                            "message": auth_err,
+                _resolved_provider = _resolve_provider(dict(self.headers))
+            except Exception:
+                _resolved_provider = None
+
+        # Validate credentials for intercepted provider requests.
+        # Client-supplied key takes precedence over any environment-level key.
+        # Bypass when the caller declared a known provider that the
+        # credential injector will resolve from managed env credentials —
+        # otherwise BYO-env-key flows (Phase 1 pack: Mistral, Groq,
+        # Together, DeepSeek, OpenRouter; also the existing
+        # tokenpak-claude-code / tokenpak-openai-codex / tokenpak-anthropic)
+        # would 401 here before injection even runs.
+        _bypass_auth_gate = False
+        if should_log and is_messages and _resolved_provider:
+            try:
+                from tokenpak.services.routing_service.credential_injector import (
+                    registered as _registered_for_gate,
+                )
+
+                if _resolved_provider in {
+                    p.name for p in _registered_for_gate()
+                }:
+                    _bypass_auth_gate = True
+            except Exception:
+                pass
+
+        if should_log and is_messages:
+            # require_auth=True for the schema-validation path even when
+            # we bypass the explicit auth check above; downstream
+            # ``forward_headers`` reads it to decide what to keep.
+            passthrough_cfg = PassthroughConfig(require_auth=True)
+            if not _bypass_auth_gate:
+                auth_ok, auth_err = validate_auth(dict(self.headers), passthrough_cfg)
+                if not auth_ok:
+                    import json as _json
+
+                    err_body = _json.dumps(
+                        {
+                            "error": {
+                                "type": "authentication_error",
+                                "message": auth_err,
+                            }
                         }
-                    }
-                ).encode()
-                self.send_response(401)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(err_body)))
-                self.end_headers()
-                self.wfile.write(err_body)
-                return
+                    ).encode()
+                    self.send_response(401)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(err_body)))
+                    self.end_headers()
+                    self.wfile.write(err_body)
+                    return
 
             # --- Request schema validation (strict/warn/off) ---
             if body:
@@ -1026,15 +1064,8 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         #                                       byte-forward which will
         #                                       fail for OpenClaw-
         #                                       style callers)
-        _resolved_provider: Optional[str] = None
-        if should_log and is_messages:
-            try:
-                from tokenpak.services.routing_service.platform_bridge import (
-                    resolve_provider as _resolve_provider,
-                )
-                _resolved_provider = _resolve_provider(dict(self.headers))
-            except Exception:
-                _resolved_provider = None
+        # ``_resolved_provider`` was resolved earlier (before auth gate);
+        # reuse it here.
 
         # (1) Subprocess dispatch for tokenpak-claude-code — DEFAULT path
         # for Claude Code traffic. Restores the Apr 15-18 companion
@@ -1097,11 +1128,28 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         #     ``~/.claude`` / ``~/.codex``).
         # Override: ``TOKENPAK_INJECTION_OVERRIDE=1`` forces full
         # injection even when caller has creds.
+        # Known providers come from the credential_injector's registry —
+        # dynamic, so adding a new CredentialProvider (e.g. Mistral,
+        # Groq, OpenRouter) automatically gates this branch. No
+        # per-platform enumeration in the proxy hot path.
         _cred_injection_plan = None
+        _known_providers: frozenset = frozenset()
+        if should_log and is_messages and _resolved_provider:
+            try:
+                from tokenpak.services.routing_service.credential_injector import (
+                    registered as _registered_providers,
+                )
+
+                _known_providers = frozenset(
+                    p.name for p in _registered_providers()
+                )
+            except Exception:
+                _known_providers = frozenset()
+
         if (
             should_log
             and is_messages
-            and _resolved_provider in ("tokenpak-openai-codex", "tokenpak-anthropic")
+            and _resolved_provider in _known_providers
             and os.environ.get("TOKENPAK_CREDENTIAL_INJECTION", "1") != "0"
         ):
             _caller_has_creds = self._caller_has_credentials(dict(self.headers))

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1187,6 +1187,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     target_url_override=_full_plan.target_url_override,
                     target_url_resolver=_full_plan.target_url_resolver,
                     body_transform=_full_plan.body_transform,
+                    header_resolver=_full_plan.header_resolver,
                 )
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
@@ -1350,6 +1351,42 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         "tokenpak.proxy: body transform failed (%s) — using original",
                         _xf_err,
                     )
+
+            # 5. Dynamic header resolution — computed from the FINAL
+            # body + URL + method (after steps 1-4). Used by AWS SigV4
+            # signing, which depends on the exact bytes being sent.
+            # Result is merged on top of the static add_headers so the
+            # signature reflects everything the upstream will see.
+            _hdr_resolver = getattr(_plan, "header_resolver", None)
+            if _hdr_resolver is not None:
+                try:
+                    _dynamic = _hdr_resolver(
+                        body or b"",
+                        target_url,
+                        method,
+                        dict(_mutable_headers),
+                    )
+                except Exception as _hr_err:
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).warning(
+                        "tokenpak.proxy: header_resolver failed (%s) — "
+                        "using static headers only",
+                        _hr_err,
+                    )
+                    _dynamic = None
+                if _dynamic:
+                    for _hk, _hv in _dynamic.items():
+                        # Case-insensitive replace: drop any caller / static
+                        # headers with the same key (case folded), then
+                        # set the dynamic value. Critical for SigV4 — the
+                        # signature must match the EXACT header set sent.
+                        for _existing in [
+                            k for k in list(_mutable_headers)
+                            if k.lower() == _hk.lower()
+                        ]:
+                            _mutable_headers.pop(_existing, None)
+                        _mutable_headers[_hk] = _hv
 
             # Build forwarding headers from the rewritten header dict.
             fwd_headers = forward_headers(_mutable_headers, passthrough_cfg)

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -103,6 +103,16 @@ class InjectionPlan:
         Callable[[bytes, Mapping[str, str]], Optional[str]]
     ] = None
     body_transform: Optional[Callable[[bytes], bytes]] = None
+    # Dynamic per-request headers — computed AFTER body_transform +
+    # URL resolution. Used when a provider's auth depends on the exact
+    # bytes being sent (AWS SigV4 is the canonical case: the Authorization
+    # header is a hash of the request including method, URL, headers,
+    # and body content). Result is merged into the request headers,
+    # OVERRIDING ``add_headers`` for any conflicting keys (because the
+    # dynamic value is the authoritative one).
+    header_resolver: Optional[
+        Callable[[bytes, str, str, Mapping[str, str]], Dict[str, str]]
+    ] = None
 
 
 # ── Provider protocol + registry ─────────────────────────────────────
@@ -713,6 +723,162 @@ class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
     }
 
 
+class BedrockClaudeCredentialProvider:
+    """AWS Bedrock for Anthropic Claude — Anthropic Messages format
+    wrapped in Bedrock's InvokeModel envelope, signed with AWS SigV4.
+
+    Bedrock takes the Messages payload directly (almost — it wants
+    ``anthropic_version: "bedrock-2023-05-31"`` and forbids the
+    ``model`` field, which is encoded in the URL instead). Auth is
+    SigV4 over the request bytes; we delegate signing to ``boto3`` to
+    avoid maintaining a hand-rolled HMAC implementation.
+
+    Required:
+
+      - ``boto3`` installed (standard AWS Python ecosystem dep).
+      - ``AWS_ACCESS_KEY_ID`` + ``AWS_SECRET_ACCESS_KEY`` env vars
+        (or any boto3-discoverable credentials: profile, IAM role,
+        SSO, etc. — we use ``boto3.Session()`` which resolves all of
+        them).
+      - ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` env var. Default
+        ``us-east-1`` if neither set.
+
+    Routing
+    -------
+
+    Bedrock specifies the model via URL path
+    (``/model/<id>/invoke``); the request body MUST NOT contain a
+    ``model`` field. The caller is expected to put the Bedrock model
+    id (e.g. ``anthropic.claude-3-5-sonnet-20241022-v2:0``, or an
+    inference-profile ARN) in the body's ``model`` field — we strip
+    it out before forwarding and use it to build the URL.
+
+    Streaming uses the ``/invoke-with-response-stream`` suffix; we
+    pick that variant when the request body sets ``stream: true``.
+
+    Plan composition
+    ----------------
+
+      - ``target_url_resolver`` — body-aware (model + stream flag).
+      - ``body_transform`` — strips ``model``, adds
+        ``anthropic_version``.
+      - ``header_resolver`` — SigV4 signs the FINAL body + URL +
+        method on every request.
+
+    No ``add_headers`` / ``Authorization`` — SigV4 puts everything in
+    the dynamic resolver because all four (Authorization, x-amz-date,
+    x-amz-content-sha256, host) depend on the exact final bytes.
+    """
+
+    name = "tokenpak-bedrock-claude"
+    _DEFAULT_REGION = "us-east-1"
+    _SERVICE = "bedrock"
+    _ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+    def _load(self) -> Optional[InjectionPlan]:
+        try:
+            import boto3  # noqa: F401  (presence check only here)
+        except ImportError:
+            logger.info(
+                "credential_injector[bedrock]: boto3 not installed; skipping. "
+                "`pip install boto3` to enable Bedrock routing."
+            )
+            return None
+
+        # Resolve region: env first, then boto3's session default.
+        region = (
+            _os.environ.get("AWS_REGION", "").strip()
+            or _os.environ.get("AWS_DEFAULT_REGION", "").strip()
+            or self._DEFAULT_REGION
+        )
+
+        # Build a session lazily so credential errors surface per-request
+        # (not at provider-resolve time when boto3 may not have looked
+        # at env vars yet).
+        endpoint_host = f"bedrock-runtime.{region}.amazonaws.com"
+
+        def _resolve_url(body: bytes, headers: Mapping[str, str]) -> Optional[str]:
+            if not body:
+                return None
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+            if not isinstance(data, dict):
+                return None
+            model = data.get("model")
+            if not isinstance(model, str) or not model.strip():
+                return None
+            stream = bool(data.get("stream"))
+            suffix = "invoke-with-response-stream" if stream else "invoke"
+            # Inference-profile ARNs contain ``:`` which must NOT be
+            # URL-encoded for Bedrock — use as-is.
+            return f"https://{endpoint_host}/model/{model.strip()}/{suffix}"
+
+        def _transform_body(body: bytes) -> bytes:
+            if not body:
+                return body
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return body
+            if not isinstance(data, dict):
+                return body
+            data.pop("model", None)
+            data.setdefault("anthropic_version", self._ANTHROPIC_VERSION)
+            try:
+                return json.dumps(data).encode("utf-8")
+            except (TypeError, ValueError):
+                return body
+
+        def _sign_request(
+            body: bytes,
+            url: str,
+            method: str,
+            _existing_headers: Mapping[str, str],
+        ) -> Dict[str, str]:
+            # Use boto3's SigV4Auth — battle-tested + handles all the
+            # canonical-request edge cases (case folding, empty bodies,
+            # query string normalisation) we'd otherwise have to
+            # replicate by hand.
+            from boto3 import Session as _Session
+            from botocore.auth import SigV4Auth
+            from botocore.awsrequest import AWSRequest
+
+            session = _Session()
+            creds = session.get_credentials()
+            if creds is None:
+                logger.warning(
+                    "credential_injector[bedrock]: no AWS credentials "
+                    "discoverable by boto3 — request will fail upstream."
+                )
+                return {}
+            frozen = creds.get_frozen_credentials()
+            req = AWSRequest(method=method, url=url, data=body or b"")
+            # ``Host`` and ``content-type`` are required for signing;
+            # set them explicitly so the signature reflects what we'll
+            # actually send.
+            from urllib.parse import urlparse as _urlparse
+
+            req.headers["Host"] = _urlparse(url).netloc
+            req.headers["Content-Type"] = "application/json"
+            SigV4Auth(frozen, self._SERVICE, region).add_auth(req)
+            # SigV4Auth mutates req.headers in-place. Pull the resulting
+            # set out as a plain dict.
+            return dict(req.headers.items())
+
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key"}),
+            add_headers={"Content-Type": "application/json"},
+            target_url_resolver=_resolve_url,
+            body_transform=_transform_body,
+            header_resolver=_sign_request,
+        )
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
 # ── Register built-ins at import ─────────────────────────────────────
 
 
@@ -724,10 +890,12 @@ register(TogetherCredentialProvider())
 register(DeepSeekCredentialProvider())
 register(OpenRouterCredentialProvider())
 register(AzureOpenAICredentialProvider())
+register(BedrockClaudeCredentialProvider())
 
 
 __all__ = [
     "AzureOpenAICredentialProvider",
+    "BedrockClaudeCredentialProvider",
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
     "CredentialProvider",

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -500,18 +500,130 @@ class CodexCredentialProvider:
         return _cached_resolve(self.name, self._load)
 
 
+# ── OpenAI-Chat-compatible providers (Phase 1 adapter pack) ──────────
+#
+# Mistral, Groq, Together, DeepSeek, OpenRouter all speak OpenAI Chat
+# Completions wire format. ``OpenAIChatAdapter`` already handles the
+# JSON shape; what differs per provider is the upstream URL and the
+# auth header value. Each gets a tiny CredentialProvider that reads
+# its own ``<NAME>_API_KEY`` env var and emits an InjectionPlan with
+# a target_url_override + Authorization: Bearer header.
+#
+# Adding another OpenAI-Chat-compatible provider is a 5-line class —
+# subclass ``_EnvKeyBearerProvider``, set name / upstream / env var.
+# No new format adapter, no edits to proxy core.
+
+
+import os as _os
+
+
+class _EnvKeyBearerProvider:
+    """Base for OpenAI-Chat-compatible providers using a single env-var key.
+
+    Subclasses set:
+      - ``name``: tokenpak provider slug (``tokenpak-mistral`` etc.).
+      - ``_UPSTREAM``: full URL the proxy rewrites the request to.
+      - ``_ENV_VAR``: environment variable holding the API key.
+      - ``_EXTRA_HEADERS`` (optional): extra static headers to inject
+        (e.g. OpenRouter requires ``HTTP-Referer`` + ``X-Title``).
+    """
+
+    name: str = ""
+    _UPSTREAM: str = ""
+    _ENV_VAR: str = ""
+    _EXTRA_HEADERS: Dict[str, str] = {}
+
+    def _load(self) -> Optional[InjectionPlan]:
+        api_key = _os.environ.get(self._ENV_VAR, "").strip()
+        if not api_key:
+            logger.info(
+                "credential_injector[%s]: env var %s not set; skipping",
+                self.name, self._ENV_VAR,
+            )
+            return None
+        headers: Dict[str, str] = {"Authorization": f"Bearer {api_key}"}
+        headers.update(self._EXTRA_HEADERS)
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key"}),
+            add_headers=headers,
+            target_url_override=self._UPSTREAM,
+        )
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
+class MistralCredentialProvider(_EnvKeyBearerProvider):
+    """Mistral AI — OpenAI-Chat-compatible, ``MISTRAL_API_KEY``."""
+
+    name = "tokenpak-mistral"
+    _UPSTREAM = "https://api.mistral.ai/v1/chat/completions"
+    _ENV_VAR = "MISTRAL_API_KEY"
+
+
+class GroqCredentialProvider(_EnvKeyBearerProvider):
+    """Groq — OpenAI-Chat-compatible, ``GROQ_API_KEY``."""
+
+    name = "tokenpak-groq"
+    _UPSTREAM = "https://api.groq.com/openai/v1/chat/completions"
+    _ENV_VAR = "GROQ_API_KEY"
+
+
+class TogetherCredentialProvider(_EnvKeyBearerProvider):
+    """Together AI — OpenAI-Chat-compatible, ``TOGETHER_API_KEY``."""
+
+    name = "tokenpak-together"
+    _UPSTREAM = "https://api.together.xyz/v1/chat/completions"
+    _ENV_VAR = "TOGETHER_API_KEY"
+
+
+class DeepSeekCredentialProvider(_EnvKeyBearerProvider):
+    """DeepSeek — OpenAI-Chat-compatible, ``DEEPSEEK_API_KEY``."""
+
+    name = "tokenpak-deepseek"
+    _UPSTREAM = "https://api.deepseek.com/v1/chat/completions"
+    _ENV_VAR = "DEEPSEEK_API_KEY"
+
+
+class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
+    """OpenRouter — meta-provider proxying ~100 models. ``OPENROUTER_API_KEY``.
+
+    Requires ``HTTP-Referer`` + ``X-Title`` headers on every request
+    (per OpenRouter's docs); without them OpenRouter rejects with a
+    400. The Referer is informational; we use the tokenpak homepage.
+    """
+
+    name = "tokenpak-openrouter"
+    _UPSTREAM = "https://openrouter.ai/api/v1/chat/completions"
+    _ENV_VAR = "OPENROUTER_API_KEY"
+    _EXTRA_HEADERS = {
+        "HTTP-Referer": "https://tokenpak.ai",
+        "X-Title": "TokenPak",
+    }
+
+
 # ── Register built-ins at import ─────────────────────────────────────
 
 
 register(ClaudeCodeCredentialProvider())
 register(CodexCredentialProvider())
+register(MistralCredentialProvider())
+register(GroqCredentialProvider())
+register(TogetherCredentialProvider())
+register(DeepSeekCredentialProvider())
+register(OpenRouterCredentialProvider())
 
 
 __all__ = [
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
     "CredentialProvider",
+    "DeepSeekCredentialProvider",
+    "GroqCredentialProvider",
     "InjectionPlan",
+    "MistralCredentialProvider",
+    "OpenRouterCredentialProvider",
+    "TogetherCredentialProvider",
     "invalidate_cache",
     "register",
     "registered",

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -54,7 +54,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, FrozenSet, List, Optional, Protocol
+from typing import Callable, Dict, FrozenSet, List, Mapping, Optional, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,17 @@ class InjectionPlan:
       merge step. Empty caller → falls back to our value.
     - ``target_url_override``: when set, replaces the original target URL
       entirely (e.g. ``chatgpt.com/backend-api/codex/responses`` for
-      Codex). ``None`` means keep the original target.
+      Codex). ``None`` means keep the original target. Static — does
+      not depend on the request body.
+    - ``target_url_resolver``: optional ``(body, headers) -> Optional[str]``
+      callable for providers that compute the URL from the request
+      payload. Azure OpenAI is the canonical case: the deployment id
+      lives in the body's ``model`` field but Azure routes it via the
+      URL path
+      (``<endpoint>/openai/deployments/<deployment>/chat/completions``).
+      When set, overrides ``target_url_override``. Returning ``None``
+      from the resolver falls back to ``target_url_override`` (then to
+      the original target).
     - ``body_transform``: optional bytes → bytes transform applied
       before forward. Codex needs a few payload-normalization tweaks
       (``stream=true``, ``store=false``, drop ``max_output_tokens``).
@@ -89,6 +99,9 @@ class InjectionPlan:
     add_headers: Dict[str, str] = field(default_factory=dict)
     merge_headers: Dict[str, str] = field(default_factory=dict)
     target_url_override: Optional[str] = None
+    target_url_resolver: Optional[
+        Callable[[bytes, Mapping[str, str]], Optional[str]]
+    ] = None
     body_transform: Optional[Callable[[bytes], bytes]] = None
 
 
@@ -585,6 +598,104 @@ class DeepSeekCredentialProvider(_EnvKeyBearerProvider):
     _ENV_VAR = "DEEPSEEK_API_KEY"
 
 
+class AzureOpenAICredentialProvider:
+    """Azure OpenAI — same wire format as OpenAI Chat Completions but
+    routes by deployment id in the URL path, uses ``api-key`` header
+    (not ``Authorization: Bearer``), and requires an ``api-version``
+    query param.
+
+    Three env vars, all required:
+
+      - ``AZURE_OPENAI_API_KEY`` — the resource's API key.
+      - ``AZURE_OPENAI_ENDPOINT`` — the resource URL, e.g.
+        ``https://my-resource.openai.azure.com``. Trailing slash is
+        tolerated.
+      - ``AZURE_OPENAI_API_VERSION`` — the API version to pin
+        (default ``2024-10-21``). Azure breaks compat across versions
+        more often than other providers; the default is a stable GA
+        line as of 2026.
+
+    Routing model
+    -------------
+
+    Azure customers create *deployments* of OpenAI models. The
+    deployment name (which the customer picks) — not the canonical
+    model id — is what Azure routes by. Two ways to supply it:
+
+      - **Default**: caller sets ``model: "<deployment-name>"`` in the
+        request body. We pull it and build
+        ``<endpoint>/openai/deployments/<deployment>/chat/completions?api-version=...``.
+      - **Override**: caller sets ``X-Azure-Deployment: <name>`` header.
+        Wins over the body field. Useful when the caller wants to keep
+        the canonical model id in the body for telemetry / cost
+        tracking but route to a deployment with a different name.
+
+    No body-side ``model`` rewrite — Azure tolerates it (and some
+    middleware chains rely on it being preserved).
+    """
+
+    name = "tokenpak-azure-openai"
+    _DEFAULT_API_VERSION = "2024-10-21"
+    _PATH_TEMPLATE = "/openai/deployments/{deployment}/chat/completions"
+
+    def _load(self) -> Optional[InjectionPlan]:
+        api_key = _os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
+        endpoint = _os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+        if not api_key:
+            logger.info(
+                "credential_injector[azure-openai]: AZURE_OPENAI_API_KEY "
+                "not set; skipping"
+            )
+            return None
+        if not endpoint:
+            logger.info(
+                "credential_injector[azure-openai]: AZURE_OPENAI_ENDPOINT "
+                "not set; skipping"
+            )
+            return None
+
+        api_version = (
+            _os.environ.get("AZURE_OPENAI_API_VERSION", "").strip()
+            or self._DEFAULT_API_VERSION
+        )
+        endpoint = endpoint.rstrip("/")
+
+        def _resolve_url(body: bytes, headers: Mapping[str, str]) -> Optional[str]:
+            # Header override wins.
+            for k, v in (headers or {}).items():
+                if k.lower() == "x-azure-deployment" and v:
+                    deployment = v.strip()
+                    if deployment:
+                        return self._build_url(endpoint, deployment, api_version)
+            # Else read deployment from body's model field.
+            if not body:
+                return None
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+            if not isinstance(data, dict):
+                return None
+            deployment = data.get("model")
+            if not isinstance(deployment, str) or not deployment.strip():
+                return None
+            return self._build_url(endpoint, deployment.strip(), api_version)
+
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key"}),
+            add_headers={"api-key": api_key},
+            target_url_resolver=_resolve_url,
+        )
+
+    @classmethod
+    def _build_url(cls, endpoint: str, deployment: str, api_version: str) -> str:
+        path = cls._PATH_TEMPLATE.format(deployment=deployment)
+        return f"{endpoint}{path}?api-version={api_version}"
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
 class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
     """OpenRouter — meta-provider proxying ~100 models. ``OPENROUTER_API_KEY``.
 
@@ -612,9 +723,11 @@ register(GroqCredentialProvider())
 register(TogetherCredentialProvider())
 register(DeepSeekCredentialProvider())
 register(OpenRouterCredentialProvider())
+register(AzureOpenAICredentialProvider())
 
 
 __all__ = [
+    "AzureOpenAICredentialProvider",
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
     "CredentialProvider",


### PR DESCRIPTION
## Summary

Second enterprise-tier provider. Bedrock takes the Anthropic Messages payload but routes the model via URL path and authenticates with AWS SigV4 over the request bytes. Required new InjectionPlan machinery beyond Phase 2a's body-aware URL resolver:

- **New `InjectionPlan.header_resolver` field** — `Callable[[bytes, url, method, headers], Dict[str, str]]`. Computed AFTER body_transform + URL resolution so dynamic headers reflect the EXACT bytes being sent. SigV4 is the canonical use case (signature is hash of method+URL+headers+body); also unlocks any future signed-request provider.
- **`BedrockClaudeCredentialProvider`** — composes target_url_resolver (URL from body's model + region) + body_transform (strip model, add anthropic_version) + header_resolver (boto3 SigV4Auth signs the final wire bytes).

## Why boto3

Hand-rolled SigV4 is ~150 LOC of HMAC + canonical-request edge cases that boto3's `botocore.auth.SigV4Auth` already handles correctly + battle-tested. Provider gracefully returns `None` (logged INFO) when boto3 isn't installed — `pip install boto3` to enable, no other config needed.

## Live verification

```
[INJECT]      provider=tokenpak-bedrock-claude  plan=applied
[POST-INJECT] url=https://bedrock-runtime.us-east-1.amazonaws.com
                  /model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke
              headers=… | x-amz-date | Authorization=<208 chars>
                       | host | content-length
```

AWS responded `The security token included in the request is invalid` — the SigV4 signature parsed correctly (right shape, right canonical bytes); AWS rejected the underlying placeholder credentials. With real AWS creds + Bedrock model access in the account, the same request returns the model's response.

## Files

- `tokenpak/services/routing_service/credential_injector.py` — `InjectionPlan.header_resolver` field + `BedrockClaudeCredentialProvider` class + auto-registration
- `tokenpak/proxy/server.py` — header_resolver invocation after body+URL transforms; case-insensitive header replacement (critical for SigV4)
- **NEW** `tests/test_phase2b_bedrock_claude.py` — 19 unit tests

## Test plan

- [x] `pytest tests/test_phase2b_bedrock_claude.py` — 19 passed
- [x] Full regression — 318 tests green
- [x] `ruff check` clean
- [x] Live: SigV4 signature emitted with placeholder creds → AWS validates shape, rejects creds (correct)
- [ ] User's first real Bedrock model invocation with real AWS creds

## Coordinates with PRs #27 and #28

This branch sits on top of `feat/azure-openai-adapter` (PR #28), which sits on `feat/codex-launcher-and-precedence` (PR #27). Merge in order: #27 → #28 → this. Splitting per `21-branching-merge-policy.md` §3.

Phase 3 (Cohere, Vertex AI, AWS Bedrock generic for non-Anthropic Bedrock model families) remains follow-up.