### PR TITLE
feat(cli): Phase 1 — tokenpak intent report (observation-only)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -611,6 +611,22 @@ options:
   --once                Print once and exit
 ```
 
+### `tokenpak intent`
+
+Intent Layer observation + reporting (read-only)
+
+```
+usage: tokenpak intent [-h] {report} ...
+
+positional arguments:
+  {report}
+    report    Summarize the intent_events telemetry over a window. Read-only;
+              never reads or emits raw prompt text.
+
+options:
+  -h, --help  show this help message and exit
+```
+
 ## Advanced
 
 ### `tokenpak trigger`

--- a/docs/reference/intent-reporting.md
+++ b/docs/reference/intent-reporting.md
@@ -1,0 +1,98 @@
+# Intent Layer — Reporting (Phase 1)
+
+> Phase 1 is **observation only**. The reporting command is read-only over the local `intent_events` SQLite table written by Phase 0. It surfaces aggregations, never raw prompts. No user-facing behavior changes; no classifier changes.
+
+## How to read the report
+
+```bash
+# Default — last 14 days (matches the proposal's observation window)
+tokenpak intent report
+
+# Custom window
+tokenpak intent report --window 7d
+tokenpak intent report --window 30d
+
+# All rows, no window
+tokenpak intent report --window 0d
+
+# Machine-readable JSON
+tokenpak intent report --json
+```
+
+The human-readable layout walks operator attention through the same questions the proposal §6 measurement plan calls out, in this order:
+
+1. **Window + telemetry-store path + total count** — sets the scope so the rest of the numbers have context.
+2. **Intent class distribution** — count and average confidence for each canonical intent. Confidence here is the rule-based classifier's normalized keyword weight (see "What `rule_based_v0` means" in `intent-layer-phase-0.md`); it is **not** a probability.
+3. **Low confidence count** — rows below the classifier's `CLASSIFY_THRESHOLD` (0.4 by default). Concentrated low confidence is a signal that the keyword table needs broadening, NOT that the prompts are ambiguous.
+4. **Wire-emission posture** — three counters: `tip_headers_emitted`, `tip_headers_stripped`, `telemetry-only`. The latter two are the same number expressed two ways; both are present so reports translate cleanly into either framing.
+5. **Top missing slots** — the slot names most often required-but-missing. Use this to decide whether a slot definition (`tokenpak/agent/compression/slot_definitions.yaml`) needs broader keywords or whether the slot is genuinely optional in real traffic.
+6. **Top catch-all reasons** — when classification fell back to `query`, the reason. The five values are documented in `intent_classifier.py::CATCH_ALL_REASONS`.
+7. **Adapters eligible / blocking** — split of registered adapters by whether they declare `tip.intent.contract-headers-v1` (per Standard #23 §4.3). Phase 0 default has every first-party adapter in *blocking*; opt-in is gated on this baseline.
+8. **Recommended review areas** — heuristic flags drawn from the aggregations. Each line names something to look at, not something to do.
+
+## What the 2-week observation window means
+
+The default `--window 14d` mirrors the proposal's recommended observation duration. It is a **measurement budget**, not a quality gate. Three signals govern when to extend or cut short:
+
+- **Confidence histogram stability** — if the shape is still drifting late in week 2, extend (`--window 28d` or `--window 0d`). If the shape stabilizes by day 7, the data is enough.
+- **Catch-all dominance** — if `intent_class = "query"` dominates (> 50 %), the canonical-intent set or keyword table needs revision before Intent-1 lifts the subsystem. Cut the window short, fix, restart.
+- **Volume floor** — proposal §6 sets 500 classifications as the meaningful-statistics floor. Below that, distribution shape is noise.
+
+Nothing in TokenPak toggles based on elapsed window time. The window scopes when you run the **baseline report** that informs the Intent-1 go/no-go decision (proposal §4 deliverable 5). Until then, Phase 0 + 1 are pure observation.
+
+## What "low confidence" and "catch-all" mean
+
+**Low confidence** = a row with `intent_confidence < CLASSIFY_THRESHOLD` (0.4 by default). The threshold is symmetric with the existing `intent_policy.CONFIDENCE_THRESHOLD` so an upstream classification that survives this gate also survives the downstream policy gate. A high low-confidence count usually means:
+
+- The keyword table is missing canonical phrases that real traffic uses (fix the table).
+- Real traffic is genuinely ambiguous between intents (the `query` catch-all picks it up).
+
+A high low-confidence count is **not** evidence that prompts are bad or that the user is doing something wrong.
+
+**Catch-all** = `intent_class = "query"`. Not a positive classification; a deliberate landing pad. The catch-all reason explains *why* the classifier landed there:
+
+- `empty_prompt` — prompt was zero or whitespace-only chars.
+- `prompt_too_short` — prompt below 3 chars after strip.
+- `keyword_miss` — every intent's keyword set scored zero.
+- `confidence_below_threshold` — top-scoring intent fell under 0.4.
+- `slot_ambiguous` — reserved (not emitted in `rule_based_v0`).
+
+## Why telemetry-only is normal unless the adapter declares the capability
+
+This is the load-bearing default-off invariant from PR #44 / PR #45. The proxy attaches the five wire headers (`X-TokenPak-Intent-Class`, `Confidence`, `Subtype`, `Contract-Risk`, `Contract-Id`) **only when the resolved request adapter declares `tip.intent.contract-headers-v1`** in its `FormatAdapter.capabilities` class attribute, per Standard #23 §4.3.
+
+In Phase 0 / Phase 1, no first-party adapter declares this label by default. Every classification stays in local telemetry only — that is the intended posture, not a bug. The report's "Adapters blocking TIP intent headers" section will list every registered adapter; this is normal.
+
+When an adapter author opts in (after the baseline report identifies where the headers add value), that adapter moves from "blocking" to "eligible" and its requests start emitting on the wire. Until then, no wire emission means no risk of breaking byte-fidelity for non-TIP providers.
+
+## What NOT to infer yet
+
+Phase 1 is observation. The following inferences are **out of scope** until later phases:
+
+- **Cost or latency conclusions per intent.** The Phase 0 telemetry row carries `tokens_in / tokens_out / latency_ms` as best-effort optional fields; they are not authoritative for cost analysis. The Intent-1 schema lift will bind them to the request-event row formally.
+- **Routing decisions.** Phase 1 does not change any routing. The Intent-2 clarification gate is the first user-facing change; that work has its own proposal.
+- **Recipe selection.** Recipe-driven behavior lands in Intent-3.
+- **Pro/OSS gating.** Intent-0 / Intent-1 are pure OSS. The split decision is queued for Intent-4 (intent memory).
+- **Prompt-side cache keying.** Cache keys are not yet derived from intent or contract. That is Intent-3+ work.
+- **Quality assertions about the classifier.** The rule-based classifier is deliberately simple (Option A in the proposal). The baseline report will tell us whether to lift to LLM-assisted classification (Option B) in Intent-1; do not draw conclusions until the report is in.
+
+## Privacy
+
+The reporting layer is read-only against `~/.tokenpak/telemetry.db`. The `intent_events` table only stores the `raw_prompt_hash` (sha256 hex digest); raw prompt text never enters the table per Architecture §7.1. The reporting paths assert this end-to-end (`tests/test_intent_report.py::TestPrivacyContract`). No prompt content, no secrets, no upstream traffic crosses the report boundary.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/proxy/intent_report.py` | aggregations + renderers (this PR) |
+| `tokenpak/cli/_impl.py::cmd_intent_report` | `tokenpak intent report` entry point |
+| `tokenpak/proxy/intent_classifier.py` | classifier (Phase 0) |
+| `tokenpak/proxy/intent_contract.py` | contract + telemetry store (Phase 0) |
+| `tokenpak/proxy/intent_doctor.py` | per-request diagnostics (Phase 0.1) |
+| `~/.tokenpak/telemetry.db` `intent_events` | source data, written by Phase 0 |
+| `docs/reference/intent-layer-phase-0.md` | the "what / why / when" doc |
+| `docs/reference/intent-reporting.md` | this document |
+
+## Proposal
+
+Full Intent-0 proposal: `~/vault/02_COMMAND_CENTER/proposals/2026-04-24-tokenpak-intent-layer-phase-0.md`. The Adj-1 + Adj-2 banner block at the top documents the 2026-04-25 cross-reference adjustment that aligned the header-emission gate with `23-provider-adapter-standard.md §4.3`.

--- a/tests/test_intent_report.py
+++ b/tests/test_intent_report.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 1 — Intent Layer reporting test suite.
+
+Six focused contracts:
+
+  - empty DB → safe, well-shaped, no-data report
+  - populated DB → all aggregations correct
+  - JSON output shape — every field the directive enumerates
+  - privacy contract — raw prompt text never appears in output
+  - window filter — rows older than ``--window Nd`` excluded
+  - adapter capability summary — eligible vs blocking split
+
+Read-only throughout. Uses temp-DB writes via the production
+:class:`IntentTelemetryStore` so the schema stays a single source
+of truth.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import (
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    build_contract,
+)
+from tokenpak.proxy.intent_report import (
+    IntentReport,
+    build_report,
+    parse_window,
+    render_human,
+    render_json,
+    window_cutoff_iso,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _classification(intent_class="summarize", confidence=0.9, slots_present=("period",), slots_missing=("target",), catch_all_reason=None):
+    return IntentClassification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+
+
+def _seed(store: IntentTelemetryStore, *, request_id: str, intent_class: str = "summarize",
+          confidence: float = 0.9, prompt: str = "summarize the vault",
+          slots_present=("period",), slots_missing=("target",),
+          catch_all_reason=None, emitted: bool = False, stripped: bool = True,
+          timestamp: str | None = None):
+    """Seed one intent_events row using the production builder."""
+    classification = _classification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+    contract = build_contract(classification=classification, raw_prompt=prompt)
+    ts = timestamp or _dt.datetime.now().isoformat(timespec="seconds")
+    store.write(IntentTelemetryRow(
+        request_id=request_id,
+        contract=contract,
+        timestamp=ts,
+        tip_headers_emitted=emitted,
+        tip_headers_stripped=stripped,
+    ))
+    return contract
+
+
+# ── Window parsing ────────────────────────────────────────────────────
+
+
+class TestWindowParsing:
+    def test_default_form(self):
+        assert parse_window("14d") == 14
+        assert parse_window("7d") == 7
+        assert parse_window("30d") == 30
+
+    def test_zero_means_no_window(self):
+        assert parse_window("0d") is None
+
+    def test_empty_means_no_window(self):
+        assert parse_window("") is None
+        assert parse_window(None) is None
+
+    def test_bad_form_raises(self):
+        with pytest.raises(ValueError):
+            parse_window("14")
+        with pytest.raises(ValueError):
+            parse_window("two-weeks")
+        with pytest.raises(ValueError):
+            parse_window("14h")
+
+
+# ── Empty DB ──────────────────────────────────────────────────────────
+
+
+class TestEmptyDB:
+    """The report MUST run cleanly when the DB doesn't exist or
+    when the table exists but has zero rows. Ship-day default —
+    a fresh install must not raise.
+    """
+
+    def test_db_missing_returns_zero_total(self, tmp_path: Path):
+        report = build_report(window_days=14, db_path=tmp_path / "nope.db")
+        assert isinstance(report, IntentReport)
+        assert report.total_classified == 0
+        assert report.intent_class_distribution == {}
+        assert report.review_areas, "review_areas should explain the empty state"
+
+    def test_table_missing_returns_zero(self, tmp_path: Path):
+        # File exists but no schema; build_report tolerates this.
+        db = tmp_path / "telemetry.db"
+        sqlite3.connect(str(db)).close()
+        report = build_report(window_days=14, db_path=db)
+        assert report.total_classified == 0
+
+    def test_human_render_empty(self, tmp_path: Path):
+        report = build_report(window_days=14, db_path=tmp_path / "nope.db")
+        text = render_human(report)
+        assert "Total classified:          0" in text
+        assert "No classified requests" in text
+
+
+# ── Populated DB summary ──────────────────────────────────────────────
+
+
+class TestPopulatedDBSummary:
+    def test_distribution_sums_to_total(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        for i in range(3):
+            _seed(store, request_id=f"a{i}", intent_class="summarize", confidence=0.9)
+        for i in range(2):
+            _seed(store, request_id=f"b{i}", intent_class="debug", confidence=0.8)
+        _seed(store, request_id="c0", intent_class="query", confidence=0.0,
+              catch_all_reason="empty_prompt", slots_present=(), slots_missing=())
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        assert report.total_classified == 6
+        dist = report.intent_class_distribution
+        assert sum(dist.values()) == 6
+        assert dist == {"summarize": 3, "debug": 2, "query": 1}
+
+    def test_avg_confidence_per_class(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", intent_class="summarize", confidence=1.0)
+        _seed(store, request_id="a1", intent_class="summarize", confidence=0.5)
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        # avg(1.0, 0.5) = 0.75
+        assert report.avg_confidence_by_class["summarize"] == 0.75
+
+    def test_low_confidence_count(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        # threshold = 0.4 (CLASSIFY_THRESHOLD)
+        _seed(store, request_id="a0", intent_class="summarize", confidence=0.9)
+        _seed(store, request_id="a1", intent_class="query", confidence=0.0,
+              catch_all_reason="keyword_miss", slots_present=(), slots_missing=())
+        _seed(store, request_id="a2", intent_class="query", confidence=0.3,
+              catch_all_reason="confidence_below_threshold", slots_present=(), slots_missing=())
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        # Two rows below 0.4 (both query rows).
+        assert report.low_confidence_count == 2
+
+    def test_catch_all_distribution(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", intent_class="summarize", confidence=0.9)
+        _seed(store, request_id="a1", intent_class="query", confidence=0.0,
+              catch_all_reason="empty_prompt", slots_present=(), slots_missing=())
+        _seed(store, request_id="a2", intent_class="query", confidence=0.0,
+              catch_all_reason="empty_prompt", slots_present=(), slots_missing=())
+        _seed(store, request_id="a3", intent_class="query", confidence=0.3,
+              catch_all_reason="confidence_below_threshold", slots_present=(), slots_missing=())
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        assert report.catch_all_reason_distribution == {
+            "empty_prompt": 2,
+            "confidence_below_threshold": 1,
+        }
+        # Top-N is sorted-by-count desc.
+        top = report.top_catch_all_reasons
+        assert top[0] == ("empty_prompt", 2)
+
+    def test_slot_frequencies(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", slots_present=("period",), slots_missing=("target",))
+        _seed(store, request_id="a1", slots_present=("period",), slots_missing=("target",))
+        _seed(store, request_id="a2", slots_present=("period", "model"), slots_missing=())
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        assert report.slots_present_frequency["period"] == 3
+        assert report.slots_present_frequency["model"] == 1
+        assert report.slots_missing_frequency["target"] == 2
+        assert report.top_missing_slots[0] == ("target", 2)
+
+    def test_wire_emission_counts(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="emit1", emitted=True, stripped=False)
+        _seed(store, request_id="emit2", emitted=True, stripped=False)
+        _seed(store, request_id="strip1", emitted=False, stripped=True)
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        assert report.tip_headers_emitted == 2
+        assert report.tip_headers_stripped == 1
+        # telemetry-only mirrors stripped (the alternative framing).
+        assert report.telemetry_only == 1
+
+
+# ── JSON shape ────────────────────────────────────────────────────────
+
+
+class TestJsonShape:
+    REQUIRED_TOP_LEVEL_KEYS = {
+        "window_days",
+        "window_cutoff_iso",
+        "db_path",
+        "total_classified",
+        "intent_class_distribution",
+        "avg_confidence_by_class",
+        "catch_all_reason_distribution",
+        "slots_present_frequency",
+        "slots_missing_frequency",
+        "low_confidence_count",
+        "low_confidence_threshold",
+        "tip_headers_emitted",
+        "tip_headers_stripped",
+        "telemetry_only",
+        "adapters_eligible",
+        "adapters_blocking",
+        "top_missing_slots",
+        "top_catch_all_reasons",
+        "review_areas",
+    }
+
+    def test_json_has_all_required_keys(self, tmp_path: Path):
+        report = build_report(window_days=14, db_path=tmp_path / "nope.db")
+        payload = json.loads(render_json(report))
+        missing = self.REQUIRED_TOP_LEVEL_KEYS - set(payload)
+        assert not missing, f"missing keys in JSON output: {missing}"
+
+    def test_json_is_round_trippable(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0")
+        store.close()
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        # Round-trip test: render → json.loads → rebuild a dict and
+        # assert equality of the dict shape.
+        payload = json.loads(render_json(report))
+        assert payload["total_classified"] == 1
+
+    def test_json_top_n_is_list_of_pairs(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", slots_missing=("target",))
+        store.close()
+        payload = json.loads(render_json(build_report(window_days=14, db_path=tmp_path / "t.db")))
+        # Tuples become 2-element lists in JSON for portability.
+        assert payload["top_missing_slots"][0] == ["target", 1]
+
+
+# ── Privacy contract ──────────────────────────────────────────────────
+
+
+class TestPrivacyContract:
+    """The report MUST NOT read or emit raw prompt content. Asserted
+    end-to-end with a sentinel substring planted in the prompt — it
+    must appear nowhere in the rendered output.
+    """
+
+    SENTINEL = "kevin-magic-prompt-marker-PHASE1"
+
+    def test_no_prompt_text_in_human_or_json(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        prompt = f"summarize the vault {self.SENTINEL}"
+        _seed(store, request_id="a0", prompt=prompt)
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        human_out = render_human(report)
+        json_out = render_json(report)
+        assert self.SENTINEL not in human_out, (
+            "raw prompt content leaked into human-readable output"
+        )
+        assert self.SENTINEL not in json_out, (
+            "raw prompt content leaked into JSON output"
+        )
+
+    def test_raw_prompt_hash_not_in_output(self, tmp_path: Path):
+        # The report MUST not even include the per-row hash digest
+        # (which is not secret, but is unnecessary aggregate noise).
+        # Verify by planting a known prompt and asserting its hash
+        # is absent. Distinct from the sentinel test above — guards
+        # against a future change that adds raw_prompt_hash to the
+        # aggregation surface.
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        prompt = "summarize the vault unique-prompt-zzz"
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        _seed(store, request_id="a0", prompt=prompt)
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db")
+        assert digest not in render_json(report)
+        assert digest not in render_human(report)
+
+
+# ── Window filter ─────────────────────────────────────────────────────
+
+
+class TestWindowFilter:
+    def test_rows_older_than_window_excluded(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        # Anchor "now" so the cutoff math is deterministic.
+        now = _dt.datetime(2026, 4, 25, 12, 0, 0)
+        # Inside window (1 day ago)
+        _seed(store, request_id="recent",
+              timestamp=(now - _dt.timedelta(days=1)).isoformat(timespec="seconds"))
+        # Outside window (30 days ago)
+        _seed(store, request_id="ancient",
+              timestamp=(now - _dt.timedelta(days=30)).isoformat(timespec="seconds"))
+        store.close()
+
+        report = build_report(window_days=14, db_path=tmp_path / "t.db", now=now)
+        assert report.total_classified == 1, (
+            f"window filter ignored: {report.total_classified} rows in 14d window "
+            "(expected 1; row 'ancient' should be excluded)"
+        )
+
+    def test_no_window_reads_all_rows(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        now = _dt.datetime(2026, 4, 25, 12, 0, 0)
+        _seed(store, request_id="recent",
+              timestamp=(now - _dt.timedelta(days=1)).isoformat(timespec="seconds"))
+        _seed(store, request_id="ancient",
+              timestamp=(now - _dt.timedelta(days=400)).isoformat(timespec="seconds"))
+        store.close()
+
+        report = build_report(window_days=None, db_path=tmp_path / "t.db", now=now)
+        assert report.total_classified == 2
+
+    def test_cutoff_iso_correct(self):
+        now = _dt.datetime(2026, 4, 25, 12, 0, 0)
+        cutoff = window_cutoff_iso(14, now=now)
+        assert cutoff == "2026-04-11T12:00:00"
+
+
+# ── Adapter capability summary ────────────────────────────────────────
+
+
+class TestAdapterCapabilitySummary:
+    """Phase 1 splits the registered adapters into ``adapters_eligible``
+    (declare ``tip.intent.contract-headers-v1``) and ``adapters_blocking``
+    (do NOT declare). In Phase 0 default state every first-party
+    adapter is in ``adapters_blocking``.
+    """
+
+    def test_phase_0_default_all_blocking(self, tmp_path: Path):
+        report = build_report(window_days=14, db_path=tmp_path / "nope.db")
+        # Every entry has shape {name, source_format}.
+        for entry in report.adapters_blocking:
+            assert "name" in entry
+            assert "source_format" in entry
+        # Phase 0 invariant from PR #44 — verified again here as
+        # the report sees the same adapter registry.
+        assert report.adapters_eligible == [], (
+            "Phase 0 default says no first-party adapter declares the "
+            "gate label; if this changed, update the corresponding "
+            "invariant test in test_intent_layer_phase0.py too."
+        )
+        # And there's at least one blocking adapter (anthropic /
+        # openai-chat / etc.).
+        assert len(report.adapters_blocking) >= 1
+
+
+# ── Subprocess-driven CLI smoke ───────────────────────────────────────
+
+
+class TestCliSubprocess:
+    """Ship the command via the real argparse path so the help
+    string + flags stay reachable. End-to-end smoke; no assertion
+    on aggregations (other tests cover those).
+    """
+
+    def test_help_includes_intent_report(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "report", "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--window" in result.stdout
+        assert "--json" in result.stdout
+
+    def test_report_runs_without_error_on_empty(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "report",
+             "--window", "0d"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, (
+            f"intent report failed: {result.stdout}\n{result.stderr}"
+        )

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -552,6 +552,37 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def cmd_intent_report(args) -> None:
+    """Phase 1 — summarize intent_events telemetry over a window.
+
+    Read-only; never reads or emits raw prompt text. Caller selects
+    a window via ``--window Nd`` (default 14d, matching the
+    proposal's 2-week observation default) and the report shape
+    via ``--json`` (machine-readable) or default (operator-readable
+    plain text).
+    """
+    from tokenpak.proxy.intent_report import (
+        build_report,
+        parse_window,
+        render_human,
+        render_json,
+    )
+
+    raw_window = getattr(args, "window", "14d")
+    try:
+        days = parse_window(raw_window)
+    except ValueError as exc:
+        print(f"[intent report] error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    report = build_report(window_days=days)
+    if getattr(args, "report_json", False):
+        print(render_json(report))
+    else:
+        print(render_human(report))
+    sys.exit(0)
+
+
 def cmd_adapter_scaffold(args) -> int:
     """Scaffold a new provider adapter from its docs URL.
 
@@ -2155,6 +2186,34 @@ def build_parser():
     )
     p_codex.add_argument("extra_args", nargs=argparse.REMAINDER)
     p_codex.set_defaults(func=cmd_codex)
+
+    # ── Intent Layer Phase 1: observation/reporting ──────────────────
+    p_intent = sub.add_parser(
+        "intent",
+        help="Intent Layer observation + reporting (read-only)",
+    )
+    p_intent_sub = p_intent.add_subparsers(dest="intent_cmd", required=False)
+    p_intent_report = p_intent_sub.add_parser(
+        "report",
+        help=(
+            "Summarize the intent_events telemetry over a window. "
+            "Read-only; never reads or emits raw prompt text."
+        ),
+    )
+    p_intent_report.add_argument(
+        "--window",
+        dest="window",
+        default="14d",
+        help="Window size in days, e.g. '14d' (default), '7d', '30d'. "
+        "Use '0d' or '' to read every row regardless of age.",
+    )
+    p_intent_report.add_argument(
+        "--json",
+        dest="report_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human-readable report",
+    )
+    p_intent_report.set_defaults(func=cmd_intent_report)
 
     p_adapter = sub.add_parser(
         "adapter",

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -87,6 +87,7 @@ _COMMAND_GROUPS = {
         ("fleet", "Multi-machine proxy fleet status"),
         ("aggregate", "Aggregate request ledger across machines"),
         ("requests", "Live request explorer"),
+        ("intent", "Intent Layer observation + reporting (read-only)"),
     ],
     "Advanced": [
         ("trigger", "Manage event triggers"),

--- a/tokenpak/proxy/intent_report.py
+++ b/tokenpak/proxy/intent_report.py
@@ -1,0 +1,532 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intent Layer Phase 1 — observation/reporting query layer + renderers.
+
+Read-only summary over the ``intent_events`` SQLite table written
+by Phase 0 (:mod:`tokenpak.proxy.intent_contract`). Surfaces the
+ten aggregations the proposal §6 measurement plan calls for, plus
+five operator-narrative sections mandated by the Phase 1 directive
+(2026-04-25):
+
+  - "Top missing slots"
+  - "Top catch-all reasons"
+  - "Adapters eligible for TIP intent headers" (declare the gate)
+  - "Adapters blocking TIP intent headers" (do NOT declare)
+  - "Recommended review areas" (heuristic flags drawn from the
+    aggregations — see :func:`_review_areas`)
+
+Privacy contract
+----------------
+
+The report **MUST NOT** read or emit raw prompt content. Every
+query in this module reads the ``raw_prompt_hash`` (sha256 hex
+digest) at most; the rendering paths assert this in tests
+(``tests/test_intent_report.py::test_no_prompt_text_in_human_or_json``).
+
+Window semantics
+----------------
+
+``--window 14d`` translates to ``timestamp >= now - 14 days`` over
+the row's ISO-8601 timestamp string. Rows older than the window are
+EXCLUDED from every aggregation. Default window is 14 days
+(matches the proposal's 2-week observation default). Pass any
+``Nd`` form (``7d``, ``30d``, ``1d``); ``0d`` and missing window
+mean "all rows".
+
+This module is read-only. It NEVER writes to the telemetry store,
+NEVER mutates adapter state, NEVER invokes a provider.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Window parsing
+# ---------------------------------------------------------------------------
+
+
+_WINDOW_RE = re.compile(r"^(\d+)d$")
+
+
+def parse_window(spec: Optional[str]) -> Optional[int]:
+    """Parse a window spec like ``"14d"`` to an integer day count.
+
+    Returns ``None`` when ``spec`` is empty / ``None`` / ``"0d"``
+    (interpret as "no window — read every row"). Raises
+    :class:`ValueError` on malformed input so the CLI can surface a
+    clean error message.
+    """
+    if spec is None or spec == "":
+        return None
+    m = _WINDOW_RE.match(spec)
+    if m is None:
+        raise ValueError(
+            f"--window must be of the form 'Nd' (e.g. '14d', '7d'); got {spec!r}"
+        )
+    n = int(m.group(1))
+    if n == 0:
+        return None
+    return n
+
+
+def window_cutoff_iso(days: int, *, now: Optional[_dt.datetime] = None) -> str:
+    """Compute the ISO-8601 timestamp ``days`` days ago.
+
+    Used as the SQL filter floor — rows with ``timestamp >= cutoff``
+    are included.
+    """
+    base = now if now is not None else _dt.datetime.now()
+    return (base - _dt.timedelta(days=days)).isoformat(timespec="seconds")
+
+
+# ---------------------------------------------------------------------------
+# Aggregations
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IntentReport:
+    """All aggregated metrics for one window. JSON-serialisable.
+
+    Field set covers every metric the directive enumerates.
+    """
+
+    # Window identity
+    window_days: Optional[int]
+    window_cutoff_iso: Optional[str]
+    db_path: str
+
+    # Volume
+    total_classified: int = 0
+
+    # Distributions
+    intent_class_distribution: Dict[str, int] = field(default_factory=dict)
+    avg_confidence_by_class: Dict[str, float] = field(default_factory=dict)
+    catch_all_reason_distribution: Dict[str, int] = field(default_factory=dict)
+    slots_present_frequency: Dict[str, int] = field(default_factory=dict)
+    slots_missing_frequency: Dict[str, int] = field(default_factory=dict)
+
+    # Confidence / wire-emission counts
+    low_confidence_count: int = 0
+    low_confidence_threshold: float = 0.4
+    tip_headers_emitted: int = 0
+    tip_headers_stripped: int = 0
+    telemetry_only: int = 0
+
+    # Adapter posture
+    adapters_eligible: List[Dict[str, Any]] = field(default_factory=list)
+    adapters_blocking: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Operator narrative
+    top_missing_slots: List[Tuple[str, int]] = field(default_factory=list)
+    top_catch_all_reasons: List[Tuple[str, int]] = field(default_factory=list)
+    review_areas: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-friendly dict (tuples → 2-element lists)."""
+        return {
+            "window_days": self.window_days,
+            "window_cutoff_iso": self.window_cutoff_iso,
+            "db_path": self.db_path,
+            "total_classified": self.total_classified,
+            "intent_class_distribution": self.intent_class_distribution,
+            "avg_confidence_by_class": self.avg_confidence_by_class,
+            "catch_all_reason_distribution": self.catch_all_reason_distribution,
+            "slots_present_frequency": self.slots_present_frequency,
+            "slots_missing_frequency": self.slots_missing_frequency,
+            "low_confidence_count": self.low_confidence_count,
+            "low_confidence_threshold": self.low_confidence_threshold,
+            "tip_headers_emitted": self.tip_headers_emitted,
+            "tip_headers_stripped": self.tip_headers_stripped,
+            "telemetry_only": self.telemetry_only,
+            "adapters_eligible": self.adapters_eligible,
+            "adapters_blocking": self.adapters_blocking,
+            "top_missing_slots": [list(t) for t in self.top_missing_slots],
+            "top_catch_all_reasons": [list(t) for t in self.top_catch_all_reasons],
+            "review_areas": list(self.review_areas),
+        }
+
+
+def _intent_db_path() -> Path:
+    """Resolved telemetry.db path. Mirrors :mod:`intent_contract`."""
+    from tokenpak.proxy.intent_contract import _DEFAULT_DB_PATH
+
+    return _DEFAULT_DB_PATH
+
+
+def _table_exists(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='intent_events'"
+    ).fetchone()
+    return row is not None
+
+
+def _collect_adapter_posture() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Walk the default adapter registry and split by gate declaration.
+
+    Returns ``(eligible, blocking)`` lists. Each entry carries
+    adapter class name + source_format. Capability sets are
+    intentionally excluded — the report is about the §4.3 gate
+    label only, and dumping every capability inflates noise.
+    """
+    eligible: List[Dict[str, Any]] = []
+    blocking: List[Dict[str, Any]] = []
+    try:
+        from tokenpak.proxy.adapters import build_default_registry
+        from tokenpak.proxy.intent_contract import GATE_CAPABILITY
+
+        for ad in build_default_registry().adapters():
+            entry = {
+                "name": ad.__class__.__name__,
+                "source_format": ad.source_format,
+            }
+            if GATE_CAPABILITY in ad.capabilities:
+                eligible.append(entry)
+            else:
+                blocking.append(entry)
+    except Exception:  # noqa: BLE001
+        # Defensive — registry should never fail, but the report
+        # MUST NOT raise on read-side traversal issues.
+        pass
+    return eligible, blocking
+
+
+def _review_areas(report: IntentReport) -> List[str]:
+    """Operator-narrative recommendations.
+
+    Heuristic, not authoritative. Each line is a sentence
+    describing a baseline pattern the operator should look at —
+    NOT a prescription. Phase 1 is observation only.
+    """
+    areas: List[str] = []
+    if report.total_classified == 0:
+        areas.append(
+            "No classified requests yet — start the proxy and route some "
+            "traffic through it before re-running this report."
+        )
+        return areas
+
+    # Catch-all dominance.
+    catch_all_count = report.intent_class_distribution.get("query", 0)
+    if catch_all_count and catch_all_count / report.total_classified > 0.5:
+        pct = round(100 * catch_all_count / report.total_classified)
+        areas.append(
+            f"Catch-all 'query' is {pct}% of classifications — the keyword "
+            f"table or canonical-intent set may need revision before Intent-1 "
+            f"lifts the subsystem (proposal §6.3)."
+        )
+
+    # Low confidence.
+    if report.total_classified and report.low_confidence_count / report.total_classified > 0.3:
+        pct = round(100 * report.low_confidence_count / report.total_classified)
+        areas.append(
+            f"{pct}% of requests fell below the {report.low_confidence_threshold} "
+            f"confidence floor. Inspect a sample of low-confidence prompts (hand-read "
+            f"the raw request log) to ground-truth the rule-based classifier."
+        )
+
+    # Missing-slot dominance.
+    if report.top_missing_slots:
+        slot_name, count = report.top_missing_slots[0]
+        if count and count / report.total_classified > 0.4:
+            pct = round(100 * count / report.total_classified)
+            areas.append(
+                f"Slot '{slot_name}' is missing in {pct}% of classifications — "
+                f"either the slot is genuinely optional in real traffic, or the "
+                f"slot definition needs broadening (slot_definitions.yaml)."
+            )
+
+    # Wire-emission posture.
+    if report.tip_headers_emitted == 0 and report.total_classified > 0:
+        if report.adapters_eligible:
+            areas.append(
+                f"{len(report.adapters_eligible)} adapter(s) declare the gate "
+                f"label but no requests emitted on the wire — confirm those "
+                f"adapters resolved at request time (check `tokenpak doctor "
+                f"--explain-last`)."
+            )
+        else:
+            areas.append(
+                "No adapter declares 'tip.intent.contract-headers-v1' — every "
+                "classification stayed in local telemetry, which is the "
+                "expected Phase 0 default. Opt-in is gated on this baseline."
+            )
+
+    # Volume.
+    if report.total_classified < 500 and report.window_days and report.window_days >= 14:
+        areas.append(
+            f"Only {report.total_classified} classifications in the {report.window_days}-day "
+            f"window — proposal §6 sets 500 as the meaningful-statistics floor. Extend "
+            f"the window before drawing distribution-shape conclusions."
+        )
+
+    return areas
+
+
+def build_report(
+    *,
+    window_days: Optional[int] = 14,
+    db_path: Optional[Path] = None,
+    now: Optional[_dt.datetime] = None,
+    top_n: int = 5,
+) -> IntentReport:
+    """Run every aggregation and return one fully-populated report.
+
+    Read-only. ``window_days=None`` reads every row.
+    """
+    path = db_path if db_path is not None else _intent_db_path()
+    cutoff = window_cutoff_iso(window_days, now=now) if window_days else None
+
+    eligible, blocking = _collect_adapter_posture()
+    report = IntentReport(
+        window_days=window_days,
+        window_cutoff_iso=cutoff,
+        db_path=str(path),
+        adapters_eligible=eligible,
+        adapters_blocking=blocking,
+    )
+    # Confidence floor mirrors the classifier's CLASSIFY_THRESHOLD.
+    try:
+        from tokenpak.proxy.intent_classifier import CLASSIFY_THRESHOLD
+
+        report.low_confidence_threshold = CLASSIFY_THRESHOLD
+    except Exception:  # noqa: BLE001
+        pass
+
+    if not path.is_file():
+        report.review_areas = _review_areas(report)
+        return report
+
+    where_clause = ""
+    params: Tuple[Any, ...] = ()
+    if cutoff is not None:
+        where_clause = " WHERE timestamp >= ?"
+        params = (cutoff,)
+
+    with sqlite3.connect(str(path)) as conn:
+        if not _table_exists(conn):
+            report.review_areas = _review_areas(report)
+            return report
+
+        # Total classified
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_events{where_clause}", params
+        ).fetchone()
+        report.total_classified = int(row[0]) if row else 0
+
+        if report.total_classified == 0:
+            report.review_areas = _review_areas(report)
+            return report
+
+        # Intent class distribution + avg confidence by class
+        for r in conn.execute(
+            f"SELECT intent_class, COUNT(*), AVG(intent_confidence) "
+            f"FROM intent_events{where_clause} GROUP BY intent_class "
+            f"ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            cls = r[0]
+            count = int(r[1])
+            avg_conf = round(float(r[2]) if r[2] is not None else 0.0, 4)
+            report.intent_class_distribution[cls] = count
+            report.avg_confidence_by_class[cls] = avg_conf
+
+        # Catch-all reason distribution (only over rows with reason set)
+        for r in conn.execute(
+            f"SELECT catch_all_reason, COUNT(*) FROM intent_events"
+            f"{where_clause}{' AND' if where_clause else ' WHERE'} "
+            f"catch_all_reason IS NOT NULL GROUP BY catch_all_reason "
+            f"ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            report.catch_all_reason_distribution[r[0]] = int(r[1])
+
+        # Low confidence count
+        floor = report.low_confidence_threshold
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_events"
+            f"{where_clause}{' AND' if where_clause else ' WHERE'} "
+            f"intent_confidence < ?",
+            (*params, floor),
+        ).fetchone()
+        report.low_confidence_count = int(row[0]) if row else 0
+
+        # Wire-path counts
+        row = conn.execute(
+            f"SELECT "
+            f"SUM(CASE WHEN tip_headers_emitted=1 THEN 1 ELSE 0 END), "
+            f"SUM(CASE WHEN tip_headers_stripped=1 THEN 1 ELSE 0 END) "
+            f"FROM intent_events{where_clause}",
+            params,
+        ).fetchone()
+        report.tip_headers_emitted = int(row[0]) if row and row[0] is not None else 0
+        report.tip_headers_stripped = int(row[1]) if row and row[1] is not None else 0
+        # telemetry-only = stripped (the equivalent framing the
+        # directive asks for, kept as a separate field so the
+        # caller doesn't have to compute it).
+        report.telemetry_only = report.tip_headers_stripped
+
+        # Slot present/missing frequency. Slot lists are stored as
+        # JSON arrays per row; aggregate by exploding in Python so
+        # the SQL stays portable and read-only.
+        slot_present_counts: Dict[str, int] = {}
+        slot_missing_counts: Dict[str, int] = {}
+        for r in conn.execute(
+            f"SELECT intent_slots_present, intent_slots_missing "
+            f"FROM intent_events{where_clause}",
+            params,
+        ).fetchall():
+            try:
+                for s in json.loads(r[0] or "[]"):
+                    slot_present_counts[s] = slot_present_counts.get(s, 0) + 1
+                for s in json.loads(r[1] or "[]"):
+                    slot_missing_counts[s] = slot_missing_counts.get(s, 0) + 1
+            except (TypeError, json.JSONDecodeError):
+                # Defensive: a corrupt row should not crash the
+                # report. Skip + continue.
+                continue
+        report.slots_present_frequency = dict(
+            sorted(slot_present_counts.items(), key=lambda kv: -kv[1])
+        )
+        report.slots_missing_frequency = dict(
+            sorted(slot_missing_counts.items(), key=lambda kv: -kv[1])
+        )
+
+    # Operator-narrative top-N
+    report.top_missing_slots = [
+        (k, v) for k, v in list(report.slots_missing_frequency.items())[:top_n]
+    ]
+    report.top_catch_all_reasons = [
+        (k, v) for k, v in list(report.catch_all_reason_distribution.items())[:top_n]
+    ]
+    report.review_areas = _review_areas(report)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def render_human(report: IntentReport) -> str:
+    """Operator-readable plain-text report.
+
+    Visual rhythm matches ``tokenpak doctor --intent`` so an
+    operator running both back-to-back gets a coherent reading
+    experience.
+    """
+    lines: List[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Intent Layer report (Phase 1)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+
+    window_str = (
+        "all rows (no window)"
+        if report.window_days is None
+        else f"last {report.window_days}d (since {report.window_cutoff_iso})"
+    )
+    lines.append(f"  Window:                    {window_str}")
+    lines.append(f"  Telemetry store:           {report.db_path}")
+    lines.append(f"  Total classified:          {report.total_classified}")
+    lines.append("")
+
+    if report.total_classified == 0:
+        lines.append("  No classified requests in this window.")
+        lines.append("")
+        if report.review_areas:
+            lines.append("  Recommended review areas:")
+            for ra in report.review_areas:
+                lines.append(f"    - {ra}")
+            lines.append("")
+        return "\n".join(lines)
+
+    lines.append("  Intent class distribution (count, avg confidence):")
+    for cls, count in report.intent_class_distribution.items():
+        avg = report.avg_confidence_by_class.get(cls, 0.0)
+        pct = round(100 * count / report.total_classified)
+        lines.append(f"    {cls:<14s} {count:>6d}  ({pct:>3d}%)   avg conf {avg:.2f}")
+    lines.append("")
+
+    floor = report.low_confidence_threshold
+    if report.total_classified:
+        lc_pct = round(100 * report.low_confidence_count / report.total_classified)
+    else:
+        lc_pct = 0
+    lines.append(
+        f"  Low confidence (<{floor}):    "
+        f"{report.low_confidence_count} ({lc_pct}%)"
+    )
+    lines.append("")
+
+    lines.append("  Wire-emission posture:")
+    lines.append(f"    tip_headers_emitted:     {report.tip_headers_emitted}")
+    lines.append(f"    tip_headers_stripped:    {report.tip_headers_stripped}")
+    lines.append(f"    telemetry-only:          {report.telemetry_only}")
+    lines.append("")
+
+    lines.append("  Top missing slots:")
+    if report.top_missing_slots:
+        for name, count in report.top_missing_slots:
+            lines.append(f"    {name:<20s} {count}")
+    else:
+        lines.append("    (none)")
+    lines.append("")
+
+    lines.append("  Top catch-all reasons:")
+    if report.top_catch_all_reasons:
+        for reason, count in report.top_catch_all_reasons:
+            lines.append(f"    {reason:<28s} {count}")
+    else:
+        lines.append("    (none)")
+    lines.append("")
+
+    lines.append("  Adapters eligible for TIP intent headers:")
+    if report.adapters_eligible:
+        for a in report.adapters_eligible:
+            lines.append(f"    ✓ {a['name']:<40s} ({a['source_format']})")
+    else:
+        lines.append("    (none — Phase 0 default; opt-in gated on this baseline)")
+    lines.append("")
+
+    lines.append("  Adapters blocking TIP intent headers:")
+    if report.adapters_blocking:
+        for a in report.adapters_blocking:
+            lines.append(f"    · {a['name']:<40s} ({a['source_format']})")
+    else:
+        lines.append("    (none)")
+    lines.append("")
+
+    lines.append("  Recommended review areas:")
+    if report.review_areas:
+        for ra in report.review_areas:
+            lines.append(f"    - {ra}")
+    else:
+        lines.append("    (no flags raised by the heuristic — keep observing)")
+    lines.append("")
+
+    lines.append("  Phase 1 is observation-only. No user-facing behavior changes.")
+    lines.append("  See docs/reference/intent-reporting.md for what NOT to infer.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(report: IntentReport) -> str:
+    """Machine-readable JSON dump of the report."""
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+__all__ = [
+    "IntentReport",
+    "build_report",
+    "parse_window",
+    "render_human",
+    "render_json",
+    "window_cutoff_iso",
+]


### PR DESCRIPTION
## Summary

Read-only summary over the `intent_events` SQLite table written by Phase 0. **Reporting only — no classifier behavior changes, no routing changes, no adapter capability flips.** Held items remain held.

## Changes

- **`tokenpak/proxy/intent_report.py`** — query layer + renderers.
  - `parse_window` / `window_cutoff_iso` for the `Nd` window form (default `14d`; `0d`/`""` = read every row).
  - `build_report` runs all aggregations against `~/.tokenpak/telemetry.db` (overridable via `db_path` for tests).
  - `render_human` + `render_json` renderers.
  - `IntentReport` dataclass carries every metric the directive enumerates plus the operator narrative (top missing slots, top catch-all reasons, eligible/blocking adapters, recommended review areas).
  - **Privacy contract**: SQL queries read `raw_prompt_hash` at most; raw prompt content never enters the read path.
  - Read-only throughout; no writes anywhere; defensive fallbacks for missing DB / missing table / corrupt JSON in slot columns.
- **`tokenpak/cli/_impl.py`** — new `intent` parent subparser with `report` subcommand. Flags: `--window Nd` (default `14d`), `--json`. Bad window strings exit `2` with a clear message. Mirrors the `adapter scaffold` subparser shape. `intent` registered in `_COMMAND_GROUPS` so the doc generator surfaces it.
- **`tests/test_intent_report.py`** — 24 tests across 8 classes covering the directive's six required test cases plus window parsing + CLI subprocess smoke.
- **`docs/reference/intent-reporting.md`** — operator-facing doc covering how to read the report, the 2-week window, low-confidence/catch-all semantics, why telemetry-only is normal, and what NOT to infer yet.
- **`docs/reference/cli.md`** — regenerated.

## Test coverage

| Class | Tests | Concern |
|---|---|---|
| `TestWindowParsing` | 4 | `Nd` parser semantics |
| `TestEmptyDB` | 3 | DB missing / table missing / human render |
| `TestPopulatedDBSummary` | 6 | distribution sums, avg confidence per class, low-confidence count, catch-all distribution, slot frequencies, wire-emission counts |
| `TestJsonShape` | 3 | required-keys cover, round-trip, top-N pair shape |
| `TestPrivacyContract` | 2 | sentinel substring + per-row hash absent from output |
| `TestWindowFilter` | 3 | rows older than window excluded, no-window reads all, cutoff-iso math |
| `TestAdapterCapabilitySummary` | 1 | Phase 0 default has every first-party adapter in `adapters_blocking` |
| `TestCliSubprocess` | 2 | argparse help reachable + empty-DB end-to-end exit `0` |

Full suite: **1018 passing** (was 994 baseline, +24), 0 regressions, 1 skip / 1 xfail unchanged.

## Acceptance

- [x] `tokenpak intent report` exists with `--window Nd` + `--json`.
- [x] Both human and JSON outputs work end-to-end (subprocess-tested).
- [x] Read-only against the local telemetry store; no writes.
- [x] No classifier behavior changes (zero edits to `tokenpak/proxy/intent_classifier.py`).
- [x] Privacy contract end-to-end tested with a sentinel substring; no raw prompts or per-row hashes appear in output.
- [x] `ruff check` clean across changed files.
- [x] `cli-docs-in-sync --check` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no further scaffold renderer expansion, **no classifier behavior changes**.