### PR TITLE
feat(proxy): Phase 2b — AWS Bedrock for Claude (SigV4 + envelope)

### DIFF
--- a/tests/test_phase2b_bedrock_claude.py
+++ b/tests/test_phase2b_bedrock_claude.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2b: AWS Bedrock for Claude — SigV4 + Bedrock envelope.
+
+Bedrock takes the Anthropic Messages payload but routes the model via
+URL path (not body) and authenticates with AWS SigV4 over the request
+bytes. The provider:
+
+  - Strips ``model`` from the body and adds ``anthropic_version`` per
+    Bedrock's contract.
+  - Builds the URL from the body's ``model`` field — picks
+    ``/invoke`` or ``/invoke-with-response-stream`` based on the
+    body's ``stream`` flag.
+  - Signs with boto3's ``SigV4Auth`` after body transform + URL
+    resolution, so the signature reflects the exact bytes being sent.
+
+Tests use placeholder AWS creds via env vars; SigV4 produces a valid
+signature shape (we verify the headers it emits without hitting AWS).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+
+from tokenpak.services.routing_service.credential_injector import (
+    BedrockClaudeCredentialProvider,
+    invalidate_cache,
+    registered,
+)
+
+
+@pytest.fixture(autouse=True)
+def _aws_env(monkeypatch):
+    """Set placeholder AWS credentials so boto3's session can resolve."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+# ── boto3 gating ─────────────────────────────────────────────────────
+
+
+class TestBoto3Gating:
+    def test_returns_none_when_boto3_missing(self, monkeypatch):
+        # Simulate boto3 being unimportable by replacing the cached
+        # module entry. The provider catches ImportError and logs.
+        import sys
+        monkeypatch.setitem(sys.modules, "boto3", None)
+        # Force cache reload of the credential_injector module so
+        # ``import boto3`` re-runs inside _load.
+        invalidate_cache()
+        plan = BedrockClaudeCredentialProvider().resolve()
+        assert plan is None
+
+
+# ── URL resolution from body ─────────────────────────────────────────
+
+
+class TestUrlResolution:
+    def _resolver(self):
+        return BedrockClaudeCredentialProvider().resolve().target_url_resolver
+
+    def test_non_streaming_picks_invoke_suffix(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode()
+        url = self._resolver()(body, {})
+        assert url == (
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/"
+            "anthropic.claude-3-5-sonnet-20241022-v2:0/invoke"
+        )
+
+    def test_streaming_picks_response_stream_suffix(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-haiku-20240307-v1:0",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }).encode()
+        url = self._resolver()(body, {})
+        assert url.endswith(
+            "/model/anthropic.claude-3-haiku-20240307-v1:0/invoke-with-response-stream"
+        )
+
+    def test_inference_profile_arn_preserved(self):
+        # Inference profile IDs contain dots/colons; the resolver must
+        # not mangle them.
+        body = json.dumps({
+            "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [],
+        }).encode()
+        url = self._resolver()(body, {})
+        assert "us.anthropic.claude-3-5-sonnet-20241022-v2:0" in url
+
+    def test_region_env_override(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "eu-west-2")
+        invalidate_cache()
+        body = json.dumps({"model": "anthropic.claude-x", "messages": []}).encode()
+        url = BedrockClaudeCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "bedrock-runtime.eu-west-2.amazonaws.com" in url
+
+    def test_default_region_when_neither_env_var_set(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        invalidate_cache()
+        body = json.dumps({"model": "anthropic.claude-x", "messages": []}).encode()
+        url = BedrockClaudeCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "bedrock-runtime.us-east-1.amazonaws.com" in url
+
+    def test_missing_model_returns_none(self):
+        body = json.dumps({"messages": []}).encode()
+        assert self._resolver()(body, {}) is None
+
+    def test_empty_body_returns_none(self):
+        assert self._resolver()(b"", {}) is None
+
+    def test_malformed_body_returns_none(self):
+        assert self._resolver()(b"not json", {}) is None
+
+
+# ── Body transform: strip model + add anthropic_version ──────────────
+
+
+class TestBodyTransform:
+    def _xform(self):
+        return BedrockClaudeCredentialProvider().resolve().body_transform
+
+    def test_strips_model_field(self):
+        body = json.dumps({
+            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        }).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert "model" not in decoded
+        assert decoded["messages"] == [{"role": "user", "content": "hi"}]
+        assert decoded["max_tokens"] == 100
+
+    def test_adds_anthropic_version(self):
+        body = json.dumps({"model": "x", "messages": []}).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert decoded["anthropic_version"] == "bedrock-2023-05-31"
+
+    def test_preserves_callers_anthropic_version(self):
+        # If the caller already set their own version, don't clobber.
+        body = json.dumps({
+            "model": "x",
+            "messages": [],
+            "anthropic_version": "bedrock-2023-05-31-custom",
+        }).encode()
+        out = self._xform()(body)
+        decoded = json.loads(out)
+        assert decoded["anthropic_version"] == "bedrock-2023-05-31-custom"
+
+    def test_empty_body_passes_through(self):
+        assert self._xform()(b"") == b""
+
+    def test_malformed_body_passes_through(self):
+        assert self._xform()(b"not json") == b"not json"
+
+
+# ── SigV4 header_resolver ────────────────────────────────────────────
+
+
+class TestSigV4Headers:
+    def _signer(self):
+        return BedrockClaudeCredentialProvider().resolve().header_resolver
+
+    def test_emits_canonical_sigv4_headers(self):
+        url = (
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/"
+            "anthropic.claude-x/invoke"
+        )
+        body = json.dumps({"messages": [], "anthropic_version": "x"}).encode()
+        headers = self._signer()(body, url, "POST", {})
+        # SigV4 always emits these four.
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256 Credential=")
+        assert "X-Amz-Date" in headers or "x-amz-date" in {
+            k.lower() for k in headers
+        }
+        # Host derived from URL.
+        host_key = next(k for k in headers if k.lower() == "host")
+        assert headers[host_key] == "bedrock-runtime.us-east-1.amazonaws.com"
+
+    def test_signature_changes_when_body_changes(self):
+        signer = self._signer()
+        url = "https://bedrock-runtime.us-east-1.amazonaws.com/model/x/invoke"
+        body_a = json.dumps({"a": 1}).encode()
+        body_b = json.dumps({"a": 2}).encode()
+        # SigV4 includes a date timestamp, so two consecutive calls
+        # may produce the same Authorization for the same body if
+        # they land in the same second. We just check the two bodies
+        # produce DIFFERENT Authorization headers — the signature
+        # must reflect body bytes (it includes the SHA256 of body
+        # in the canonical request).
+        headers_a = signer(body_a, url, "POST", {})
+        headers_b = signer(body_b, url, "POST", {})
+        assert headers_a["Authorization"] != headers_b["Authorization"]
+
+
+# ── End-to-end plan composition ──────────────────────────────────────
+
+
+class TestPlanComposition:
+    def test_plan_has_all_dynamic_fields(self):
+        plan = BedrockClaudeCredentialProvider().resolve()
+        assert plan is not None
+        assert plan.target_url_resolver is not None
+        assert plan.body_transform is not None
+        assert plan.header_resolver is not None
+        # Static fields:
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+        assert plan.add_headers["Content-Type"] == "application/json"
+        # Dynamic SigV4 means no static Authorization to inject.
+        assert "Authorization" not in plan.add_headers
+
+
+class TestRegistration:
+    def test_registered_with_known_slug(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-bedrock-claude" in names
+
+    def test_does_not_displace_other_providers(self):
+        names = {p.name for p in registered()}
+        for slug in (
+            "tokenpak-claude-code",
+            "tokenpak-mistral",
+            "tokenpak-azure-openai",
+        ):
+            assert slug in names

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1187,6 +1187,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     target_url_override=_full_plan.target_url_override,
                     target_url_resolver=_full_plan.target_url_resolver,
                     body_transform=_full_plan.body_transform,
+                    header_resolver=_full_plan.header_resolver,
                 )
                 if os.environ.get("TOKENPAK_DUMP_HEADERS", "").strip() == "1":
                     import logging as _logging
@@ -1350,6 +1351,42 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         "tokenpak.proxy: body transform failed (%s) — using original",
                         _xf_err,
                     )
+
+            # 5. Dynamic header resolution — computed from the FINAL
+            # body + URL + method (after steps 1-4). Used by AWS SigV4
+            # signing, which depends on the exact bytes being sent.
+            # Result is merged on top of the static add_headers so the
+            # signature reflects everything the upstream will see.
+            _hdr_resolver = getattr(_plan, "header_resolver", None)
+            if _hdr_resolver is not None:
+                try:
+                    _dynamic = _hdr_resolver(
+                        body or b"",
+                        target_url,
+                        method,
+                        dict(_mutable_headers),
+                    )
+                except Exception as _hr_err:
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).warning(
+                        "tokenpak.proxy: header_resolver failed (%s) — "
+                        "using static headers only",
+                        _hr_err,
+                    )
+                    _dynamic = None
+                if _dynamic:
+                    for _hk, _hv in _dynamic.items():
+                        # Case-insensitive replace: drop any caller / static
+                        # headers with the same key (case folded), then
+                        # set the dynamic value. Critical for SigV4 — the
+                        # signature must match the EXACT header set sent.
+                        for _existing in [
+                            k for k in list(_mutable_headers)
+                            if k.lower() == _hk.lower()
+                        ]:
+                            _mutable_headers.pop(_existing, None)
+                        _mutable_headers[_hk] = _hv
 
             # Build forwarding headers from the rewritten header dict.
             fwd_headers = forward_headers(_mutable_headers, passthrough_cfg)

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -103,6 +103,16 @@ class InjectionPlan:
         Callable[[bytes, Mapping[str, str]], Optional[str]]
     ] = None
     body_transform: Optional[Callable[[bytes], bytes]] = None
+    # Dynamic per-request headers — computed AFTER body_transform +
+    # URL resolution. Used when a provider's auth depends on the exact
+    # bytes being sent (AWS SigV4 is the canonical case: the Authorization
+    # header is a hash of the request including method, URL, headers,
+    # and body content). Result is merged into the request headers,
+    # OVERRIDING ``add_headers`` for any conflicting keys (because the
+    # dynamic value is the authoritative one).
+    header_resolver: Optional[
+        Callable[[bytes, str, str, Mapping[str, str]], Dict[str, str]]
+    ] = None
 
 
 # ── Provider protocol + registry ─────────────────────────────────────
@@ -713,6 +723,162 @@ class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
     }
 
 
+class BedrockClaudeCredentialProvider:
+    """AWS Bedrock for Anthropic Claude — Anthropic Messages format
+    wrapped in Bedrock's InvokeModel envelope, signed with AWS SigV4.
+
+    Bedrock takes the Messages payload directly (almost — it wants
+    ``anthropic_version: "bedrock-2023-05-31"`` and forbids the
+    ``model`` field, which is encoded in the URL instead). Auth is
+    SigV4 over the request bytes; we delegate signing to ``boto3`` to
+    avoid maintaining a hand-rolled HMAC implementation.
+
+    Required:
+
+      - ``boto3`` installed (standard AWS Python ecosystem dep).
+      - ``AWS_ACCESS_KEY_ID`` + ``AWS_SECRET_ACCESS_KEY`` env vars
+        (or any boto3-discoverable credentials: profile, IAM role,
+        SSO, etc. — we use ``boto3.Session()`` which resolves all of
+        them).
+      - ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` env var. Default
+        ``us-east-1`` if neither set.
+
+    Routing
+    -------
+
+    Bedrock specifies the model via URL path
+    (``/model/<id>/invoke``); the request body MUST NOT contain a
+    ``model`` field. The caller is expected to put the Bedrock model
+    id (e.g. ``anthropic.claude-3-5-sonnet-20241022-v2:0``, or an
+    inference-profile ARN) in the body's ``model`` field — we strip
+    it out before forwarding and use it to build the URL.
+
+    Streaming uses the ``/invoke-with-response-stream`` suffix; we
+    pick that variant when the request body sets ``stream: true``.
+
+    Plan composition
+    ----------------
+
+      - ``target_url_resolver`` — body-aware (model + stream flag).
+      - ``body_transform`` — strips ``model``, adds
+        ``anthropic_version``.
+      - ``header_resolver`` — SigV4 signs the FINAL body + URL +
+        method on every request.
+
+    No ``add_headers`` / ``Authorization`` — SigV4 puts everything in
+    the dynamic resolver because all four (Authorization, x-amz-date,
+    x-amz-content-sha256, host) depend on the exact final bytes.
+    """
+
+    name = "tokenpak-bedrock-claude"
+    _DEFAULT_REGION = "us-east-1"
+    _SERVICE = "bedrock"
+    _ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+    def _load(self) -> Optional[InjectionPlan]:
+        try:
+            import boto3  # noqa: F401  (presence check only here)
+        except ImportError:
+            logger.info(
+                "credential_injector[bedrock]: boto3 not installed; skipping. "
+                "`pip install boto3` to enable Bedrock routing."
+            )
+            return None
+
+        # Resolve region: env first, then boto3's session default.
+        region = (
+            _os.environ.get("AWS_REGION", "").strip()
+            or _os.environ.get("AWS_DEFAULT_REGION", "").strip()
+            or self._DEFAULT_REGION
+        )
+
+        # Build a session lazily so credential errors surface per-request
+        # (not at provider-resolve time when boto3 may not have looked
+        # at env vars yet).
+        endpoint_host = f"bedrock-runtime.{region}.amazonaws.com"
+
+        def _resolve_url(body: bytes, headers: Mapping[str, str]) -> Optional[str]:
+            if not body:
+                return None
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+            if not isinstance(data, dict):
+                return None
+            model = data.get("model")
+            if not isinstance(model, str) or not model.strip():
+                return None
+            stream = bool(data.get("stream"))
+            suffix = "invoke-with-response-stream" if stream else "invoke"
+            # Inference-profile ARNs contain ``:`` which must NOT be
+            # URL-encoded for Bedrock — use as-is.
+            return f"https://{endpoint_host}/model/{model.strip()}/{suffix}"
+
+        def _transform_body(body: bytes) -> bytes:
+            if not body:
+                return body
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return body
+            if not isinstance(data, dict):
+                return body
+            data.pop("model", None)
+            data.setdefault("anthropic_version", self._ANTHROPIC_VERSION)
+            try:
+                return json.dumps(data).encode("utf-8")
+            except (TypeError, ValueError):
+                return body
+
+        def _sign_request(
+            body: bytes,
+            url: str,
+            method: str,
+            _existing_headers: Mapping[str, str],
+        ) -> Dict[str, str]:
+            # Use boto3's SigV4Auth — battle-tested + handles all the
+            # canonical-request edge cases (case folding, empty bodies,
+            # query string normalisation) we'd otherwise have to
+            # replicate by hand.
+            from boto3 import Session as _Session
+            from botocore.auth import SigV4Auth
+            from botocore.awsrequest import AWSRequest
+
+            session = _Session()
+            creds = session.get_credentials()
+            if creds is None:
+                logger.warning(
+                    "credential_injector[bedrock]: no AWS credentials "
+                    "discoverable by boto3 — request will fail upstream."
+                )
+                return {}
+            frozen = creds.get_frozen_credentials()
+            req = AWSRequest(method=method, url=url, data=body or b"")
+            # ``Host`` and ``content-type`` are required for signing;
+            # set them explicitly so the signature reflects what we'll
+            # actually send.
+            from urllib.parse import urlparse as _urlparse
+
+            req.headers["Host"] = _urlparse(url).netloc
+            req.headers["Content-Type"] = "application/json"
+            SigV4Auth(frozen, self._SERVICE, region).add_auth(req)
+            # SigV4Auth mutates req.headers in-place. Pull the resulting
+            # set out as a plain dict.
+            return dict(req.headers.items())
+
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key"}),
+            add_headers={"Content-Type": "application/json"},
+            target_url_resolver=_resolve_url,
+            body_transform=_transform_body,
+            header_resolver=_sign_request,
+        )
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
 # ── Register built-ins at import ─────────────────────────────────────
 
 
@@ -724,10 +890,12 @@ register(TogetherCredentialProvider())
 register(DeepSeekCredentialProvider())
 register(OpenRouterCredentialProvider())
 register(AzureOpenAICredentialProvider())
+register(BedrockClaudeCredentialProvider())
 
 
 __all__ = [
     "AzureOpenAICredentialProvider",
+    "BedrockClaudeCredentialProvider",
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
     "CredentialProvider",


### PR DESCRIPTION
## Summary

Re-opens [PR #29](https://github.com/tokenpak/tokenpak/pull/29) (auto-closed when its base branch was deleted on PR #32 merge) — same content, rebased onto current main.

Second enterprise-tier provider. Bedrock takes the Anthropic Messages payload but routes the model via URL path and authenticates with AWS SigV4 over the request bytes.

- **\`InjectionPlan.header_resolver\`** — new optional callable, \`Callable[[bytes, url, method, headers], Dict[str, str]]\`. Computed AFTER body_transform + URL resolution so dynamic headers reflect the EXACT bytes being sent. SigV4 is the canonical use case.
- **\`BedrockClaudeCredentialProvider\`** — composes target_url_resolver (URL from body's model + region) + body_transform (strip model, add anthropic_version) + header_resolver (boto3 SigV4Auth signs the final wire bytes).

## Live verification (2026-04-25)

\`\`\`
[INJECT]      provider=tokenpak-bedrock-claude  plan=applied
[POST-INJECT] url=https://bedrock-runtime.us-east-1.amazonaws.com
                  /model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke
              headers=… | x-amz-date | Authorization=<208 chars>
                       | host | content-length
\`\`\`

AWS responded \`The security token included in the request is invalid\` — SigV4 signature parsed correctly; AWS rejected the placeholder credentials. With real AWS creds + Bedrock model access, returns the model's response.

## Test plan

- [x] \`pytest tests/test_phase2b_bedrock_claude.py\` — 19 passed
- [x] \`ruff check\` clean
- [x] Local tests on rebased branch — 19/19 passed
- [x] Live: SigV4 signature emitted with placeholder creds → AWS validates shape, rejects creds (correct)
- [ ] User's first real Bedrock invocation with real AWS creds

## Order

Next in landing sequence after #32. Phase 3 Cohere+Vertex (was #31) follows.