### PR TITLE
feat(cli): Phase 0.1 — Intent Layer doctor view + explain output + docs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -413,21 +413,29 @@ Run diagnostics
 
 ```
 usage: tokenpak doctor [-h] [--fix] [--fleet] [--deploy] [--claude-code]
-                       [--privacy] [--conformance] [--json]
+                       [--privacy] [--conformance] [--intent] [--explain-last]
+                       [--json]
 
 options:
-  -h, --help     show this help message and exit
-  --fix          Auto-fix issues where possible
-  --fleet        Check all agents in ~/.tokenpak/fleet.yaml
-  --deploy       Push latest doctor to all agents (use with --fleet)
-  --claude-code  Run Claude Code-specific checks (companion settings, drift,
-                 base-url routing)
-  --privacy      Summarize TokenPak's privacy posture (what stays local, what
-                 leaves, where compliance docs live)
-  --conformance  Run TIP-1.0 self-conformance checks (capability set,
-                 profiles, manifests, live emissions)
-  --json         Emit machine-readable JSON instead of the human table
-                 (conformance mode)
+  -h, --help      show this help message and exit
+  --fix           Auto-fix issues where possible
+  --fleet         Check all agents in ~/.tokenpak/fleet.yaml
+  --deploy        Push latest doctor to all agents (use with --fleet)
+  --claude-code   Run Claude Code-specific checks (companion settings, drift,
+                  base-url routing)
+  --privacy       Summarize TokenPak's privacy posture (what stays local, what
+                  leaves, where compliance docs live)
+  --conformance   Run TIP-1.0 self-conformance checks (capability set,
+                  profiles, manifests, live emissions)
+  --intent        (Phase 0.1) Show the Intent Layer Phase 0 diagnostic view:
+                  classifier activation, proxy self-capability publication,
+                  per-adapter §4.3 gate declaration, and whether wire emission
+                  is currently enabled on this host.
+  --explain-last  (Phase 0.1) Render the most recent intent_events row
+                  (contract_id, intent_class, confidence, slots,
+                  catch_all_reason, tip_headers_emitted/stripped). Read-only.
+  --json          Emit machine-readable JSON instead of the human table
+                  (applies to --conformance, --intent, --explain-last)
 ```
 
 ### `tokenpak dashboard`

--- a/docs/reference/intent-layer-phase-0.md
+++ b/docs/reference/intent-layer-phase-0.md
@@ -1,0 +1,115 @@
+# Intent Layer — Phase 0
+
+> Phase 0 is **telemetry-only**. The classifier observes; nothing about your request body, routing, caching, or response changes. This document explains what happens, when wire headers are emitted, what stays local, and how to read the 2-week observation window.
+
+## What Phase 0 does
+
+On every request that flows through the proxy, the rule-based classifier runs upstream of dispatch and produces an `IntentContract`:
+
+| Field | Phase 0 source |
+|---|---|
+| `contract_id` | ULID-shaped opaque id (ms timestamp + random tail), 1:1 with `request_id` |
+| `intent_class` | one of the 10 canonical intents from `tokenpak.proxy.intent_policy.CANONICAL_INTENTS` |
+| `confidence` | `[0.0, 1.0]` — max matched-keyword weight for the winning intent |
+| `subtype` | reserved (always `None` in Phase 0; Intent-1 lifts the typed-class taxonomy) |
+| `risk` | `low \| medium \| high` — heuristic, see `derive_risk` |
+| `slots_present` / `slots_missing` | from `SlotFiller` over `slot_definitions.yaml` |
+| `intent_source` | `rule_based_v0` (see below) |
+| `catch_all_reason` | populated when classification falls through to `query` |
+| `raw_prompt_hash` | sha256 hex of the concatenated user-message text — dedup key only |
+
+Every contract becomes one row in `~/.tokenpak/telemetry.db` `intent_events`.
+
+## When TIP intent headers are emitted on the wire
+
+The proxy attaches the five wire headers — `X-TokenPak-Intent-Class`, `X-TokenPak-Intent-Confidence`, `X-TokenPak-Intent-Subtype`, `X-TokenPak-Contract-Risk`, `X-TokenPak-Contract-Id` — **only when the resolved request adapter declares the capability**:
+
+```python
+# tokenpak/proxy/server.py — Standard #23 §4.3 capability gate (verbatim)
+if request_adapter is not None and "tip.intent.contract-headers-v1" in request_adapter.capabilities:
+    attach_intent_headers(request, contract)
+# else: skip; headers stay in local telemetry only
+```
+
+Adapters declare capabilities as a class attribute:
+
+```python
+class MyAdapter(FormatAdapter):
+    capabilities = frozenset({
+        "tip.intent.contract-headers-v1",
+        # …
+    })
+```
+
+In Phase 0, **no first-party adapter declares this label by default**. First-party opt-in is gated on the Phase 0 baseline report. The `tests/test_intent_layer_phase0.py::TestCapabilityGate::test_no_first_party_adapter_declares_label_in_phase_0` regression test enforces this contract.
+
+### Why headers stay local unless the adapter declares the capability
+
+The default-off posture preserves two architecture invariants:
+
+1. **Byte-fidelity for non-TIP providers** (Architecture §5.1). Some upstreams care about request-body bytes for billing routing or signature verification; injecting unsolicited TIP headers risks observable side-effects.
+2. **Explicit opt-in over implicit support** (Standard #23 §4.2). An adapter that doesn't declare a label MUST NOT have that label's behavior applied. Telemetry stays local until the adapter author confirms the upstream tolerates the new headers.
+
+The contract is symmetric: declaring without publishing is also a violation. The proxy publishes `tip.intent.contract-headers-v1` in `tokenpak.core.contracts.capabilities.SELF_CAPABILITIES_PROXY`, mirrored in `tokenpak/manifests/tokenpak-proxy.json` and `tokenpak/registry`'s `capability-catalog.json`.
+
+## What `rule_based_v0` means
+
+The Phase 0 classifier is **deterministic, regex/keyword-driven, no LLM** (Option A in the proposal). Every classification is reproducible from the raw prompt + the keyword table at `tokenpak/proxy/intent_classifier.py::_KEYWORD_PATTERNS`.
+
+The `intent_source = "rule_based_v0"` field on every telemetry row is a deliberate marker:
+
+- It lets a future Intent-1 LLM-assisted classifier (Option B) backfill rows under a different `intent_source` value without invalidating the Phase 0 baseline.
+- It makes A/B comparisons trivial: filter `intent_events` by `intent_source` to compare distributions.
+- It makes upgrades auditable: if classifier behavior changes in v1, the source value increments to `rule_based_v1` (or whatever) so old rows aren't conflated.
+
+**Do not treat `rule_based_v0` confidence values as probabilistic.** They are normalized keyword weights, not posteriors. A confidence of `0.8` means "the canonical keyword for `summarize` matched"; it does not mean "an 80 % chance the intent is `summarize`". Phase 0's measurement plan (proposal §6) treats the confidence histogram as a tuning input, not as a probability.
+
+## How to read the 2-week observation window
+
+The proposal sets the default observation window at **2 weeks of live traffic** on Kevin's fleet. The window is a **measurement budget**, not a quality gate. Three things govern when to extend or cut short:
+
+1. **Does the confidence histogram stabilize?** If the shape drifts late in week 2, extend to 4 weeks. If it's stable by day 7, the data is enough.
+2. **Is `intent_class = "query"` (the catch-all) > 50 %?** If so, the canonical-intent set or the keyword table needs revision before Intent-1 lifts the subsystem. Cut the window short, fix the keyword set, restart.
+3. **Is volume < 500 classifications?** Below that threshold, distribution statistics aren't meaningful. Extend until ≥ 500 rows accumulate.
+
+The window has no effect on user-facing behavior. Nothing toggles based on the window's elapsed time — Phase 0 is observation-only. The window simply scopes when to run the **baseline report** (proposal §4 deliverable 5) that informs the Intent-1 go/no-go decision.
+
+## Operator commands
+
+```bash
+# Diagnostic snapshot — classifier active? proxy publishing the label?
+# which adapters declare the capability? would headers emit on the wire?
+tokenpak doctor --intent
+tokenpak doctor --intent --json    # machine-readable
+
+# Full row dump for the most recent classification
+tokenpak doctor --explain-last
+tokenpak doctor --explain-last --json
+```
+
+## Privacy
+
+Raw prompt text never enters the telemetry DB. Only the `raw_prompt_hash` (sha256 hex digest) is stored. Per-request prompts stay in the local request log under `~/.tokenpak/` (subject to `TOKENPAK_LOG_ENABLED` and `telemetry.store_prompts` per Architecture §7.1). No prompt data leaves the machine.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/proxy/intent_classifier.py` | rule-based classifier (Option A) |
+| `tokenpak/proxy/intent_contract.py` | `IntentContract`, telemetry store, `attach_intent_headers` |
+| `tokenpak/proxy/intent_doctor.py` | doctor / explain renderers (Phase 0.1) |
+| `tokenpak/proxy/intent_policy.py` | existing policy table + 10 canonical intents |
+| `tokenpak/agent/compression/slot_filler.py` | slot extractor |
+| `tokenpak/agent/compression/slot_definitions.yaml` | per-intent slot schemas |
+| `tokenpak/manifests/tokenpak-proxy.json` | published TIP capability set |
+
+## Standards
+
+- `23-provider-adapter-standard.md §4.3` — capability-gated middleware activation, the canonical pattern this layer implements.
+- `01-architecture-standard.md §5.1` — byte-fidelity rule for non-TIP providers.
+- `01-architecture-standard.md §7.1` — prompt-locality rule (raw prompts never cross the machine boundary).
+- `00-product-constitution.md §13` — TokenPak as TIP-1.0 reference implementation.
+
+## Proposal
+
+Full Intent-0 proposal (Phase 0 scope, decisions, measurement plan, risk + mitigation): `~/vault/02_COMMAND_CENTER/proposals/2026-04-24-tokenpak-intent-layer-phase-0.md` (Adj-1 + Adj-2 banner block at top documents the 2026-04-25 cross-reference adjustment to align with Standard #23).

--- a/tests/test_intent_layer_phase01_invariant.py
+++ b/tests/test_intent_layer_phase01_invariant.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 0.1 — load-bearing invariant test.
+
+The invariant: when the resolved request adapter does NOT declare
+``tip.intent.contract-headers-v1``, the proxy MUST NOT emit the
+five wire intent headers, AND the local intent_events row MUST
+still be written with ``tip_headers_emitted=False`` and
+``tip_headers_stripped=True``.
+
+This is the load-bearing default-off-and-still-observing contract
+from the proposal §5.2 + Standard #23 §4.3. Any future change that
+flips a first-party adapter's capability declaration, alters the
+gate condition in ``server.py``, or skips the telemetry write on
+the strip path will trip this test.
+
+Phase 0.1's existing regression suite covers the gate semantics in
+isolation (``tests/test_intent_layer_phase0.py::TestCapabilityGate``).
+This test stitches the contract-construction → gate-check →
+telemetry-write sequence together as one transaction so the
+end-to-end wire-vs-local discrimination is enforced explicitly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tokenpak.proxy.intent_classifier import classify_intent
+from tokenpak.proxy.intent_contract import (
+    GATE_CAPABILITY,
+    INTENT_HEADER_CLASS,
+    INTENT_HEADER_CONFIDENCE,
+    INTENT_HEADER_ID,
+    INTENT_HEADER_RISK,
+    INTENT_HEADER_SUBTYPE,
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    attach_intent_headers,
+    build_contract,
+)
+
+
+def _classify_and_build(prompt: str):
+    """Run the actual Phase 0 classifier + contract builder.
+
+    Uses the real production code paths (not test-only doubles) so
+    the invariant survives refactors of the classifier internals.
+    """
+    classification = classify_intent(prompt)
+    contract = build_contract(classification=classification, raw_prompt=prompt)
+    return classification, contract
+
+
+def _simulate_gate(adapter, contract, headers):
+    """Simulate the verbatim §4.3 gate from server.py.
+
+    Returns ``(emitted, stripped)`` matching the bits server.py
+    writes onto the telemetry row. The gate condition mirrors the
+    server.py source verbatim — keeping both expressions
+    syntactically aligned makes a future drift loud.
+    """
+    if adapter is not None and GATE_CAPABILITY in adapter.capabilities:
+        attach_intent_headers(headers, contract)
+        return True, False
+    return False, True
+
+
+class _AdapterWithoutLabel:
+    """Stands in for any first-party adapter in Phase 0.
+
+    Declares a non-Intent capability so the test gate negotiates
+    the strip path in the way it would for any production adapter
+    that hasn't opted in.
+    """
+
+    capabilities = frozenset({"tip.compression.v1"})
+
+
+class _AdapterWithLabel:
+    """Synthetic opt-in adapter for the symmetry assertion.
+
+    Used only to prove the gate is real — flipping the capability
+    flips the wire-emission result.
+    """
+
+    capabilities = frozenset({GATE_CAPABILITY})
+
+
+def test_invariant_no_capability_no_wire_emission_telemetry_still_written(tmp_path: Path):
+    """Phase 0.1 load-bearing invariant.
+
+    Adapter does not declare ``tip.intent.contract-headers-v1``:
+      1. Wire headers MUST NOT appear on the outbound header dict.
+      2. The intent_events row MUST still land in the local DB.
+      3. The row's ``tip_headers_emitted`` MUST be False (0).
+      4. The row's ``tip_headers_stripped`` MUST be True (1).
+      5. The row's ``intent_source`` MUST be ``rule_based_v0`` —
+         confirms classification was real (not a no-op silently
+         skipped because of an exception).
+      6. The row's ``raw_prompt_hash`` MUST be the sha256 of the
+         prompt — confirms no raw prompt content leaked into the
+         row payload.
+    """
+    db_path = tmp_path / "telemetry.db"
+    store = IntentTelemetryStore(db_path=db_path)
+
+    classification, contract = _classify_and_build(
+        "summarize the vault for last 7 days"
+    )
+    # Sanity: classifier produced a real classification (not a
+    # catch-all). If this ever changes, the rest of the assertions
+    # are still meaningful but the test no longer exercises the
+    # main pathway.
+    assert classification.intent_class == "summarize"
+
+    headers: dict = {}
+    adapter = _AdapterWithoutLabel()
+    emitted, stripped = _simulate_gate(adapter, contract, headers)
+
+    # (1) No wire headers attached.
+    assert emitted is False
+    assert stripped is True
+    for hk in (
+        INTENT_HEADER_CLASS,
+        INTENT_HEADER_CONFIDENCE,
+        INTENT_HEADER_SUBTYPE,
+        INTENT_HEADER_RISK,
+        INTENT_HEADER_ID,
+    ):
+        assert hk not in headers, f"{hk!r} leaked onto the wire"
+
+    # (2) Telemetry row still lands.
+    store.write(
+        IntentTelemetryRow(
+            request_id="req-no-capability-1",
+            contract=contract,
+            timestamp="2026-04-25T22:00:00",
+            tip_headers_emitted=emitted,
+            tip_headers_stripped=stripped,
+            tokens_in=42,
+            tokens_out=None,
+            latency_ms=None,
+        )
+    )
+    store.close()
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT intent_class, intent_source, raw_prompt_hash, "
+        "tip_headers_emitted, tip_headers_stripped "
+        "FROM intent_events WHERE request_id = 'req-no-capability-1'"
+    ).fetchone()
+    conn.close()
+
+    assert row is not None, "telemetry row missing — strip path lost the row"
+    assert row[0] == "summarize"
+    # (5) Source marker.
+    assert row[1] == "rule_based_v0"
+    # (6) raw_prompt_hash is the sha256 hex of the prompt.
+    import hashlib
+
+    expected_hash = hashlib.sha256(
+        b"summarize the vault for last 7 days"
+    ).hexdigest()
+    assert row[2] == expected_hash, (
+        "raw_prompt_hash mismatch — either content drifted or the "
+        "row stored something other than the canonical digest"
+    )
+    # (3, 4) Bits set as expected.
+    assert row[3] == 0
+    assert row[4] == 1
+
+
+def test_invariant_symmetry_capability_present_emits_headers(tmp_path: Path):
+    """Mirror assertion: when the adapter DOES declare the label,
+    the gate flips, headers attach, and the telemetry row reflects
+    emission. Stops the no-emission test from passing trivially
+    because (e.g.) ``attach_intent_headers`` was no-op'd.
+    """
+    db_path = tmp_path / "telemetry.db"
+    store = IntentTelemetryStore(db_path=db_path)
+
+    _, contract = _classify_and_build("summarize the vault")
+    headers: dict = {}
+    adapter = _AdapterWithLabel()
+    emitted, stripped = _simulate_gate(adapter, contract, headers)
+
+    assert emitted is True
+    assert stripped is False
+    assert headers[INTENT_HEADER_CLASS] == contract.intent_class
+    assert headers[INTENT_HEADER_ID] == contract.contract_id
+
+    store.write(
+        IntentTelemetryRow(
+            request_id="req-with-capability-1",
+            contract=contract,
+            timestamp="2026-04-25T22:00:00",
+            tip_headers_emitted=emitted,
+            tip_headers_stripped=stripped,
+        )
+    )
+    store.close()
+
+    conn = sqlite3.connect(str(db_path))
+    bits = conn.execute(
+        "SELECT tip_headers_emitted, tip_headers_stripped FROM intent_events "
+        "WHERE request_id = 'req-with-capability-1'"
+    ).fetchone()
+    conn.close()
+    assert bits == (1, 0)
+
+
+def test_invariant_raw_prompt_not_in_row(tmp_path: Path):
+    """Guards the privacy contract: the row carries the digest, not
+    the raw prompt body. A regression that accidentally serializes
+    the prompt onto the row (e.g. into an unused ``extra`` column)
+    would trip this test by storing the prompt verbatim somewhere
+    else. We assert by reading every column of the latest row and
+    confirming the prompt substring appears nowhere.
+    """
+    db_path = tmp_path / "telemetry.db"
+    store = IntentTelemetryStore(db_path=db_path)
+
+    secret_token = "kevin-magic-prompt-marker-zzz"
+    prompt = f"summarize the vault {secret_token}"
+    _, contract = _classify_and_build(prompt)
+
+    store.write(
+        IntentTelemetryRow(
+            request_id="req-privacy-check-1",
+            contract=contract,
+            timestamp="2026-04-25T22:00:00",
+            tip_headers_emitted=False,
+            tip_headers_stripped=True,
+        )
+    )
+    store.close()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM intent_events WHERE request_id = 'req-privacy-check-1'"
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    for column in row.keys():
+        value = row[column]
+        if value is None:
+            continue
+        assert secret_token not in str(value), (
+            f"raw prompt content leaked into intent_events column "
+            f"{column!r}: privacy contract violated"
+        )

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -1687,6 +1687,41 @@ def cmd_doctor(args):
         )
         sys.exit(rc)
 
+    # ── Intent Layer Phase 0.1 — operator-readable diagnostic views ──
+    # ``--intent`` shows classifier activation, proxy self-capability
+    # publication, per-adapter §4.3 gate declaration, and whether wire
+    # emission is currently enabled. ``--explain-last`` shows the most
+    # recent ``intent_events`` row in full.
+    if getattr(args, "intent_view", False):
+        import json as _json
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_intent_view,
+            render_intent_view,
+        )
+
+        view = collect_intent_view()
+        if getattr(args, "doctor_json", False):
+            print(_json.dumps(view, indent=2, sort_keys=True))
+        else:
+            print(render_intent_view(view))
+        sys.exit(0)
+
+    if getattr(args, "explain_last", False):
+        import json as _json
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+
+        payload = collect_explain_last()
+        if getattr(args, "doctor_json", False):
+            print(_json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(render_explain_last(payload))
+        sys.exit(0)
+
     # P2-1 --privacy is a short static summary (not a probe). No net work,
     # just render the canonical data-handling posture + link to the live
     # compliance pages on tokenpak.ai.
@@ -2414,10 +2449,27 @@ def build_parser():
         help="Run TIP-1.0 self-conformance checks (capability set, profiles, manifests, live emissions)",
     )
     p_doctor.add_argument(
+        "--intent",
+        dest="intent_view",
+        action="store_true",
+        help="(Phase 0.1) Show the Intent Layer Phase 0 diagnostic view: classifier "
+        "activation, proxy self-capability publication, per-adapter §4.3 gate declaration, "
+        "and whether wire emission is currently enabled on this host.",
+    )
+    p_doctor.add_argument(
+        "--explain-last",
+        dest="explain_last",
+        action="store_true",
+        help="(Phase 0.1) Render the most recent intent_events row "
+        "(contract_id, intent_class, confidence, slots, catch_all_reason, "
+        "tip_headers_emitted/stripped). Read-only.",
+    )
+    p_doctor.add_argument(
         "--json",
         dest="doctor_json",
         action="store_true",
-        help="Emit machine-readable JSON instead of the human table (conformance mode)",
+        help="Emit machine-readable JSON instead of the human table "
+        "(applies to --conformance, --intent, --explain-last)",
     )
     p_doctor.set_defaults(func=cmd_doctor)
 

--- a/tokenpak/proxy/intent_doctor.py
+++ b/tokenpak/proxy/intent_doctor.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Doctor / explain renderers for Intent Layer Phase 0.
+
+Two diagnostic views, both surfaced via ``tokenpak doctor``:
+
+  - :func:`render_intent_view` (``--intent``) — operator-readable
+    snapshot of: classifier activation, proxy self-capability
+    publication, every registered adapter's declaration of
+    ``tip.intent.contract-headers-v1``, and whether wire-emission is
+    currently enabled for any adapter.
+
+  - :func:`render_explain_last` (``--explain-last``) — most recent
+    ``intent_events`` row rendered with every field the proposal
+    §5.3 schema declares (contract_id, intent_class, confidence,
+    slots present/missing, catch_all_reason, tip_headers_emitted,
+    tip_headers_stripped, plus join helpers).
+
+Read-only — never writes to the telemetry store, never mutates any
+adapter state, never invokes a provider. Safe to run on any host.
+
+Privacy contract: only the ``raw_prompt_hash`` (sha256 hex digest)
+is rendered. The raw prompt body never leaves the per-request log
+per Architecture §7.1.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _intent_db_path() -> Path:
+    """Resolved telemetry.db path; falls back to ~/.tokenpak/telemetry.db.
+
+    Mirrors the resolution in :mod:`tokenpak.proxy.intent_contract`
+    (single source of truth there). Re-derived here to avoid pulling
+    in the writer's lifecycle when only the read path is needed.
+    """
+    from tokenpak.proxy.intent_contract import _DEFAULT_DB_PATH
+
+    return _DEFAULT_DB_PATH
+
+
+# ---------------------------------------------------------------------------
+# --intent view
+# ---------------------------------------------------------------------------
+
+
+def collect_intent_view() -> Dict[str, Any]:
+    """Gather the data points rendered by :func:`render_intent_view`.
+
+    Returned shape is JSON-serialisable so callers that pass
+    ``--json`` can dump the structure as-is. Keys:
+
+      ``classifier_active`` — Phase 0 always classifies; this is
+      ``True`` if the classifier module imports cleanly.
+
+      ``intent_source`` — the value the Phase 0 classifier stamps on
+      every ``intent_events`` row.
+
+      ``classify_threshold`` — minimum normalized score for a
+      non-catch-all classification.
+
+      ``proxy_publishes_label`` — whether the proxy
+      ``SELF_CAPABILITIES_PROXY`` set declares the gate label
+      (``tip.intent.contract-headers-v1``). Per proposal §5.2,
+      declaring without publishing is an audit finding.
+
+      ``adapters`` — list of ``{name, source_format, declares_label,
+      capabilities}`` dicts for every adapter in the default
+      registry. ``declares_label`` is the per-adapter §4.3 gate
+      result.
+
+      ``would_emit_headers`` — ``True`` iff at least one registered
+      adapter declares the gate label. False = every request runs
+      telemetry-only on this host.
+
+      ``intent_events_db`` — path + row count of the
+      ``intent_events`` SQLite table on this host. ``None`` for the
+      count if the DB doesn't exist yet (no requests classified
+      since last reset).
+    """
+    out: Dict[str, Any] = {
+        "classifier_active": False,
+        "intent_source": None,
+        "classify_threshold": None,
+        "proxy_publishes_label": False,
+        "adapters": [],
+        "would_emit_headers": False,
+        "intent_events_db": {"path": None, "row_count": None},
+        "errors": [],
+    }
+
+    try:
+        from tokenpak.proxy.intent_classifier import (
+            CLASSIFY_THRESHOLD,
+            INTENT_SOURCE_V0,
+        )
+
+        out["classifier_active"] = True
+        out["intent_source"] = INTENT_SOURCE_V0
+        out["classify_threshold"] = CLASSIFY_THRESHOLD
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"classifier import failed: {exc!r}")
+
+    try:
+        from tokenpak.core.contracts.capabilities import SELF_CAPABILITIES_PROXY
+        from tokenpak.proxy.intent_contract import GATE_CAPABILITY
+
+        out["proxy_publishes_label"] = GATE_CAPABILITY in SELF_CAPABILITIES_PROXY
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"capability set unreachable: {exc!r}")
+
+    try:
+        from tokenpak.proxy.adapters import build_default_registry
+        from tokenpak.proxy.intent_contract import GATE_CAPABILITY
+
+        registry = build_default_registry()
+        adapters: List[Dict[str, Any]] = []
+        for ad in registry.adapters():
+            declares = GATE_CAPABILITY in ad.capabilities
+            adapters.append({
+                "name": ad.__class__.__name__,
+                "source_format": ad.source_format,
+                "declares_label": declares,
+                "capabilities": sorted(ad.capabilities),
+            })
+        out["adapters"] = adapters
+        out["would_emit_headers"] = any(a["declares_label"] for a in adapters)
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"adapter registry unreachable: {exc!r}")
+
+    try:
+        db_path = _intent_db_path()
+        out["intent_events_db"]["path"] = str(db_path)
+        if db_path.is_file():
+            with sqlite3.connect(str(db_path)) as conn:
+                # Table only exists once the writer has committed at
+                # least once. Treat absence as 0 rows (not an error)
+                # — it's the common state on a fresh install.
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_events'"
+                ).fetchone()
+                if exists is None:
+                    out["intent_events_db"]["row_count"] = 0
+                else:
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM intent_events"
+                    ).fetchone()
+                    out["intent_events_db"]["row_count"] = int(row[0]) if row else 0
+        else:
+            out["intent_events_db"]["row_count"] = 0
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"intent_events read failed: {exc!r}")
+
+    return out
+
+
+def render_intent_view(view: Optional[Dict[str, Any]] = None) -> str:
+    """Format an :func:`collect_intent_view` payload for stdout.
+
+    Plain text, no escape codes. Mirrors the visual rhythm of
+    ``--privacy`` so operators don't have to context-switch.
+    """
+    v = view if view is not None else collect_intent_view()
+    lines: List[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Doctor (Intent Layer Phase 0)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+
+    classifier = "active" if v["classifier_active"] else "import-failed"
+    src = v["intent_source"] or "?"
+    thr = v["classify_threshold"]
+    lines.append(f"  Classifier:                {classifier} (source={src}, threshold={thr})")
+    lines.append("")
+
+    pub = "yes" if v["proxy_publishes_label"] else "NO  ← audit finding"
+    lines.append(f"  Proxy publishes label:     {pub}")
+    lines.append("    tip.intent.contract-headers-v1 (Standard #23 §4.3)")
+    lines.append("")
+
+    lines.append("  Registered adapters (gate declaration):")
+    if not v["adapters"]:
+        lines.append("    (none registered)")
+    else:
+        for a in v["adapters"]:
+            mark = "✓" if a["declares_label"] else "·"
+            lines.append(
+                f"    {mark} {a['name']:<40s} ({a['source_format']})"
+            )
+    lines.append("")
+
+    if v["would_emit_headers"]:
+        lines.append("  Wire emission:             ENABLED for adapters above marked ✓")
+        lines.append("    Other adapters route telemetry-only (local intent_events row).")
+    else:
+        lines.append("  Wire emission:             telemetry-only on this host")
+        lines.append("    No registered adapter declares the gate label, so no")
+        lines.append("    request emits TIP intent / contract headers on the wire.")
+        lines.append("    All classifications are recorded locally in intent_events.")
+    lines.append("")
+
+    db = v["intent_events_db"]
+    rows = db["row_count"]
+    rows_str = "(db not yet initialized)" if rows is None else f"{rows} row(s)"
+    lines.append(f"  intent_events store:       {db['path']}")
+    lines.append(f"                             {rows_str}")
+    lines.append("")
+
+    if v["errors"]:
+        lines.append("  Diagnostic errors:")
+        for e in v["errors"]:
+            lines.append(f"    ! {e}")
+        lines.append("")
+
+    lines.append("  Run `tokenpak doctor --explain-last` to inspect the most")
+    lines.append("  recent classification (full intent_events row).")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# --explain-last view
+# ---------------------------------------------------------------------------
+
+
+def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Read the most recent ``intent_events`` row.
+
+    Returns ``None`` when the DB doesn't exist or the table is
+    empty. Caller renders the absent case with a clear message.
+    """
+    path = db_path if db_path is not None else _intent_db_path()
+    if not path.is_file():
+        return None
+    try:
+        with sqlite3.connect(str(path)) as conn:
+            # Be quiet when the table doesn't exist yet — the
+            # renderer treats ``None`` as "no rows" and prints the
+            # operator-friendly message rather than a stack trace.
+            exists = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='intent_events'"
+            ).fetchone()
+            if exists is None:
+                return None
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT request_id, contract_id, timestamp, raw_prompt_hash, "
+                "intent_class, intent_confidence, intent_slots_present, "
+                "intent_slots_missing, intent_source, catch_all_reason, "
+                "tip_headers_emitted, tip_headers_stripped, "
+                "tokens_in, tokens_out, latency_ms "
+                "FROM intent_events "
+                "ORDER BY timestamp DESC LIMIT 1"
+            ).fetchone()
+    except sqlite3.DatabaseError:
+        return None
+    if row is None:
+        return None
+
+    return {
+        "request_id": row["request_id"],
+        "contract_id": row["contract_id"],
+        "timestamp": row["timestamp"],
+        "raw_prompt_hash": row["raw_prompt_hash"],
+        "intent_class": row["intent_class"],
+        "intent_confidence": row["intent_confidence"],
+        "intent_slots_present": json.loads(row["intent_slots_present"] or "[]"),
+        "intent_slots_missing": json.loads(row["intent_slots_missing"] or "[]"),
+        "intent_source": row["intent_source"],
+        "catch_all_reason": row["catch_all_reason"],
+        "tip_headers_emitted": bool(row["tip_headers_emitted"]),
+        "tip_headers_stripped": bool(row["tip_headers_stripped"]),
+        "tokens_in": row["tokens_in"],
+        "tokens_out": row["tokens_out"],
+        "latency_ms": row["latency_ms"],
+    }
+
+
+def render_explain_last(payload: Optional[Dict[str, Any]] = None) -> str:
+    """Render the latest intent_events row in operator-readable form.
+
+    When ``payload is None`` the renderer emits a clear "no rows
+    yet" message so a fresh install doesn't look broken.
+    """
+    p = payload if payload is not None else collect_explain_last()
+    if p is None:
+        return (
+            "\nTOKENPAK  |  Doctor (Intent Layer — explain last)\n"
+            "──────────────────────────────\n"
+            "\n"
+            "  No intent_events rows yet.\n"
+            "\n"
+            "  The classifier writes one row per request that flows through\n"
+            "  the proxy. Send a request via `tokenpak proxy` and re-run\n"
+            "  this command. See `tokenpak doctor --intent` for activation\n"
+            "  state.\n"
+        )
+
+    lines: List[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Doctor (Intent Layer — explain last)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+    lines.append(f"  request_id:                {p['request_id']}")
+    lines.append(f"  contract_id:               {p['contract_id']}")
+    lines.append(f"  timestamp:                 {p['timestamp']}")
+    lines.append("")
+    lines.append(f"  intent_class:              {p['intent_class']}")
+    lines.append(f"  confidence:                {p['intent_confidence']:.4f}")
+    lines.append(f"  intent_source:             {p['intent_source']}")
+    catch = p.get("catch_all_reason")
+    catch_str = catch if catch else "(none — non-catch-all classification)"
+    lines.append(f"  catch_all_reason:          {catch_str}")
+    lines.append("")
+    lines.append(f"  slots_present:             {p['intent_slots_present']}")
+    lines.append(f"  slots_missing:             {p['intent_slots_missing']}")
+    lines.append("")
+    lines.append(f"  tip_headers_emitted:       {p['tip_headers_emitted']}")
+    lines.append(f"  tip_headers_stripped:      {p['tip_headers_stripped']}")
+    if p["tip_headers_emitted"]:
+        lines.append("    → resolved request adapter declared")
+        lines.append("      'tip.intent.contract-headers-v1'; the five wire")
+        lines.append("      headers were attached to the outbound request.")
+    elif p["tip_headers_stripped"]:
+        lines.append("    → adapter did not declare the gate label;")
+        lines.append("      contract stayed in local telemetry only (this row).")
+    lines.append("")
+    lines.append(f"  raw_prompt_hash:           {p['raw_prompt_hash']}")
+    lines.append("    (sha256 dedup digest only — prompts stay in the")
+    lines.append("     per-request log per Architecture §7.1.)")
+    lines.append("")
+    if any(p[k] is not None for k in ("tokens_in", "tokens_out", "latency_ms")):
+        lines.append("  Joined cost / latency (Phase 0 best-effort):")
+        lines.append(f"    tokens_in:               {p['tokens_in']}")
+        lines.append(f"    tokens_out:              {p['tokens_out']}")
+        lines.append(f"    latency_ms:              {p['latency_ms']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "collect_explain_last",
+    "collect_intent_view",
+    "render_explain_last",
+    "render_intent_view",
+]


### PR DESCRIPTION
## Summary

Stabilization-only follow-up to PR #44 (Intent Layer Phase 0). Surfaces the Phase 0 telemetry path through operator-readable diagnostics + adds the load-bearing default-off invariant test.

**No classifier behavior changes** — no bug observed, no scope creep. Held items remain held.

## Changes

- **`tokenpak/proxy/intent_doctor.py`** — read-only renderers for two new doctor views (`collect_intent_view`/`render_intent_view`, `collect_explain_last`/`render_explain_last`). Treats absent rows + missing table gracefully — no stack traces on a fresh install.
- **`tokenpak/cli/_impl.py`** — two new flags on `tokenpak doctor`:
  - `--intent` — operator-friendly diagnostic view: classifier active, intent_source, threshold, proxy self-capability publication, per-adapter §4.3 gate declaration, would-emit vs telemetry-only summary, intent_events DB row count.
  - `--explain-last` — most recent `intent_events` row in full (every field the proposal §5.3 schema declares).
  Both honour `--json`. Read-only, no provider invocation, no writes anywhere.
- **`docs/reference/intent-layer-phase-0.md`** — operator-facing doc explaining when TIP intent headers are emitted, why headers stay local unless the adapter declares the capability, what `rule_based_v0` means (and what it does NOT mean — confidence values are normalized keyword weights, not posteriors), how to read the 2-week observation window (measurement budget, not quality gate; three signals to extend or cut short), operator commands, privacy contract, file map, standards cross-refs.
- **`tests/test_intent_layer_phase01_invariant.py`** — three tests on the load-bearing default-off invariant:
  - `test_invariant_no_capability_no_wire_emission_telemetry_still_written` — adapter without the label MUST NOT emit any of the five wire headers AND the row MUST still land with bits `(emitted=0, stripped=1)`, `intent_source=rule_based_v0`, and `raw_prompt_hash = sha256(prompt)`.
  - `test_invariant_symmetry_capability_present_emits_headers` — same path, gate flipped on, asserts `(1, 0)` and headers present. Stops the no-emission test from passing trivially.
  - `test_invariant_raw_prompt_not_in_row` — **privacy contract**: a sentinel substring of the prompt appears in zero columns of the row. Guards against any future regression that accidentally serializes the prompt body onto the telemetry row.

## Acceptance

- [x] Issue #39 already closed (verified pre-cleanup; no token-permission action required this turn).
- [x] Intent behavior visible via `tokenpak doctor --intent` + `tokenpak doctor --explain-last` + `docs/reference/intent-layer-phase-0.md`.
- [x] Header emission invariant tested (3 tests, including privacy contract).
- [x] No raw prompt content or secrets in row payload (sentinel-substring assertion).
- [x] 994 passing (was 991 baseline), 0 regressions, 1 skip / 1 xfail unchanged.
- [x] `ruff check` clean across changed files.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no further scaffold renderer expansion, **no classifier behavior changes**.