### PR TITLE
feat(proxy): Phase 3 — Cohere v2 + Vertex AI Gemini credential providers

### DIFF
--- a/tests/test_phase3_cohere_vertex.py
+++ b/tests/test_phase3_cohere_vertex.py
@@ -59,6 +59,29 @@ class TestCohere:
 
 
 # ── Vertex AI Gemini ─────────────────────────────────────────────────
+#
+# google-auth is an optional dependency — production behavior is that
+# VertexAIGeminiCredentialProvider returns None when it's not installed
+# (verified by ``test_returns_none_without_google_auth``, which mocks
+# the import failure and runs unconditionally). The other Vertex tests
+# need the real library to exercise URL resolver / body transform /
+# header_resolver paths, so they're skipped when google-auth is
+# absent (CI hosts that don't pull the optional extra). Same pattern
+# boto3 follows for the Bedrock test module.
+
+try:
+    import google.auth  # noqa: F401
+    _HAS_GOOGLE_AUTH = True
+except ImportError:
+    _HAS_GOOGLE_AUTH = False
+
+_REQUIRES_GOOGLE_AUTH = pytest.mark.skipif(
+    not _HAS_GOOGLE_AUTH,
+    reason="google-auth not installed (optional dep). The provider "
+    "gracefully returns None in this case — see "
+    "TestVertexGating::test_returns_none_without_google_auth which "
+    "verifies that path unconditionally.",
+)
 
 
 @pytest.fixture
@@ -82,11 +105,13 @@ class TestVertexGating:
         monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
         assert VertexAIGeminiCredentialProvider().resolve() is None
 
+    @_REQUIRES_GOOGLE_AUTH
     def test_returns_plan_when_both_present(self, monkeypatch, _vertex_env):
         # google-auth IS importable in this test env; project IS set.
         plan = VertexAIGeminiCredentialProvider().resolve()
         assert plan is not None
 
+    @_REQUIRES_GOOGLE_AUTH
     def test_project_via_legacy_gcloud_env(self, monkeypatch):
         monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         monkeypatch.setenv("GCLOUD_PROJECT", "legacy-project-id")
@@ -98,6 +123,7 @@ class TestVertexGating:
         assert "/projects/legacy-project-id/" in url
 
 
+@_REQUIRES_GOOGLE_AUTH
 class TestVertexUrlResolution:
     def _resolver(self):
         return VertexAIGeminiCredentialProvider().resolve().target_url_resolver
@@ -147,6 +173,7 @@ class TestVertexUrlResolution:
         assert self._resolver()(body, {}) is None
 
 
+@_REQUIRES_GOOGLE_AUTH
 class TestVertexBodyTransform:
     def _xform(self, _vertex_env):
         return VertexAIGeminiCredentialProvider().resolve().body_transform
@@ -190,6 +217,7 @@ class TestVertexBodyTransform:
         }
 
 
+@_REQUIRES_GOOGLE_AUTH
 class TestVertexHeaderResolver:
     def test_emits_bearer_token_when_creds_resolvable(self, _vertex_env, monkeypatch):
         # Mock google.auth.default so we don't need real GCP creds.

--- a/tests/test_phase3_cohere_vertex.py
+++ b/tests/test_phase3_cohere_vertex.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 3: Cohere v2 (OpenAI-Chat-compat) + Vertex AI Gemini.
+
+Cohere v2's chat endpoint mirrors OpenAI Chat Completions wire format,
+so it slots into the Phase 1 ``_EnvKeyBearerProvider`` pattern as a
+five-line subclass.
+
+Vertex AI Gemini reuses the GoogleGenerativeAIAdapter for body shape
+but routes by ``publishers/google/models/<id>:streamGenerateContent``
+in the URL path and authenticates with OAuth2 access tokens fetched
+via Application Default Credentials (google-auth).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tokenpak.services.routing_service.credential_injector import (
+    CohereCredentialProvider,
+    VertexAIGeminiCredentialProvider,
+    invalidate_cache,
+    registered,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
+# ── Cohere v2 — Phase-1-style provider ───────────────────────────────
+
+
+class TestCohere:
+    def test_no_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        assert CohereCredentialProvider().resolve() is None
+
+    def test_valid_key_emits_bearer_plan(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "co-test-1234567890")
+        plan = CohereCredentialProvider().resolve()
+        assert plan is not None
+        assert plan.add_headers["Authorization"] == "Bearer co-test-1234567890"
+
+    def test_targets_v2_chat_endpoint(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "co-test")
+        plan = CohereCredentialProvider().resolve()
+        assert plan.target_url_override == "https://api.cohere.ai/v2/chat"
+
+    def test_strips_caller_auth_headers(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "co-test")
+        plan = CohereCredentialProvider().resolve()
+        assert "authorization" in plan.strip_headers
+        assert "x-api-key" in plan.strip_headers
+
+
+# ── Vertex AI Gemini ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def _vertex_env(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project-1234")
+    monkeypatch.setenv("VERTEX_REGION", "us-central1")
+    yield
+
+
+class TestVertexGating:
+    def test_returns_none_without_google_auth(self, monkeypatch):
+        import sys
+        monkeypatch.setitem(sys.modules, "google.auth", None)
+        invalidate_cache()
+        # Need the project too to isolate the boto3-style gate.
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "p")
+        assert VertexAIGeminiCredentialProvider().resolve() is None
+
+    def test_returns_none_without_project(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
+        assert VertexAIGeminiCredentialProvider().resolve() is None
+
+    def test_returns_plan_when_both_present(self, monkeypatch, _vertex_env):
+        # google-auth IS importable in this test env; project IS set.
+        plan = VertexAIGeminiCredentialProvider().resolve()
+        assert plan is not None
+
+    def test_project_via_legacy_gcloud_env(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.setenv("GCLOUD_PROJECT", "legacy-project-id")
+        plan = VertexAIGeminiCredentialProvider().resolve()
+        assert plan is not None
+        # And the URL should reflect that project.
+        body = json.dumps({"model": "gemini-pro", "contents": []}).encode()
+        url = plan.target_url_resolver(body, {})
+        assert "/projects/legacy-project-id/" in url
+
+
+class TestVertexUrlResolution:
+    def _resolver(self):
+        return VertexAIGeminiCredentialProvider().resolve().target_url_resolver
+
+    def test_non_streaming_picks_generateContent(self, _vertex_env):
+        body = json.dumps({"model": "gemini-1.5-pro", "contents": []}).encode()
+        url = self._resolver()(body, {})
+        assert url == (
+            "https://us-central1-aiplatform.googleapis.com/v1"
+            "/projects/my-project-1234/locations/us-central1"
+            "/publishers/google/models/gemini-1.5-pro:generateContent"
+        )
+
+    def test_streaming_picks_streamGenerateContent(self, _vertex_env):
+        body = json.dumps({
+            "model": "gemini-1.5-pro",
+            "contents": [],
+            "stream": True,
+        }).encode()
+        url = self._resolver()(body, {})
+        assert url.endswith(
+            "/publishers/google/models/gemini-1.5-pro:streamGenerateContent"
+        )
+
+    def test_region_env_override(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "p")
+        monkeypatch.setenv("VERTEX_REGION", "europe-west4")
+        body = json.dumps({"model": "gemini-pro", "contents": []}).encode()
+        url = VertexAIGeminiCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "europe-west4-aiplatform.googleapis.com" in url
+        assert "/locations/europe-west4/" in url
+
+    def test_default_region_when_unset(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "p")
+        monkeypatch.delenv("VERTEX_REGION", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_REGION", raising=False)
+        body = json.dumps({"model": "gemini-pro", "contents": []}).encode()
+        url = VertexAIGeminiCredentialProvider().resolve().target_url_resolver(
+            body, {}
+        )
+        assert "us-central1" in url
+
+    def test_missing_model_returns_none(self, _vertex_env):
+        body = json.dumps({"contents": []}).encode()
+        assert self._resolver()(body, {}) is None
+
+
+class TestVertexBodyTransform:
+    def _xform(self, _vertex_env):
+        return VertexAIGeminiCredentialProvider().resolve().body_transform
+
+    def test_strips_model_field(self, _vertex_env):
+        body = json.dumps({
+            "model": "gemini-1.5-pro",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        }).encode()
+        out = self._xform(_vertex_env)(body)
+        decoded = json.loads(out)
+        assert "model" not in decoded
+        assert decoded["contents"] == [
+            {"role": "user", "parts": [{"text": "hi"}]}
+        ]
+
+    def test_strips_stream_field(self, _vertex_env):
+        # Vertex encodes stream-vs-non-stream via the URL verb suffix,
+        # NOT a body field. Strip stream from body to avoid the
+        # backend rejecting it as an unknown field.
+        body = json.dumps({
+            "model": "gemini-pro",
+            "stream": True,
+            "contents": [],
+        }).encode()
+        out = self._xform(_vertex_env)(body)
+        decoded = json.loads(out)
+        assert "stream" not in decoded
+
+    def test_preserves_generation_config(self, _vertex_env):
+        body = json.dumps({
+            "model": "gemini-pro",
+            "contents": [],
+            "generationConfig": {"maxOutputTokens": 100, "temperature": 0.5},
+        }).encode()
+        out = self._xform(_vertex_env)(body)
+        decoded = json.loads(out)
+        assert decoded["generationConfig"] == {
+            "maxOutputTokens": 100,
+            "temperature": 0.5,
+        }
+
+
+class TestVertexHeaderResolver:
+    def test_emits_bearer_token_when_creds_resolvable(self, _vertex_env, monkeypatch):
+        # Mock google.auth.default so we don't need real GCP creds.
+        from unittest.mock import MagicMock
+
+        fake_creds = MagicMock()
+        fake_creds.valid = True
+        fake_creds.token = "ya29.fake-access-token"
+
+        import google.auth as _ga
+        monkeypatch.setattr(
+            _ga, "default", lambda scopes=None: (fake_creds, "my-project-1234")
+        )
+
+        plan = VertexAIGeminiCredentialProvider().resolve()
+        url = (
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/p/"
+            "locations/us-central1/publishers/google/models/gemini:generateContent"
+        )
+        headers = plan.header_resolver(b'{"contents": []}', url, "POST", {})
+        assert headers["Authorization"] == "Bearer ya29.fake-access-token"
+
+    def test_returns_empty_dict_on_creds_failure(self, _vertex_env, monkeypatch):
+        import google.auth as _ga
+
+        def _explode(scopes=None):
+            raise RuntimeError("no creds discoverable")
+
+        monkeypatch.setattr(_ga, "default", _explode)
+        plan = VertexAIGeminiCredentialProvider().resolve()
+        headers = plan.header_resolver(b"{}", "https://x", "POST", {})
+        assert headers == {}
+
+
+# ── Auto-registration ────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_both_registered(self):
+        names = {p.name for p in registered()}
+        assert "tokenpak-cohere" in names
+        assert "tokenpak-vertex-gemini" in names
+
+    def test_existing_providers_intact(self):
+        names = {p.name for p in registered()}
+        for slug in (
+            "tokenpak-claude-code",
+            "tokenpak-mistral",
+            "tokenpak-azure-openai",
+            "tokenpak-bedrock-claude",
+        ):
+            assert slug in names, f"Phase 3 displaced {slug!r}"

--- a/tokenpak/services/routing_service/credential_injector.py
+++ b/tokenpak/services/routing_service/credential_injector.py
@@ -706,6 +706,23 @@ class AzureOpenAICredentialProvider:
         return _cached_resolve(self.name, self._load)
 
 
+class CohereCredentialProvider(_EnvKeyBearerProvider):
+    """Cohere Chat v2 — OpenAI-Chat-compatible, ``COHERE_API_KEY``.
+
+    Cohere's v2 chat endpoint mirrors the OpenAI Chat Completions
+    request/response shape, so the existing ``OpenAIChatAdapter``
+    handles the wire format without modification. Bearer auth.
+
+    The older ``/v1/chat`` endpoint had Cohere's distinct shape and
+    would need a dedicated FormatAdapter — explicitly NOT what we
+    target here.
+    """
+
+    name = "tokenpak-cohere"
+    _UPSTREAM = "https://api.cohere.ai/v2/chat"
+    _ENV_VAR = "COHERE_API_KEY"
+
+
 class OpenRouterCredentialProvider(_EnvKeyBearerProvider):
     """OpenRouter — meta-provider proxying ~100 models. ``OPENROUTER_API_KEY``.
 
@@ -879,6 +896,181 @@ class BedrockClaudeCredentialProvider:
         return _cached_resolve(self.name, self._load)
 
 
+class VertexAIGeminiCredentialProvider:
+    """Google Vertex AI for Gemini — same wire format as the public
+    Generative AI API but a different endpoint, project-scoped URLs,
+    and OAuth-2-access-token auth via Application Default Credentials.
+
+    Required:
+
+      - ``google-auth`` installed (standard GCP Python ecosystem dep).
+        Graceful skip with logged INFO if not — ``pip install
+        google-auth`` to enable.
+      - ``GOOGLE_CLOUD_PROJECT`` env var (or ``GCLOUD_PROJECT``).
+      - GCP credentials discoverable by ADC: ``GOOGLE_APPLICATION_CREDENTIALS``
+        pointing at a service-account JSON key, ``gcloud auth
+        application-default login``, GCE/GKE metadata server, or
+        workload identity.
+
+    Optional:
+
+      - ``VERTEX_REGION`` / ``GOOGLE_CLOUD_REGION`` (default
+        ``us-central1``).
+
+    Routing
+    -------
+
+    Vertex routes by model id in the URL path
+    (``publishers/google/models/<model>:streamGenerateContent``)
+    similar to Bedrock. Picks ``:streamGenerateContent`` when the
+    request body sets ``"stream": true`` (or the body's content type
+    suggests SSE), else ``:generateContent``.
+
+    Auth
+    ----
+
+    Like Bedrock, the auth header is computed per-request — the
+    ``google-auth`` library returns a short-lived OAuth2 access token
+    that auto-refreshes. Cached internally by google-auth so the
+    network round-trip happens at most every ~50 minutes.
+
+    Body shape
+    ----------
+
+    Vertex accepts the same body as the public Gemini API
+    (``contents`` array, ``generationConfig``, etc.). The existing
+    ``GoogleGenerativeAIAdapter`` handles the wire format. We strip
+    the ``model`` field (Vertex routes by URL) but leave everything
+    else byte-stable so the user's ``contents`` flow through cleanly.
+    """
+
+    name = "tokenpak-vertex-gemini"
+    _DEFAULT_REGION = "us-central1"
+    _SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+    def _load(self) -> Optional[InjectionPlan]:
+        try:
+            import google.auth  # noqa: F401  (presence check only)
+        except ImportError:
+            logger.info(
+                "credential_injector[vertex-gemini]: google-auth not "
+                "installed; skipping. `pip install google-auth` to enable "
+                "Vertex AI routing."
+            )
+            return None
+
+        project = (
+            _os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip()
+            or _os.environ.get("GCLOUD_PROJECT", "").strip()
+        )
+        if not project:
+            logger.info(
+                "credential_injector[vertex-gemini]: GOOGLE_CLOUD_PROJECT "
+                "not set; skipping."
+            )
+            return None
+
+        region = (
+            _os.environ.get("VERTEX_REGION", "").strip()
+            or _os.environ.get("GOOGLE_CLOUD_REGION", "").strip()
+            or self._DEFAULT_REGION
+        )
+
+        host = f"{region}-aiplatform.googleapis.com"
+
+        def _resolve_url(body: bytes, headers: Mapping[str, str]) -> Optional[str]:
+            if not body:
+                return None
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+            if not isinstance(data, dict):
+                return None
+            model = data.get("model")
+            if not isinstance(model, str) or not model.strip():
+                return None
+            stream = bool(data.get("stream"))
+            verb = "streamGenerateContent" if stream else "generateContent"
+            # Vertex inference profile / publisher path. Anthropic
+            # Claude on Vertex would use ``publishers/anthropic/...``
+            # but that's a separate provider (different body shape).
+            return (
+                f"https://{host}/v1/projects/{project}/locations/{region}"
+                f"/publishers/google/models/{model.strip()}:{verb}"
+            )
+
+        def _transform_body(body: bytes) -> bytes:
+            if not body:
+                return body
+            try:
+                data = json.loads(body)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return body
+            if not isinstance(data, dict):
+                return body
+            data.pop("model", None)
+            data.pop("stream", None)  # Vertex encodes via URL verb, not body field.
+            try:
+                return json.dumps(data).encode("utf-8")
+            except (TypeError, ValueError):
+                return body
+
+        # Cache the credentials object across requests; google-auth
+        # itself memoizes the access token until expiry, so a single
+        # ``creds.refresh()`` call costs nothing on subsequent hits.
+        _creds_cache = {"creds": None}
+
+        def _sign_request(
+            body: bytes,
+            url: str,
+            method: str,
+            _existing_headers: Mapping[str, str],
+        ) -> Dict[str, str]:
+            from google.auth import default as _ga_default
+            from google.auth.transport.requests import Request as _GARequest
+
+            creds = _creds_cache["creds"]
+            if creds is None:
+                try:
+                    creds, _proj = _ga_default(scopes=[self._SCOPE])
+                    _creds_cache["creds"] = creds
+                except Exception as exc:
+                    logger.warning(
+                        "credential_injector[vertex-gemini]: "
+                        "google.auth.default() failed (%s: %s) — "
+                        "request will fail upstream",
+                        type(exc).__name__, exc,
+                    )
+                    return {}
+            try:
+                # Refresh only when needed; google-auth checks expiry.
+                if not creds.valid:
+                    creds.refresh(_GARequest())
+            except Exception as exc:
+                logger.warning(
+                    "credential_injector[vertex-gemini]: token refresh "
+                    "failed (%s: %s)",
+                    type(exc).__name__, exc,
+                )
+                return {}
+            token = getattr(creds, "token", None)
+            if not token:
+                return {}
+            return {"Authorization": f"Bearer {token}"}
+
+        return InjectionPlan(
+            strip_headers=frozenset({"authorization", "x-api-key", "x-goog-api-key"}),
+            add_headers={"Content-Type": "application/json"},
+            target_url_resolver=_resolve_url,
+            body_transform=_transform_body,
+            header_resolver=_sign_request,
+        )
+
+    def resolve(self) -> Optional[InjectionPlan]:
+        return _cached_resolve(self.name, self._load)
+
+
 # ── Register built-ins at import ─────────────────────────────────────
 
 
@@ -888,9 +1080,11 @@ register(MistralCredentialProvider())
 register(GroqCredentialProvider())
 register(TogetherCredentialProvider())
 register(DeepSeekCredentialProvider())
+register(CohereCredentialProvider())
 register(OpenRouterCredentialProvider())
 register(AzureOpenAICredentialProvider())
 register(BedrockClaudeCredentialProvider())
+register(VertexAIGeminiCredentialProvider())
 
 
 __all__ = [
@@ -898,6 +1092,7 @@ __all__ = [
     "BedrockClaudeCredentialProvider",
     "ClaudeCodeCredentialProvider",
     "CodexCredentialProvider",
+    "CohereCredentialProvider",
     "CredentialProvider",
     "DeepSeekCredentialProvider",
     "GroqCredentialProvider",
@@ -905,6 +1100,7 @@ __all__ = [
     "MistralCredentialProvider",
     "OpenRouterCredentialProvider",
     "TogetherCredentialProvider",
+    "VertexAIGeminiCredentialProvider",
     "invalidate_cache",
     "register",
     "registered",


### PR DESCRIPTION
## Summary

Re-opens [PR #31](https://github.com/tokenpak/tokenpak/pull/31) (auto-closed when its base branch was deleted on PR #33 merge) — same content, rebased onto current main.

Two more enterprise-tier providers, completing the major-cloud + major-provider matrix.

- **Cohere v2** — five-line \`_EnvKeyBearerProvider\` subclass. \`/v2/chat\` is OpenAI-Chat-compatible at the wire level; existing \`OpenAIChatAdapter\` handles the body shape with no modifications.
- **Vertex AI Gemini** — full credential provider with body-aware URL + \`header_resolver\` for OAuth2 token fetching via \`google-auth\` (Application Default Credentials). Reuses existing \`GoogleGenerativeAIAdapter\` for body shape; routes by \`publishers/google/models/<id>:generateContent\` URL path.

## Provider matrix after this PR

| Tier | Count | Providers |
|---|---|---|
| Built-in formats | 5 | Anthropic, OpenAI Responses (+ Codex variant), OpenAI Chat, Google Generative AI |
| Phase 1 (OpenAI-Chat-compat) | 5 | Mistral, Groq, Together, DeepSeek, OpenRouter |
| Phase 2 (enterprise) | 2 | Azure OpenAI, AWS Bedrock for Claude |
| **Phase 3 (this PR)** | **2** | **Cohere, Vertex AI Gemini** |

## Live verification (2026-04-25)

**Cohere**: \`{"message": "Incorrect API key provided: ***********ting..."}\` — Cohere parsed our request, recognized the fake key, pointed at their docs.

**Vertex** (no ADC on test host): URL composed correctly to \`https://us-central1-aiplatform.googleapis.com/v1/projects/test-project-12345/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent\`. google-auth gracefully failed (no ADC), Vertex 401'd asking for OAuth2 — exactly right behavior.

## Test plan

- [x] \`pytest tests/test_phase3_cohere_vertex.py\` — 20 passed
- [x] \`ruff check\` clean
- [x] Local tests on rebased branch — 20/20 passed
- [x] Live: Cohere routing + Vertex URL composition verified
- [ ] Live: real Cohere key + real GCP ADC

## Order

Last PR in the landing sequence. After this lands, post-merge adapter standardization report follows per Kevin's directive.