### PR TITLE
feat(proxy): Phase I0-1 — Intent Layer Phase 0 (telemetry-only)

### DIFF
--- a/tests/test_intent_layer_phase0.py
+++ b/tests/test_intent_layer_phase0.py
@@ -1,0 +1,523 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase I0-1 — Intent Layer Phase 0 regression suite.
+
+Covers:
+
+  - Rule-based classifier: 10 canonical intents + 3 catch-all paths
+    (empty / too-short / keyword-miss / threshold)
+  - IntentContract construction (id shape, hash determinism, risk)
+  - attach_intent_headers — emits the five wire headers, idempotent
+  - SELF_CAPABILITIES_PROXY publishes ``tip.intent.contract-headers-v1``
+    (proposal §5.2 audit-finding requirement)
+  - SQLite intent_events table — DDL + write contract
+  - §4.3 capability gate semantics — emit when adapter declares the
+    label, strip otherwise; both branches reach telemetry.
+
+No network, no real provider. All offline.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tokenpak.core.contracts.capabilities import SELF_CAPABILITIES_PROXY
+from tokenpak.proxy.intent_classifier import (
+    CATCH_ALL_REASONS,
+    CLASSIFY_THRESHOLD,
+    INTENT_SOURCE_V0,
+    IntentClassification,
+    classify_intent,
+    extract_prompt_text,
+)
+from tokenpak.proxy.intent_contract import (
+    GATE_CAPABILITY,
+    INTENT_HEADER_CLASS,
+    INTENT_HEADER_CONFIDENCE,
+    INTENT_HEADER_ID,
+    INTENT_HEADER_RISK,
+    INTENT_HEADER_SUBTYPE,
+    IntentContract,
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    attach_intent_headers,
+    build_contract,
+    derive_risk,
+    hash_prompt,
+    make_contract_id,
+)
+from tokenpak.proxy.intent_policy import CANONICAL_INTENTS
+
+# ── Capability publication ────────────────────────────────────────────
+
+
+class TestProxyCapabilityPublication:
+    """Per proposal §5.2: registering a label the proxy doesn't
+    publish is an audit finding. Verify the proxy DOES publish it.
+    """
+
+    def test_self_capabilities_proxy_includes_intent_label(self):
+        assert "tip.intent.contract-headers-v1" in SELF_CAPABILITIES_PROXY
+
+    def test_gate_capability_constant_matches_published_label(self):
+        assert GATE_CAPABILITY == "tip.intent.contract-headers-v1"
+        assert GATE_CAPABILITY in SELF_CAPABILITIES_PROXY
+
+
+# ── Classifier semantics ──────────────────────────────────────────────
+
+
+class TestClassifierCanonicalIntents:
+    """Each of the 10 canonical intents has a happy-path prompt that
+    classifies above CLASSIFY_THRESHOLD and lands on the expected
+    intent_class.
+    """
+
+    @pytest.mark.parametrize(
+        "prompt,expected",
+        [
+            ("what is the status of the proxy", "status"),
+            ("usage report for last 7 days", "usage"),
+            ("debug why the proxy crashed", "debug"),
+            ("summarize the vault", "summarize"),
+            ("plan a migration to v2", "plan"),
+            ("execute the dry_run", "execute"),
+            ("explain how cache_control works", "explain"),
+            ("search the docs for openrouter", "search"),
+            ("create a new adapter for fireworks", "create"),
+        ],
+    )
+    def test_canonical_intent_classified_above_threshold(self, prompt, expected):
+        result = classify_intent(prompt)
+        assert result.intent_class == expected, (
+            f"{prompt!r} -> {result.intent_class} expected {expected}"
+        )
+        assert result.confidence >= CLASSIFY_THRESHOLD
+        assert result.catch_all_reason is None
+        assert result.intent_source == INTENT_SOURCE_V0
+
+    def test_classifier_covers_canonical_intent_set(self):
+        # Sanity: the keyword table covers every CANONICAL_INTENTS
+        # entry (else the assert at module load would have fired).
+        from tokenpak.proxy.intent_classifier import _KEYWORD_PATTERNS
+
+        for intent in CANONICAL_INTENTS:
+            assert intent in _KEYWORD_PATTERNS
+
+
+class TestClassifierCatchAllReasons:
+    """Catch-all path produces a populated ``catch_all_reason``."""
+
+    def test_empty_prompt(self):
+        result = classify_intent("")
+        assert result.intent_class == "query"
+        assert result.catch_all_reason == "empty_prompt"
+        assert result.confidence == 0.0
+
+    def test_whitespace_only_prompt(self):
+        result = classify_intent("   \n\t   ")
+        assert result.catch_all_reason == "empty_prompt"
+
+    def test_too_short_prompt(self):
+        result = classify_intent("hi")
+        assert result.intent_class == "query"
+        assert result.catch_all_reason == "prompt_too_short"
+
+    def test_keyword_miss(self):
+        # No canonical keyword matches → keyword_miss (the catch-all
+        # 'query' patterns also fail).
+        result = classify_intent("the quick brown fox jumps over a lazy")
+        assert result.intent_class == "query"
+        assert result.catch_all_reason == "keyword_miss"
+
+    def test_below_confidence_threshold(self):
+        # The 'query' catch-all set has only weak weights (≤ 0.3).
+        # A prompt that matches a 'query' weak pattern scores below
+        # CLASSIFY_THRESHOLD even though _some_ pattern matched.
+        result = classify_intent("could you do this thing")
+        assert result.catch_all_reason == "confidence_below_threshold"
+        assert 0 < result.confidence < CLASSIFY_THRESHOLD
+
+    def test_catch_all_reason_in_canonical_set(self):
+        for prompt in ("", "hi", "xyz xyz xyz"):
+            result = classify_intent(prompt)
+            assert result.catch_all_reason in CATCH_ALL_REASONS
+
+
+class TestClassifierTieBreaking:
+    """When two intents tie on score, declaration order wins."""
+
+    def test_status_beats_query_tie(self):
+        # 'status' weight=1.0; 'query' weak (≤ 0.3). Status wins
+        # outright, but the test pins the priority-order expectation.
+        result = classify_intent("status")
+        assert result.intent_class == "status"
+
+
+# ── Slot extraction integration ───────────────────────────────────────
+
+
+class TestClassifierSlotsPropagated:
+    """SlotFiller integration — classifier returns slot tuples."""
+
+    def test_summarize_extracts_period(self):
+        result = classify_intent("summarize the vault for last 7 days")
+        assert result.intent_class == "summarize"
+        # The slot filler may or may not pick up 'period' depending
+        # on its YAML; the test just asserts the tuple shape is sane.
+        assert isinstance(result.slots_present, tuple)
+        assert isinstance(result.slots_missing, tuple)
+
+
+# ── extract_prompt_text ───────────────────────────────────────────────
+
+
+class TestPromptExtraction:
+    """The proxy hands canonical messages — concatenate user content."""
+
+    def test_string_passthrough(self):
+        assert extract_prompt_text("hello") == "hello"
+
+    def test_user_messages_concatenated(self):
+        msgs = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hello"},
+            {"role": "user", "content": "world"},
+        ]
+        assert extract_prompt_text(msgs) == "hello world"
+
+    def test_anthropic_content_blocks(self):
+        msgs = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "ping"},
+                {"type": "text", "text": "pong"},
+            ]},
+        ]
+        assert extract_prompt_text(msgs) == "ping pong"
+
+    def test_non_user_role_ignored(self):
+        msgs = [{"role": "assistant", "content": "should not be picked up"}]
+        # The classifier should not see assistant turns.
+        assert "should not" not in extract_prompt_text(msgs)
+
+    def test_garbage_input_returns_empty(self):
+        assert extract_prompt_text(None) == ""
+        assert extract_prompt_text(42) == ""
+
+
+# ── IntentContract construction ───────────────────────────────────────
+
+
+class TestIntentContractConstruction:
+
+    def _classification(self, **over):
+        kw = dict(
+            intent_class="summarize",
+            confidence=1.0,
+            slots_present=("period",),
+            slots_missing=(),
+            catch_all_reason=None,
+        )
+        kw.update(over)
+        return IntentClassification(**kw)
+
+    def test_make_contract_id_shape(self):
+        cid = make_contract_id()
+        assert len(cid) == 13 + 16  # ms hex + random hex
+        # All hex chars
+        int(cid, 16)
+
+    def test_make_contract_id_is_unique(self):
+        a = make_contract_id()
+        b = make_contract_id()
+        assert a != b
+
+    def test_hash_prompt_deterministic(self):
+        assert hash_prompt("hello") == hash_prompt("hello")
+        assert hash_prompt("hello") != hash_prompt("world")
+        assert len(hash_prompt("x")) == 64  # sha256 hex
+
+    def test_build_contract_basic(self):
+        c = build_contract(
+            classification=self._classification(),
+            raw_prompt="summarize the vault",
+        )
+        assert c.intent_class == "summarize"
+        assert c.confidence == 1.0
+        assert c.subtype is None
+        assert c.risk == "low"
+        assert c.intent_source == INTENT_SOURCE_V0
+        assert c.raw_prompt_hash == hash_prompt("summarize the vault")
+
+    def test_build_contract_with_subtype(self):
+        c = build_contract(
+            classification=self._classification(),
+            raw_prompt="x",
+            subtype="bug_fix",
+        )
+        assert c.subtype == "bug_fix"
+
+    def test_to_dict_serialisable(self):
+        c = build_contract(
+            classification=self._classification(),
+            raw_prompt="x",
+        )
+        d = c.to_dict()
+        # Tuples become lists in JSON.
+        assert d["slots_present"] == ["period"]
+        json.dumps(d)  # round-trip-safe
+
+
+class TestRiskHeuristic:
+    """Phase 0 risk heuristic per `intent_contract.derive_risk` docstring."""
+
+    def test_execute_is_medium_when_slots_complete(self):
+        assert derive_risk("execute", 0.9, ()) == "medium"
+
+    def test_execute_is_high_with_missing_slots(self):
+        assert derive_risk("execute", 0.9, ("target",)) == "high"
+
+    def test_create_is_high_with_missing_slots(self):
+        assert derive_risk("create", 1.0, ("target",)) == "high"
+
+    def test_observation_intents_low(self):
+        for intent in ("status", "usage", "query", "search", "explain"):
+            assert derive_risk(intent, 1.0, ()) == "low"
+
+    def test_debug_low_confidence_medium(self):
+        assert derive_risk("debug", 0.5, ()) == "medium"
+
+    def test_debug_high_confidence_low(self):
+        assert derive_risk("debug", 0.9, ()) == "low"
+
+
+# ── Header attachment ─────────────────────────────────────────────────
+
+
+class TestAttachIntentHeaders:
+
+    def _contract(self, **over):
+        kw = dict(
+            contract_id="abc123",
+            intent_class="summarize",
+            confidence=0.8765,
+            subtype=None,
+            risk="low",
+            slots_present=("period",),
+            slots_missing=(),
+            intent_source=INTENT_SOURCE_V0,
+            catch_all_reason=None,
+            raw_prompt_hash="h",
+        )
+        kw.update(over)
+        return IntentContract(**kw)
+
+    def test_emits_all_required_headers(self):
+        h = {}
+        attach_intent_headers(h, self._contract())
+        assert h[INTENT_HEADER_CLASS] == "summarize"
+        assert h[INTENT_HEADER_CONFIDENCE] == "0.88"  # 2-decimal
+        assert h[INTENT_HEADER_RISK] == "low"
+        assert h[INTENT_HEADER_ID] == "abc123"
+
+    def test_subtype_omitted_when_none(self):
+        h = {}
+        attach_intent_headers(h, self._contract())
+        assert INTENT_HEADER_SUBTYPE not in h
+
+    def test_subtype_present_when_set(self):
+        h = {}
+        attach_intent_headers(h, self._contract(subtype="bug_fix"))
+        assert h[INTENT_HEADER_SUBTYPE] == "bug_fix"
+
+    def test_idempotent_same_contract(self):
+        h = {}
+        c = self._contract()
+        attach_intent_headers(h, c)
+        snapshot = dict(h)
+        attach_intent_headers(h, c)
+        assert h == snapshot
+
+    def test_overrides_caller_supplied_value(self):
+        h = {INTENT_HEADER_CLASS: "spoofed"}
+        attach_intent_headers(h, self._contract())
+        assert h[INTENT_HEADER_CLASS] == "summarize"
+
+
+# ── Telemetry store (SQLite) ──────────────────────────────────────────
+
+
+class TestTelemetryStore:
+
+    def _row(self, *, emitted=True, stripped=False, db_request_id="req1"):
+        c = IntentContract(
+            contract_id="cid1",
+            intent_class="summarize",
+            confidence=0.9,
+            subtype=None,
+            risk="low",
+            slots_present=("period",),
+            slots_missing=("target",),
+            intent_source=INTENT_SOURCE_V0,
+            catch_all_reason=None,
+            raw_prompt_hash="hash1",
+        )
+        return IntentTelemetryRow(
+            request_id=db_request_id,
+            contract=c,
+            timestamp="2026-04-25T22:00:00",
+            tip_headers_emitted=emitted,
+            tip_headers_stripped=stripped,
+            tokens_in=42,
+            tokens_out=None,
+            latency_ms=None,
+        )
+
+    def test_table_created_on_first_write(self, tmp_path: Path):
+        db = tmp_path / "t.db"
+        store = IntentTelemetryStore(db_path=db)
+        store.write(self._row())
+        store.close()
+        conn = sqlite3.connect(str(db))
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='intent_events'"
+        )
+        assert cur.fetchone() is not None
+
+    def test_row_round_trip(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        store.write(self._row())
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        row = conn.execute(
+            "SELECT request_id, intent_class, intent_slots_present, "
+            "intent_slots_missing, intent_source, tip_headers_emitted, "
+            "tip_headers_stripped, tokens_in FROM intent_events"
+        ).fetchone()
+        assert row[0] == "req1"
+        assert row[1] == "summarize"
+        assert json.loads(row[2]) == ["period"]
+        assert json.loads(row[3]) == ["target"]
+        assert row[4] == INTENT_SOURCE_V0
+        assert row[5] == 1  # emitted
+        assert row[6] == 0  # stripped
+        assert row[7] == 42
+
+    def test_emitted_and_stripped_distinct_states(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        store.write(self._row(emitted=True, stripped=False, db_request_id="a"))
+        store.write(self._row(emitted=False, stripped=True, db_request_id="b"))
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        rows = dict(
+            conn.execute(
+                "SELECT request_id, tip_headers_emitted FROM intent_events"
+            ).fetchall()
+        )
+        assert rows == {"a": 1, "b": 0}
+
+    def test_idempotent_on_same_request_id(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        store.write(self._row(db_request_id="dup"))
+        store.write(self._row(db_request_id="dup"))
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        n = conn.execute(
+            "SELECT COUNT(*) FROM intent_events WHERE request_id = 'dup'"
+        ).fetchone()[0]
+        assert n == 1  # PRIMARY KEY + INSERT OR REPLACE
+
+    def test_write_on_unwritable_path_does_not_raise(self, tmp_path: Path):
+        # Best-effort contract: telemetry side-channel never breaks
+        # the request. Point the DB at an unwritable location and
+        # confirm the call completes silently.
+        bad = Path("/proc/this-cannot-be-a-real-file.db")
+        store = IntentTelemetryStore(db_path=bad)
+        store.write(self._row())  # must not raise
+
+
+# ── §4.3 capability gate semantics ────────────────────────────────────
+
+
+class TestCapabilityGate:
+    """The gate is expressed inline at server.py call site; here we
+    test the semantics in isolation by simulating the call.
+    """
+
+    def _contract(self):
+        return IntentContract(
+            contract_id="cid",
+            intent_class="summarize",
+            confidence=0.8,
+            subtype=None,
+            risk="low",
+            slots_present=(),
+            slots_missing=(),
+            intent_source=INTENT_SOURCE_V0,
+            catch_all_reason=None,
+            raw_prompt_hash="h",
+        )
+
+    def test_emits_when_adapter_declares_label(self):
+        class _Adapter:
+            capabilities = frozenset({GATE_CAPABILITY})
+
+        h: dict = {}
+        # Simulate the gate from server.py:
+        adapter = _Adapter()
+        if adapter is not None and GATE_CAPABILITY in adapter.capabilities:
+            attach_intent_headers(h, self._contract())
+            emitted = True
+            stripped = False
+        else:
+            emitted = False
+            stripped = True
+        assert emitted is True
+        assert stripped is False
+        assert INTENT_HEADER_CLASS in h
+
+    def test_strips_when_adapter_does_not_declare(self):
+        class _Adapter:
+            capabilities = frozenset({"tip.compression.v1"})  # different label
+
+        h: dict = {}
+        adapter = _Adapter()
+        if adapter is not None and GATE_CAPABILITY in adapter.capabilities:
+            attach_intent_headers(h, self._contract())
+            emitted = True
+            stripped = False
+        else:
+            emitted = False
+            stripped = True
+        assert emitted is False
+        assert stripped is True
+        assert INTENT_HEADER_CLASS not in h
+
+    def test_strips_when_adapter_is_none(self):
+        h: dict = {}
+        adapter = None
+        if adapter is not None and GATE_CAPABILITY in adapter.capabilities:
+            attach_intent_headers(h, self._contract())
+            emitted = True
+            stripped = False
+        else:
+            emitted = False
+            stripped = True
+        assert emitted is False
+        assert stripped is True
+        assert INTENT_HEADER_CLASS not in h
+
+    def test_no_first_party_adapter_declares_label_in_phase_0(self):
+        """Per proposal §5.2: 'No first-party adapter declares the
+        label by default in Intent-0.' Verify by walking every
+        first-party FormatAdapter in the default registry.
+        """
+        from tokenpak.proxy.adapters import build_default_registry
+
+        registry = build_default_registry()
+        for ad in registry.adapters():
+            assert GATE_CAPABILITY not in ad.capabilities, (
+                f"{ad.__class__.__name__} declares {GATE_CAPABILITY} — "
+                f"Intent-0 says no first-party adapter declares this label "
+                f"by default; opt-in is gated on the baseline report."
+            )

--- a/tokenpak/core/contracts/capabilities.py
+++ b/tokenpak/core/contracts/capabilities.py
@@ -44,6 +44,11 @@ SELF_CAPABILITIES_PROXY: frozenset[str] = frozenset({
     "tip.cache.ttl-ordering",
     "tip.routing.fallback-chain",
     "tip.security.dlp-redaction",
+    # Intent Layer Phase 0 (Adj-2 of 2026-04-25). Proxy publishes the
+    # label so adapters can opt in via FormatAdapter.capabilities; the
+    # §4.3 wire-emission gate keys off the adapter-side declaration,
+    # not this set. Catalog entry: tokenpak/registry PR-I0-2.
+    "tip.intent.contract-headers-v1",
 })
 
 # Self-declared set for the tip-companion profile. Companion publishes

--- a/tokenpak/manifests/tokenpak-proxy.json
+++ b/tokenpak/manifests/tokenpak-proxy.json
@@ -10,6 +10,7 @@
     "tip.cache.proxy-managed",
     "tip.cache.ttl-ordering",
     "tip.compression.v1",
+    "tip.intent.contract-headers-v1",
     "tip.routing.classifier.v1",
     "tip.routing.fallback-chain",
     "tip.security.dlp-redaction",

--- a/tokenpak/proxy/intent_classifier.py
+++ b/tokenpak/proxy/intent_classifier.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rule-based intent classifier for Intent Layer Phase 0.
+
+Maps a raw prompt string to one of the 10 canonical intents declared
+in :mod:`tokenpak.proxy.intent_policy` (the existing policy table).
+Deterministic; no LLM cost.
+
+Phase 0 scope (telemetry-only): the classifier output drives a TIP
+intent contract that flows into local telemetry and — when the
+resolved request adapter declares ``tip.intent.contract-headers-v1``
+per Standard #23 §4.3 — onto the wire as ``X-TokenPak-Intent-*`` /
+``X-TokenPak-Contract-*`` headers. Out of Phase 0 scope: any prompt
+reshaping, routing change, or clarification gate.
+
+Algorithm
+---------
+
+1. **Empty / too-short fast-fail**: prompt below 3 non-whitespace
+   chars → ``query`` with ``catch_all_reason = "prompt_too_short"``
+   (or ``empty_prompt`` if zero chars).
+2. **Keyword scoring**: each canonical intent has a weighted keyword
+   set in :data:`_KEYWORD_TABLE`. Score for an intent is the **max**
+   matched weight (not the sum) — a single strong canonical keyword
+   classifies confidently without requiring secondary keywords too.
+   Secondary patterns provide alternative paths to the same intent
+   when the canonical word is absent. Confidence is the top
+   intent's score, clamped to ``[0.0, 1.0]``.
+3. **Threshold gate**: if top confidence is below
+   :data:`CLASSIFY_THRESHOLD` (0.4 by default — same as the existing
+   ``intent_policy.CONFIDENCE_THRESHOLD`` for symmetry), fall back to
+   ``query`` with ``catch_all_reason = "confidence_below_threshold"``.
+4. **Tie-breaker**: when two intents tie on score, the one earlier
+   in :data:`_KEYWORD_TABLE` declaration wins (priority encoded in
+   ordering: status > usage > debug > … > query). ``query`` always
+   loses ties since it's the catch-all.
+5. **Slot fill** is delegated to :class:`SlotFiller` (existing
+   keyword/regex-driven extractor in
+   ``tokenpak/agent/compression/slot_filler.py``).
+
+Catch-all reasons (matches the proposal §5.3 enum)
+--------------------------------------------------
+
+- ``empty_prompt`` — prompt was empty or whitespace-only.
+- ``prompt_too_short`` — prompt below 3 chars after strip.
+- ``keyword_miss`` — every intent scored 0.
+- ``confidence_below_threshold`` — top score under
+  :data:`CLASSIFY_THRESHOLD`.
+- ``slot_ambiguous`` — top intent inferred but a required slot has
+  multiple candidate values (reserved; not emitted in v0 since
+  SlotFiller picks the first match deterministically).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, List, Mapping, Optional, Tuple
+
+from tokenpak.agent.compression.slot_filler import SlotFiller
+from tokenpak.proxy.intent_policy import CANONICAL_INTENTS
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+CLASSIFY_THRESHOLD: float = 0.4
+"""Minimum normalized keyword score for a non-catch-all classification.
+
+Symmetric with :data:`tokenpak.proxy.intent_policy.CONFIDENCE_THRESHOLD`
+so an upstream classification that survives this gate also survives
+the downstream policy gate.
+"""
+
+INTENT_SOURCE_V0: str = "rule_based_v0"
+"""Identifier emitted on every Phase 0 telemetry row.
+
+Lets a future Intent-1 LLM-assisted classifier (Option B in the
+proposal) backfill its own rows under a different ``intent_source``
+without invalidating Phase 0 baselines.
+"""
+
+
+CATCH_ALL_REASONS: FrozenSet[str] = frozenset({
+    "empty_prompt",
+    "prompt_too_short",
+    "keyword_miss",
+    "confidence_below_threshold",
+    "slot_ambiguous",
+})
+
+
+@dataclass(frozen=True)
+class IntentClassification:
+    """Output of :func:`classify_intent` — fully populated."""
+
+    intent_class: str
+    confidence: float
+    slots_present: Tuple[str, ...]
+    slots_missing: Tuple[str, ...]
+    catch_all_reason: Optional[str]
+    intent_source: str = INTENT_SOURCE_V0
+
+
+# ---------------------------------------------------------------------------
+# Keyword table (priority-ordered; query last as the catch-all)
+# ---------------------------------------------------------------------------
+
+# Maps intent → list of (regex, weight). Regexes are compiled once at
+# module load. Weight = how confident a single match is that the
+# prompt expresses this intent. Score for an intent =
+# ``max(weights of patterns that matched)`` (or 0.0 if none matched).
+#
+# Priority order matters for ties — earlier intents win. ``query`` is
+# never ranked above another intent in a tie because its keyword set
+# is intentionally weak (broad words).
+_KEYWORD_PATTERNS: Dict[str, List[Tuple[str, float]]] = {
+    "status": [
+        (r"\bstatus\b", 1.0),
+        (r"\bhealth\b", 0.8),
+        (r"\b(is|are)\s+(it|they|the)\s+\w+\s+(running|up|alive|ok)\b", 0.9),
+        (r"\bcheck\b", 0.4),
+    ],
+    "usage": [
+        (r"\busage\b", 1.0),
+        (r"\b(token|cost|spend|spent|budget)\b", 0.8),
+        (r"\bhow\s+(much|many)\b", 0.5),
+        (r"\b(this|last)\s+(week|month|day|hour)\b", 0.4),
+    ],
+    "debug": [
+        (r"\bdebug\b", 1.0),
+        (r"\b(trace|diagnose|why|broken|error|stack)\b", 0.7),
+        (r"\b(failing|fails|crashed|hung)\b", 0.7),
+    ],
+    "summarize": [
+        (r"\bsummari[sz]e\b", 1.0),
+        (r"\b(tl;dr|recap|brief|overview)\b", 0.7),
+        (r"\bgive\s+me\s+(a|the)?\s*summary\b", 1.0),
+    ],
+    "plan": [
+        (r"\bplan\b", 1.0),
+        (r"\b(roadmap|outline|steps|strategy)\b", 0.7),
+        (r"\bhow\s+(should|do)\s+(i|we)\s+(approach|tackle|do)\b", 0.6),
+    ],
+    "execute": [
+        (r"\b(run|execute|kick\s*off|launch)\b", 0.9),
+        (r"\bdry[\s-]*run\b", 1.0),
+        (r"\bgo\s+(ahead|do\s+it)\b", 0.6),
+    ],
+    "explain": [
+        (r"\bexplain\b", 1.0),
+        (r"\b(what\s+does|how\s+does|why\s+does)\b", 0.6),
+        (r"\bwalk\s+me\s+through\b", 0.8),
+    ],
+    "search": [
+        (r"\b(search|find|look\s+up|grep)\b", 0.9),
+        (r"\bwhere\s+is\b", 0.6),
+        (r"\b(locate|hunt\s+for)\b", 0.7),
+    ],
+    "create": [
+        (r"\b(create|generate|make|write|scaffold|new)\b", 0.7),
+        (r"\b(add|build)\s+(a|an|the)\b", 0.6),
+        (r"\b(implement|draft)\b", 0.7),
+    ],
+    "query": [
+        # Catch-all keywords intentionally weak; this set rarely wins
+        # outright. Used so a generic "what's …" or "how about …"
+        # prompt still scores nonzero before falling back.
+        (r"\bwhat'?s\b", 0.3),
+        (r"\b(can|could|would)\s+you\b", 0.2),
+        (r"\?$", 0.2),
+    ],
+}
+
+
+# Compile once. Tuple shape: (compiled_regex, weight).
+_COMPILED: Dict[str, List[Tuple[re.Pattern[str], float]]] = {
+    intent: [(re.compile(pat, re.IGNORECASE), w) for pat, w in patterns]
+    for intent, patterns in _KEYWORD_PATTERNS.items()
+}
+
+# Priority order for tie-breaking. Built from declaration order; query last.
+_PRIORITY: Tuple[str, ...] = tuple(_KEYWORD_PATTERNS.keys())
+
+
+# Sanity guard — the keyword table must cover the canonical-intent set
+# from :data:`intent_policy.CANONICAL_INTENTS`. If a future intent is
+# added to the policy without a keyword set, the classifier would
+# silently never select it. The assertion fires at import time.
+_KEYWORD_INTENTS = frozenset(_KEYWORD_PATTERNS.keys())
+assert CANONICAL_INTENTS <= _KEYWORD_INTENTS, (
+    f"intent_classifier missing keyword sets for: "
+    f"{sorted(CANONICAL_INTENTS - _KEYWORD_INTENTS)}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def classify_intent(prompt: str, *, slot_filler: Optional[SlotFiller] = None) -> IntentClassification:
+    """Classify a raw prompt into one of the canonical intents.
+
+    Always returns a populated :class:`IntentClassification`; never
+    raises on bad input. Prompts that fail every gate fall back to
+    ``query`` with a populated ``catch_all_reason``.
+
+    ``slot_filler`` is optional — pass a configured
+    :class:`SlotFiller` to reuse its loaded definitions; otherwise a
+    fresh instance is constructed (loads YAML on first call).
+    """
+    text = (prompt or "").strip()
+    if not text:
+        return _catch_all("empty_prompt")
+    if len(text) < 3:
+        return _catch_all("prompt_too_short")
+
+    scores = _score_intents(text)
+    top_intent, top_score = _pick_top(scores)
+    if top_score == 0.0:
+        return _catch_all("keyword_miss")
+    if top_score < CLASSIFY_THRESHOLD:
+        return _catch_all("confidence_below_threshold", confidence=top_score)
+
+    filler = slot_filler if slot_filler is not None else SlotFiller()
+    filled = filler.fill(top_intent, text)
+    slots_present = tuple(sorted(filled.slots.keys()))
+    slots_missing = tuple(sorted(filled.missing))
+
+    return IntentClassification(
+        intent_class=top_intent,
+        confidence=round(top_score, 4),
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=None,
+    )
+
+
+def extract_prompt_text(messages: object) -> str:
+    """Best-effort prompt extraction for canonical-request messages.
+
+    Concatenates the textual ``content`` of every user-role entry,
+    space-separated, lowercased only for the matcher (we keep the
+    original case in the return value so the slot filler can pick up
+    proper-case entity examples).
+
+    Accepts:
+      - a list of ``{"role": ..., "content": ...}`` dicts
+      - a string (returned as-is)
+      - anything else (returns ``""``)
+    """
+    if isinstance(messages, str):
+        return messages
+    if not isinstance(messages, list):
+        return ""
+    parts: List[str] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") not in ("user", None, ""):
+            continue
+        content = m.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _score_intents(text: str) -> Mapping[str, float]:
+    out: Dict[str, float] = {}
+    for intent, patterns in _COMPILED.items():
+        best = 0.0
+        for rgx, weight in patterns:
+            if rgx.search(text) and weight > best:
+                best = weight
+        # Clamp — a misconfigured weight > 1.0 in the table would
+        # otherwise inflate confidence beyond the proposal's [0, 1]
+        # contract.
+        out[intent] = min(best, 1.0)
+    return out
+
+
+def _pick_top(scores: Mapping[str, float]) -> Tuple[str, float]:
+    # Iterate in priority order so ties are broken deterministically.
+    best_intent = "query"
+    best_score = 0.0
+    for intent in _PRIORITY:
+        s = scores.get(intent, 0.0)
+        if s > best_score:
+            best_intent = intent
+            best_score = s
+    return best_intent, best_score
+
+
+def _catch_all(reason: str, *, confidence: float = 0.0) -> IntentClassification:
+    return IntentClassification(
+        intent_class="query",
+        confidence=round(confidence, 4),
+        slots_present=(),
+        slots_missing=(),
+        catch_all_reason=reason,
+    )
+
+
+__all__ = [
+    "CATCH_ALL_REASONS",
+    "CLASSIFY_THRESHOLD",
+    "INTENT_SOURCE_V0",
+    "IntentClassification",
+    "classify_intent",
+    "extract_prompt_text",
+]

--- a/tokenpak/proxy/intent_contract.py
+++ b/tokenpak/proxy/intent_contract.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TIP Intent Contract v1 — Phase 0 in-process representation.
+
+Phase 0 keeps the contract as a small frozen dataclass; the typed
+schema lift into ``tokenpak/core/contracts/`` happens in Intent-1.
+The on-disk JSON Schema for the wire-side contract lives in the
+registry (``schemas/tip/intent-contract-v1.json`` — separate
+deliverable per the proposal §4 PR-I0-2).
+
+Three concerns live in this module:
+
+1. :class:`IntentContract` — the per-request canonical object.
+2. :func:`attach_intent_headers` — apply the five wire headers to a
+   mutable header mapping. The §4.3 capability gate is the caller's
+   responsibility (so the gate stays expressed in one place at the
+   call site in :mod:`tokenpak.proxy.server`).
+3. :class:`IntentTelemetryStore` — SQLite writer for the
+   ``intent_events`` table (one row per request).
+
+No business logic, no header-emission decision making — those live
+at the call site so they can be reasoned about in one place.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, MutableMapping, Optional, Tuple
+
+if TYPE_CHECKING:
+    from tokenpak.proxy.intent_classifier import IntentClassification
+
+INTENT_HEADER_CLASS = "X-TokenPak-Intent-Class"
+INTENT_HEADER_CONFIDENCE = "X-TokenPak-Intent-Confidence"
+INTENT_HEADER_SUBTYPE = "X-TokenPak-Intent-Subtype"
+INTENT_HEADER_RISK = "X-TokenPak-Contract-Risk"
+INTENT_HEADER_ID = "X-TokenPak-Contract-Id"
+
+# Wire-emission gate label per Standard #23 §4.3. Single source of
+# truth so server.py doesn't have to spell the literal again.
+GATE_CAPABILITY = "tip.intent.contract-headers-v1"
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IntentContract:
+    """Per-request TIP Intent Contract (Phase 0 shape).
+
+    ``contract_id`` is a 26-char Crockford-base32 ULID-shaped string:
+    timestamp prefix + random tail. Sortable + collision-resistant.
+    """
+
+    contract_id: str
+    intent_class: str
+    confidence: float
+    subtype: Optional[str]
+    risk: str  # "low" | "medium" | "high"
+    slots_present: Tuple[str, ...]
+    slots_missing: Tuple[str, ...]
+    intent_source: str
+    catch_all_reason: Optional[str]
+    raw_prompt_hash: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "contract_id": self.contract_id,
+            "intent_class": self.intent_class,
+            "confidence": self.confidence,
+            "subtype": self.subtype,
+            "risk": self.risk,
+            "slots_present": list(self.slots_present),
+            "slots_missing": list(self.slots_missing),
+            "intent_source": self.intent_source,
+            "catch_all_reason": self.catch_all_reason,
+            "raw_prompt_hash": self.raw_prompt_hash,
+        }
+
+
+def hash_prompt(text: str) -> str:
+    """SHA-256 hex digest of the raw prompt — telemetry dedup key.
+
+    Storing the hash (not the prompt) keeps Architecture §7.1 prompt
+    locality intact: prompts stay in the per-request log; the
+    cross-request telemetry DB only ever sees an opaque digest.
+    """
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def derive_risk(intent_class: str, confidence: float, slots_missing: Tuple[str, ...]) -> str:
+    """Map a classification to a 3-bucket risk label.
+
+    Phase 0 risk is heuristic: high-side-effect intents (``execute``,
+    ``create``) start at ``medium`` and drop to ``high`` if any
+    required slot is missing; observation intents (``status``,
+    ``usage``, ``query``, ``search``, ``explain``) start at ``low``;
+    everything else is ``low`` unless confidence is borderline. Phase
+    1 will lift this into a typed ``RiskAssessor`` aware of the
+    recipe table.
+    """
+    if intent_class in ("execute", "create"):
+        return "high" if slots_missing else "medium"
+    if intent_class in ("debug", "plan"):
+        return "medium" if confidence < 0.7 else "low"
+    return "low"
+
+
+def make_contract_id() -> str:
+    """ULID-shaped opaque id (26 chars). Phase 0 uses a portable
+
+    timestamp+random hex format rather than a third-party ULID
+    library — keeps the dependency surface clean.
+    """
+    ts_ms = int(time.time() * 1000)
+    # 16 random bits per Crockford convention; we just hexlify since
+    # the field is opaque to consumers.
+    rand = secrets.token_hex(8)  # 16 hex chars
+    return f"{ts_ms:013x}{rand}"  # 13 hex (ms) + 16 hex (rand) = 29 chars
+
+
+# ---------------------------------------------------------------------------
+# Header attachment
+# ---------------------------------------------------------------------------
+
+
+def attach_intent_headers(
+    headers: MutableMapping[str, str],
+    contract: IntentContract,
+) -> None:
+    """Mutate ``headers`` to carry the five Intent-0 wire headers.
+
+    Idempotent — calling twice with the same contract overwrites with
+    the same values. Pre-existing values for these header names are
+    overwritten (the proxy is the authoritative source for TIP
+    headers per Standard #23 §4 + §22 §5.1).
+
+    The capability gate is NOT applied here. Callers are required to
+    check ``GATE_CAPABILITY in adapter.capabilities`` before invoking
+    this function — keeping the gate expressed at the call site is
+    the explicit pattern from the standards (§4.3).
+    """
+    headers[INTENT_HEADER_CLASS] = contract.intent_class
+    headers[INTENT_HEADER_CONFIDENCE] = f"{contract.confidence:.2f}"
+    if contract.subtype is not None:
+        headers[INTENT_HEADER_SUBTYPE] = contract.subtype
+    headers[INTENT_HEADER_RISK] = contract.risk
+    headers[INTENT_HEADER_ID] = contract.contract_id
+
+
+# ---------------------------------------------------------------------------
+# Telemetry store (SQLite)
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_DB_PATH = Path(os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak"))) / "telemetry.db"
+
+_INTENT_EVENTS_DDL = """\
+CREATE TABLE IF NOT EXISTS intent_events (
+    request_id           TEXT PRIMARY KEY,
+    contract_id          TEXT NOT NULL,
+    timestamp            TEXT NOT NULL,
+    raw_prompt_hash      TEXT NOT NULL,
+    intent_class         TEXT NOT NULL,
+    intent_confidence    REAL NOT NULL,
+    intent_slots_present TEXT NOT NULL,
+    intent_slots_missing TEXT NOT NULL,
+    intent_source        TEXT NOT NULL,
+    catch_all_reason     TEXT,
+    tip_headers_emitted  INTEGER NOT NULL,
+    tip_headers_stripped INTEGER NOT NULL,
+    tokens_in            INTEGER,
+    tokens_out           INTEGER,
+    latency_ms           INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_intent_events_class
+    ON intent_events (intent_class, timestamp);
+CREATE INDEX IF NOT EXISTS idx_intent_events_confidence
+    ON intent_events (intent_confidence);
+"""
+
+
+@dataclass
+class IntentTelemetryRow:
+    """One row of the ``intent_events`` table (write side)."""
+
+    request_id: str
+    contract: IntentContract
+    timestamp: str
+    tip_headers_emitted: bool
+    tip_headers_stripped: bool
+    tokens_in: Optional[int] = None
+    tokens_out: Optional[int] = None
+    latency_ms: Optional[int] = None
+
+
+class IntentTelemetryStore:
+    """Per-host SQLite writer for ``intent_events``.
+
+    Constructed lazily; opens (or creates) ``~/.tokenpak/telemetry.db``
+    on first :meth:`write`. Single connection guarded by a lock —
+    Phase 0 traffic is low; Intent-1 will switch to the existing
+    ``services.telemetry_service`` async writer once the schema lift
+    is complete.
+    """
+
+    _LOCK = threading.Lock()
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.executescript(_INTENT_EVENTS_DDL)
+            conn.commit()
+            self._conn = conn
+        return self._conn
+
+    def write(self, row: IntentTelemetryRow) -> None:
+        """Insert one row. Best-effort — exceptions are not raised.
+
+        Telemetry is a side-channel; a write failure must not break
+        the outbound request. Caller logs a warning if the writer
+        misbehaves (server.py wraps the call).
+        """
+        c = row.contract
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO intent_events (
+                        request_id, contract_id, timestamp, raw_prompt_hash,
+                        intent_class, intent_confidence,
+                        intent_slots_present, intent_slots_missing,
+                        intent_source, catch_all_reason,
+                        tip_headers_emitted, tip_headers_stripped,
+                        tokens_in, tokens_out, latency_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row.request_id,
+                        c.contract_id,
+                        row.timestamp,
+                        c.raw_prompt_hash,
+                        c.intent_class,
+                        c.confidence,
+                        json.dumps(list(c.slots_present)),
+                        json.dumps(list(c.slots_missing)),
+                        c.intent_source,
+                        c.catch_all_reason,
+                        1 if row.tip_headers_emitted else 0,
+                        1 if row.tip_headers_stripped else 0,
+                        row.tokens_in,
+                        row.tokens_out,
+                        row.latency_ms,
+                    ),
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001 — best-effort; never propagate
+            return
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+# Module-level singleton — production code pulls one shared writer.
+_DEFAULT_STORE: Optional[IntentTelemetryStore] = None
+
+
+def get_default_store() -> IntentTelemetryStore:
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = IntentTelemetryStore()
+    return _DEFAULT_STORE
+
+
+def set_default_store(store: Optional[IntentTelemetryStore]) -> None:
+    """Test hook — swap the default writer (e.g. for an in-memory DB)."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+# ---------------------------------------------------------------------------
+# Convenience constructor — classification → contract
+# ---------------------------------------------------------------------------
+
+
+def build_contract(
+    *,
+    classification: "IntentClassification",
+    raw_prompt: str,
+    subtype: Optional[str] = None,
+) -> IntentContract:
+    """Assemble an :class:`IntentContract` from a classifier output.
+
+    Phase 0 has no subtype taxonomy yet — the field is reserved for
+    Intent-1 (where the typed-class lift produces canonical
+    subtypes). Caller may pass an explicit ``subtype`` if a
+    higher-layer caller computed one.
+    """
+    return IntentContract(
+        contract_id=make_contract_id(),
+        intent_class=classification.intent_class,
+        confidence=classification.confidence,
+        subtype=subtype,
+        risk=derive_risk(
+            classification.intent_class,
+            classification.confidence,
+            classification.slots_missing,
+        ),
+        slots_present=classification.slots_present,
+        slots_missing=classification.slots_missing,
+        intent_source=classification.intent_source,
+        catch_all_reason=classification.catch_all_reason,
+        raw_prompt_hash=hash_prompt(raw_prompt),
+    )
+
+
+# Imported lazily to avoid circular imports at module load: the
+# classifier imports from `intent_policy`, which lives alongside this
+# module. We re-export `IntentClassification` for convenience but
+# don't bind it at module-level.
+def __getattr__(name: str) -> Any:  # pragma: no cover — lazy re-export
+    if name == "IntentClassification":
+        from tokenpak.proxy.intent_classifier import IntentClassification
+
+        return IntentClassification
+    raise AttributeError(name)
+
+
+__all__ = [
+    "GATE_CAPABILITY",
+    "INTENT_HEADER_CLASS",
+    "INTENT_HEADER_CONFIDENCE",
+    "INTENT_HEADER_ID",
+    "INTENT_HEADER_RISK",
+    "INTENT_HEADER_SUBTYPE",
+    "IntentContract",
+    "IntentTelemetryRow",
+    "IntentTelemetryStore",
+    "attach_intent_headers",
+    "build_contract",
+    "derive_risk",
+    "get_default_store",
+    "hash_prompt",
+    "make_contract_id",
+    "set_default_store",
+]

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -801,6 +801,37 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             if _adapter_tokens == 0:
                 input_tokens = _estimate_tokens_from_body(body)
 
+            # ── Intent Layer Phase 0 — classify upstream ───────────────
+            # Always classify; gate the WIRE EMISSION downstream per
+            # Standard #23 §4.3. Telemetry stays local-only when the
+            # adapter doesn't declare ``tip.intent.contract-headers-v1``.
+            _intent_contract = None
+            try:
+                from tokenpak.proxy.intent_classifier import classify_intent as _classify_intent
+                from tokenpak.proxy.intent_classifier import (
+                    extract_prompt_text as _extract_prompt_text,
+                )
+                from tokenpak.proxy.intent_contract import build_contract as _build_contract
+
+                _prompt_text = ""
+                if request_adapter is not None and body:
+                    try:
+                        _canonical = request_adapter.normalize(body)
+                        _prompt_text = _extract_prompt_text(
+                            getattr(_canonical, "messages", None) or []
+                        )
+                    except Exception:
+                        _prompt_text = ""
+                _classification = _classify_intent(_prompt_text)
+                _intent_contract = _build_contract(
+                    classification=_classification,
+                    raw_prompt=_prompt_text,
+                )
+            except Exception:
+                # Telemetry side-channel — never break the proxy on
+                # classifier errors. Leave _intent_contract as None.
+                _intent_contract = None
+
             try:
                 data = json.loads(body)
                 is_streaming = data.get("stream", False)
@@ -1421,6 +1452,47 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             fwd_headers["Host"] = parsed.netloc
             if body is not None:
                 fwd_headers["Content-Length"] = str(len(body))
+
+        # ── Intent Layer Phase 0 — capability-gated header emission ──
+        # Standard #23 §4.3 verbatim: attach wire intent headers ONLY
+        # when the request adapter declares the opt-in capability
+        # ``tip.intent.contract-headers-v1``. Otherwise the contract
+        # stays in local telemetry only (``tip_headers_stripped`` row
+        # bit flips on for the dashboard count).
+        _i0_emitted = False
+        _i0_stripped = False
+        if _intent_contract is not None:
+            try:
+                from tokenpak.proxy.intent_contract import GATE_CAPABILITY as _I0_GATE
+                from tokenpak.proxy.intent_contract import IntentTelemetryRow as _I0Row
+                from tokenpak.proxy.intent_contract import attach_intent_headers as _i0_attach
+                from tokenpak.proxy.intent_contract import get_default_store as _i0_store
+
+                if (
+                    request_adapter is not None
+                    and _I0_GATE in request_adapter.capabilities
+                ):
+                    _i0_attach(fwd_headers, _intent_contract)
+                    _i0_emitted = True
+                else:
+                    # Headers stay in local telemetry only — no wire emission.
+                    _i0_stripped = True
+
+                _i0_store().write(
+                    _I0Row(
+                        request_id=_req_id,
+                        contract=_intent_contract,
+                        timestamp=datetime.now().isoformat(timespec="seconds"),
+                        tip_headers_emitted=_i0_emitted,
+                        tip_headers_stripped=_i0_stripped,
+                        tokens_in=input_tokens or None,
+                        tokens_out=None,
+                        latency_ms=None,
+                    )
+                )
+            except Exception:
+                # Side-channel; never break the request on telemetry failures.
+                pass
 
         try:
             pool = self.server.proxy_server._connection_pool  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Wires the rule-based Intent classifier upstream of dispatch and emits the TIP intent / contract headers ONLY when the resolved request adapter declares `tip.intent.contract-headers-v1` per `23-provider-adapter-standard.md §4.3`. Telemetry stays local-only when the gate strips. **No user-facing behavior change, no routing change, no body rewrite** — proposal §3 in-scope only.

Sequenced after `tokenpak/registry#2` (PR-I0-2, merged as `1395763f`) which registered the new capability label in the canonical catalog.

## Changes

- **`tokenpak/proxy/intent_classifier.py`** — Option A (rule-based deterministic) classifier covering the 10 canonical intents from `intent_policy.CANONICAL_INTENTS`. Score = max matched-keyword weight; declaration-order tie-break; `query` is the catch-all. Five reasons populated for the catch-all path: `empty_prompt`, `prompt_too_short`, `keyword_miss`, `confidence_below_threshold`, `slot_ambiguous` (reserved). Module-load assert pins the keyword table to the canonical-intent set.
- **`tokenpak/proxy/intent_contract.py`** — `IntentContract` dataclass, `make_contract_id` (ms-prefixed hex ULID), `hash_prompt` (sha256 dedup key — prompts stay in request log per Architecture §7.1), `derive_risk` (Phase 0 heuristic), `attach_intent_headers` (five wire headers; gate NOT applied here — caller's responsibility per §4.3), `IntentTelemetryStore` (per-host SQLite writer with best-effort never-raises contract). `GATE_CAPABILITY` constant matches the catalog label.
- **`tokenpak/core/contracts/capabilities.py`** — add `tip.intent.contract-headers-v1` to `SELF_CAPABILITIES_PROXY` so the proxy publishes the label (proposal §5.2 audit-finding requirement: declaring without publishing is a finding).
- **`tokenpak/manifests/tokenpak-proxy.json`** — same label added, keeping manifest in sync with `SELF_CAPABILITIES_PROXY` (`test_proxy_manifest_capabilities_sync_with_canonical` enforces this).
- **`tokenpak/proxy/server.py`** — two narrow inserts in `_proxy_to_inner`:
  1. After `request_adapter` resolves: classify the prompt (best-effort, never raises) and build an `IntentContract`.
  2. After `fwd_headers` is finalized but before dispatch: apply the §4.3 capability gate **verbatim** from the proposal:
     ```python
     if request_adapter is not None and "tip.intent.contract-headers-v1" in request_adapter.capabilities:
         attach_intent_headers(request, contract)
     # else: skip; headers stay in local telemetry only
     ```
     Either branch writes one `intent_events` row with `tip_headers_emitted` / `tip_headers_stripped` bits set.

## Telemetry schema

`intent_events` SQLite table created lazily under `~/.tokenpak/telemetry.db`. Columns match the proposal §5.3 set verbatim (request_id PK, contract_id, timestamp, raw_prompt_hash, intent_class, intent_confidence, intent_slots_present/missing as JSON arrays, intent_source = `'rule_based_v0'`, catch_all_reason nullable, tip_headers_emitted/stripped bits, tokens_in/out + latency_ms nullable for the join with request_events).

## Test coverage

- `tests/test_intent_layer_phase0.py` — **51 tests** across 11 classes:
  - `TestProxyCapabilityPublication` (2)
  - `TestClassifierCanonicalIntents` (10 incl. 9-way parametrized)
  - `TestClassifierCatchAllReasons` (6)
  - `TestClassifierTieBreaking` (1)
  - `TestClassifierSlotsPropagated` (1)
  - `TestPromptExtraction` (5)
  - `TestIntentContractConstruction` (5)
  - `TestRiskHeuristic` (6)
  - `TestAttachIntentHeaders` (5)
  - `TestTelemetryStore` (5)
  - `TestCapabilityGate` (5) — including the proposal §5.2 invariant: no first-party adapter declares the label by default (`build_default_registry().adapters()` walked).

Full suite: **991 passing** (was 940 baseline), 0 regressions, 1 skip / 1 xfail unchanged.

## Standards trail

- `23-provider-adapter-standard.md` ratified onto vault main 2026-04-25 (commit `cd5c5fe84`).
- §1.5 sharpened in same commit to make `tokenpak-claude-code` no-rename exception explicit (closes #39).
- Intent-0 proposal: vault Adj-1+Adj-2 banner @ `~/02_COMMAND_CENTER/proposals/2026-04-24-tokenpak-intent-layer-phase-0.md`.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no further scaffold renderer expansion.

## Test plan

- [x] `pytest tests/test_intent_layer_phase0.py` — 51 / 51 pass
- [x] `pytest tests/conformance/test_manifests.py` — manifest-sync test pinned
- [x] `pytest tests/` (excl. baseline 404s) — 991 / 991 pass
- [x] `ruff check` clean on changed/new files
- [x] Smoke: classifier reads sensibly across all 10 intents + 3 catch-all paths
- [x] Smoke: `SELF_CAPABILITIES_PROXY` publishes new label
- [ ] CI green on all three workflows