### PR TITLE
feat(cli): Phase 4.2 scaffold renderer expansion — anthropic + bearer-passthrough + parameterized auth header

### DIFF
--- a/docs/internal/specs/phase4.2-scaffold-renderer-expansion-2026-04-25.md
+++ b/docs/internal/specs/phase4.2-scaffold-renderer-expansion-2026-04-25.md
@@ -1,0 +1,137 @@
+# Phase 4.2 — Scaffold Renderer Expansion
+
+**Date**: 2026-04-25
+**Branch**: `feat/phase4.2-scaffold-renderer-expansion`
+**Predecessor**: PR #42 (Phase 4.1 — Scaffold Hardening, merged as `98d565f6`)
+
+---
+
+## Scope
+
+Deterministic template expansion only. Three new / extended renderers
+covering the next-tier provider integrations beyond the Phase 4.1 MVP.
+
+Per Kevin's directive (2026-04-25): **no cloud-wrapper renderers** —
+Bedrock generic, Anthropic-on-Vertex, IBM watsonx, SigV4 scaffolding,
+OAuth scaffolding, and `--llm-assist` are all explicitly held.
+
+---
+
+## Deliverables
+
+### 1. `openai-chat + api-key-header` — auth header parameterized
+
+The Phase 4.1 renderer hardcoded `_AUTH_HEADER = "api-key"` (Azure
+convention). Phase 4.2 adds a CLI flag so vendor-specific headers
+(`X-API-Key`, `Api-Key`, etc.) emit at scaffold-time without a
+post-edit.
+
+| Field | Value |
+|---|---|
+| Renderer key | `openai_chat_apikey` (unchanged) |
+| New CLI flag | `--auth-header NAME` |
+| Default | `api-key` (Azure) for `openai-chat`; `x-api-key` for `anthropic-messages` |
+| ScaffoldParams field | `auth_header: Optional[str] = None` |
+| Strip-set updated | Lowercased configured header added alongside `authorization` + `x-api-key` |
+
+### 2. `anthropic-messages + api-key-header` — new renderer
+
+Anthropic Messages API shape, `x-api-key` auth, required
+`anthropic-version: 2023-06-01` header. Capability declarations are
+**explicit and empty by default** — no implicit TIP support, opt-in
+per capability after the maintainer reviews the upstream's
+body-rewrite tolerance.
+
+| Field | Value |
+|---|---|
+| Renderer key | `anthropic_messages_apikey` (new) |
+| Class structure | Standalone (no base class), `_AUTH_HEADER` + `_ANTHROPIC_VERSION` constants |
+| Capabilities | `frozenset()` — explicit empty; comment lists candidate `tip.*` flags |
+| Request fixture | `max_tokens` required, `system` as top-level field, no `temperature` |
+| Response fixture | `content` blocks (`type: "text"`), `usage.input_tokens` / `usage.output_tokens` |
+| Test class | `TestCapabilityDeclarations` asserts no implicit TIP support |
+| Strip-set | Includes `anthropic-version` so caller variants don't override the proxy's value |
+
+### 3. `openai-chat + bearer-passthrough` — new renderer
+
+For OpenRouter-style providers that need extra/non-standard request
+body fields (`provider`, `transforms`, `route`, etc.) preserved
+end-to-end. Identical to Pattern A at the InjectionPlan level (no
+`body_transform` set → body forwarded byte-for-byte) but adds an
+explicit `_BODY_PASSTHROUGH = True` annotation + a `TestBodyPassThrough`
+test class asserting the contract.
+
+| Field | Value |
+|---|---|
+| Renderer key | `openai_chat_bearer_passthrough` (new) |
+| New auth value | `bearer-passthrough` (added to `KNOWN_AUTHS`) |
+| Class annotation | `_BODY_PASSTHROUGH = True` |
+| Test class | `TestBodyPassThrough` — asserts `plan.body_transform is None` |
+
+---
+
+## Dogfood runs
+
+Three runs against synthetic `--out-dir` paths in `/tmp/`:
+
+| Slug | Family | Auth | Header | Notes |
+|---|---|---|---|---|
+| `tokenpak-acme-xapi` | `openai-chat` | `api-key-header` | `--auth-header X-API-Key` | Verifies #1 |
+| `tokenpak-anthropic-stub` | `anthropic-messages` | `api-key-header` | (default `x-api-key`) | Verifies #2 |
+| `tokenpak-openrouter-passthrough` | `openai-chat` | `bearer-passthrough` | + `--extra-header HTTP-Referer` + `X-Title` | Verifies #3 |
+
+All three runs:
+- Produce 5 files (provider class, test file, request fixture, response fixture, docs stub) + paste-ready follow-up issue.
+- Generate a provider class that passes `python3 -m ruff check` standalone.
+- Compile via `py_compile.compile(..., doraise=True)`.
+- Generate a test file that passes ruff once placed in canonical position (`tests/test_<vendor>_offline.py` alongside `tokenpak/services/routing_service/extras/<vendor>.py`). Standalone ruff in `/tmp/` reports `I001` because the imported `extras.<vendor>` module hasn't been placed yet — this is a tooling artifact (ruff's first-party detection requires the module to exist on disk), not a generator bug. Verified by copying generated files into the canonical positions and re-running ruff: clean.
+- Pass JSON-validity checks on both fixtures.
+
+---
+
+## Acceptance criteria
+
+| Criterion | Status |
+|---|---|
+| New renderers are deterministic templates | ✅ no LLM, classifier-dispatched |
+| Dry-run works for each renderer | ✅ verified for anthropic + bearer-passthrough |
+| Non-interactive mode fails safely on missing fields | ✅ `TestPhase42NonInteractiveSafety` covers slug + endpoint |
+| Generated code follows Standard #23 | ✅ slug regex, class naming, `live_verified=False` default, capability declaration form |
+| Generated files pass ruff | ✅ provider class standalone; test file in canonical position |
+| Generated offline tests pass | ✅ verified via `pytest tests/test_scaffold.py` (110 tests) |
+| Extra headers represented in fixtures/tests | ✅ `_render_extra_header_test_block` reused for bearer-passthrough; explicit assertion classes elsewhere |
+| `live_verified=False` remains default | ✅ all three renderers emit `live_verified = False` |
+| No live credentials required | ✅ AST-level guardrail enforced; no `--llm-assist` |
+| No destructive registration by default | ✅ `--register` remains opt-in (Phase 4.1) |
+| Existing scaffold tests remain green | ✅ 110 / 110 pass (was 80 in Phase 4.1) |
+| Full suite remains green | ✅ 940 pass / 1 skipped / 1 xfailed (was 910 baseline) |
+
+---
+
+## What was NOT done (per directive)
+
+- AWS Bedrock generic
+- Anthropic Claude on Vertex (`publishers/anthropic/...` URL + envelope)
+- IBM watsonx
+- SigV4 scaffolding
+- OAuth scaffolding
+- `--llm-assist` (still stubbed; exits 2)
+- Any cloud-wrapper renderer family
+
+Held for future explicit direction.
+
+---
+
+## Test count delta
+
+| Suite | Phase 4.1 | Phase 4.2 | Δ |
+|---|---|---|---|
+| `tests/test_scaffold.py` | 80 | 110 | +30 |
+| Full suite (excluding baseline 404s) | 910 | 940 | +30 |
+
+New test classes:
+
+- `TestApiKeyHeaderConfigurable` — 5 tests covering default + custom auth header emission, lowercased strip-set entry, ruff cleanliness.
+- `TestBearerPassthroughRenderer` — 8 tests covering classifier dispatch, `_BODY_PASSTHROUGH` annotation, `_EnvKeyBearerProvider` inheritance, ruff/compile, `TestBodyPassThrough` class generation, extra-header support.
+- `TestAnthropicMessagesApikeyRenderer` — 14 tests covering classifier dispatch, default + custom auth header, `anthropic-version` emission, explicit empty capabilities, ruff/compile, fixture shape (Anthropic-specific keys), test-file capability class, docs stub, dry-run.
+- `TestPhase42NonInteractiveSafety` — 3 tests covering missing endpoint + invalid slug for the new renderers.

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -921,3 +921,309 @@ class TestRegisterPatch:
                 vendor_safe="x",
                 class_name="XProviderCredentialProvider",
             )
+
+
+# ── Phase 4.2: configurable auth header for api-key-header renderer ──
+
+
+class TestApiKeyHeaderConfigurable:
+    """Phase 4.2 — ``--auth-header NAME`` overrides the default
+    ``api-key`` so vendor-specific headers (``X-API-Key``,
+    ``Api-Key``, etc.) are emitted at scaffold-time without a
+    post-edit.
+    """
+
+    def _params(self, **over):
+        kw = dict(DEFAULT_KW)
+        kw["auth"] = "api-key-header"
+        kw.update(over)
+        return ScaffoldParams(**kw)
+
+    def test_default_auth_header_is_api_key(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert '_AUTH_HEADER = "api-key"' in provider_art.content
+
+    def test_custom_auth_header_emitted_in_class(self):
+        arts = generate_artifacts(self._params(auth_header="X-API-Key"))
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert '_AUTH_HEADER = "X-API-Key"' in provider_art.content
+        assert '_AUTH_HEADER = "api-key"' not in provider_art.content
+
+    def test_custom_auth_header_asserted_in_test_file(self):
+        arts = generate_artifacts(self._params(auth_header="X-API-Key"))
+        test_art = next(a for a in arts if a.kind == "test")
+        # The test file's header-injection assertion uses the
+        # configured header name, not the default.
+        assert '"X-API-Key"' in test_art.content
+
+    def test_custom_auth_header_lowercased_in_strip_set(self):
+        # Caller-sent variants should be stripped — proxy is the
+        # authoritative source for the configured header.
+        arts = generate_artifacts(self._params(auth_header="X-API-Key"))
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        # Strip set is alphabetised; check the lowercased name is in.
+        assert '"x-api-key"' in provider_art.content
+
+    def test_custom_auth_header_passes_ruff(self, tmp_path: Path):
+        arts = generate_artifacts(self._params(auth_header="X-API-Key"))
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        scratch = tmp_path / "scaffold_apikey_custom.py"
+        scratch.write_text(provider_art.content)
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", str(scratch)],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        assert result.returncode == 0, (
+            f"custom-header provider failed ruff: "
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+
+# ── Phase 4.2: bearer-passthrough renderer ───────────────────────────
+
+
+class TestBearerPassthroughRenderer:
+    """Phase 4.2 — ``--auth bearer-passthrough`` for OpenRouter-style
+    providers preserving extra/non-standard request body fields.
+    Generates Pattern A class + ``_BODY_PASSTHROUGH = True`` annotation
+    + a ``TestBodyPassThrough`` class asserting ``body_transform`` is
+    None on the InjectionPlan.
+    """
+
+    def _params(self, **over):
+        kw = dict(DEFAULT_KW)
+        kw["auth"] = "bearer-passthrough"
+        kw.update(over)
+        return ScaffoldParams(**kw)
+
+    def test_classifier_picks_passthrough_renderer(self):
+        arts = generate_artifacts(self._params())
+        assert len(arts) == 6  # 5 files + 1 instructions
+
+    def test_provider_class_declares_body_passthrough(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert "_BODY_PASSTHROUGH = True" in provider_art.content
+
+    def test_provider_class_subclasses_env_key_bearer(self):
+        # Same base class as Pattern A — the only difference is the
+        # explicit passthrough annotation + a stricter test contract.
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert "(_EnvKeyBearerProvider)" in provider_art.content
+
+    def test_provider_class_compiles(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        compile(provider_art.content, provider_art.relative_path, "exec")
+
+    def test_provider_class_passes_ruff(self, tmp_path: Path):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        scratch = tmp_path / "scaffold_passthrough_check.py"
+        scratch.write_text(provider_art.content)
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", str(scratch)],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        assert result.returncode == 0, (
+            f"passthrough provider failed ruff: "
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+    def test_test_file_has_body_passthrough_class(self):
+        arts = generate_artifacts(self._params())
+        test_art = next(a for a in arts if a.kind == "test")
+        assert "class TestBodyPassThrough" in test_art.content
+        assert "test_no_body_transform_in_plan" in test_art.content
+        assert "test_class_declares_passthrough" in test_art.content
+
+    def test_test_file_compiles(self):
+        arts = generate_artifacts(self._params())
+        test_art = next(a for a in arts if a.kind == "test")
+        compile(test_art.content, test_art.relative_path, "exec")
+
+    def test_extra_headers_supported(self):
+        # OpenRouter-style: HTTP-Referer + X-Title alongside body
+        # pass-through.
+        arts = generate_artifacts(
+            self._params(extra_headers={"HTTP-Referer": "https://x.example"})
+        )
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert "_EXTRA_HEADERS" in provider_art.content
+        assert "HTTP-Referer" in provider_art.content
+
+
+# ── Phase 4.2: anthropic-messages + api-key-header renderer ──────────
+
+
+class TestAnthropicMessagesApikeyRenderer:
+    """Phase 4.2 — Anthropic Messages adapter via x-api-key auth +
+    anthropic-version header. Capability declarations are EXPLICIT;
+    no implicit TIP support. Fixtures use Anthropic shape (content
+    blocks, max_tokens required, system as top-level field).
+    """
+
+    def _params(self, **over):
+        kw = dict(DEFAULT_KW)
+        kw["family"] = "anthropic-messages"
+        kw["auth"] = "api-key-header"
+        kw["endpoint"] = "https://api.example.com/v1/messages"
+        kw.update(over)
+        return ScaffoldParams(**kw)
+
+    def test_classifier_picks_anthropic_renderer(self):
+        arts = generate_artifacts(self._params())
+        assert len(arts) == 6  # 5 files + 1 instructions
+
+    def test_default_auth_header_is_x_api_key(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert '_AUTH_HEADER = "x-api-key"' in provider_art.content
+
+    def test_custom_auth_header_override(self):
+        arts = generate_artifacts(self._params(auth_header="X-API-Key"))
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert '_AUTH_HEADER = "X-API-Key"' in provider_art.content
+
+    def test_anthropic_version_emitted(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        assert '_ANTHROPIC_VERSION = "2023-06-01"' in provider_art.content
+        assert '"anthropic-version"' in provider_art.content
+
+    def test_capabilities_declared_explicit_empty(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        # Explicit empty frozenset — no implicit TIP support.
+        assert "capabilities: frozenset = frozenset()" in provider_art.content
+        # The candidate capability names appear in the surrounding
+        # comment block (not as declared values).
+        assert "tip.compression.v1" in provider_art.content
+        assert "tip.cache.proxy-managed" in provider_art.content
+
+    def test_provider_class_compiles(self):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        compile(provider_art.content, provider_art.relative_path, "exec")
+
+    def test_provider_class_passes_ruff(self, tmp_path: Path):
+        arts = generate_artifacts(self._params())
+        provider_art = next(a for a in arts if a.kind == "provider-class")
+        scratch = tmp_path / "scaffold_anthropic_check.py"
+        scratch.write_text(provider_art.content)
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", str(scratch)],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        assert result.returncode == 0, (
+            f"anthropic provider failed ruff: "
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+    def test_request_fixture_has_anthropic_shape(self):
+        arts = generate_artifacts(self._params())
+        req_art = next(a for a in arts if a.kind == "fixture" and "request" in a.relative_path)
+        body = json.loads(req_art.content)
+        # Anthropic-specific: max_tokens required, system at top level.
+        assert "max_tokens" in body
+        assert "system" in body
+        # No OpenAI-Chat-specific fields.
+        assert "temperature" not in body
+
+    def test_response_fixture_has_anthropic_shape(self):
+        arts = generate_artifacts(self._params())
+        resp_art = next(a for a in arts if a.kind == "fixture" and "response" in a.relative_path)
+        body = json.loads(resp_art.content)
+        # Anthropic content blocks (not OpenAI choices array).
+        assert "content" in body
+        assert isinstance(body["content"], list)
+        assert body["content"][0]["type"] == "text"
+        # Anthropic usage shape.
+        assert "input_tokens" in body["usage"]
+        assert "output_tokens" in body["usage"]
+        # No OpenAI-specific fields.
+        assert "choices" not in body
+        assert "prompt_tokens" not in body.get("usage", {})
+
+    def test_test_file_has_capability_class(self):
+        arts = generate_artifacts(self._params())
+        test_art = next(a for a in arts if a.kind == "test")
+        assert "class TestCapabilityDeclarations" in test_art.content
+        assert "test_no_implicit_tip_support" in test_art.content
+
+    def test_test_file_compiles(self):
+        arts = generate_artifacts(self._params())
+        test_art = next(a for a in arts if a.kind == "test")
+        compile(test_art.content, test_art.relative_path, "exec")
+
+    def test_test_file_asserts_anthropic_version(self):
+        arts = generate_artifacts(self._params())
+        test_art = next(a for a in arts if a.kind == "test")
+        assert "test_emits_anthropic_version" in test_art.content
+        assert '"anthropic-version"' in test_art.content
+        assert "2023-06-01" in test_art.content
+
+    def test_docs_stub_documents_anthropic_specifics(self):
+        arts = generate_artifacts(self._params())
+        docs_art = next(a for a in arts if a.kind == "docs")
+        assert "anthropic-version" in docs_art.content
+        assert "Capability declarations" in docs_art.content
+        # Curl example uses Anthropic shape (max_tokens, anthropic-version).
+        assert "max_tokens" in docs_art.content
+
+    def test_dry_run_works(self, tmp_path: Path):
+        # Acceptance criterion: dry-run works for each renderer.
+        params = self._params(out_dir=tmp_path, dry_run=True)
+        arts = generate_artifacts(params)
+        check_artifacts(arts)  # passes guardrails
+        # Nothing on disk — dry_run doesn't write here, but
+        # generate_artifacts itself doesn't write either; this asserts
+        # the generation pipeline is clean for the new renderer.
+        assert (tmp_path / "request.json").exists() is False
+
+
+# ── Phase 4.2: non-interactive failure on missing required fields ────
+
+
+class TestPhase42NonInteractiveSafety:
+    """Acceptance criterion: non-interactive mode fails safely when
+    required fields are missing for the new renderers.
+    """
+
+    def test_anthropic_missing_endpoint_fails(self):
+        params = ScaffoldParams(
+            docs_url="https://docs.example.com",
+            slug="tokenpak-x",
+            family="anthropic-messages",
+            auth="api-key-header",
+            endpoint="",  # empty — should fail
+            non_interactive=True,
+        )
+        with pytest.raises(ScaffoldError):
+            params.validate()
+
+    def test_passthrough_missing_endpoint_fails(self):
+        params = ScaffoldParams(
+            docs_url="https://docs.example.com",
+            slug="tokenpak-x",
+            family="openai-chat",
+            auth="bearer-passthrough",
+            endpoint="",
+            non_interactive=True,
+        )
+        with pytest.raises(ScaffoldError):
+            params.validate()
+
+    def test_invalid_slug_rejected_for_anthropic(self):
+        # Standard #23 §1.1 slug rules apply across renderers.
+        params = ScaffoldParams(
+            docs_url="https://docs.example.com",
+            slug="Bad_Slug",
+            family="anthropic-messages",
+            auth="api-key-header",
+            endpoint="https://api.example.com/v1/messages",
+        )
+        with pytest.raises(ScaffoldError):
+            params.validate()

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -607,6 +607,7 @@ def cmd_adapter_scaffold(args) -> int:
         streaming=args.streaming,
         optional_deps=parse_optional_dep_list(getattr(args, "optional_dep", "")),
         extra_headers=extra_headers,
+        auth_header=getattr(args, "auth_header", None),
         out_dir=out_dir,
         dry_run=bool(getattr(args, "dry_run", False)),
         non_interactive=bool(getattr(args, "non_interactive", False)),
@@ -2167,13 +2168,16 @@ def build_parser():
         required=True,
         choices=sorted([
             "bearer",
+            "bearer-passthrough",
             "api-key-header",
             "sigv4",
             "oauth-adc",
             "oauth-token-file",
             "custom",
         ]),
-        help="Auth scheme. MVP fully implements 'bearer'.",
+        help="Auth scheme. Phase 4.2 implements: 'bearer', "
+        "'bearer-passthrough' (OpenRouter-style body pass-through), "
+        "'api-key-header' (paired with --auth-header).",
     )
     p_scaffold.add_argument(
         "--endpoint",
@@ -2199,6 +2203,15 @@ def build_parser():
         default=[],
         help="Extra static header to inject (KEY=VALUE; repeatable). "
         "OpenRouter's HTTP-Referer + X-Title are the canonical case.",
+    )
+    p_scaffold.add_argument(
+        "--auth-header",
+        dest="auth_header",
+        default=None,
+        help="(Phase 4.2) Auth header name for --auth api-key-header. "
+        "Defaults to 'api-key' (Azure convention) for openai-chat or "
+        "'x-api-key' for anthropic-messages. Use 'X-API-Key' or any "
+        "vendor-specific header to override at scaffold-time.",
     )
     p_scaffold.add_argument(
         "--out-dir",

--- a/tokenpak/scaffold/_classifier.py
+++ b/tokenpak/scaffold/_classifier.py
@@ -26,9 +26,24 @@ REFERENCE_PRS = {
         "tokenpak-deepseek, tokenpak-cohere, tokenpak-openrouter. "
         "PR #27 + #34 + #36."
     ),
+    ("openai-chat", "bearer-passthrough"): (
+        "Pattern A-passthrough — OpenAI-Chat + Bearer with explicit "
+        "body pass-through (extra provider fields preserved). "
+        "Reference: tokenpak-openrouter (HTTP-Referer + X-Title "
+        "headers + ``provider``/``transforms`` body fields)."
+    ),
+    ("openai-chat", "api-key-header"): (
+        "Pattern A-prime — OpenAI-Chat + non-Bearer header auth. "
+        "Configurable header name via ``--auth-header`` (defaults "
+        "to ``api-key``)."
+    ),
     ("openai-responses", "oauth-token-file"): (
         "Pattern B — OpenAI-Responses + file-OAuth (Codex). "
         "Reference: tokenpak-openai-codex. PR #27."
+    ),
+    ("anthropic-messages", "api-key-header"): (
+        "Pattern A-anthropic — Anthropic Messages + x-api-key auth + "
+        "anthropic-version header. Phase 4.2."
     ),
     ("anthropic-messages", "oauth-token-file"): (
         "Pattern C — Anthropic Messages + file-OAuth + merge_headers. "
@@ -69,8 +84,12 @@ def renderer_name(params: ScaffoldParams) -> str:
 
     if key == ("openai-chat", "bearer"):
         return "openai_chat_bearer"
+    if key == ("openai-chat", "bearer-passthrough"):
+        return "openai_chat_bearer_passthrough"
     if key == ("openai-chat", "api-key-header"):
         return "openai_chat_apikey"
+    if key == ("anthropic-messages", "api-key-header"):
+        return "anthropic_messages_apikey"
 
     # Combination is recognised but not implemented in MVP:
     if key in REFERENCE_PRS:

--- a/tokenpak/scaffold/_config.py
+++ b/tokenpak/scaffold/_config.py
@@ -34,8 +34,17 @@ KNOWN_FAMILIES = frozenset({
 })
 
 # All auth schemes MVP can classify (spec §3 + §6).
+#
+# ``bearer-passthrough`` (Phase 4.2): bearer auth + explicit
+# guarantee that the request body is forwarded unmodified — i.e.
+# extra/non-standard provider fields (OpenRouter's ``provider`` /
+# ``transforms`` / ``route``, etc.) are preserved end-to-end. The
+# generated InjectionPlan has no ``body_transform``; the renderer
+# adds an explicit ``_BODY_PASSTHROUGH = True`` annotation + a test
+# class asserting the contract. Pattern A applies otherwise.
 KNOWN_AUTHS = frozenset({
     "bearer",
+    "bearer-passthrough",
     "api-key-header",
     "sigv4",
     "oauth-adc",
@@ -116,6 +125,18 @@ class ScaffoldParams:
     """Vendor-required extra headers (e.g. OpenRouter's
     ``HTTP-Referer`` + ``X-Title``). MVP supports passing these via
     ``--extra-header KEY=VALUE`` (repeatable).
+    """
+
+    auth_header: Optional[str] = None
+    """Auth header name (Phase 4.2) for ``api-key-header`` auth.
+
+    When ``None`` (default) the renderer picks a sensible default:
+    ``api-key`` for the ``openai-chat + api-key-header`` pattern
+    (Azure convention), ``x-api-key`` for the
+    ``anthropic-messages + api-key-header`` pattern (Anthropic
+    convention). Pass ``--auth-header X-API-Key`` (or any
+    vendor-specific header) to override at scaffold-time so the
+    generated class doesn't need a post-edit.
     """
 
     def validate(self) -> None:

--- a/tokenpak/scaffold/_generator.py
+++ b/tokenpak/scaffold/_generator.py
@@ -39,13 +39,137 @@ def generate_artifacts(params: ScaffoldParams) -> List[GeneratedArtifact]:
     renderer = _classifier.renderer_name(params)
     if renderer == "openai_chat_bearer":
         return _generate_openai_chat_bearer(params)
+    if renderer == "openai_chat_bearer_passthrough":
+        return _generate_openai_chat_bearer_passthrough(params)
     if renderer == "openai_chat_apikey":
         return _generate_openai_chat_apikey(params)
+    if renderer == "anthropic_messages_apikey":
+        return _generate_anthropic_messages_apikey(params)
     # Classifier raises on unknown combinations; this is unreachable
     # but kept for defensive completeness.
     raise NotImplementedError(  # pragma: no cover
         f"renderer {renderer!r} not yet implemented in MVP"
     )
+
+
+def _generate_openai_chat_bearer_passthrough(
+    params: ScaffoldParams,
+) -> List[GeneratedArtifact]:
+    """Generate artifacts for Pattern A-passthrough.
+
+    Same artifact set as Pattern A; provider-class + test-file
+    renderers are passthrough-aware. Fixtures + docs stub are reused
+    from Pattern A (the wire shape is identical OpenAI-Chat).
+    """
+    out: List[GeneratedArtifact] = []
+    vendor_safe = params.vendor.replace("-", "_")
+
+    out.append(
+        GeneratedArtifact(
+            relative_path=_provider_class_path(params),
+            content=_templates.render_openai_chat_bearer_passthrough_provider_class(
+                params
+            ),
+            kind="provider-class",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_test_path(params, vendor_safe),
+            content=_templates.render_openai_chat_bearer_passthrough_test_file(
+                params
+            ),
+            kind="test",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_fixture_path(params, "request.json"),
+            content=_templates.render_request_fixture(params),
+            kind="fixture",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_fixture_path(params, "response.json"),
+            content=_templates.render_response_fixture(params),
+            kind="fixture",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_docs_stub_path(params),
+            content=_templates.render_docs_stub(params),
+            kind="docs",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path="<stdout: follow-up issue>",
+            content=_templates.render_followup_issue_text(params),
+            kind="instructions",
+        )
+    )
+    return out
+
+
+def _generate_anthropic_messages_apikey(
+    params: ScaffoldParams,
+) -> List[GeneratedArtifact]:
+    """Generate artifacts for Pattern A-anthropic.
+
+    Anthropic Messages has a materially different request/response
+    shape from OpenAI Chat, so fixtures + docs stub are
+    Anthropic-specific (separate renderers in :mod:`._templates`).
+    """
+    out: List[GeneratedArtifact] = []
+    vendor_safe = params.vendor.replace("-", "_")
+
+    out.append(
+        GeneratedArtifact(
+            relative_path=_provider_class_path(params),
+            content=_templates.render_anthropic_messages_apikey_provider_class(
+                params
+            ),
+            kind="provider-class",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_test_path(params, vendor_safe),
+            content=_templates.render_anthropic_messages_apikey_test_file(params),
+            kind="test",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_fixture_path(params, "request.json"),
+            content=_templates.render_anthropic_messages_request_fixture(params),
+            kind="fixture",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_fixture_path(params, "response.json"),
+            content=_templates.render_anthropic_messages_response_fixture(params),
+            kind="fixture",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path=_docs_stub_path(params),
+            content=_templates.render_anthropic_messages_docs_stub(params),
+            kind="docs",
+        )
+    )
+    out.append(
+        GeneratedArtifact(
+            relative_path="<stdout: follow-up issue>",
+            content=_templates.render_followup_issue_text(params),
+            kind="instructions",
+        )
+    )
+    return out
 
 
 def _generate_openai_chat_apikey(params: ScaffoldParams) -> List[GeneratedArtifact]:

--- a/tokenpak/scaffold/_templates.py
+++ b/tokenpak/scaffold/_templates.py
@@ -128,11 +128,13 @@ def render_openai_chat_apikey_provider_class(p: ScaffoldParams) -> str:
     standalone class with a fully-spelled-out ``_load`` method
     (mirrors ``AzureOpenAICredentialProvider``'s shape from PR #32).
 
-    The auth header NAME defaults to ``api-key`` (Azure
-    convention). Custom header names can be set on the generated
-    class's ``_AUTH_HEADER`` constant post-generation.
+    The auth header NAME is configurable via ``--auth-header`` and
+    defaults to ``api-key`` (Azure convention). Phase 4.2 added the
+    flag so the generated class doesn't need a post-edit for
+    vendor-specific headers like ``X-API-Key`` or ``Api-Key``.
     """
     cls_name = f"{p.class_basename}CredentialProvider"
+    auth_header = p.auth_header or "api-key"
     lines: list[str] = []
 
     lines.append("# SPDX-License-Identifier: Apache-2.0")
@@ -191,17 +193,16 @@ def render_openai_chat_apikey_provider_class(p: ScaffoldParams) -> str:
     lines.append("")
     lines.extend(live_status_lines)
     lines.append("")
-    lines.append("    Custom auth header name? Override ``_AUTH_HEADER`` on a")
-    lines.append('    subclass — defaults to ``"api-key"`` (Azure convention).')
-    lines.append("    Common variants: ``X-API-Key`` (Anthropic-style),")
-    lines.append('    ``Api-Key`` (some vendors).')
+    lines.append('    Auth header configured at scaffold-time via ``--auth-header``.')
+    lines.append('    Common variants: ``api-key`` (Azure / default), ``X-API-Key``')
+    lines.append('    or ``x-api-key`` (Anthropic-style), ``Api-Key`` (some vendors).')
     lines.append('    """')
     lines.append("")
     lines.append(f"    live_verified = {p.live_verified!r}")
     lines.append(f'    name = "{p.slug}"')
     lines.append(f'    _UPSTREAM = "{p.endpoint}"')
     lines.append(f'    _ENV_VAR = "{p.env_var}"')
-    lines.append('    _AUTH_HEADER = "api-key"')
+    lines.append(f'    _AUTH_HEADER = "{auth_header}"')
     lines.append("")
     lines.append("    def _load(self) -> Optional[InjectionPlan]:")
     lines.append("        api_key = os.environ.get(self._ENV_VAR, '').strip()")
@@ -218,8 +219,13 @@ def render_openai_chat_apikey_provider_class(p: ScaffoldParams) -> str:
         for k, v in sorted(p.extra_headers.items()):
             lines.append(f"        headers[{json.dumps(k)}] = {json.dumps(v)}")
 
+    # Always strip caller-sent variants of any auth header that
+    # might have leaked through — the proxy is the sole authority
+    # on which key reaches the upstream.
+    strip_set = sorted({"authorization", "x-api-key", auth_header.lower()})
+    strip_literal = ", ".join(f'"{h}"' for h in strip_set)
     lines.append("        return InjectionPlan(")
-    lines.append('            strip_headers=frozenset({"authorization", "x-api-key"}),')
+    lines.append(f'            strip_headers=frozenset({{{strip_literal}}}),')
     lines.append("            add_headers=headers,")
     lines.append("            target_url_override=self._UPSTREAM,")
     lines.append("        )")
@@ -233,6 +239,7 @@ def render_openai_chat_apikey_provider_class(p: ScaffoldParams) -> str:
 def render_openai_chat_apikey_test_file(p: ScaffoldParams) -> str:
     """Render offline contract tests for the api-key-header pattern."""
     cls_name = f"{p.class_basename}CredentialProvider"
+    auth_header = p.auth_header or "api-key"
     extra_assertions = ""
     if p.extra_headers:
         extra_lines = [
@@ -292,8 +299,8 @@ def render_openai_chat_apikey_test_file(p: ScaffoldParams) -> str:
         '    def test_emits_api_key_header_not_bearer(self, monkeypatch):\n'
         f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
         f'        plan = {cls_name}().resolve()\n'
-        '        # api-key header (default for this pattern) — NOT Bearer.\n'
-        '        assert plan.add_headers["api-key"] == "test-fake-key"\n'
+        f'        # Configured auth header for this provider — NOT Bearer.\n'
+        f'        assert plan.add_headers[{json.dumps(auth_header)}] == "test-fake-key"\n'
         '        assert "Authorization" not in plan.add_headers\n'
         '\n'
         '    def test_strips_caller_auth(self, monkeypatch):\n'
@@ -301,6 +308,7 @@ def render_openai_chat_apikey_test_file(p: ScaffoldParams) -> str:
         f'        plan = {cls_name}().resolve()\n'
         '        assert "authorization" in plan.strip_headers\n'
         '        assert "x-api-key" in plan.strip_headers\n'
+        f'        assert {json.dumps(auth_header.lower())} in plan.strip_headers\n'
         '\n'
         '    def test_target_url_override(self, monkeypatch):\n'
         f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
@@ -626,3 +634,606 @@ def render_followup_issue_text(p: ScaffoldParams) -> str:
         f"- Offline contract tests: tests/test_{vendor_safe}_offline.py\n"
         "- Standard #23 §6.4 (live_verified marker semantics)\n"
     )
+
+
+# ── Provider class (Pattern A-passthrough: openai-chat + bearer + body-pass-through) ──
+
+
+def render_openai_chat_bearer_passthrough_provider_class(p: ScaffoldParams) -> str:
+    """Render Pattern A-passthrough: OpenAI-Chat + Bearer auth with
+    explicit body pass-through.
+
+    Identical to the bearer renderer at the InjectionPlan level
+    (no ``body_transform`` set → request body is forwarded
+    unmodified) but emits an explicit ``_BODY_PASSTHROUGH = True``
+    annotation so the maintainer + reviewers can see the contract
+    declaratively. Use this for OpenRouter-style providers that
+    accept extra/non-standard body fields (``provider``,
+    ``transforms``, ``route``, etc.) that must reach the upstream
+    intact.
+    """
+    cls_name = f"{p.class_basename}CredentialProvider"
+    lines: list[str] = []
+
+    lines.append("# SPDX-License-Identifier: Apache-2.0")
+    lines.append(
+        f'"""Auto-scaffolded credential provider for {p.slug}.\n'
+        f'\n'
+        f'Source docs: {p.docs_url}\n'
+        f'\n'
+        f'Pattern A-passthrough: OpenAI-Chat + Bearer auth with explicit\n'
+        f'body pass-through. Extra/non-standard request body fields\n'
+        f'(OpenRouter-style ``provider`` / ``transforms`` / ``route``,\n'
+        f'etc.) are forwarded to the upstream unmodified.\n'
+        f'\n'
+        f'Generated by ``tokenpak adapter scaffold`` per Standard #23.\n'
+        f'``live_verified`` is False until an ``{p.env_var}`` is available\n'
+        f'and the route is smoke-tested against the live upstream.\n'
+        f'"""'
+    )
+    lines.append("")
+    lines.append("from __future__ import annotations")
+    lines.append("")
+    lines.append("from tokenpak.services.routing_service.credential_injector import (")
+    lines.append("    _EnvKeyBearerProvider,")
+    lines.append(")")
+    lines.append("")
+    lines.append("")
+
+    if p.live_verified:
+        live_status_lines = [
+            '    **Live status: smoke-tested live before merge.**',
+        ]
+    else:
+        article = (
+            "an" if p.env_var[:1].upper() in {"A", "E", "I", "O", "U"} else "a"
+        )
+        live_status_lines = [
+            f'    **Live status: contract-tested offline only.** No '
+            f'``{p.env_var}`` was available when this',
+            '    route was scaffolded. Body pass-through is enforced by '
+            'NOT setting a',
+            '    ``body_transform`` on the InjectionPlan — the proxy '
+            'forwards the request',
+            '    body byte-for-byte. Live verification is tracked '
+            'separately — when',
+            f'    {article} ``{p.env_var}`` becomes available, smoke-test '
+            f'the route against the',
+            '    upstream, then flip ``live_verified`` to ``True`` and '
+            'update this',
+            '    docstring per Standard #23 §6.4.',
+        ]
+
+    lines.append(f"class {cls_name}(_EnvKeyBearerProvider):")
+    lines.append(f'    """{p.class_basename} — OpenAI-Chat + Bearer + body-pass-through, ``{p.env_var}``.')
+    lines.append("")
+    lines.append(f"    Source: {p.docs_url}")
+    lines.append("")
+    lines.extend(live_status_lines)
+    lines.append("")
+    lines.append("    Body pass-through contract: the InjectionPlan emitted by")
+    lines.append("    this provider has NO ``body_transform``, so unknown /")
+    lines.append("    non-standard request fields (e.g. OpenRouter's")
+    lines.append("    ``provider``, ``transforms``, ``route``) reach the upstream")
+    lines.append("    unmodified. The ``_BODY_PASSTHROUGH = True`` class")
+    lines.append("    attribute makes the contract greppable + auditable.")
+    lines.append('    """')
+    lines.append("")
+    lines.append(f"    live_verified = {p.live_verified!r}")
+    lines.append(f'    name = "{p.slug}"')
+    lines.append(f'    _UPSTREAM = "{p.endpoint}"')
+    lines.append(f'    _ENV_VAR = "{p.env_var}"')
+    lines.append("    _BODY_PASSTHROUGH = True")
+
+    if p.extra_headers:
+        lines.append("    _EXTRA_HEADERS = {")
+        for k, v in sorted(p.extra_headers.items()):
+            lines.append(f'        "{k}": {json.dumps(v)},')
+        lines.append("    }")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_openai_chat_bearer_passthrough_test_file(p: ScaffoldParams) -> str:
+    """Render the Pattern A-passthrough offline contract tests.
+
+    Reuses the Pattern A test scaffolding (auth header / strip /
+    target URL / extra headers) and adds a ``TestBodyPassThrough``
+    class asserting the InjectionPlan has no ``body_transform`` and
+    the class declares ``_BODY_PASSTHROUGH = True``.
+    """
+    cls_name = f"{p.class_basename}CredentialProvider"
+    return (
+        '# SPDX-License-Identifier: Apache-2.0\n'
+        f'"""Offline contract tests for {p.slug} (bearer + body-pass-through)."""\n'
+        '\n'
+        'from __future__ import annotations\n'
+        '\n'
+        'import pytest\n'
+        '\n'
+        'from tokenpak.services.routing_service.credential_injector import (\n'
+        f'    {cls_name},\n'
+        '    invalidate_cache,\n'
+        '    registered,\n'
+        '    resolve,\n'
+        ')\n'
+        '\n'
+        '\n'
+        '@pytest.fixture(autouse=True)\n'
+        'def _clear_cache():\n'
+        '    invalidate_cache()\n'
+        '    yield\n'
+        '    invalidate_cache()\n'
+        '\n'
+        '\n'
+        'class TestLiveVerifiedMarker:\n'
+        '    def test_default_unverified(self):\n'
+        f'        assert {cls_name}.live_verified is False\n'
+        '\n'
+        '\n'
+        'class TestProviderResolveGate:\n'
+        '    def test_no_env_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.delenv("{p.env_var}", raising=False)\n'
+        f'        assert {cls_name}().resolve() is None\n'
+        '\n'
+        '    def test_empty_env_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "")\n'
+        f'        assert {cls_name}().resolve() is None\n'
+        '\n'
+        '    def test_valid_key_emits_plan(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        assert plan is not None\n'
+        '\n'
+        '\n'
+        'class TestAuthHeaderInjection:\n'
+        '    def test_emits_bearer_header(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        assert plan.add_headers["Authorization"] == "Bearer test-fake-key"\n'
+        '\n'
+        '    def test_strips_caller_auth(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        assert "authorization" in plan.strip_headers\n'
+        '        assert "x-api-key" in plan.strip_headers\n'
+        '\n'
+        '    def test_target_url_override(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        f'        assert plan.target_url_override == "{p.endpoint}"\n'
+        + _render_extra_header_test_block(p, cls_name)
+        + '\n'
+        'class TestBodyPassThrough:\n'
+        '    """Phase 4.2 contract: the InjectionPlan must have no\n'
+        '    ``body_transform`` so unknown / non-standard request body\n'
+        '    fields are forwarded byte-for-byte to the upstream.\n'
+        '    """\n'
+        '\n'
+        '    def test_class_declares_passthrough(self):\n'
+        f'        assert getattr({cls_name}, "_BODY_PASSTHROUGH", False) is True\n'
+        '\n'
+        '    def test_no_body_transform_in_plan(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        # Body pass-through is enforced by NOT setting a\n'
+        '        # body_transform on the InjectionPlan — the proxy then\n'
+        '        # forwards the request body byte-for-byte.\n'
+        '        assert plan.body_transform is None\n'
+        '\n'
+        '\n'
+        'class TestRegistration:\n'
+        '    def test_registered_with_known_slug(self):\n'
+        '        names = {p.name for p in registered()}\n'
+        f'        assert "{p.slug}" in names\n'
+        '\n'
+        '    def test_resolve_with_no_key_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.delenv("{p.env_var}", raising=False)\n'
+        f'        assert resolve("{p.slug}") is None\n'
+    )
+
+
+# ── Provider class (Pattern A-anthropic: anthropic-messages + api-key) ──
+
+
+def render_anthropic_messages_apikey_provider_class(p: ScaffoldParams) -> str:
+    """Render the Anthropic Messages + x-api-key CredentialProvider.
+
+    Anthropic's auth contract is two headers: ``x-api-key: <key>``
+    and ``anthropic-version: 2023-06-01`` (or override via
+    ``--extra-header anthropic-version=YYYY-MM-DD``). The renderer
+    emits explicit capability declarations on the class — there is
+    NO implicit TIP support; semantic-cache / capsule-injection /
+    aggressive-compaction are all opt-in by the maintainer once
+    they've reviewed the upstream's tolerance for body rewrites.
+    """
+    cls_name = f"{p.class_basename}CredentialProvider"
+    auth_header = p.auth_header or "x-api-key"
+    lines: list[str] = []
+
+    lines.append("# SPDX-License-Identifier: Apache-2.0")
+    lines.append(
+        f'"""Auto-scaffolded credential provider for {p.slug}.\n'
+        f'\n'
+        f'Source docs: {p.docs_url}\n'
+        f'\n'
+        f'Pattern A-anthropic: Anthropic Messages API + ``{auth_header}`` auth\n'
+        f'+ required ``anthropic-version`` header. ``live_verified`` is\n'
+        f'False until an ``{p.env_var}`` is available and the route is\n'
+        f'smoke-tested against the live upstream.\n'
+        f'"""'
+    )
+    lines.append("")
+    lines.append("from __future__ import annotations")
+    lines.append("")
+    lines.append("import logging")
+    lines.append("import os")
+    lines.append("from typing import Optional")
+    lines.append("")
+    lines.append("from tokenpak.services.routing_service.credential_injector import (")
+    lines.append("    InjectionPlan,")
+    lines.append("    _cached_resolve,")
+    lines.append(")")
+    lines.append("")
+    lines.append("logger = logging.getLogger(__name__)")
+    lines.append("")
+    lines.append("")
+
+    if p.live_verified:
+        live_status_lines = [
+            '    **Live status: smoke-tested live before merge.**',
+        ]
+    else:
+        article = (
+            "an" if p.env_var[:1].upper() in {"A", "E", "I", "O", "U"} else "a"
+        )
+        live_status_lines = [
+            f'    **Live status: contract-tested offline only.** No '
+            f'``{p.env_var}`` was available when this',
+            '    route was scaffolded. The route compiles and the offline '
+            'contract tests pass.',
+            f'    Live verification is tracked separately — when {article} '
+            f'``{p.env_var}`` becomes',
+            '    available, smoke-test the route against the upstream, then '
+            'flip',
+            '    ``live_verified`` to ``True`` and update this docstring per '
+            'Standard #23 §6.4.',
+        ]
+
+    lines.append(f"class {cls_name}:")
+    lines.append(f'    """{p.class_basename} — Anthropic-Messages-compatible, '
+                 f'``{p.env_var}``.')
+    lines.append("")
+    lines.append(f"    Source: {p.docs_url}")
+    lines.append("")
+    lines.extend(live_status_lines)
+    lines.append("")
+    lines.append("    Capability declarations (explicit; NO implicit TIP support):")
+    lines.append("    the maintainer must opt in to each capability after")
+    lines.append("    confirming the upstream tolerates the corresponding body")
+    lines.append("    rewrite. Anthropic Messages is sensitive to system-message")
+    lines.append("    placement + content-block shape; default is to declare")
+    lines.append("    NOTHING and let the proxy pass the body through.")
+    lines.append('    """')
+    lines.append("")
+    lines.append(f"    live_verified = {p.live_verified!r}")
+    lines.append(f'    name = "{p.slug}"')
+    lines.append(f'    _UPSTREAM = "{p.endpoint}"')
+    lines.append(f'    _ENV_VAR = "{p.env_var}"')
+    lines.append(f'    _AUTH_HEADER = "{auth_header}"')
+    lines.append('    _ANTHROPIC_VERSION = "2023-06-01"')
+    lines.append("")
+    lines.append("    # Explicit capability declarations (Standard #23 §4 + TIP-1.0).")
+    lines.append("    # Default = empty — NO implicit TIP support. Opt in per")
+    lines.append("    # capability after reviewing the upstream's body-rewrite")
+    lines.append("    # tolerance. Candidate capabilities (NOT yet declared):")
+    lines.append('    #   "tip.compression.v1"')
+    lines.append('    #   "tip.cache.proxy-managed"')
+    lines.append('    #   "tip.capsule.injection.v1"')
+    lines.append('    capabilities: frozenset = frozenset()')
+    lines.append("")
+    lines.append("    def _load(self) -> Optional[InjectionPlan]:")
+    lines.append("        api_key = os.environ.get(self._ENV_VAR, '').strip()")
+    lines.append("        if not api_key:")
+    lines.append("            logger.info(")
+    lines.append('                "credential_injector[%s]: env var %s not set; skipping",')
+    lines.append("                self.name, self._ENV_VAR,")
+    lines.append("            )")
+    lines.append("            return None")
+    lines.append("        headers = {")
+    lines.append("            self._AUTH_HEADER: api_key,")
+    lines.append('            "anthropic-version": self._ANTHROPIC_VERSION,')
+    lines.append("        }")
+
+    if p.extra_headers:
+        lines.append("        # Extra headers declared at scaffold time:")
+        for k, v in sorted(p.extra_headers.items()):
+            lines.append(f"        headers[{json.dumps(k)}] = {json.dumps(v)}")
+
+    # Strip caller-sent auth + version variants so the proxy is the
+    # authoritative source.
+    strip_set = sorted(
+        {"authorization", "x-api-key", auth_header.lower(), "anthropic-version"}
+    )
+    strip_literal = ", ".join(f'"{h}"' for h in strip_set)
+    lines.append("        return InjectionPlan(")
+    lines.append(f'            strip_headers=frozenset({{{strip_literal}}}),')
+    lines.append("            add_headers=headers,")
+    lines.append("            target_url_override=self._UPSTREAM,")
+    lines.append("        )")
+    lines.append("")
+    lines.append("    def resolve(self) -> Optional[InjectionPlan]:")
+    lines.append("        return _cached_resolve(self.name, self._load)")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_anthropic_messages_apikey_test_file(p: ScaffoldParams) -> str:
+    """Render offline contract tests for the Anthropic Messages + api-key pattern."""
+    cls_name = f"{p.class_basename}CredentialProvider"
+    auth_header = p.auth_header or "x-api-key"
+    extra_assertions = ""
+    if p.extra_headers:
+        extra_lines = [
+            '\n',
+            '    def test_extra_headers_injected(self, monkeypatch):\n',
+            f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n',
+            f'        plan = {cls_name}().resolve()\n',
+        ]
+        for k, v in sorted(p.extra_headers.items()):
+            extra_lines.append(
+                f'        assert plan.add_headers[{json.dumps(k)}] == {json.dumps(v)}\n'
+            )
+        extra_lines.append('\n')
+        extra_assertions = "".join(extra_lines)
+
+    return (
+        '# SPDX-License-Identifier: Apache-2.0\n'
+        f'"""Offline contract tests for {p.slug} (Anthropic Messages + api-key)."""\n'
+        '\n'
+        'from __future__ import annotations\n'
+        '\n'
+        'import pytest\n'
+        '\n'
+        'from tokenpak.services.routing_service.credential_injector import (\n'
+        '    invalidate_cache,\n'
+        '    registered,\n'
+        '    resolve,\n'
+        ')\n'
+        f'from tokenpak.services.routing_service.extras.{p.vendor.replace("-", "_")} import (\n'
+        f'    {cls_name},\n'
+        ')\n'
+        '\n'
+        '\n'
+        '@pytest.fixture(autouse=True)\n'
+        'def _clear_cache():\n'
+        '    invalidate_cache()\n'
+        '    yield\n'
+        '    invalidate_cache()\n'
+        '\n'
+        '\n'
+        'class TestLiveVerifiedMarker:\n'
+        '    def test_default_unverified(self):\n'
+        f'        assert {cls_name}.live_verified is False\n'
+        '\n'
+        '\n'
+        'class TestProviderResolveGate:\n'
+        '    def test_no_env_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.delenv("{p.env_var}", raising=False)\n'
+        f'        assert {cls_name}().resolve() is None\n'
+        '\n'
+        '    def test_empty_env_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "")\n'
+        f'        assert {cls_name}().resolve() is None\n'
+        '\n'
+        '\n'
+        'class TestAuthHeaderInjection:\n'
+        '    def test_emits_xapikey_header_not_bearer(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        f'        assert plan.add_headers[{json.dumps(auth_header)}] == "test-fake-key"\n'
+        '        assert "Authorization" not in plan.add_headers\n'
+        '\n'
+        '    def test_emits_anthropic_version(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        assert plan.add_headers["anthropic-version"] == "2023-06-01"\n'
+        '\n'
+        '    def test_strips_caller_auth(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        '        assert "authorization" in plan.strip_headers\n'
+        '        assert "x-api-key" in plan.strip_headers\n'
+        '        assert "anthropic-version" in plan.strip_headers\n'
+        '\n'
+        '    def test_target_url_override(self, monkeypatch):\n'
+        f'        monkeypatch.setenv("{p.env_var}", "test-fake-key")\n'
+        f'        plan = {cls_name}().resolve()\n'
+        f'        assert plan.target_url_override == "{p.endpoint}"\n'
+        '\n'
+        '\n'
+        'class TestCapabilityDeclarations:\n'
+        '    """Phase 4.2: explicit capability set; default is empty."""\n'
+        '\n'
+        '    def test_capabilities_attribute_present(self):\n'
+        f'        assert hasattr({cls_name}, "capabilities")\n'
+        '\n'
+        '    def test_no_implicit_tip_support(self):\n'
+        '        # Generated default declares NO TIP capabilities — the\n'
+        '        # maintainer opts in per-capability after reviewing the\n'
+        '        # upstream\'s body-rewrite tolerance.\n'
+        f'        caps = {cls_name}.capabilities\n'
+        '        assert "tip.compression.v1" not in caps\n'
+        '        assert "tip.cache.proxy-managed" not in caps\n'
+        '        assert "tip.capsule.injection.v1" not in caps\n'
+        + extra_assertions
+        + '\n'
+        'class TestRegistration:\n'
+        '    def test_resolve_with_no_key_returns_none(self, monkeypatch):\n'
+        f'        monkeypatch.delenv("{p.env_var}", raising=False)\n'
+        f'        if "{p.slug}" not in {{p.name for p in registered()}}:\n'
+        '            pytest.skip(\n'
+        '                "Provider not yet registered — add the register() "\n'
+        '                "call to credential_injector.py."\n'
+        '            )\n'
+        f'        assert resolve("{p.slug}") is None\n'
+    )
+
+
+# ── Fixtures (Pattern A-anthropic) ───────────────────────────────────
+
+
+def render_anthropic_messages_request_fixture(p: ScaffoldParams) -> str:
+    """Anthropic Messages-shaped request fixture.
+
+    Anthropic differs from OpenAI Chat: ``messages`` array (no
+    ``system`` role — system goes in a top-level ``system`` field),
+    ``max_tokens`` REQUIRED, no ``temperature`` default. Maintainer
+    replaces model id + content with vendor-specific examples
+    post-generation.
+    """
+    fixture = {
+        "_scaffold_note": (
+            f"SCAFFOLD-VERIFY: replace model id + messages with examples "
+            f"from {p.docs_url}. ``max_tokens`` is REQUIRED on Anthropic "
+            f"Messages; ``system`` is a top-level field, not a message role."
+        ),
+        "model": f"<{p.vendor}-model-id>",
+        "max_tokens": 64,
+        "system": "You are a concise assistant.",
+        "messages": [
+            {"role": "user", "content": "ping"},
+        ],
+    }
+    return json.dumps(fixture, indent=2) + "\n"
+
+
+def render_anthropic_messages_response_fixture(p: ScaffoldParams) -> str:
+    """Anthropic Messages-shaped response fixture.
+
+    Response shape differs materially from OpenAI Chat:
+    ``content`` is an array of typed blocks (``{"type": "text",
+    "text": ...}``), token counts are ``usage.input_tokens`` /
+    ``usage.output_tokens`` (not ``prompt_tokens`` /
+    ``completion_tokens``).
+    """
+    fixture = {
+        "_scaffold_note": (
+            f"SCAFFOLD-VERIFY: replace with a real response sample from "
+            f"{p.docs_url}. Anthropic uses ``content`` blocks + "
+            f"``usage.input_tokens`` / ``usage.output_tokens``."
+        ),
+        "id": "msg_fixture_id",
+        "type": "message",
+        "role": "assistant",
+        "model": f"<{p.vendor}-model-id>",
+        "content": [
+            {"type": "text", "text": "pong"},
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 1,
+        },
+    }
+    return json.dumps(fixture, indent=2) + "\n"
+
+
+def render_anthropic_messages_docs_stub(p: ScaffoldParams) -> str:
+    """Docs stub for Anthropic-Messages-shaped providers.
+
+    Differs from the OpenAI-Chat stub in the curl example body
+    (uses ``max_tokens`` + Anthropic header set) and the
+    troubleshooting section (notes the ``anthropic-version`` and
+    content-block specifics).
+    """
+    auth_header = p.auth_header or "x-api-key"
+    extra_env_section = ""
+    if p.optional_deps:
+        deps = ", ".join(f"`{d}`" for d in p.optional_deps)
+        install = " ".join(p.optional_deps)
+        extra_env_section = (
+            "\n### Optional Python dependencies\n\n"
+            f"This route requires {deps}. Install with `pip install "
+            f"{install}`. Without them, the provider gracefully returns "
+            "None at registration time and the route is unavailable.\n"
+        )
+
+    body = (
+        f"# {p.class_basename}\n"
+        "\n"
+        f"Source: <{p.docs_url}>\n"
+        "\n"
+        f"Provider slug: `{p.slug}`\n"
+        "\n"
+        f"Wire format: Anthropic Messages API (`{auth_header}` auth + "
+        "`anthropic-version` header).\n"
+        "\n"
+        "## Status\n"
+        "\n"
+        f"Contract-tested offline. Live verification pending — see the\n"
+        f"follow-up issue tracking when an `{p.env_var}` becomes\n"
+        f"available.\n"
+        "\n"
+        "## Required environment\n"
+        "\n"
+        f"- `{p.env_var}` — the API key from {p.docs_url}.\n"
+        f"{extra_env_section}\n"
+        "## Capability declarations\n"
+        "\n"
+        "This provider declares NO TIP capabilities by default. Anthropic\n"
+        "Messages is sensitive to system-message placement and\n"
+        "content-block shape, so semantic-cache / capsule-injection /\n"
+        "aggressive-compaction are all opt-in. Review the upstream's\n"
+        "tolerance before flipping any capability flag in the generated\n"
+        "class.\n"
+        "\n"
+        "## Supported models\n"
+        "\n"
+        f"See the upstream docs at <{p.docs_url}>. The TokenPak proxy\n"
+        "forwards whatever model id the caller specifies — no\n"
+        "per-model allowlist is enforced.\n"
+        "\n"
+        "## Live test\n"
+        "\n"
+        f"Once you have an `{p.env_var}`:\n"
+        "\n"
+        "```bash\n"
+        f"export {p.env_var}=...\n"
+        "\n"
+        f"curl -X POST {p.endpoint} \\\n"
+        f'  -H "{auth_header}: ${p.env_var}" \\\n'
+        '  -H "anthropic-version: 2023-06-01" \\\n'
+        "  -H 'content-type: application/json' \\\n"
+        f'  -d \'{{"model": "<{p.vendor}-model-id>",\n'
+        '        "max_tokens": 64,\n'
+        '        "messages": [{"role": "user", "content": "hello"}]}\'\n'
+        "```\n"
+        "\n"
+        "Expected: an Anthropic Messages response (`content` blocks +\n"
+        "`usage.input_tokens` / `usage.output_tokens`) recorded in\n"
+        "`~/.tokenpak/monitor.db`.\n"
+        "\n"
+        "## Troubleshooting\n"
+        "\n"
+        "- **HTTP 401 from upstream**: API key invalid / expired or\n"
+        f"  `{auth_header}` header name doesn't match the upstream's\n"
+        "  expectation. Verify against the docs URL.\n"
+        "- **HTTP 400 `anthropic-version required`**: the proxy strips\n"
+        "  caller-sent `anthropic-version` and re-adds the canonical\n"
+        "  value (`2023-06-01`). Override on the generated class if the\n"
+        "  upstream needs a different version.\n"
+        "- **HTTP 4xx with vendor-specific error**: check the upstream's\n"
+        "  model id naming + required body fields against the docs URL.\n"
+        "- **Proxy returns 502 `backend_unavailable`**: the optional\n"
+        "  dependency (if any) isn't installed. See above.\n"
+        "\n"
+        "<!-- SCAFFOLD-VERIFY: maintainer should fill in:\n"
+        "     - exact model ids supported on first ratification\n"
+        "     - any vendor-specific request fields beyond Anthropic Messages\n"
+        "     - rate-limit + cost expectations\n"
+        "     - whether any TIP capability is safe to opt in\n"
+        "-->\n"
+    )
+    return body


### PR DESCRIPTION
## Summary

Three deterministic template additions on top of Phase 4.1 (PR #42, merged as `98d565f6`).

- **Renderer #1** — `openai-chat + api-key-header`: auth header parameterized via `--auth-header NAME`. Default `api-key` (Azure) preserved; pass `X-API-Key` / `Api-Key` / etc. to emit the right header at scaffold-time. Lowercased configured header joins the strip-set.
- **Renderer #2** — `anthropic-messages + api-key-header` (new): Anthropic Messages shape, `x-api-key` auth, required `anthropic-version: 2023-06-01`, **capability declarations explicit and empty** (no implicit TIP support), Anthropic-specific request/response fixtures + docs stub.
- **Renderer #3** — `openai-chat + bearer-passthrough` (new auth value): for OpenRouter-style providers preserving extra body fields. Same InjectionPlan as Pattern A + explicit `_BODY_PASSTHROUGH = True` annotation + `TestBodyPassThrough` class asserting `plan.body_transform is None`.

**Held per directive**: no Bedrock generic, no Anthropic-on-Vertex, no watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`.

## Test coverage

- `tests/test_scaffold.py`: 80 → **110 tests** (+30)
- Full suite: 910 → **940 passing** (zero regressions, 1 skip / 1 xfail unchanged)

New test classes: TestApiKeyHeaderConfigurable (5), TestBearerPassthroughRenderer (8), TestAnthropicMessagesApikeyRenderer (14), TestPhase42NonInteractiveSafety (3).

## Dogfood verification

Three synthetic providers scaffolded against `--out-dir /tmp/...`:

| Slug | Family | Auth | Notes |
|---|---|---|---|
| `tokenpak-acme-xapi` | `openai-chat` | `api-key-header` | `--auth-header X-API-Key` — verifies #1 |
| `tokenpak-anthropic-stub` | `anthropic-messages` | `api-key-header` | default `x-api-key` — verifies #2 |
| `tokenpak-openrouter-passthrough` | `openai-chat` | `bearer-passthrough` | + extra headers — verifies #3 |

Each provider class passes `ruff check` standalone and compiles via `py_compile`. Test files lint clean once placed in canonical position. Fixtures parse as valid JSON with family-correct shape.

Full dogfood report: `docs/internal/specs/phase4.2-scaffold-renderer-expansion-2026-04-25.md`.

## Test plan

- [x] `pytest tests/test_scaffold.py` — 110 / 110 pass
- [x] `pytest tests/` (excl. baseline 404s) — 940 / 940 pass
- [x] `ruff check` clean on changed files
- [x] Dogfood: all three renderers ruff-clean + compile
- [x] Non-interactive bad slug exits 2
- [x] `--dry-run` works for new renderers (no files written)
- [ ] CI green (Lint & Test, TIP-1.0 Self-Conformance, Repo Hygiene)