### PR TITLE
fix(integrations/openclaw): flip inject default to additive — destructive behind --exclusive

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -8,12 +8,27 @@ Full reference: <https://docs.tokenpak.ai/integrations/openclaw>
 
 ## Files
 
-- `tokenpak-inject.sh` — idempotent installer that mutates
-  `~/.openclaw/openclaw.json` to add `tokenpak-*` providers, mirror auth
-  profiles, stamp the `X-TokenPak-Backend` header, sync the Codex JWT,
-  and write a one-time `.pre-tokenpak-backup` for clean revert. Designed
-  to run as `ExecStartPre=` on `openclaw-gateway.service`, so the
-  TokenPak entries self-heal on every gateway restart.
+- `tokenpak-inject.sh` — idempotent installer with two modes:
+
+  - **Default (additive)** — Mirrors providers as `tokenpak-*`,
+    copies auth profiles, adds `tokenpak-*` model refs to the
+    allowlist, syncs the Codex JWT. Your existing primary model,
+    fallback chains, and per-agent model selections are
+    **untouched**. Result: you see `tokenpak-*` providers in OpenClaw
+    as new options alongside your existing routing; you opt in by
+    manually selecting one.
+  - **Exclusive (`--exclusive` or `TOKENPAK_INJECT_EXCLUSIVE=1`)** —
+    Additionally rewrites every primary model to its `tokenpak-*`
+    version and clears fallback chains, so all agent traffic
+    auto-routes through the proxy. Use this for hosts dedicated to
+    tokenpak (single-purpose bots, testbeds). Destructive — overwrites
+    your model selections.
+
+  Either way, existing non-tokenpak provider entries are **never
+  removed**. A one-time `.pre-tokenpak-backup` is written so
+  `tokenpak-uninstall.sh` can restore the pre-injection state cleanly.
+  Designed to run as `ExecStartPre=` on `openclaw-gateway.service`, so
+  the TokenPak entries self-heal on every gateway restart.
 - `tokenpak-uninstall.sh` — companion that restores the pre-install
   config from the backup (or strips `tokenpak-*` entries in place when no
   backup exists), removes the systemd drop-in, optionally stops the
@@ -35,6 +50,15 @@ systemctl --user daemon-reload
 # Then restart the gateway by killing its main PID:
 kill $(systemctl --user show openclaw-gateway.service -p MainPID --value)
 ```
+
+For exclusive (proxy-only) routing, add the flag to the drop-in:
+
+```ini
+[Service]
+ExecStartPre=%h/.local/bin/tokenpak-inject.sh --exclusive
+```
+
+…or set `TOKENPAK_INJECT_EXCLUSIVE=1` in the gateway's environment.
 
 ## Quick uninstall
 

--- a/integrations/openclaw/tokenpak-inject.sh
+++ b/integrations/openclaw/tokenpak-inject.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 # tokenpak-inject.sh — Auto-inject TokenPak provider routing into OpenClaw config
 #
-# What it does:
-#   1. Mirrors every provider as tokenpak-* with baseUrl → proxy
-#   2. Interleaves model chains: [tp-primary, primary, tp-fb, fb, ...]
-#   3. Updates allowlist, copies auth profiles
-#   4. Processes both openclaw.json and agent models.json files
-#   5. Idempotent — safe to run repeatedly
+# Two modes:
+#
+#   DEFAULT (additive — 2026-04-25):
+#     Mirrors providers, copies auth profiles, adds tokenpak-* entries
+#     to the model allowlist. The user's primary model, fallback chains,
+#     and per-agent model selections are LEFT UNTOUCHED. Result: users
+#     see tokenpak-* providers as new options in their dropdown but
+#     keep their existing routing intact. They opt in to tokenpak by
+#     manually selecting a tokenpak-* model in OpenClaw's UI/config.
+#
+#   EXCLUSIVE (--exclusive flag or TOKENPAK_INJECT_EXCLUSIVE=1):
+#     Additionally rewrites primary models to their tokenpak-* version
+#     and clears fallback chains, so ALL agent traffic auto-routes
+#     through the proxy. Use this for hosts dedicated to tokenpak
+#     (single-purpose bots, testbeds). Destructive — overwrites the
+#     user's chosen primary/fallback selections.
+#
+# Either way:
+#   - Idempotent — safe to run repeatedly.
+#   - Existing non-tokenpak providers are NEVER removed from the config.
+#   - Restoring previous behavior is a `tokenpak-uninstall.sh` away
+#     (uses the .pre-tokenpak-backup snapshot).
 #
 # Runs as ExecStartPre before openclaw-gateway starts.
 #
@@ -29,6 +45,18 @@ set -euo pipefail
 
 PROXY_URL="${TOKENPAK_URL:-http://localhost:8766}"
 
+# ── Mode flag ────────────────────────────────────────────────────────
+# Default = additive. Pass --exclusive (or set
+# TOKENPAK_INJECT_EXCLUSIVE=1) to also rewrite primary models +
+# clear fallbacks. The flag-style and env-style trigger the same mode.
+INJECT_EXCLUSIVE="${TOKENPAK_INJECT_EXCLUSIVE:-0}"
+for arg in "$@"; do
+    case "$arg" in
+        --exclusive|-x) INJECT_EXCLUSIVE=1 ;;
+    esac
+done
+export INJECT_EXCLUSIVE
+
 python3 << 'PYEOF'
 import json, os, shutil
 from pathlib import Path
@@ -36,6 +64,7 @@ from glob import glob
 
 PROXY_URL = os.environ.get("TOKENPAK_URL", "http://localhost:8766")
 PREFIX = "tokenpak"
+EXCLUSIVE = os.environ.get("INJECT_EXCLUSIVE", "0").strip() in {"1", "true", "yes"}
 
 # Honor the OpenClaw-native env var that systemd units set per service
 # (governor → ~/.openclaw-governor, gateway → ~/.openclaw, etc.). Falls
@@ -106,14 +135,25 @@ def mirror_providers(providers):
 
 def interleave(model_cfg, pm):
     """
-    Promote primary to tokenpak version. NO fallbacks.
-    
+    EXCLUSIVE-mode-only: Promote primary to tokenpak version + clear fallbacks.
+
     Input:  primary=opus4.6, fallbacks=[anything]
     Output: primary=tp-opus4.6, fallbacks=[]
-    
-    Direct provider refs are kept in config for emergency use but never
-    auto-routed. Kevin can manually switch to anthropic/* if proxy is down.
+
+    DEFAULT MODE (not EXCLUSIVE): returns (model_cfg, False) without
+    mutation — the user's primary + fallback selections are left as-is.
+    Tokenpak-* providers are still added to the allowlist by
+    update_allowlist() so they appear as options; the user opts in by
+    manually selecting one.
+
+    Direct provider refs are always kept in the config so the user can
+    manually switch to non-tokenpak routing whenever they want.
     """
+    if not EXCLUSIVE:
+        # Additive default: do not mutate primary or fallbacks.
+        # Caller may still see (cfg, False) and skip the write.
+        return model_cfg, False
+
     # Normalize to dict
     if isinstance(model_cfg, str):
         model_cfg = {"primary": model_cfg, "fallbacks": []}
@@ -348,13 +388,15 @@ def process_main(path):
     config = load_json(path)
     if not config: return False, {}
 
+    log(f"Mode: {'EXCLUSIVE (rewrites primary + clears fallbacks)' if EXCLUSIVE else 'additive (mirrors providers + allowlist; leaves user routing untouched)'}")
+
     config.setdefault("models", {}).setdefault("providers", {})
     config["models"]["mode"] = "merge"
 
     c1, pm = mirror_providers(config["models"]["providers"])
     c1b = inject_claude_code_provider(config["models"]["providers"])
-    c2 = interleave_defaults(config, pm)
-    c3 = interleave_agents(config, pm)
+    c2 = interleave_defaults(config, pm)  # no-op when not EXCLUSIVE
+    c3 = interleave_agents(config, pm)    # no-op when not EXCLUSIVE
     c4 = update_allowlist(config, pm)
     c5 = copy_auth(config, pm)
 

--- a/tests/test_inject_additive_default.py
+++ b/tests/test_inject_additive_default.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""tokenpak-inject.sh — default mode is additive; --exclusive is destructive.
+
+Verifies the standing rule (``feedback_tokenpak_additive_only.md``):
+
+  - Default mode mirrors providers + adds tokenpak-* to the model
+    allowlist + copies auth profiles, but does NOT touch the user's
+    ``primary``, ``fallbacks``, or per-agent model selections.
+  - ``--exclusive`` mode (or ``TOKENPAK_INJECT_EXCLUSIVE=1`` env)
+    additionally rewrites primary to ``tokenpak-*`` and clears
+    fallbacks.
+
+Tests run the script against synthetic openclaw.json fixtures in tmp
+dirs — no host config is touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "integrations/openclaw/tokenpak-inject.sh"
+
+
+def _make_config(tmp_path: Path) -> Path:
+    """Synthesize a minimal openclaw.json fixture with two providers,
+    a primary, and a fallback chain — the shape inject is supposed to
+    leave alone in default mode."""
+    cfg_dir = tmp_path / "openclaw"
+    cfg_dir.mkdir()
+    config = {
+        "models": {
+            "providers": {
+                "anthropic": {
+                    "baseUrl": "https://api.anthropic.com",
+                    "api": "anthropic-messages",
+                    "models": [
+                        {"id": "claude-opus-4-7", "name": "Opus 4.7"},
+                        {"id": "claude-haiku-4-5", "name": "Haiku 4.5"},
+                    ],
+                },
+                "openai": {
+                    "baseUrl": "https://api.openai.com",
+                    "api": "openai-responses",
+                    "models": [
+                        {"id": "gpt-5.4", "name": "GPT 5.4"},
+                    ],
+                },
+            }
+        },
+        "agents": {
+            "defaults": {
+                "model": {
+                    "primary": "anthropic/claude-opus-4-7",
+                    "fallbacks": [
+                        "anthropic/claude-haiku-4-5",
+                        "openai/gpt-5.4",
+                    ],
+                },
+                "models": {
+                    "anthropic/claude-opus-4-7": {},
+                    "anthropic/claude-haiku-4-5": {},
+                    "openai/gpt-5.4": {},
+                },
+            },
+            "list": [
+                {
+                    "id": "test-agent",
+                    "model": {
+                        "primary": "anthropic/claude-haiku-4-5",
+                        "fallbacks": ["openai/gpt-5.4"],
+                    },
+                }
+            ],
+        },
+    }
+    path = cfg_dir / "openclaw.json"
+    path.write_text(json.dumps(config, indent=2))
+    return path
+
+
+def _run_inject(config_path: Path, *, exclusive: bool) -> subprocess.CompletedProcess:
+    """Run the inject script against a tmp config dir."""
+    env = os.environ.copy()
+    # OPENCLAW_CONFIG_PATH is the env var the script honors to find
+    # the config file (instead of the default ~/.openclaw/openclaw.json).
+    env["OPENCLAW_CONFIG_PATH"] = str(config_path)
+    if exclusive:
+        env["TOKENPAK_INJECT_EXCLUSIVE"] = "1"
+    else:
+        env.pop("TOKENPAK_INJECT_EXCLUSIVE", None)
+    return subprocess.run(
+        [str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+# ── DEFAULT MODE: additive only ──────────────────────────────────────
+
+
+class TestDefaultModeAdditive:
+    def test_mirrors_providers_without_removing_originals(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        result = _run_inject(cfg_path, exclusive=False)
+        assert result.returncode == 0, f"script failed:\n{result.stderr}"
+        config = json.loads(cfg_path.read_text())
+        providers = config["models"]["providers"]
+        # Originals preserved
+        assert "anthropic" in providers
+        assert "openai" in providers
+        # Tokenpak mirrors added
+        assert "tokenpak-anthropic" in providers
+        assert "tokenpak-openai" in providers
+
+    def test_does_not_touch_primary_in_defaults(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=False)
+        config = json.loads(cfg_path.read_text())
+        primary = config["agents"]["defaults"]["model"]["primary"]
+        assert primary == "anthropic/claude-opus-4-7", (
+            f"default mode mutated primary: {primary!r}"
+        )
+
+    def test_does_not_clear_fallbacks_in_defaults(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=False)
+        config = json.loads(cfg_path.read_text())
+        fallbacks = config["agents"]["defaults"]["model"]["fallbacks"]
+        assert fallbacks == [
+            "anthropic/claude-haiku-4-5",
+            "openai/gpt-5.4",
+        ], f"default mode mutated fallbacks: {fallbacks!r}"
+
+    def test_does_not_touch_per_agent_model(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=False)
+        config = json.loads(cfg_path.read_text())
+        agent = config["agents"]["list"][0]
+        assert agent["model"]["primary"] == "anthropic/claude-haiku-4-5"
+        assert agent["model"]["fallbacks"] == ["openai/gpt-5.4"]
+
+    def test_adds_tokenpak_models_to_allowlist(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=False)
+        config = json.loads(cfg_path.read_text())
+        allowlist = config["agents"]["defaults"]["models"]
+        # Originals preserved
+        assert "anthropic/claude-opus-4-7" in allowlist
+        # Tokenpak version added
+        assert "tokenpak-anthropic/claude-opus-4-7" in allowlist
+
+
+# ── EXCLUSIVE MODE: destructive routing ──────────────────────────────
+
+
+class TestExclusiveMode:
+    def test_replaces_primary_with_tokenpak_version(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=True)
+        config = json.loads(cfg_path.read_text())
+        primary = config["agents"]["defaults"]["model"]["primary"]
+        assert primary == "tokenpak-anthropic/claude-opus-4-7", (
+            f"exclusive mode should rewrite primary, got {primary!r}"
+        )
+
+    def test_clears_fallbacks(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=True)
+        config = json.loads(cfg_path.read_text())
+        fallbacks = config["agents"]["defaults"]["model"]["fallbacks"]
+        assert fallbacks == []
+
+    def test_still_does_not_remove_original_providers(self, tmp_path: Path):
+        # Even in exclusive mode, original provider entries must
+        # remain — the user can still manually flip back to a raw
+        # provider via OpenClaw's UI/config.
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=True)
+        config = json.loads(cfg_path.read_text())
+        providers = config["models"]["providers"]
+        assert "anthropic" in providers
+        assert "openai" in providers
+
+
+# ── Mode reporting in script output ──────────────────────────────────
+
+
+class TestModeLogging:
+    def test_default_mode_logs_additive(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        result = _run_inject(cfg_path, exclusive=False)
+        assert "additive" in result.stdout.lower()
+        assert "exclusive" not in result.stdout.lower() or "rewrites" not in result.stdout.lower()
+
+    def test_exclusive_mode_logs_warning(self, tmp_path: Path):
+        cfg_path = _make_config(tmp_path)
+        result = _run_inject(cfg_path, exclusive=True)
+        assert "exclusive" in result.stdout.lower()
+
+
+# ── Idempotent in both modes ─────────────────────────────────────────
+
+
+class TestIdempotent:
+    @pytest.mark.parametrize("exclusive", [False, True])
+    def test_running_twice_yields_same_output(self, tmp_path: Path, exclusive):
+        cfg_path = _make_config(tmp_path)
+        _run_inject(cfg_path, exclusive=exclusive)
+        first = json.loads(cfg_path.read_text())
+        _run_inject(cfg_path, exclusive=exclusive)
+        second = json.loads(cfg_path.read_text())
+        assert first == second


### PR DESCRIPTION
## Summary

Implements the standing rule Kevin flagged 2026-04-25: **tokenpak integrations add options alongside the user's setup; never remove providers, wipe fallbacks, or replace primary model selections without explicit opt-in**.

The inject script previously had `model_cfg["fallbacks"] = []` unconditionally — fine for Kevin's dedicated-bot host but hostile to any general user, who would silently lose their fallback chain on first install.

## Changes

- **Default mode (additive)** — mirrors providers as `tokenpak-*`, copies auth profiles, syncs Codex JWT, adds `tokenpak-*` to the model allowlist. **User's primary, fallbacks, and per-agent model selections are untouched.** They opt in to tokenpak by manually selecting a `tokenpak-*` model.
- **Exclusive mode (`--exclusive` flag or `TOKENPAK_INJECT_EXCLUSIVE=1`)** — additionally rewrites primary to `tokenpak-*` and clears fallbacks. The v1 destructive default, gated. Use for dedicated tokenpak hosts.
- Either way, **existing non-tokenpak provider entries are never removed** — the user can always manually flip back.

## Migration

| User | Impact |
|---|---|
| General users (default) | Now does what they'd expect all along — see `tokenpak-*` providers as options without losing their routing |
| Kevin's host (currently running destructive default) | Next `ExecStartPre` run won't re-mutate (old changes are persistent in config). To keep current proxy-only routing, add `--exclusive` to systemd drop-in. To restore mixed routing, `tokenpak-uninstall.sh` then re-install in default mode. |

## Files

- `integrations/openclaw/tokenpak-inject.sh` — `--exclusive` flag, `EXCLUSIVE` Python global, `interleave()` early-returns when not exclusive, mode logged at startup
- `integrations/openclaw/README.md` — documents both modes with additive-default upfront, exclusive as opt-in
- **NEW** `tests/test_inject_additive_default.py` — 12 tests running the script against synthetic openclaw.json fixtures in tmp dirs

## Test plan

- [x] `pytest tests/test_inject_additive_default.py` — 12 passed
  - Default mode: providers mirrored, originals preserved, primary/fallbacks/per-agent models untouched, allowlist additive
  - Exclusive mode: primary rewritten, fallbacks cleared, originals still present
  - Mode reporting in script output
  - Both modes idempotent (re-run yields identical config)
- [x] `ruff check` clean
- [ ] Live: install on a fresh OpenClaw config + verify primary/fallbacks intact
- [ ] Live: install with `--exclusive` + verify primary rewritten + fallbacks cleared

## Standing rule

Captured in `feedback_tokenpak_additive_only.md` (auto-memory). Future integration scripts (Cursor, Claude Code, future platforms) inherit the additive-default rule from the start.