### PR TITLE
feat(proxy): Phase 2a — Azure OpenAI adapter + body-aware URL resolution

### DIFF
--- a/tests/test_phase2a_azure_openai.py
+++ b/tests/test_phase2a_azure_openai.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2a: Azure OpenAI adapter — body-aware URL resolution.
+
+Azure OpenAI uses the same wire format as OpenAI Chat Completions but
+routes by deployment id in the URL path
+(``<endpoint>/openai/deployments/<dep>/chat/completions``) and uses
+``api-key`` instead of ``Authorization: Bearer``. Tests verify:
+
+  - The InjectionPlan's ``target_url_resolver`` is called with the
+    request body + headers and returns a fully-qualified Azure URL.
+  - Header override (``X-Azure-Deployment``) wins over body's model field.
+  - Missing creds / endpoint / model field returns None at each layer.
+  - ``api-key`` header replaces caller's auth.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tokenpak.services.routing_service.credential_injector import (
+    AzureOpenAICredentialProvider,
+    invalidate_cache,
+    registered,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+def _set_creds(monkeypatch, key="sk-azure-test", endpoint="https://my-resource.openai.azure.com"):
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", key)
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", endpoint)
+
+
+# ── resolve() returns plan only when both env vars set ────────────────
+
+
+class TestResolveGate:
+    def test_no_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_only_key_returns_none(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_only_endpoint_returns_none(self, monkeypatch):
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com")
+        assert AzureOpenAICredentialProvider().resolve() is None
+
+    def test_both_set_returns_plan(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan is not None
+
+
+# ── Auth shape: api-key header replaces caller auth ───────────────────
+
+
+class TestAuthHeader:
+    def test_emits_api_key_header_not_bearer(self, monkeypatch):
+        _set_creds(monkeypatch, key="sk-real-azure-key")
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.add_headers == {"api-key": "sk-real-azure-key"}
+        # Must NOT inject a Bearer Authorization (Azure doesn't accept it).
+        assert "Authorization" not in plan.add_headers
+
+    def test_strips_callers_auth_headers(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+
+
+# ── URL resolution: body's model field → deployment id ────────────────
+
+
+class TestUrlResolution:
+    def test_model_field_becomes_deployment_in_url(self, monkeypatch):
+        _set_creds(monkeypatch, endpoint="https://my-resource.openai.azure.com")
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "my-gpt4-deployment", "messages": []}).encode()
+        url = plan.target_url_resolver(body, {})
+        assert url == (
+            "https://my-resource.openai.azure.com/openai/deployments/"
+            "my-gpt4-deployment/chat/completions?api-version=2024-10-21"
+        )
+
+    def test_uses_explicit_api_version_env(self, monkeypatch):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2025-03-15-preview")
+        # Recreate provider so env is reread (cache cleared by fixture).
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "x"}).encode()
+        url = plan.target_url_resolver(body, {})
+        assert "api-version=2025-03-15-preview" in url
+
+    def test_endpoint_trailing_slash_tolerated(self, monkeypatch):
+        _set_creds(monkeypatch, endpoint="https://x.openai.azure.com///")
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "d"}).encode()
+        url = plan.target_url_resolver(body, {})
+        # No double slashes after the host.
+        assert url.startswith("https://x.openai.azure.com/openai/deployments/d/")
+        assert "//openai" not in url
+
+    def test_missing_model_field_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"messages": []}).encode()
+        assert plan.target_url_resolver(body, {}) is None
+
+    def test_empty_model_field_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "", "messages": []}).encode()
+        assert plan.target_url_resolver(body, {}) is None
+
+    def test_malformed_body_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.target_url_resolver(b"not json", {}) is None
+
+    def test_empty_body_returns_none(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        assert plan.target_url_resolver(b"", {}) is None
+
+
+class TestHeaderOverride:
+    def test_x_azure_deployment_header_wins_over_body(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-deployment"}).encode()
+        url = plan.target_url_resolver(
+            body, {"X-Azure-Deployment": "header-deployment"}
+        )
+        assert "/deployments/header-deployment/" in url
+        assert "body-deployment" not in url
+
+    def test_lowercase_header_lookup(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-d"}).encode()
+        url = plan.target_url_resolver(
+            body, {"x-azure-deployment": "lower-d"}
+        )
+        assert "/deployments/lower-d/" in url
+
+    def test_empty_header_falls_through_to_body(self, monkeypatch):
+        _set_creds(monkeypatch)
+        plan = AzureOpenAICredentialProvider().resolve()
+        body = json.dumps({"model": "body-d"}).encode()
+        url = plan.target_url_resolver(body, {"X-Azure-Deployment": "  "})
+        assert "/deployments/body-d/" in url
+
+
+# ── Auto-registration ────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_registered_with_known_slug(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-azure-openai" in names
+
+    def test_does_not_displace_existing_providers(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-claude-code" in names
+        assert "tokenpak-mistral" in names

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1185,6 +1185,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     add_headers={},
                     merge_headers={},
                     target_url_override=_full_plan.target_url_override,
+                    target_url_resolver=_full_plan.target_url_resolver,
                     body_transform=_full_plan.body_transform,
                 )
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
@@ -1297,8 +1298,27 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         _mutable_headers[_mk] = _merged
                 else:
                     _mutable_headers[_mk] = _mv
-            # 3. Rewrite the target URL when the plan specifies (Codex).
-            if _plan.target_url_override:
+            # 3. Rewrite the target URL when the plan specifies. Two
+            # mechanisms, in priority order:
+            #   - ``target_url_resolver``: body-aware resolution (Azure
+            #     OpenAI routes by deployment id from the body's
+            #     ``model`` field). Returning ``None`` falls back to
+            #     the static override.
+            #   - ``target_url_override``: static rewrite (Codex points
+            #     at ChatGPT backend regardless of body).
+            _resolver = getattr(_plan, "target_url_resolver", None)
+            if _resolver is not None:
+                try:
+                    _resolved_url = _resolver(body or b"", dict(self.headers))
+                except Exception:
+                    _resolved_url = None
+                if _resolved_url:
+                    target_url = _resolved_url
+                    parsed = urlparse(target_url)
+                elif _plan.target_url_override:
+                    target_url = _plan.target_url_override
+                    parsed = urlparse(target_url)
+            elif _plan.target_url_override:
                 target_url = _plan.target_url_override
                 parsed = urlparse(target_url)
             # 3b. Claude Code identity: ensure ``?beta=true`` is on the

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -54,7 +54,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, FrozenSet, List, Optional, Protocol
+from typing import Callable, Dict, FrozenSet, List, Mapping, Optional, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,17 @@ class InjectionPlan:
       merge step. Empty caller → falls back to our value.
     - ``target_url_override``: when set, replaces the original target URL
       entirely (e.g. ``chatgpt.com/backend-api/codex/responses`` for
-      Codex). ``None`` means keep the original target.
+      Codex). ``None`` means keep the original target. Static — does
+      not depend on the request body.
+    - ``target_url_resolver``: optional ``(body, headers) -> Optional[str]``
+      callable for providers that compute the URL from the request
+      payload. Azure OpenAI is the canonical case: the deployment id
+      lives in the body's ``model`` field but Azure routes it via the
+      URL path
+      (``<endpoint>/openai/deployments/<deployment>/chat/completions``).
+      When set, overrides ``target_url_override``. Returning ``None``
+      from the resolver falls back to ``target_url_override`` (then to
+      the original target).
     - ``body_transform``: optional bytes → bytes transform applied
       before forward. Codex needs a few payload-normalization tweaks
       (``stream=true``, ``store=false``, drop ``max_output_tokens``).
@@ -89,6 +99,9 @@ class InjectionPlan:
     add_headers: Dict[str, str] = field(default_factory=dict)
     merge_headers: Dict[str, str] = field(default_factory=dict)
     target_url_override: Optional[str] = None
+    target_url_resolver: Optional[
+        Callable[[bytes, Mapping[str, str]], Optional[str]]
+    ] = None
     body_transform: Optional[Callable[[bytes], bytes]] = None
 
 
@@ -585,6 +598,104 @@ class DeepSeekCredentialProvider(_EnvKeyBearerProvider):
     _ENV_VAR = "DEEPSEEK_API_KEY"
 
 
+class AzureOpenAICredentialProvider:
+    """Azure OpenAI — same wire format as OpenAI Chat Completions but
+    routes by deployment id in the URL path, uses ``api-key`` header
+    (not ``Authorization: Bearer``), and requires an ``api-version``
+    query param.
+
+    Three env vars, all required:
+
+      - ``AZURE_OPENAI_API_KEY`` — the resource's API key.
+      - ``AZURE_OPENAI_ENDPOINT`` — the resource URL, e.g.
+        ``https://my-resource.openai.azure.com``. Trailing slash is
+        tolerated.
+      - ``AZURE_OPENAI_API_VERSION`` — the API version to pin
+        (default ``2024-10-21``). Azure breaks compat across versions
+        more often than other providers; the default is a stable GA
+        line as of 2026.
+
+    Routing model
+    -------------
+
+    Azure customers create *deployments* of OpenAI models. The
+    deployment name (which the customer picks) — not the canonical
+    model id — is what Azure routes by. Two ways to supply it:
+
+      - **Default**: caller sets ``model: "<deployment-name>"`` in the
+        request body. We pull it and build
+        ``<endpoint>/openai/deployments/<deployment>/chat/completions?api-version=...``.
+      - **Override**: caller sets ``X-Azure-Deployment: <name>`` header.
+        Wins over the body field. Useful when the caller wants to keep
+        the canonical model id in the body for telemetry / cost
+        tracking but route to a deployment with a different name.
+
+    No body-side ``model`` rewrite — Azure tolerates it (and some
+    middleware chains rely on it being preserved).
+    """
+
+    name = "tokenpak-azure-openai"
+    _DEFAULT_API_VERSION = "2024-10-21"
+    _PATH_TEMPLATE = "/openai/deployments/{deployment}/chat/completions"
+
+    def _load(self) -> Optional[InjectionPlan]:
+        api_key = _os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
+        endpoint = _os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+        if not api_key:
+            logger.info(
+                "credential_injector[azure-openai]: AZURE_OPENAI_API_KEY "
+                "not set; skipping"
+            )
+            return None
+        if not endpoint:
+            logger.info(
+                "credential_injector[azure-openai]: AZURE_OPENAI_ENDPOINT "
+                "not set; skipping"
+            )
+            return None
+
+        api_version = (
+            _os.environ.get("AZURE_OPENAI_API_VERSION", "").strip()
+            or self._DEFAULT_API_VERSION
+        )
+        endpoint = endpoint.rstrip("/")
+
+        def _resolve_url(body: bytes, headers: Mapping[str, str]) -> Optional[str]:
+            # Header override wins.
+            for k, v in (headers or {}).items():
+                if k.lower() == "x-azure-deployment" and v:
+                    deployment = v.strip()
+                    if deployment:
+                        return self._build_url(endpoint, deployment, api_version)
+            # Else read deployment from body's model field.
+            if not body:
+                return None
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+            if not isinstance(data, dict):
+                return None
+            deployment = data.get("model")
+            if not isinstance(deployment, str) or not deployment.strip():
+                return None
+            return self._build_url(endpoint, deployment.strip(), api_version)
+
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key"}),
+            add_headers={"api-key": api_key},
+            target_url_resolver=_resolve_url,
+        )
+
+    @classmethod
+    def _build_url(cls, endpoint: str, deployment: str, api_version: str) -> str:
+        path = cls._PATH_TEMPLATE.format(deployment=deployment)
+        return f"{endpoint}{path}?api-version={api_version}"
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
 class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
     """OpenRouter — meta-provider proxying ~100 models. ``OPENROUTER_API_KEY``.
 
@@ -612,9 +723,11 @@ register(GroqCredentialProvider())
 register(TogetherCredentialProvider())
 register(DeepSeekCredentialProvider())
 register(OpenRouterCredentialProvider())
+register(AzureOpenAICredentialProvider())
 
 
 __all__ = [
+    "AzureOpenAICredentialProvider",
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
     "CredentialProvider",


### PR DESCRIPTION
## Summary

Re-opens [PR #28](https://github.com/tokenpak/tokenpak/pull/28) (auto-closed when its base branch \`feat/codex-launcher-and-precedence\` was deleted on PR #27 merge) — same content, rebased onto current main.

First enterprise-tier provider in the adapter program. Azure OpenAI shares OpenAI's Chat Completions wire format but routes by deployment id (URL path) and uses \`api-key\` headers (not \`Authorization: Bearer\`).

- **\`InjectionPlan.target_url_resolver\`** — new optional callable, \`Callable[[bytes, headers], Optional[str]]\`. Lets a plan compute the URL from the request body. Codex's existing static \`target_url_override\` path is unchanged.
- **\`AzureOpenAICredentialProvider\`** — reads \`AZURE_OPENAI_API_KEY\` + \`AZURE_OPENAI_ENDPOINT\` env vars. Deployment from request body's \`model\` field, or \`X-Azure-Deployment\` header override.

## Live verification (2026-04-25)

\`\`\`
[INJECT]      provider=tokenpak-azure-openai  plan=applied
[POST-INJECT] url=https://test-resource.openai.azure.com/openai
                  /deployments/my-gpt4-deployment/chat/completions
              headers=… | api-key | host
\`\`\`

Azure 401 \`Access denied due to invalid subscription key\` — wire fully connected; with a real key + resource the request routes to the customer's actual deployment.

## Test plan

- [x] \`pytest tests/test_phase2a_azure_openai.py\` — 18 passed
- [x] \`ruff check\` clean
- [x] \`lint-imports\` clean (5/5 contracts kept)
- [x] Live: body-derived deployment routing through proxy → real Azure URL → Azure 401 (correct: fake key)
- [x] Live: \`X-Azure-Deployment\` header override wins over body's model field

## Order

This is the next PR in the landing sequence after #27. Phase 2b Bedrock (#29 → reopens as new) and Phase 3 Cohere/Vertex (#31 → reopens as new) follow.