### PR TITLE
feat(proxy,dashboard): Phase 1.1 — intent dashboard / read-model

### DIFF
--- a/docs/reference/intent-dashboard.md
+++ b/docs/reference/intent-dashboard.md
@@ -1,0 +1,170 @@
+# Intent Layer — Dashboard / Read-Model (Phase 1.1)
+
+> Phase 1.1 is **observation only**. It surfaces the Phase 1 reporting layer through a stable read-model + JSON API + dashboard panel. No classifier behavior changes. No routing changes. No raw prompt content leaves the local store.
+
+## Surface
+
+Three layers, all backed by the same query function (`build_report` from Phase 1):
+
+| Layer | Where | Audience |
+|---|---|---|
+| Python read-model | `tokenpak.proxy.intent_dashboard.collect_dashboard` | programmatic callers, embeds |
+| HTTP API | `GET /api/intent/report?window=Nd` | dashboard UI, third-party tools, scripts |
+| Dashboard panel | `tokenpak/dashboard/index.html` (Intent Layer section) | operator browsing the local UI |
+
+The wire shape is the same across all three. Schema version stamp: `intent-dashboard-v1` (carried as `metadata.schema_version`).
+
+## API contract
+
+```http
+GET /api/intent/report
+GET /api/intent/report?window=14d
+GET /api/intent/report?window=7d
+GET /api/intent/report?window=0d            # 0d / "" / missing → defaults differ; see below
+```
+
+Response: `200 OK` with `Content-Type: application/json` carrying the payload shape below. Errors:
+
+- `400 bad_request` — malformed `window` (anything other than `Nd`, including the literal `"all"` or `"forever"`).
+- `500 intent_dashboard_failed` — internal failure during aggregation. Best-effort path; should be rare.
+
+Read-only. The endpoint never writes to the telemetry store, never invokes a provider, never alters adapter state.
+
+### Window semantics
+
+The dashboard surface and the CLI surface intentionally differ on the **default** window:
+
+| Surface | Missing / empty | `0d` |
+|---|---|---|
+| `tokenpak intent report` (CLI) | `None` (read every row) | `None` (read every row) |
+| `GET /api/intent/report` | **`14d` (default observation window)** | `None` (read every row) |
+| `collect_dashboard()` Python | caller-specified | `None` (caller passed `window_days=None`) |
+
+The dashboard default is 14d so a naive `curl /api/intent/report` doesn't accidentally surface multi-year history. Pass `?window=0d` explicitly when you want all rows.
+
+### Payload shape
+
+```jsonc
+{
+  "metadata": {
+    "schema_version": "intent-dashboard-v1",
+    "phase": "intent-layer-phase-1.1",
+    "observation_only": true,
+    "window_days": 14,
+    "window_cutoff_iso": "2026-04-12T17:31:39",
+    "telemetry_store_path": "/home/.../telemetry.db",
+    "low_confidence_threshold": 0.4
+  },
+  "cards": {
+    "total_classified":             { "value": <int> },
+    "intent_class_distribution":    {
+      "items": [
+        { "intent_class": "summarize", "count": 12, "pct": 60.0, "avg_confidence": 0.93 }
+      ]
+    },
+    "average_confidence":           { "value": <float, weighted by class volume> },
+    "low_confidence_count":         { "value": <int>, "pct_of_total": <float>, "threshold": 0.4 },
+    "catch_all_reason_distribution": {
+      "items": [{ "catch_all_reason": "empty_prompt", "count": 3, "pct": 15.0 }]
+    },
+    "top_missing_slots":            {
+      "items": [{ "slot": "target", "count": 8, "pct": 40.0 }]
+    },
+    "tip_headers_emitted_vs_telemetry_only": {
+      "tip_headers_emitted": <int>,
+      "telemetry_only": <int>,
+      "tip_headers_stripped": <int>,           // mirror of telemetry_only
+      "emitted_pct": <float>,
+      "telemetry_only_pct": <float>
+    },
+    "adapters_eligible":            { "items": [...], "count": <int> },
+    "adapters_blocking":            { "items": [...], "count": <int> }
+  },
+  "operator_panel": {
+    "most_common_missing_slots":                  [...],
+    "most_common_catch_all_reasons":              [...],
+    "adapters_eligible_for_tip_headers":          [...],
+    "adapters_requiring_capability_declaration":  [...],
+    "recommended_review_areas":                   [<string>, ...]
+  }
+}
+```
+
+Pre-computed percentages are floats rounded to 1 decimal place (cards) or 4 decimal places (`average_confidence` weighted mean). Underlying counts remain available for clients that want to compute their own ratios.
+
+## How dashboard metrics map to `tokenpak intent report`
+
+Every card and operator-panel item in the dashboard comes from the same `build_report` query as the CLI's `tokenpak intent report --json`. The CLI is the ground truth; the dashboard reshapes for UI rendering and adds pre-computed percentages. If a number ever differs between the two for the same window, the report is authoritative.
+
+| Dashboard card | Maps to (CLI / `--json` field) |
+|---|---|
+| Total Classified | `total_classified` |
+| Intent class distribution | `intent_class_distribution` × `avg_confidence_by_class` |
+| Average confidence | volume-weighted mean of `avg_confidence_by_class` × counts |
+| Low confidence | `low_confidence_count` + `low_confidence_threshold` |
+| Catch-all reason distribution | `catch_all_reason_distribution` |
+| Top missing slots | `top_missing_slots` |
+| TIP headers emitted vs telemetry-only | `tip_headers_emitted` + `tip_headers_stripped` (= `telemetry_only`) |
+| Adapters eligible | `adapters_eligible` |
+| Adapters blocking | `adapters_blocking` |
+
+## Why telemetry-only is normal
+
+In Phase 0/1/1.1, **no first-party adapter declares `tip.intent.contract-headers-v1`**. The proxy attaches the five wire headers (`X-TokenPak-Intent-Class`, `Confidence`, `Subtype`, `Contract-Risk`, `Contract-Id`) only when the resolved request adapter declares this capability per Standard #23 §4.3. With every adapter in `adapters_blocking`, every request stays in local telemetry only. The "TIP Headers Emitted" card reading 0 is the **expected default**, not a bug.
+
+When an adapter author opts in (after the baseline report identifies where the headers add value), that adapter moves to `adapters_eligible` and its requests start emitting. The dashboard card flips on automatically.
+
+## What "low confidence" means
+
+`low_confidence_count` is the count of rows where `intent_confidence < low_confidence_threshold` (0.4 by default — symmetric with the existing `intent_policy.CONFIDENCE_THRESHOLD`). The Phase 0 classifier stamps `intent_source = "rule_based_v0"` on every row; confidence is a normalized keyword weight, **not** a probability. A prompt classified at 0.9 means "the canonical keyword for that intent matched"; it does NOT mean "90 % chance the intent is X".
+
+A high low-confidence count is usually a signal that the keyword table needs broader phrases, not that the prompts are ambiguous.
+
+## What NOT to infer yet
+
+Phase 1.1 is observation. The dashboard surface is **NOT** authoritative for:
+
+- **Cost or latency conclusions per intent.** The Phase 0 row carries `tokens_in / tokens_out / latency_ms` as best-effort optional fields; they are not bound to the request-event row formally until Intent-1.
+- **Routing decisions.** Phase 1.1 changes no routing.
+- **Recipe selection.** Recipe-driven behavior lands in Intent-3.
+- **Pro/OSS gating.** Intent-0 / Intent-1 / Intent-1.1 are pure OSS.
+- **Prompt-side cache keying.** Cache keys are not derived from intent or contract yet.
+- **Quality assertions about the classifier.** Phase 0 chose Option A (rule-based). The baseline report informs the Intent-1 go/no-go on Option B.
+
+## Why Phase 1.1 is observation-only
+
+The proposal sets a 2-week (`14d`) baseline-observation window before any user-facing behavior change can be considered. Phase 1.1 surfaces aggregations through more reach surfaces (Python, HTTP, UI) so the operator can read the same baseline from any vantage. None of those surfaces makes a routing or rewrite decision; that is reserved for Intent-2 onward.
+
+## Privacy
+
+The Python read-model, the HTTP endpoint, and the dashboard panel all share one privacy contract:
+
+- Raw prompt text NEVER enters the read path.
+- The `raw_prompt_hash` (sha256 hex digest) MAY appear in `intent_events` rows, but the dashboard surface does NOT include it in the payload.
+- All percentages and counts are aggregations across the window — no per-request identifiers leave the response except the adapter class names (which are public symbols).
+
+The privacy contract is asserted end-to-end via sentinel-substring tests:
+
+- `tests/test_intent_report.py::TestPrivacyContract` — Phase 1 CLI report
+- `tests/test_intent_dashboard.py::TestPrivacyContract` — Phase 1.1 dashboard
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/proxy/intent_dashboard.py` | read-model (`collect_dashboard`, schema version stamp) |
+| `tokenpak/proxy/server.py::do_GET` | `/api/intent/report` HTTP endpoint |
+| `tokenpak/dashboard/index.html` | "Intent Layer" panel — cards + tables + operator review areas |
+| `tokenpak/dashboard/intent.js` | UI fetch + render |
+| `tokenpak/proxy/intent_report.py` | Phase 1 query layer (reused) |
+| `~/.tokenpak/telemetry.db` `intent_events` | source data, written by Phase 0 |
+| `docs/reference/intent-layer-phase-0.md` | Phase 0 fundamentals |
+| `docs/reference/intent-reporting.md` | Phase 1 CLI report |
+
+## Cross-references
+
+- Standard #23 §4.3 — the canonical capability-gated middleware-activation pattern.
+- Architecture §5.1 — byte-fidelity rule for non-TIP providers.
+- Architecture §7.1 — prompt-locality rule.
+- Constitution §13 — TokenPak as TIP-1.0 reference implementation.
+- Intent-0 proposal: `~/vault/02_COMMAND_CENTER/proposals/2026-04-24-tokenpak-intent-layer-phase-0.md` (Adj-1 + Adj-2 banner block at top).

--- a/tests/test_intent_dashboard.py
+++ b/tests/test_intent_dashboard.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 1.1 — Intent Layer dashboard / read-model regression suite.
+
+Seven contracts, one per directive bullet:
+
+  - read-model output from empty DB
+  - read-model output from populated DB
+  - window filtering
+  - JSON / API schema stability
+  - no raw prompt content emitted
+  - adapter capability summary
+  - dashboard / API handles missing telemetry.db gracefully
+
+Read-only throughout. Reuses :class:`IntentTelemetryStore` (Phase
+0) to seed temp DBs so the schema stays a single source of truth.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import (
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    build_contract,
+)
+from tokenpak.proxy.intent_dashboard import (
+    DASHBOARD_SCHEMA_VERSION,
+    collect_dashboard,
+    parse_window_or_default,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _classification(intent_class="summarize", confidence=0.9,
+                    slots_present=("period",), slots_missing=("target",),
+                    catch_all_reason=None):
+    return IntentClassification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+
+
+def _seed(store, *, request_id, intent_class="summarize", confidence=0.9,
+          prompt="summarize the vault", slots_present=("period",),
+          slots_missing=("target",), catch_all_reason=None,
+          emitted=False, stripped=True, timestamp=None):
+    classification = _classification(
+        intent_class=intent_class, confidence=confidence,
+        slots_present=slots_present, slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+    contract = build_contract(classification=classification, raw_prompt=prompt)
+    ts = timestamp or _dt.datetime.now().isoformat(timespec="seconds")
+    store.write(IntentTelemetryRow(
+        request_id=request_id,
+        contract=contract,
+        timestamp=ts,
+        tip_headers_emitted=emitted,
+        tip_headers_stripped=stripped,
+    ))
+    return contract
+
+
+# ── 1. Empty DB ───────────────────────────────────────────────────────
+
+
+class TestReadModelEmptyDB:
+    """Acceptance bullet 1 — read-model handles an empty store
+    cleanly. Every card slot is present, with zero/empty values.
+    """
+
+    def test_db_missing_returns_well_shaped(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert "metadata" in payload
+        assert "cards" in payload
+        assert "operator_panel" in payload
+        assert payload["cards"]["total_classified"]["value"] == 0
+        assert payload["cards"]["intent_class_distribution"]["items"] == []
+        assert payload["cards"]["catch_all_reason_distribution"]["items"] == []
+
+    def test_db_missing_recommended_review_areas_populated(self, tmp_path: Path):
+        # Operator panel still surfaces a meaningful review area when
+        # the DB is empty (the "no rows yet" hint).
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        areas = payload["operator_panel"]["recommended_review_areas"]
+        assert len(areas) >= 1
+
+    def test_db_missing_avg_confidence_is_zero_not_null(self, tmp_path: Path):
+        # Dashboards prefer 0.0 to None for numeric fields — easier
+        # to render. The contract pins this.
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["cards"]["average_confidence"]["value"] == 0.0
+
+
+# ── 2. Populated DB ───────────────────────────────────────────────────
+
+
+class TestReadModelPopulatedDB:
+    """Acceptance bullet 2 — every card has the expected counts /
+    derived values when the store has data. Pre-computed
+    percentages match what the Phase 1 report would produce.
+    """
+
+    def test_total_and_distribution(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        for i in range(3):
+            _seed(store, request_id=f"a{i}", intent_class="summarize", confidence=0.9)
+        for i in range(2):
+            _seed(store, request_id=f"b{i}", intent_class="debug", confidence=0.6)
+        store.close()
+
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db")
+        assert payload["cards"]["total_classified"]["value"] == 5
+
+        items = {
+            i["intent_class"]: i
+            for i in payload["cards"]["intent_class_distribution"]["items"]
+        }
+        assert items["summarize"]["count"] == 3
+        assert items["summarize"]["pct"] == 60.0
+        assert items["debug"]["count"] == 2
+        assert items["debug"]["pct"] == 40.0
+
+    def test_low_confidence_card(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="hi", confidence=0.9)
+        _seed(store, request_id="lo", intent_class="query", confidence=0.0,
+              catch_all_reason="empty_prompt", slots_present=(), slots_missing=())
+        store.close()
+
+        card = collect_dashboard(window_days=14, db_path=tmp_path / "t.db") \
+            ["cards"]["low_confidence_count"]
+        assert card["value"] == 1
+        assert card["pct_of_total"] == 50.0
+        assert card["threshold"] == 0.4
+
+    def test_wire_emission_card_with_pcts(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="emit", emitted=True, stripped=False)
+        _seed(store, request_id="strip1", emitted=False, stripped=True)
+        _seed(store, request_id="strip2", emitted=False, stripped=True)
+        store.close()
+
+        card = collect_dashboard(window_days=14, db_path=tmp_path / "t.db") \
+            ["cards"]["tip_headers_emitted_vs_telemetry_only"]
+        assert card["tip_headers_emitted"] == 1
+        assert card["telemetry_only"] == 2
+        assert card["tip_headers_stripped"] == 2
+        # Pre-computed percentages.
+        assert card["emitted_pct"] == round(100.0 * 1 / 3, 1)
+        assert card["telemetry_only_pct"] == round(100.0 * 2 / 3, 1)
+
+    def test_top_missing_slots_card(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", slots_missing=("target",))
+        _seed(store, request_id="a1", slots_missing=("target",))
+        _seed(store, request_id="a2", slots_missing=("period",))
+        store.close()
+
+        card = collect_dashboard(window_days=14, db_path=tmp_path / "t.db") \
+            ["cards"]["top_missing_slots"]
+        items = card["items"]
+        assert items[0] == {"slot": "target", "count": 2, "pct": round(100.0 * 2 / 3, 1)}
+        assert items[1] == {"slot": "period", "count": 1, "pct": round(100.0 * 1 / 3, 1)}
+
+    def test_average_confidence_volume_weighted(self, tmp_path: Path):
+        # Volume-weighted: 2 rows at 1.0 (summarize) + 2 rows at 0.5 (debug)
+        # = (2*1.0 + 2*0.5) / 4 = 0.75 across all classifications.
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", intent_class="summarize", confidence=1.0)
+        _seed(store, request_id="a1", intent_class="summarize", confidence=1.0)
+        _seed(store, request_id="b0", intent_class="debug", confidence=0.5)
+        _seed(store, request_id="b1", intent_class="debug", confidence=0.5)
+        store.close()
+
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db")
+        assert payload["cards"]["average_confidence"]["value"] == 0.75
+
+
+# ── 3. Window filtering ───────────────────────────────────────────────
+
+
+class TestWindowFilter:
+    """Acceptance bullet 3 — rows older than ``window_days``
+    excluded. The dashboard surface defaults to 14d when no
+    explicit window is provided (distinct from the CLI's '0d ='
+    all-rows behavior — the API default-14d posture prevents a
+    naïve curl from accidentally surfacing multi-year history).
+    """
+
+    def test_rows_outside_window_excluded(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        now = _dt.datetime(2026, 4, 25, 12, 0, 0)
+        _seed(store, request_id="recent",
+              timestamp=(now - _dt.timedelta(days=2)).isoformat(timespec="seconds"))
+        _seed(store, request_id="ancient",
+              timestamp=(now - _dt.timedelta(days=60)).isoformat(timespec="seconds"))
+        store.close()
+
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db", now=now)
+        assert payload["cards"]["total_classified"]["value"] == 1
+
+    def test_default_window_is_14(self):
+        # The dashboard wrapper for parse_window defaults to 14d
+        # when the spec is missing or empty (vs the CLI's parse_window
+        # which returns None for missing → "all rows").
+        assert parse_window_or_default(None) == 14
+        assert parse_window_or_default("") == 14
+
+    def test_explicit_window_passes_through(self):
+        assert parse_window_or_default("7d") == 7
+        assert parse_window_or_default("30d") == 30
+
+    def test_zero_window_means_all_rows(self):
+        assert parse_window_or_default("0d") is None
+
+    def test_bad_window_raises_for_api_400(self):
+        with pytest.raises(ValueError):
+            parse_window_or_default("forever")
+        with pytest.raises(ValueError):
+            parse_window_or_default("14h")
+
+
+# ── 4. JSON / API schema stability ────────────────────────────────────
+
+
+class TestSchemaStability:
+    """Acceptance bullet 4 — the wire shape is the documented API
+    contract. Pin the required-key sets so a future drift trips
+    here loudly instead of silently breaking dashboard consumers.
+    """
+
+    REQUIRED_CARD_KEYS = {
+        "total_classified",
+        "intent_class_distribution",
+        "average_confidence",
+        "low_confidence_count",
+        "catch_all_reason_distribution",
+        "top_missing_slots",
+        "tip_headers_emitted_vs_telemetry_only",
+        "adapters_eligible",
+        "adapters_blocking",
+    }
+
+    REQUIRED_OPERATOR_PANEL_KEYS = {
+        "most_common_missing_slots",
+        "most_common_catch_all_reasons",
+        "adapters_eligible_for_tip_headers",
+        "adapters_requiring_capability_declaration",
+        "recommended_review_areas",
+    }
+
+    REQUIRED_METADATA_KEYS = {
+        "schema_version",
+        "window_days",
+        "window_cutoff_iso",
+        "telemetry_store_path",
+        "low_confidence_threshold",
+        "phase",
+        "observation_only",
+    }
+
+    def test_top_level_shape(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert set(payload) == {"metadata", "cards", "operator_panel"}
+
+    def test_cards_keys(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_CARD_KEYS - set(payload["cards"])
+        assert not missing, f"missing card keys: {missing}"
+
+    def test_operator_panel_keys(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_OPERATOR_PANEL_KEYS - set(payload["operator_panel"])
+        assert not missing, f"missing operator_panel keys: {missing}"
+
+    def test_metadata_keys(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_METADATA_KEYS - set(payload["metadata"])
+        assert not missing, f"missing metadata keys: {missing}"
+
+    def test_schema_version_pinned(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["metadata"]["schema_version"] == DASHBOARD_SCHEMA_VERSION
+        assert payload["metadata"]["schema_version"] == "intent-dashboard-v1"
+
+    def test_observation_only_flag_pinned(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["metadata"]["observation_only"] is True
+        assert payload["metadata"]["phase"] == "intent-layer-phase-1.1"
+
+    def test_payload_is_json_serialisable(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        _seed(store, request_id="a0", slots_missing=("target",))
+        store.close()
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db")
+        # Round-trip — all fields must serialise.
+        json.dumps(payload)
+
+
+# ── 5. Privacy contract ───────────────────────────────────────────────
+
+
+class TestPrivacyContract:
+    """Acceptance bullet 5 — no raw prompt content. Plant a
+    sentinel substring in the prompt and assert it appears nowhere
+    in the dashboard payload (neither human nor JSON form).
+    """
+
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-1-1"
+
+    def test_sentinel_absent_from_payload(self, tmp_path: Path):
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        prompt = f"summarize the vault {self.SENTINEL}"
+        _seed(store, request_id="a0", prompt=prompt)
+        store.close()
+
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db")
+        serialized = json.dumps(payload)
+        assert self.SENTINEL not in serialized, (
+            "raw prompt content leaked into dashboard JSON"
+        )
+
+    def test_raw_prompt_hash_absent_from_payload(self, tmp_path: Path):
+        # The hash isn't secret, but the dashboard surface MUST NOT
+        # include it (it's a per-row dedup key, not an aggregation
+        # input). Guards against a future change that pulls
+        # raw_prompt_hash into the payload.
+        import hashlib
+
+        store = IntentTelemetryStore(db_path=tmp_path / "t.db")
+        prompt = "summarize the vault unique-prompt-zzz-dashboard"
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        _seed(store, request_id="a0", prompt=prompt)
+        store.close()
+
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "t.db")
+        assert digest not in json.dumps(payload)
+
+
+# ── 6. Adapter capability summary ─────────────────────────────────────
+
+
+class TestAdapterCapabilitySummary:
+    """Acceptance bullet 6 — eligible vs blocking split. Phase 0
+    default has every first-party adapter in 'blocking'; the
+    dashboard surfaces both sides so an operator can see which
+    adapters need to declare the gate label.
+    """
+
+    def test_split_shapes(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        eligible = payload["cards"]["adapters_eligible"]
+        blocking = payload["cards"]["adapters_blocking"]
+        assert "items" in eligible and "count" in eligible
+        assert "items" in blocking and "count" in blocking
+        assert eligible["count"] == len(eligible["items"])
+        assert blocking["count"] == len(blocking["items"])
+
+    def test_phase_0_default_all_blocking(self, tmp_path: Path):
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        # Phase 0 invariant: no first-party adapter declares the gate
+        # label by default. This is also pinned in
+        # tests/test_intent_layer_phase0.py — keep both in sync.
+        assert payload["cards"]["adapters_eligible"]["count"] == 0
+        assert payload["cards"]["adapters_blocking"]["count"] >= 1
+
+    def test_operator_panel_mirrors_card_data(self, tmp_path: Path):
+        # The operator panel rephrases the card data narratively; the
+        # underlying lists must be the same (one card-side, one
+        # panel-side, both reading the same source).
+        payload = collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        cards = payload["cards"]
+        panel = payload["operator_panel"]
+        assert cards["adapters_eligible"]["items"] == \
+            panel["adapters_eligible_for_tip_headers"]
+        assert cards["adapters_blocking"]["items"] == \
+            panel["adapters_requiring_capability_declaration"]
+
+
+# ── 7. Missing telemetry.db handled gracefully ────────────────────────
+
+
+class TestMissingTelemetryDb:
+    """Acceptance bullet 7 — the API path MUST NOT raise when the
+    telemetry.db doesn't exist (fresh install). The read-model
+    returns a well-shaped zero payload; the API endpoint returns
+    200 with that payload, never 5xx.
+    """
+
+    def test_missing_db_returns_zeroed_payload(self, tmp_path: Path):
+        # Path that absolutely doesn't exist.
+        absent = tmp_path / "absolutely-not-a-real-path" / "telemetry.db"
+        payload = collect_dashboard(window_days=14, db_path=absent)
+        assert payload["cards"]["total_classified"]["value"] == 0
+        # Adapter posture still computed from the in-process
+        # registry — independent of the DB.
+        assert payload["cards"]["adapters_blocking"]["count"] >= 1
+
+    def test_missing_db_does_not_raise(self, tmp_path: Path):
+        # Best-effort contract. If this test ever flips, it means
+        # the API endpoint will start emitting 5xx — bad for
+        # dashboard polling.
+        try:
+            collect_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"collect_dashboard raised on missing DB: {exc!r}")

--- a/tokenpak/dashboard/__init__.py
+++ b/tokenpak/dashboard/__init__.py
@@ -25,6 +25,9 @@ def get_dashboard_files():
         "index.html": DASHBOARD_DIR / "index.html",
         "metrics.js": DASHBOARD_DIR / "metrics.js",
         "charts.js": DASHBOARD_DIR / "charts.js",
+        # Phase 1.1 — intent dashboard cards. Read-only; consumes
+        # /api/intent/report?window=14d.
+        "intent.js": DASHBOARD_DIR / "intent.js",
         "styles.css": DASHBOARD_DIR / "styles.css",
     }
 

--- a/tokenpak/dashboard/index.html
+++ b/tokenpak/dashboard/index.html
@@ -104,20 +104,91 @@
                     </tbody>
                 </table>
             </div>
+
+            <!-- Intent Layer (Phase 1.1) — observation-only -->
+            <div class="chart-container">
+                <h2>Intent Layer
+                    <small id="intent-window-badge" style="font-weight: normal; opacity: 0.7;">— last 14d (observation-only)</small>
+                </h2>
+                <div class="stats-row">
+                    <div class="stat-card">
+                        <div class="stat-label">Total Classified</div>
+                        <div class="stat-value" id="intent-total-classified">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Avg Confidence</div>
+                        <div class="stat-value" id="intent-avg-confidence">0.00</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Low Confidence</div>
+                        <div class="stat-value" id="intent-low-confidence">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">TIP Headers Emitted</div>
+                        <div class="stat-value" id="intent-headers-emitted">0</div>
+                    </div>
+                </div>
+                <div class="stats-row">
+                    <div class="stat-card">
+                        <div class="stat-label">Telemetry-Only</div>
+                        <div class="stat-value" id="intent-telemetry-only">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Adapters Eligible</div>
+                        <div class="stat-value" id="intent-adapters-eligible">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Adapters Blocking</div>
+                        <div class="stat-value" id="intent-adapters-blocking">0</div>
+                    </div>
+                </div>
+                <h3>Intent class distribution</h3>
+                <table class="metrics-table">
+                    <thead>
+                        <tr>
+                            <th>Intent</th>
+                            <th>Count</th>
+                            <th>%</th>
+                            <th>Avg confidence</th>
+                        </tr>
+                    </thead>
+                    <tbody id="intent-class-distribution-body">
+                    </tbody>
+                </table>
+                <h3>Top missing slots</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Slot</th><th>Count</th><th>%</th></tr></thead>
+                    <tbody id="intent-top-missing-slots-body"></tbody>
+                </table>
+                <h3>Top catch-all reasons</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Reason</th><th>Count</th><th>%</th></tr></thead>
+                    <tbody id="intent-catch-all-body"></tbody>
+                </table>
+                <h3>Operator panel</h3>
+                <ul id="intent-review-areas" style="line-height: 1.6;"></ul>
+            </div>
         </div>
     </div>
 
     <script src="metrics.js"></script>
     <script src="charts.js"></script>
     <script src="goals.js"></script>
+    <script src="intent.js"></script>
     <script>
         // Auto-refresh every 5 seconds
         setInterval(() => {
             fetchAndUpdateMetrics();
+            if (typeof fetchAndUpdateIntentDashboard === "function") {
+                fetchAndUpdateIntentDashboard();
+            }
         }, 5000);
-        
+
         // Initial load
         fetchAndUpdateMetrics();
+        if (typeof fetchAndUpdateIntentDashboard === "function") {
+            fetchAndUpdateIntentDashboard();
+        }
     </script>
 </body>
 </html>

--- a/tokenpak/dashboard/intent.js
+++ b/tokenpak/dashboard/intent.js
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Intent Layer Phase 1.1 — dashboard-card fetch + render.
+//
+// Reads /api/intent/report?window=14d (the documented contract;
+// see docs/reference/intent-dashboard.md). Updates nine card
+// elements + three tables + the operator panel.
+//
+// Read-only. No prompt content; the API never emits raw prompts.
+// All percentages are pre-computed server-side; this script just
+// renders them.
+
+async function fetchAndUpdateIntentDashboard() {
+    let payload;
+    try {
+        const response = await fetch('/api/intent/report?window=14d');
+        if (!response.ok) {
+            return;  // Silent — the panel stays blank on transient failure.
+        }
+        payload = await response.json();
+    } catch (err) {
+        return;
+    }
+    if (!payload || !payload.cards) {
+        return;
+    }
+
+    const cards = payload.cards;
+    const panel = payload.operator_panel || {};
+    const meta = payload.metadata || {};
+
+    // Window badge (e.g. "— last 14d (observation-only)").
+    const winBadge = document.getElementById('intent-window-badge');
+    if (winBadge && meta.window_days != null) {
+        winBadge.textContent = `— last ${meta.window_days}d (observation-only)`;
+    }
+
+    // Top stat cards.
+    setText('intent-total-classified', cards.total_classified.value);
+    setText('intent-avg-confidence', (cards.average_confidence.value || 0).toFixed(2));
+    setText('intent-low-confidence', cards.low_confidence_count.value);
+    setText('intent-headers-emitted', cards.tip_headers_emitted_vs_telemetry_only.tip_headers_emitted);
+    setText('intent-telemetry-only', cards.tip_headers_emitted_vs_telemetry_only.telemetry_only);
+    setText('intent-adapters-eligible', cards.adapters_eligible.count);
+    setText('intent-adapters-blocking', cards.adapters_blocking.count);
+
+    // Intent class distribution table.
+    const distBody = document.getElementById('intent-class-distribution-body');
+    if (distBody) {
+        distBody.innerHTML = '';
+        for (const item of cards.intent_class_distribution.items) {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${escapeHtml(item.intent_class)}</td>
+                <td>${item.count}</td>
+                <td>${item.pct.toFixed(1)}%</td>
+                <td>${item.avg_confidence.toFixed(2)}</td>
+            `;
+            distBody.appendChild(row);
+        }
+    }
+
+    // Top missing slots.
+    const missingBody = document.getElementById('intent-top-missing-slots-body');
+    if (missingBody) {
+        missingBody.innerHTML = '';
+        for (const item of cards.top_missing_slots.items) {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${escapeHtml(item.slot)}</td>
+                <td>${item.count}</td>
+                <td>${item.pct.toFixed(1)}%</td>
+            `;
+            missingBody.appendChild(row);
+        }
+    }
+
+    // Top catch-all reasons.
+    const catchAllBody = document.getElementById('intent-catch-all-body');
+    if (catchAllBody) {
+        catchAllBody.innerHTML = '';
+        for (const item of cards.catch_all_reason_distribution.items) {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${escapeHtml(item.catch_all_reason)}</td>
+                <td>${item.count}</td>
+                <td>${item.pct.toFixed(1)}%</td>
+            `;
+            catchAllBody.appendChild(row);
+        }
+    }
+
+    // Operator panel — recommended review areas.
+    const ul = document.getElementById('intent-review-areas');
+    if (ul) {
+        ul.innerHTML = '';
+        const areas = panel.recommended_review_areas || [];
+        if (areas.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = '(no flags raised by the heuristic — keep observing)';
+            ul.appendChild(li);
+        } else {
+            for (const area of areas) {
+                const li = document.createElement('li');
+                li.textContent = area;
+                ul.appendChild(li);
+            }
+        }
+    }
+}
+
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.textContent = String(value ?? 0);
+    }
+}
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/tokenpak/proxy/intent_dashboard.py
+++ b/tokenpak/proxy/intent_dashboard.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intent Layer Phase 1.1 — dashboard-shaped read-model.
+
+A thin UI-friendly view over the Phase 1 :func:`build_report`
+output. The wire shape produced by :func:`collect_dashboard` is
+the **stable API contract** consumed by:
+
+  - the proxy's ``GET /api/intent/report?window=Nd`` endpoint
+  - the dashboard UI's intent panel (``tokenpak/dashboard/``)
+  - any third-party tool that wants to read TokenPak's intent
+    aggregations programmatically
+
+Three sections in the returned dict:
+
+  - ``cards`` — the nine numeric / list cards the dashboard panel
+    renders (one card = one box on screen).
+  - ``operator_panel`` — the five narrative items the Phase 1
+    report surfaces under "Recommended review areas" + the top-N
+    slot/reason lists.
+  - ``metadata`` — window identity, telemetry-store path, schema
+    version stamp.
+
+**This module is read-only.** Reuses Phase 1's query layer
+verbatim — every privacy / window / never-raises invariant flows
+through unchanged. Percentages are pre-computed here so the UI
+doesn't have to do float math; the underlying counts remain
+available for clients that prefer to compute their own ratios.
+
+No raw prompt content. The Phase 1 query layer reads
+``raw_prompt_hash`` at most; this read-model does not surface even
+that. Asserted in
+``tests/test_intent_dashboard.py::TestPrivacyContract``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Bumped when the wire shape changes in a backward-incompatible
+# way. Consumers can pin against this version.
+DASHBOARD_SCHEMA_VERSION: str = "intent-dashboard-v1"
+
+
+def _pct(numer: int, denom: int) -> float:
+    """Percentage (0.0–100.0), rounded to one decimal place."""
+    if denom <= 0:
+        return 0.0
+    return round(100.0 * numer / denom, 1)
+
+
+def collect_dashboard(
+    *,
+    window_days: Optional[int] = 14,
+    db_path: Optional[Path] = None,
+    now: Optional[_dt.datetime] = None,
+    top_n: int = 5,
+) -> Dict[str, Any]:
+    """Run :func:`build_report` and reshape it for dashboard consumers.
+
+    The returned dict is the **API contract**. Every key documented
+    in :mod:`tokenpak.proxy.intent_dashboard` is part of the
+    stable surface; new keys may be added in v1 without bumping
+    :data:`DASHBOARD_SCHEMA_VERSION`, but existing keys MUST NOT
+    change shape or semantics.
+    """
+    from tokenpak.proxy.intent_report import build_report
+
+    report = build_report(
+        window_days=window_days,
+        db_path=db_path,
+        now=now,
+        top_n=top_n,
+    )
+
+    total = report.total_classified
+
+    # ── Cards (nine boxes) ─────────────────────────────────────────
+    intent_class_dist = []
+    for cls, count in report.intent_class_distribution.items():
+        intent_class_dist.append({
+            "intent_class": cls,
+            "count": count,
+            "pct": _pct(count, total),
+            "avg_confidence": report.avg_confidence_by_class.get(cls, 0.0),
+        })
+
+    catch_all_dist = []
+    for reason, count in report.catch_all_reason_distribution.items():
+        catch_all_dist.append({
+            "catch_all_reason": reason,
+            "count": count,
+            "pct": _pct(count, total),
+        })
+
+    top_missing_slots = [
+        {"slot": name, "count": count, "pct": _pct(count, total)}
+        for name, count in report.top_missing_slots
+    ]
+
+    cards: Dict[str, Any] = {
+        "total_classified": {
+            "value": total,
+        },
+        "intent_class_distribution": {
+            "items": intent_class_dist,
+        },
+        "average_confidence": {
+            # Single weighted average across all classifications.
+            # Weighted by per-class count so the value reflects the
+            # mix of traffic, not an unweighted mean of class
+            # averages.
+            "value": _weighted_avg_confidence(report),
+        },
+        "low_confidence_count": {
+            "value": report.low_confidence_count,
+            "pct_of_total": _pct(report.low_confidence_count, total),
+            "threshold": report.low_confidence_threshold,
+        },
+        "catch_all_reason_distribution": {
+            "items": catch_all_dist,
+        },
+        "top_missing_slots": {
+            "items": top_missing_slots,
+        },
+        "tip_headers_emitted_vs_telemetry_only": {
+            "tip_headers_emitted": report.tip_headers_emitted,
+            "telemetry_only": report.telemetry_only,
+            "tip_headers_stripped": report.tip_headers_stripped,
+            "emitted_pct": _pct(report.tip_headers_emitted, total),
+            "telemetry_only_pct": _pct(report.telemetry_only, total),
+        },
+        "adapters_eligible": {
+            # Adapters that DECLARE tip.intent.contract-headers-v1.
+            "items": list(report.adapters_eligible),
+            "count": len(report.adapters_eligible),
+        },
+        "adapters_blocking": {
+            # Adapters that do NOT declare the gate label — the
+            # Phase 0 default.
+            "items": list(report.adapters_blocking),
+            "count": len(report.adapters_blocking),
+        },
+    }
+
+    # ── Operator panel (five narrative items) ──────────────────────
+    operator_panel: Dict[str, Any] = {
+        "most_common_missing_slots": top_missing_slots,
+        "most_common_catch_all_reasons": catch_all_dist[:top_n],
+        "adapters_eligible_for_tip_headers": list(report.adapters_eligible),
+        "adapters_requiring_capability_declaration": list(report.adapters_blocking),
+        "recommended_review_areas": list(report.review_areas),
+    }
+
+    # ── Metadata ───────────────────────────────────────────────────
+    metadata: Dict[str, Any] = {
+        "schema_version": DASHBOARD_SCHEMA_VERSION,
+        "window_days": report.window_days,
+        "window_cutoff_iso": report.window_cutoff_iso,
+        "telemetry_store_path": report.db_path,
+        "low_confidence_threshold": report.low_confidence_threshold,
+        "phase": "intent-layer-phase-1.1",
+        "observation_only": True,
+    }
+
+    return {
+        "metadata": metadata,
+        "cards": cards,
+        "operator_panel": operator_panel,
+    }
+
+
+def _weighted_avg_confidence(report) -> float:
+    """Volume-weighted mean confidence across all classifications.
+
+    Falls back to ``0.0`` on zero-volume windows so the dashboard
+    card has a sane numeric value to render (rather than ``null``).
+    """
+    total = report.total_classified
+    if total <= 0:
+        return 0.0
+    weighted = 0.0
+    for cls, count in report.intent_class_distribution.items():
+        weighted += count * report.avg_confidence_by_class.get(cls, 0.0)
+    return round(weighted / total, 4)
+
+
+# ---------------------------------------------------------------------------
+# Window parsing — re-export from intent_report so the API endpoint
+# has one import target.
+# ---------------------------------------------------------------------------
+
+
+def parse_window_or_default(spec: Optional[str]) -> Optional[int]:
+    """Validate ``spec`` (an ``Nd`` form). Default to 14 days when
+    missing. Raises :class:`ValueError` on bad input so the API
+    caller surfaces a clean 400.
+
+    Distinct from :func:`tokenpak.proxy.intent_report.parse_window`
+    — that one returns ``None`` for empty/missing (= "all rows").
+    Dashboard semantics require the **default to be 14d** so a
+    fresh API call without ``?window=`` doesn't accidentally
+    surface a multi-year history.
+    """
+    from tokenpak.proxy.intent_report import parse_window
+
+    if spec is None or spec == "":
+        return 14
+    return parse_window(spec)
+
+
+__all__ = [
+    "DASHBOARD_SCHEMA_VERSION",
+    "collect_dashboard",
+    "parse_window_or_default",
+]

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -496,6 +496,39 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             except Exception as e:
                 self._send_json({"error": str(e)})
             return
+        if path.startswith("/api/intent/report"):
+            # Phase 1.1 — observation-only dashboard / read-model
+            # surface over the Phase 0 intent_events store. Reuses
+            # the Phase 1 query layer; never reads or emits raw
+            # prompt content. Default window is 14d (matches the
+            # proposal's observation default).
+            from urllib.parse import parse_qs
+            from urllib.parse import urlparse as _urlparse
+
+            from tokenpak.proxy.intent_dashboard import (
+                collect_dashboard,
+                parse_window_or_default,
+            )
+
+            parsed_path = _urlparse(path)
+            qs = parse_qs(parsed_path.query)
+            raw_window = (qs.get("window") or [""])[0]
+            try:
+                days = parse_window_or_default(raw_window)
+            except ValueError as exc:
+                self._send_json_error(400, "bad_request", str(exc))
+                return
+            try:
+                payload = collect_dashboard(window_days=days)
+            except Exception as exc:  # noqa: BLE001 — read-only path
+                self._send_json_error(
+                    500,
+                    "intent_dashboard_failed",
+                    f"intent dashboard failed: {exc!r}",
+                )
+                return
+            self._send_json(payload)
+            return
         if path == "/traces":
             traces = ps.trace_storage.get_all()
             self._send_json({"traces": [t.to_dict() for t in traces], "count": len(traces)})


### PR DESCRIPTION
## Summary

Observation-only dashboard surface for Phase 1's reporting layer. **Three layers, one query function** — the Phase 1 `build_report` is reused verbatim so privacy / window / never-raises invariants flow through unchanged.

| Layer | Where |
|---|---|
| Python read-model | `tokenpak.proxy.intent_dashboard.collect_dashboard` |
| HTTP API | `GET /api/intent/report?window=Nd` |
| Dashboard panel | `tokenpak/dashboard/{index.html, intent.js}` |

**Held items remain held.** No classifier behavior changes. No routing behavior changes. No intent-based routing decisions.

## Changes

- **`tokenpak/proxy/intent_dashboard.py`** — read-model. Pre-computes percentages so the UI doesn't need float math; underlying counts remain available. Volume-weighted avg confidence so the card reflects traffic mix, not unweighted class means. Schema version `intent-dashboard-v1`.
- **`tokenpak/proxy/server.py`** — `GET /api/intent/report?window=Nd`. Default 14d (distinct from the CLI's `0d = all rows` so a naive curl doesn't accidentally surface multi-year history). Returns 400 on malformed window, 500 on aggregation failure, 200 with the documented payload otherwise.
- **`tokenpak/dashboard/{index.html, intent.js, __init__.py}`** — new "Intent Layer" panel. Seven stat cards + three tables (intent distribution, top missing slots, top catch-all reasons) + operator review areas. Polls every 5 s alongside the existing metrics fetch; silently skips on transient failure.
- **`tests/test_intent_dashboard.py`** — 27 tests across seven classes (one per directive bullet).
- **`docs/reference/intent-dashboard.md`** — full API contract docs: payload schema, window semantics across all three surfaces, error responses, mapping back to the Phase 1 CLI report, why telemetry-only is normal, what NOT to infer.
- **`docs/reference/cli.md`** — regenerated.

## Test coverage

| Class | Tests | Concern |
|---|---|---|
| `TestReadModelEmptyDB` | 3 | well-shaped zero payload, review-areas populated, avg-confidence numeric (not null) |
| `TestReadModelPopulatedDB` | 5 | counts, distributions, wire-emission percentages, top-N, weighted confidence |
| `TestWindowFilter` | 5 | exclusion, default-14d, explicit windows, `0d = all rows`, bad input raises (for API 400) |
| `TestSchemaStability` | 7 | required keys for cards / panel / metadata; schema_version pinned; `observation_only` flag |
| `TestPrivacyContract` | 2 | sentinel substring + per-row hash absent from payload |
| `TestAdapterCapabilitySummary` | 3 | eligible/blocking shapes; Phase 0 default invariant; card↔panel mirror |
| `TestMissingTelemetryDb` | 2 | graceful zero on absent path; never raises |

Full suite: **1045 passing** (was 1018 baseline, +27), 0 regressions, 1 skip / 1 xfail unchanged.

## Acceptance

- [x] Dashboard / read-model surface exists across Python, HTTP, and UI.
- [x] Reuses Phase 1 reporting semantics (`build_report` under the hood).
- [x] Default window is 14d on the HTTP endpoint.
- [x] Output is aggregate-only; raw prompt content + per-row hash absent from payload (sentinel-substring asserted).
- [x] No classifier behavior changes (zero edits to `intent_classifier.py`).
- [x] No routing behavior changes (no edits to dispatch / forward paths beyond the new GET handler).
- [x] `ruff check` clean.
- [x] `cli-docs-in-sync --check` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no further scaffold renderer expansion, **no classifier behavior changes**, **no intent-based routing decisions**.