### PR TITLE
feat(proxy,cli): Phase 2.1 — dry-run intent policy engine

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -616,15 +616,17 @@ options:
 Intent Layer observation + reporting (read-only)
 
 ```
-usage: tokenpak intent [-h] {report} ...
+usage: tokenpak intent [-h] {report,policy-preview} ...
 
 positional arguments:
-  {report}
-    report    Summarize the intent_events telemetry over a window. Read-only;
-              never reads or emits raw prompt text.
+  {report,policy-preview}
+    report              Summarize the intent_events telemetry over a window.
+                        Read-only; never reads or emits raw prompt text.
+    policy-preview      Show the latest intent policy decision (Phase 2.1 dry-
+                        run; read-only).
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
 ```
 
 ## Advanced

--- a/docs/reference/intent-policy-preview.md
+++ b/docs/reference/intent-policy-preview.md
@@ -1,0 +1,149 @@
+# Intent Layer — Policy Preview (Phase 2.1)
+
+> Phase 2.1 ships a **dry-run** intent policy engine. It evaluates every classified request against a pure-function policy and writes the decision to a separate SQLite table (`intent_policy_decisions`). **Nothing about the request changes.** No routing, no model swap, no body mutation, no header injection. The decisions are observational only — what a future opt-in suggest mode (Phase 2.4 per the spec) might recommend.
+
+## Engine semantics
+
+The engine is a pure function:
+
+```python
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyInput, evaluate_policy, load_default_config,
+)
+
+cfg = load_default_config()    # observe_only / dry_run=true / no auto-routing
+inp = PolicyInput(...)         # built from IntentContract + request context
+decision = evaluate_policy(inp, cfg)
+```
+
+It reads:
+
+- The 10 canonical intent class + classifier confidence (Phase 0).
+- Slot present/missing tuples (Phase 0).
+- Catch-all reason (Phase 0).
+- Resolved provider + model (request resolution).
+- Adapter capabilities (Phase 0 §4.3 gate label, plus any cache/delivery labels).
+- The provider's `live_verified` status (Standard #23 §6.4).
+
+It returns a `PolicyDecision` with the 15 fields the directive enumerates: `decision_id`, `mode = "dry_run"`, `intent_class`, `confidence`, `action`, `recommended_provider`, `recommended_model`, `budget_action`, `compression_profile`, `cache_strategy`, `delivery_strategy`, `warning_message`, `requires_user_confirmation`, `decision_reason`, `safety_flags`.
+
+## The seven actions
+
+| Action | When emitted in 2.1 | Phase 2.x roadmap |
+|---|---|---|
+| `observe_only` | default; no heuristic matched | always available |
+| `warn_only` | any safety flag tripped | always available |
+| `suggest_route` | `allow_auto_routing=true` AND no safety flags | wired in 2.4+ |
+| `suggest_compression_profile` | intent has a heuristic in the table AND no safety flags | wired in 2.4+ |
+| `suggest_cache_policy` | adapter declares any `tip.cache.*` capability AND no safety flags | wired in 2.4+ |
+| `suggest_delivery_policy` | intent has a delivery heuristic AND no safety flags | wired in 2.4+ |
+| `flag_budget_risk` | reserved (not emitted in 2.1) | wired in 2.6 (limited enforce) |
+
+Multiple suggestions may apply to one request; Phase 2.1 picks the **single** highest-priority action per the spec §3 ordering and populates only that field. Phase 2.2's explain extension surfaces lower-priority suggestions in the JSON / dashboard view.
+
+## Safety rules (always on)
+
+Four safety rules cannot be disabled by config:
+
+1. **Low confidence** (`confidence < 0.65` by default) → `warn_only`, no routing-affecting action emitted.
+2. **Catch-all** (`catch_all_reason is not None`) → `warn_only`.
+3. **Missing required slots** (any `required_slots[i] in slots_missing`) → `warn_only`. Required-slot derivation from `slot_definitions.yaml` is plumbed in by Phase 2.2; Phase 2.1's engine accepts the set as a `PolicyInput.required_slots` tuple.
+4. **`live_verified=False` provider** with `allow_unverified_providers=false` (default) → `warn_only`.
+
+The `warning_message` field is built from a templated string + the safety-flag identifiers. **No caller-supplied substring ever appears in the message body.** The privacy contract is asserted end-to-end with the sentinel-substring pattern from Phase 1.
+
+## Default config
+
+Phase 2.1 ships without a config-file loader; the default is hard-wired:
+
+```python
+PolicyEngineConfig(
+    mode="observe_only",
+    dry_run=True,
+    allow_auto_routing=False,
+    allow_unverified_providers=False,
+    low_confidence_threshold=0.65,
+)
+```
+
+A future Phase 2.2 will read `~/.tokenpak/policy.yaml` per the spec §7 schema. Until then, every host runs the default — meaning every decision in 2.1 is either `observe_only` (when no heuristic matched) or a `suggest_*` (when a heuristic did, with no safety flag tripped) or `warn_only` (when a safety flag tripped). **No host can make a routing decision.**
+
+## CLI
+
+```bash
+# Render the most recent decision (operator-readable plain text)
+tokenpak intent policy-preview
+tokenpak intent policy-preview --last      # alias for default behavior
+
+# Same row, machine-readable JSON
+tokenpak intent policy-preview --json
+```
+
+Returns a friendly "no decisions yet" message when the table is empty (fresh install).
+
+## Telemetry
+
+Decisions land in `~/.tokenpak/telemetry.db` `intent_policy_decisions`. Linked to the Phase 0 `intent_events` row via `contract_id`. Every column is either an id (`decision_id`, `request_id`, `contract_id`), a structured field from the decision, or a config-snapshot column. **No raw prompt text. No per-row content.**
+
+Schema:
+
+```sql
+CREATE TABLE intent_policy_decisions (
+    decision_id              TEXT PRIMARY KEY,
+    request_id               TEXT,
+    contract_id              TEXT,
+    timestamp                TEXT NOT NULL,
+    mode                     TEXT NOT NULL,
+    intent_class             TEXT NOT NULL,
+    intent_confidence        REAL NOT NULL,
+    action                   TEXT NOT NULL,
+    decision_reason          TEXT NOT NULL,
+    safety_flags             TEXT NOT NULL,    -- JSON array of safety flag ids
+    recommended_provider     TEXT,
+    recommended_model        TEXT,
+    budget_action            TEXT,
+    compression_profile      TEXT,
+    cache_strategy           TEXT,
+    delivery_strategy        TEXT,
+    warning_message          TEXT,
+    requires_user_confirmation INTEGER NOT NULL,
+    config_mode              TEXT,
+    config_dry_run           INTEGER,
+    config_allow_auto_routing INTEGER,
+    config_allow_unverified_providers INTEGER,
+    config_low_confidence_threshold REAL
+);
+```
+
+## What NOT to infer yet
+
+Phase 2.1 is dry-run. The decisions surface what an operator's future config might do. They are **not** authoritative for:
+
+- **Routing decisions.** No request reroutes based on `recommended_provider`. That's Phase 2.4 with explicit opt-in.
+- **Compression behavior.** The `compression_profile` field is observational; the actual compression hook still runs from the existing `tip.compression.v1` capability gate.
+- **Cache policy.** Same — observational only.
+- **Budget enforcement.** `flag_budget_risk` is reserved; budget caps land in Phase 2.6.
+- **Required-slot derivation.** Phase 2.1's engine reads required slots from a `PolicyInput.required_slots` tuple supplied by the caller. Phase 2.2 will plumb this from `slot_definitions.yaml` automatically.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/proxy/intent_policy_engine.py` | pure engine (`evaluate_policy`, action / reason / flag enums) |
+| `tokenpak/proxy/intent_policy_telemetry.py` | SQLite store (`intent_policy_decisions` table) |
+| `tokenpak/proxy/intent_policy_preview.py` | CLI render functions |
+| `tokenpak/proxy/server.py` | call site in `_proxy_to_inner` (after Phase 0 contract write) |
+| `tokenpak/cli/_impl.py::cmd_intent_policy_preview` | `tokenpak intent policy-preview` entry point |
+| `~/.tokenpak/telemetry.db` `intent_policy_decisions` | source data |
+| `docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md` | the unified Phase 2 design spec |
+| `docs/reference/intent-policy-preview.md` | this document |
+
+## Standards / cross-references
+
+- Phase 2 spec: `docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md` (sub-phase 2.1).
+- Standard #23 §4.3 — capability gate (still load-bearing for any wire-side header emission a later sub-phase introduces).
+- Standard #23 §6.4 — `live_verified` semantics (driver of safety rule 4).
+- Architecture §7.1 — prompt-locality rule (driver of the privacy contract).
+- Phase 0 docs: `docs/reference/intent-layer-phase-0.md`.
+- Phase 1 docs: `docs/reference/intent-reporting.md`.
+- Phase 1.1 docs: `docs/reference/intent-dashboard.md`.

--- a/tests/test_intent_policy_engine_phase21.py
+++ b/tests/test_intent_policy_engine_phase21.py
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.1 — dry-run intent policy engine regression suite.
+
+Nine directive-mandated test categories, one class per category:
+
+  - high-confidence policy decision
+  - low-confidence safety behavior
+  - catch_all safety behavior
+  - missing slots safety behavior
+  - live_verified=False safety behavior
+  - default observe_only behavior
+  - no runtime route mutation
+  - no raw prompt / secrets in policy telemetry
+  - config default tests
+
+Plus three cross-cutting classes:
+  - decision shape pinned (the directive's 14 fields)
+  - CLI `policy-preview` end-to-end smoke
+  - telemetry round-trip
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_policy_engine import (
+    ACTION_OBSERVE_ONLY,
+    ACTION_SUGGEST_COMPRESSION_PROFILE,
+    ACTION_SUGGEST_ROUTE,
+    ACTION_WARN_ONLY,
+    ACTIONS_PHASE_2_1,
+    REASON_CATCH_ALL_BLOCKED_ROUTING,
+    REASON_DEFAULT_OBSERVE_ONLY,
+    REASON_DRY_RUN_SUGGEST,
+    REASON_LOW_CONFIDENCE_BLOCKED_ROUTING,
+    REASON_MISSING_SLOTS_BLOCKED_ROUTING,
+    REASON_UNVERIFIED_PROVIDER_BLOCKED,
+    SAFETY_CATCH_ALL,
+    SAFETY_LOW_CONFIDENCE,
+    SAFETY_MISSING_SLOTS,
+    SAFETY_UNVERIFIED_PROVIDER,
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+    load_default_config,
+    make_decision_id,
+)
+from tokenpak.proxy.intent_policy_telemetry import (
+    IntentPolicyDecisionRow,
+    IntentPolicyDecisionStore,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _safe_input(**over) -> PolicyInput:
+    """Build a high-confidence, fully-classified safe input.
+
+    Default values represent the happy path: confidence above the
+    threshold, no catch-all, no missing required slots,
+    live_verified=True. Tests override fields to drive each branch.
+    """
+    kw = dict(
+        intent_class="summarize",
+        confidence=0.9,
+        slots_present=("period",),
+        slots_missing=(),
+        catch_all_reason=None,
+        provider="tokenpak-test",
+        model="test-model",
+        estimated_cost_usd=None,
+        adapter_capabilities=frozenset(),
+        delivery_target_capabilities=frozenset(),
+        live_verified_status=True,
+        required_slots=(),
+    )
+    kw.update(over)
+    return PolicyInput(**kw)
+
+
+# ── 1. High-confidence policy decision ────────────────────────────────
+
+
+class TestHighConfidenceDecision:
+    """High confidence + safe inputs produces a non-warn action.
+
+    With the default config (allow_auto_routing=false), a
+    suggest_compression_profile or other suggest_* fires for
+    intents with heuristics; observe_only for those without.
+    """
+
+    def test_summarize_emits_compression_suggestion(self):
+        d = evaluate_policy(_safe_input(intent_class="summarize"))
+        assert d.action == ACTION_SUGGEST_COMPRESSION_PROFILE
+        assert d.compression_profile == "aggressive"
+        assert d.safety_flags == ()
+        assert d.decision_reason == REASON_DRY_RUN_SUGGEST
+
+    def test_status_no_heuristic_falls_back_to_observe_only(self):
+        # 'status' has no compression / delivery heuristic in the
+        # Phase 2.1 table. With no cache-capable adapter, the engine
+        # falls through to observe_only.
+        d = evaluate_policy(_safe_input(intent_class="status"))
+        assert d.action == ACTION_OBSERVE_ONLY
+        assert d.safety_flags == ()
+
+    def test_suggest_route_when_auto_routing_allowed(self):
+        cfg = PolicyEngineConfig(allow_auto_routing=True)
+        d = evaluate_policy(_safe_input(), cfg)
+        assert d.action == ACTION_SUGGEST_ROUTE
+        # In dry-run, recommended_provider mirrors the request's
+        # current provider (Phase 2.4 will introduce real routing
+        # heuristics).
+        assert d.recommended_provider == "tokenpak-test"
+        assert d.recommended_model == "test-model"
+
+    def test_decision_id_unique_per_call(self):
+        d1 = evaluate_policy(_safe_input())
+        d2 = evaluate_policy(_safe_input())
+        assert d1.decision_id != d2.decision_id
+
+
+# ── 2. Low-confidence safety behavior ─────────────────────────────────
+
+
+class TestLowConfidenceSafety:
+    """confidence < threshold MUST suppress routing-affecting
+    actions and emit warn_only with safety_flags=('low_confidence',).
+    """
+
+    def test_low_confidence_suppresses_routing(self):
+        # Even with allow_auto_routing=True, low confidence should
+        # prevent suggest_route.
+        cfg = PolicyEngineConfig(allow_auto_routing=True)
+        d = evaluate_policy(_safe_input(confidence=0.4), cfg)
+        assert d.action == ACTION_WARN_ONLY
+        assert SAFETY_LOW_CONFIDENCE in d.safety_flags
+        assert d.recommended_provider is None
+        assert d.recommended_model is None
+
+    def test_low_confidence_decision_reason(self):
+        d = evaluate_policy(_safe_input(confidence=0.3))
+        assert d.decision_reason == REASON_LOW_CONFIDENCE_BLOCKED_ROUTING
+
+    def test_low_confidence_warning_message_set(self):
+        d = evaluate_policy(_safe_input(confidence=0.3))
+        assert d.warning_message
+        assert "low_confidence" in d.warning_message
+        # Templated string — never includes prompt content.
+
+    def test_at_threshold_passes(self):
+        # At exactly the threshold (>=), engine treats as safe.
+        d = evaluate_policy(_safe_input(confidence=0.65))
+        assert SAFETY_LOW_CONFIDENCE not in d.safety_flags
+
+    def test_just_below_threshold_blocks(self):
+        d = evaluate_policy(_safe_input(confidence=0.6499))
+        assert SAFETY_LOW_CONFIDENCE in d.safety_flags
+
+
+# ── 3. Catch-all safety behavior ──────────────────────────────────────
+
+
+class TestCatchAllSafety:
+    """catch_all_reason is not None MUST suppress routing-affecting
+    actions.
+    """
+
+    def test_catch_all_blocks_routing(self):
+        cfg = PolicyEngineConfig(allow_auto_routing=True)
+        d = evaluate_policy(_safe_input(catch_all_reason="empty_prompt",
+                                         confidence=1.0), cfg)
+        assert d.action == ACTION_WARN_ONLY
+        assert SAFETY_CATCH_ALL in d.safety_flags
+
+    def test_catch_all_decision_reason(self):
+        # The reason taxonomy prioritises low_confidence first when
+        # both flags trip. Test catch_all in isolation by keeping
+        # confidence high.
+        d = evaluate_policy(_safe_input(catch_all_reason="keyword_miss",
+                                         confidence=1.0))
+        assert d.decision_reason == REASON_CATCH_ALL_BLOCKED_ROUTING
+
+
+# ── 4. Missing slots safety behavior ──────────────────────────────────
+
+
+class TestMissingSlotsSafety:
+    """Missing required slots MUST block routing-affecting actions.
+
+    The engine's ``required_slots`` field on PolicyInput is the
+    contract — Phase 2.1 doesn't auto-derive from
+    slot_definitions.yaml; that wiring is sub-phase 2.2 work.
+    """
+
+    def test_missing_required_slot_blocks_routing(self):
+        cfg = PolicyEngineConfig(allow_auto_routing=True)
+        d = evaluate_policy(
+            _safe_input(
+                slots_missing=("target",),
+                required_slots=("target",),
+            ),
+            cfg,
+        )
+        assert d.action == ACTION_WARN_ONLY
+        assert SAFETY_MISSING_SLOTS in d.safety_flags
+
+    def test_missing_optional_slot_does_not_block(self):
+        # 'target' is NOT in required_slots, so its absence from
+        # slots_present + presence in slots_missing must NOT trip.
+        d = evaluate_policy(_safe_input(slots_missing=("target",)))
+        assert SAFETY_MISSING_SLOTS not in d.safety_flags
+
+    def test_missing_slots_decision_reason(self):
+        d = evaluate_policy(
+            _safe_input(
+                slots_missing=("target",),
+                required_slots=("target",),
+                confidence=1.0,
+            )
+        )
+        assert d.decision_reason == REASON_MISSING_SLOTS_BLOCKED_ROUTING
+
+
+# ── 5. live_verified=False safety behavior ────────────────────────────
+
+
+class TestLiveVerifiedFalseSafety:
+    """A provider with live_verified=False MUST NOT be recommended
+    unless ``allow_unverified_providers=true`` in config.
+    """
+
+    def test_unverified_provider_blocked_by_default(self):
+        cfg = PolicyEngineConfig(allow_auto_routing=True)
+        d = evaluate_policy(
+            _safe_input(live_verified_status=False),
+            cfg,
+        )
+        assert d.action == ACTION_WARN_ONLY
+        assert SAFETY_UNVERIFIED_PROVIDER in d.safety_flags
+        assert d.recommended_provider is None
+
+    def test_unverified_allowed_when_config_flips(self):
+        cfg = PolicyEngineConfig(
+            allow_auto_routing=True,
+            allow_unverified_providers=True,
+        )
+        d = evaluate_policy(
+            _safe_input(live_verified_status=False),
+            cfg,
+        )
+        assert SAFETY_UNVERIFIED_PROVIDER not in d.safety_flags
+        assert d.action == ACTION_SUGGEST_ROUTE
+
+    def test_unverified_decision_reason(self):
+        d = evaluate_policy(_safe_input(
+            live_verified_status=False, confidence=1.0,
+        ))
+        # In isolation (only unverified-provider trips), the reason
+        # is the unverified one. With other safety flags, taxonomy
+        # priority would re-rank.
+        assert d.decision_reason == REASON_UNVERIFIED_PROVIDER_BLOCKED
+
+
+# ── 6. Default observe_only behavior ──────────────────────────────────
+
+
+class TestDefaultObserveOnly:
+    """With default config and an intent that lacks any heuristic
+    + no cache-capable adapter, the engine emits observe_only.
+    Zero behavior change vs. Phase 1.1.
+    """
+
+    def test_default_for_status_intent(self):
+        # 'status' has no compression / delivery heuristic.
+        d = evaluate_policy(_safe_input(intent_class="status"))
+        assert d.action == ACTION_OBSERVE_ONLY
+        assert d.decision_reason == REASON_DEFAULT_OBSERVE_ONLY
+        assert d.warning_message is None
+        assert d.recommended_provider is None
+        assert d.compression_profile is None
+
+    def test_default_config_does_not_emit_suggest_route(self):
+        # Default allow_auto_routing=False → never emits suggest_route
+        # even for safe inputs.
+        d = evaluate_policy(_safe_input())  # default cfg
+        assert d.action != ACTION_SUGGEST_ROUTE
+
+
+# ── 7. No runtime route mutation ──────────────────────────────────────
+
+
+class TestNoRouteMutation:
+    """The engine MUST be a pure function. Verify by passing a
+    mutable bag of kwargs and asserting it's untouched after.
+    """
+
+    def test_input_unchanged_after_evaluate(self):
+        inp = _safe_input(intent_class="summarize")
+        # Capture pre-call state.
+        snapshot = (
+            inp.intent_class, inp.confidence,
+            inp.slots_present, inp.slots_missing,
+            inp.catch_all_reason, inp.provider, inp.model,
+            inp.adapter_capabilities, inp.live_verified_status,
+            inp.required_slots,
+        )
+        evaluate_policy(inp)
+        assert (
+            inp.intent_class, inp.confidence,
+            inp.slots_present, inp.slots_missing,
+            inp.catch_all_reason, inp.provider, inp.model,
+            inp.adapter_capabilities, inp.live_verified_status,
+            inp.required_slots,
+        ) == snapshot
+
+    def test_decision_is_immutable(self):
+        # PolicyDecision is a frozen dataclass — assignment should
+        # raise. This pins the mutation guarantee at the type level.
+        d = evaluate_policy(_safe_input())
+        with pytest.raises(Exception):
+            d.action = "spoofed"  # type: ignore[misc]
+
+
+# ── 8. No raw prompts / secrets in policy telemetry ───────────────────
+
+
+class TestPrivacyContract:
+    """The schema and writer MUST NOT carry raw prompt content. The
+    sentinel-substring pattern from Phase 1 carries forward.
+    """
+
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-2-1"
+
+    def test_engine_output_carries_no_caller_supplied_string(self):
+        # The engine takes no string the caller could supply that
+        # ends up in PolicyDecision. Smoke this by injecting the
+        # sentinel into every input string field and asserting it
+        # appears nowhere in the serialized decision.
+        inp = _safe_input(
+            intent_class="summarize",
+            provider=self.SENTINEL + "-provider",
+            model=self.SENTINEL + "-model",
+        )
+        d = evaluate_policy(inp)
+        # Provider / model do flow through to suggest_route. With
+        # allow_auto_routing=False (default), that path doesn't
+        # fire — assert the sentinel is absent.
+        payload = json.dumps(d.to_dict())
+        assert self.SENTINEL not in payload, (
+            "default-config decision leaked caller-supplied provider/model"
+        )
+
+    def test_telemetry_row_has_no_prompt_content(self, tmp_path: Path):
+        store = IntentPolicyDecisionStore(db_path=tmp_path / "t.db")
+        # Build a decision with a templated warning message.
+        d = evaluate_policy(_safe_input(confidence=0.3))
+        row = IntentPolicyDecisionRow(
+            request_id="req-priv-1",
+            contract_id="cid-priv-1",
+            timestamp="2026-04-25T22:00:00",
+            decision=d,
+        )
+        store.write(row)
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        conn.row_factory = sqlite3.Row
+        rec = conn.execute(
+            "SELECT * FROM intent_policy_decisions WHERE request_id = 'req-priv-1'"
+        ).fetchone()
+        conn.close()
+        # No column should ever contain a sentinel — the engine
+        # never received one. This guards against a future change
+        # that pulls prompt-derived strings into a column.
+        for col in rec.keys():
+            v = rec[col]
+            if v is not None:
+                assert self.SENTINEL not in str(v), (
+                    f"sentinel substring leaked into column {col!r}"
+                )
+
+    def test_warning_message_is_templated(self):
+        # The warning_message MUST not include any caller-supplied
+        # substring; only the safety-flag identifiers built by the
+        # engine.
+        inp = _safe_input(
+            intent_class="summarize",
+            confidence=0.3,
+            provider=self.SENTINEL + "-prov",
+            model=self.SENTINEL + "-model",
+        )
+        d = evaluate_policy(inp)
+        assert d.warning_message
+        assert self.SENTINEL not in d.warning_message
+
+
+# ── 9. Config default tests ───────────────────────────────────────────
+
+
+class TestConfigDefaults:
+    """The directive pins the default config exactly. Test each
+    field so a future change requires explicit ratification.
+    """
+
+    def test_default_config_values(self):
+        cfg = load_default_config()
+        assert cfg.mode == "observe_only"
+        assert cfg.dry_run is True
+        assert cfg.allow_auto_routing is False
+        assert cfg.allow_unverified_providers is False
+        assert cfg.low_confidence_threshold == 0.65
+
+    def test_config_is_frozen(self):
+        cfg = load_default_config()
+        with pytest.raises(Exception):
+            cfg.mode = "enforce"  # type: ignore[misc]
+
+    def test_action_enum_has_seven_values(self):
+        # Phase 2.1 directive enumerates exactly seven actions.
+        assert len(ACTIONS_PHASE_2_1) == 7
+
+
+# ── 10. Decision shape (cross-cutting) ────────────────────────────────
+
+
+class TestDecisionShape:
+    """The directive enumerates 15 PolicyDecision fields. Pin them
+    so a future shape change requires explicit ratification.
+    """
+
+    REQUIRED_FIELDS = {
+        "decision_id",
+        "mode",
+        "intent_class",
+        "confidence",
+        "action",
+        "recommended_provider",
+        "recommended_model",
+        "budget_action",
+        "compression_profile",
+        "cache_strategy",
+        "delivery_strategy",
+        "warning_message",
+        "requires_user_confirmation",
+        "decision_reason",
+        "safety_flags",
+    }
+
+    def test_to_dict_contains_required_fields(self):
+        d = evaluate_policy(_safe_input())
+        payload = d.to_dict()
+        missing = self.REQUIRED_FIELDS - set(payload)
+        assert not missing, f"missing required fields in to_dict: {missing}"
+
+    def test_mode_is_dry_run_in_phase_2_1(self):
+        d = evaluate_policy(_safe_input())
+        assert d.mode == "dry_run"
+
+    def test_decision_id_shape(self):
+        d = evaluate_policy(_safe_input())
+        assert isinstance(d.decision_id, str)
+        # ms-prefixed hex + random hex tail (29 chars total).
+        assert len(d.decision_id) == 13 + 16
+
+    def test_make_decision_id_unique(self):
+        a = make_decision_id()
+        b = make_decision_id()
+        assert a != b
+
+
+# ── 11. Telemetry round-trip (cross-cutting) ──────────────────────────
+
+
+class TestTelemetryRoundTrip:
+
+    def test_table_created_on_first_write(self, tmp_path: Path):
+        store = IntentPolicyDecisionStore(db_path=tmp_path / "t.db")
+        d = evaluate_policy(_safe_input())
+        store.write(IntentPolicyDecisionRow(
+            request_id="rt1", contract_id="c1",
+            timestamp="2026-04-25T22:00:00", decision=d,
+            config_mode="observe_only", config_dry_run=True,
+            config_allow_auto_routing=False,
+            config_allow_unverified_providers=False,
+            config_low_confidence_threshold=0.65,
+        ))
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='intent_policy_decisions'"
+        )
+        assert cur.fetchone() is not None
+
+    def test_fetch_latest_returns_inserted_row(self, tmp_path: Path):
+        store = IntentPolicyDecisionStore(db_path=tmp_path / "t.db")
+        d = evaluate_policy(_safe_input(intent_class="summarize"))
+        store.write(IntentPolicyDecisionRow(
+            request_id="rt2", contract_id="c2",
+            timestamp="2026-04-25T22:01:00", decision=d,
+        ))
+        latest = store.fetch_latest()
+        assert latest is not None
+        assert latest["intent_class"] == "summarize"
+        assert latest["action"] in ACTIONS_PHASE_2_1
+        assert isinstance(latest["safety_flags"], list)
+
+    def test_fetch_latest_returns_none_on_empty(self, tmp_path: Path):
+        store = IntentPolicyDecisionStore(db_path=tmp_path / "absent.db")
+        assert store.fetch_latest() is None
+
+    def test_writer_does_not_raise_on_unwritable_path(self):
+        bad = Path("/proc/this-cannot-be-a-real-file.db")
+        store = IntentPolicyDecisionStore(db_path=bad)
+        d = evaluate_policy(_safe_input())
+        # Best-effort contract — never propagates to caller.
+        store.write(IntentPolicyDecisionRow(
+            request_id="bad", contract_id="c", timestamp="t",
+            decision=d,
+        ))
+
+
+# ── 12. CLI policy-preview end-to-end ─────────────────────────────────
+
+
+class TestCliPreview:
+
+    def test_help_includes_policy_preview(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "policy-preview", "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--last" in result.stdout
+        assert "--json" in result.stdout
+
+    def test_preview_runs_without_error_on_empty(self, tmp_path: Path, monkeypatch):
+        # Point the store at a fresh empty path; the command must
+        # exit 0 with the friendly "no rows yet" message.
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "policy-preview"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, (
+            f"policy-preview failed: {result.stdout}\n{result.stderr}"
+        )
+
+    def test_preview_json_mode_returns_json(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "policy-preview", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        # Output is JSON-parseable.
+        json.loads(result.stdout)

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -553,6 +553,27 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def cmd_intent_policy_preview(args) -> None:
+    """Phase 2.1 — show the latest dry-run policy decision.
+
+    Read-only over the ``intent_policy_decisions`` table. The
+    ``--last`` flag is the default behavior; passing ``--json``
+    returns the row as machine-readable JSON.
+    """
+    from tokenpak.proxy.intent_policy_preview import (
+        collect_latest,
+        render_human,
+        render_json,
+    )
+
+    payload = collect_latest()
+    if getattr(args, "preview_json", False):
+        print(render_json(payload))
+    else:
+        print(render_human(payload))
+    sys.exit(0)
+
+
 def cmd_intent_report(args) -> None:
     """Phase 1 — summarize intent_events telemetry over a window.
 
@@ -2215,6 +2236,29 @@ def build_parser():
         help="Emit machine-readable JSON instead of the human-readable report",
     )
     p_intent_report.set_defaults(func=cmd_intent_report)
+
+    # Phase 2.1 — dry-run policy preview. Read-only over the
+    # intent_policy_decisions table; renders the latest row.
+    p_intent_policy_preview = p_intent_sub.add_parser(
+        "policy-preview",
+        help=(
+            "Show the latest intent policy decision (Phase 2.1 dry-run; "
+            "read-only)."
+        ),
+    )
+    p_intent_policy_preview.add_argument(
+        "--last",
+        dest="preview_last",
+        action="store_true",
+        help="Show the most recent policy decision (default behavior).",
+    )
+    p_intent_policy_preview.add_argument(
+        "--json",
+        dest="preview_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human-readable view.",
+    )
+    p_intent_policy_preview.set_defaults(func=cmd_intent_policy_preview)
 
     p_adapter = sub.add_parser(
         "adapter",

--- a/tokenpak/proxy/intent_policy_engine.py
+++ b/tokenpak/proxy/intent_policy_engine.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.1 — dry-run intent policy engine.
+
+Pure function: ``evaluate_policy(input, config) -> PolicyDecision``.
+Reads structured inputs (the IntentContract from Phase 0 plus
+request context — provider, model, adapter capabilities,
+live_verified status), returns one decision. No I/O during
+evaluation, no globals, no mutation. Telemetry write is a separate
+concern (:mod:`tokenpak.proxy.intent_policy_telemetry`).
+
+Phase 2.1 ships in **dry-run mode**. The engine emits decisions
+that *describe* what a future opt-in suggest mode (Phase 2.4)
+might recommend, but never mutates the request or causes a
+re-route. The default config (:data:`_DEFAULT_CONFIG`) is
+``observe_only`` + ``dry_run=true``, so an operator who has not
+configured anything sees zero behavior change vs. Phase 1.1.
+
+The seven actions in the Phase 2.1 enum:
+
+  - ``observe_only`` — default, no fields populated beyond identity.
+  - ``warn_only`` — emitted whenever any safety flag trips.
+  - ``suggest_route`` — populated when ``allow_auto_routing=true``
+    AND the request is safe (no flag tripped). Carries
+    ``recommended_provider`` / ``recommended_model``.
+  - ``suggest_compression_profile`` — populated when the intent
+    has a heuristic recommendation AND the request is safe.
+  - ``suggest_cache_policy`` — populated when the resolved
+    adapter declares a cache capability AND the request is safe.
+  - ``suggest_delivery_policy`` — populated when the intent has
+    a delivery heuristic AND the request is safe.
+  - ``flag_budget_risk`` — reserved; not emitted in 2.1 (real
+    budget caps land in 2.6).
+
+Multiple suggestions could apply to one request; Phase 2.1 picks
+the *single* highest-priority action and populates only its
+matching field. Spec §3 envisions an ``actions: list[str]`` shape
+in 2.4+; the directive's "action" (singular) is honored here.
+Lower-priority suggestions are deferred to Phase 2.2's explain
+extension.
+
+Safety rules (always on; cannot be disabled by config):
+
+  1. Low confidence — ``confidence < threshold`` blocks routing-
+     affecting actions; engine emits ``warn_only``.
+  2. Catch-all — ``catch_all_reason is not None`` blocks routing-
+     affecting actions.
+  3. Missing required slots — any required slot in
+     ``slots_missing`` blocks routing-affecting actions.
+  4. ``live_verified=False`` provider — blocked unless
+     ``allow_unverified_providers=true`` in config.
+
+Privacy: the engine reads structured fields only. Raw prompt text
+is never an input. ``warning_message`` is built from a templated
+string + the safety flag id; no caller-supplied substring ever
+touches the message body.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Action / decision-reason enums
+# ---------------------------------------------------------------------------
+
+
+# Phase 2.1 action enum (seven). Reserved set may grow in later
+# sub-phases per the Phase 2 spec §3.
+ACTION_OBSERVE_ONLY: str = "observe_only"
+ACTION_WARN_ONLY: str = "warn_only"
+ACTION_SUGGEST_ROUTE: str = "suggest_route"
+ACTION_SUGGEST_COMPRESSION_PROFILE: str = "suggest_compression_profile"
+ACTION_SUGGEST_CACHE_POLICY: str = "suggest_cache_policy"
+ACTION_SUGGEST_DELIVERY_POLICY: str = "suggest_delivery_policy"
+ACTION_FLAG_BUDGET_RISK: str = "flag_budget_risk"
+
+ACTIONS_PHASE_2_1: FrozenSet[str] = frozenset({
+    ACTION_OBSERVE_ONLY,
+    ACTION_WARN_ONLY,
+    ACTION_SUGGEST_ROUTE,
+    ACTION_SUGGEST_COMPRESSION_PROFILE,
+    ACTION_SUGGEST_CACHE_POLICY,
+    ACTION_SUGGEST_DELIVERY_POLICY,
+    ACTION_FLAG_BUDGET_RISK,
+})
+
+# Decision reason enum — stable identifiers, not free text. Phase 2
+# spec §5 enumerates this set.
+REASON_DEFAULT_OBSERVE_ONLY: str = "default_observe_only"
+REASON_LOW_CONFIDENCE_BLOCKED_ROUTING: str = "low_confidence_blocked_routing"
+REASON_CATCH_ALL_BLOCKED_ROUTING: str = "catch_all_blocked_routing"
+REASON_MISSING_SLOTS_BLOCKED_ROUTING: str = "missing_slots_blocked_routing"
+REASON_UNVERIFIED_PROVIDER_BLOCKED: str = "unverified_provider_blocked"
+REASON_ROUTING_DISABLED_BY_CONFIG: str = "routing_disabled_by_config"
+REASON_DRY_RUN_SUGGEST: str = "dry_run_suggest"
+
+# Safety flag identifiers — appear in PolicyDecision.safety_flags
+# tuple. Each maps to a §6 spec rule and a test in Phase 2.1.
+SAFETY_LOW_CONFIDENCE: str = "low_confidence"
+SAFETY_CATCH_ALL: str = "catch_all"
+SAFETY_MISSING_SLOTS: str = "missing_slots"
+SAFETY_UNVERIFIED_PROVIDER: str = "unverified_provider"
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass + defaults
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicyEngineConfig:
+    """Engine-side projection of the ``intent_policy`` config block.
+
+    Phase 2.1 covers exactly the five fields the directive
+    enumerates. The Phase 2 spec §7 defines additional fields
+    (``budget_caps``, ``class_rules``, ``class_groups``) that
+    later sub-phases will plumb in.
+    """
+
+    mode: str = "observe_only"  # observe_only | suggest | confirm | enforce
+    dry_run: bool = True
+    allow_auto_routing: bool = False
+    allow_unverified_providers: bool = False
+    low_confidence_threshold: float = 0.65
+
+
+_DEFAULT_CONFIG: PolicyEngineConfig = PolicyEngineConfig()
+
+
+def load_default_config() -> PolicyEngineConfig:
+    """Return the Phase 2.1 default config.
+
+    Phase 2.1 ships without a config-file loader; the directive
+    explicitly limits scope to the dry-run engine. The Phase 2.2
+    sub-phase will add ``~/.tokenpak/policy.yaml`` parsing per the
+    spec §7 schema. Until then, the default config is the only
+    config a host can have.
+    """
+    return _DEFAULT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Inputs / outputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicyInput:
+    """Bundle of facts the engine reads.
+
+    Mirrors Phase 2 spec §4 verbatim. No raw prompt text; no
+    undocumented globals. Future inputs require both a spec update
+    and a corresponding test under §9.
+    """
+
+    intent_class: str
+    confidence: float
+    slots_present: Tuple[str, ...]
+    slots_missing: Tuple[str, ...]
+    catch_all_reason: Optional[str]
+    provider: str
+    model: str
+    estimated_cost_usd: Optional[float] = None
+    adapter_capabilities: FrozenSet[str] = frozenset()
+    delivery_target_capabilities: FrozenSet[str] = frozenset()
+    live_verified_status: Optional[bool] = None
+    required_slots: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Engine output. Field set matches the directive exactly.
+
+    All fields except ``decision_id`` / ``mode`` /
+    ``intent_class`` / ``confidence`` / ``action`` /
+    ``decision_reason`` / ``safety_flags`` are nullable; the JSON
+    serializer emits explicit ``null`` for unset fields so
+    consumers can rely on field presence.
+    """
+
+    decision_id: str
+    mode: str  # always "dry_run" in Phase 2.1
+    intent_class: str
+    confidence: float
+    action: str
+    recommended_provider: Optional[str] = None
+    recommended_model: Optional[str] = None
+    budget_action: Optional[str] = None
+    compression_profile: Optional[str] = None
+    cache_strategy: Optional[str] = None
+    delivery_strategy: Optional[str] = None
+    warning_message: Optional[str] = None
+    requires_user_confirmation: bool = False
+    decision_reason: str = REASON_DEFAULT_OBSERVE_ONLY
+    safety_flags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "mode": self.mode,
+            "intent_class": self.intent_class,
+            "confidence": self.confidence,
+            "action": self.action,
+            "recommended_provider": self.recommended_provider,
+            "recommended_model": self.recommended_model,
+            "budget_action": self.budget_action,
+            "compression_profile": self.compression_profile,
+            "cache_strategy": self.cache_strategy,
+            "delivery_strategy": self.delivery_strategy,
+            "warning_message": self.warning_message,
+            "requires_user_confirmation": self.requires_user_confirmation,
+            "decision_reason": self.decision_reason,
+            "safety_flags": list(self.safety_flags),
+        }
+
+
+def make_decision_id() -> str:
+    """ULID-shaped opaque id for the policy decision (29 hex chars).
+
+    Mirrors :func:`tokenpak.proxy.intent_contract.make_contract_id`
+    so consumers can sort policy + contract ids by the same prefix.
+    """
+    ts_ms = int(time.time() * 1000)
+    rand = secrets.token_hex(8)
+    return f"{ts_ms:013x}{rand}"
+
+
+# ---------------------------------------------------------------------------
+# Heuristic tables
+# ---------------------------------------------------------------------------
+
+
+# Phase 2.1 minimal per-intent heuristics. These describe what a
+# 2.4+ suggest mode might recommend; in 2.1 they only populate the
+# corresponding fields when the engine emits a suggest_* action.
+# The table is intentionally small and conservative — bigger
+# heuristics (recipes, cost-aware routing) live in 2.3+ designs.
+_COMPRESSION_HEURISTIC: Dict[str, str] = {
+    "summarize": "aggressive",
+    "plan": "conservative",
+    "explain": "conservative",
+    "create": "conservative",
+    "debug": "conservative",
+    # status / usage / search / execute / query — no profile suggested
+    # by default. The Phase 0 baseline-report deliverable will tell
+    # us whether the table needs broadening.
+}
+
+_DELIVERY_HEURISTIC: Dict[str, str] = {
+    "debug": "streaming",
+    "summarize": "non_streaming",
+    "explain": "streaming",
+    "plan": "non_streaming",
+    "create": "streaming",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure engine
+# ---------------------------------------------------------------------------
+
+
+def evaluate_policy(
+    inp: PolicyInput, config: Optional[PolicyEngineConfig] = None
+) -> PolicyDecision:
+    """Pure function. Phase 2.1's only entry point.
+
+    Reads ``inp`` + ``config``, returns one :class:`PolicyDecision`.
+    Never mutates either input. Never performs I/O. Safe to call
+    from any thread.
+    """
+    cfg = config if config is not None else _DEFAULT_CONFIG
+
+    decision_id = make_decision_id()
+    safety: list[str] = []
+
+    # ── Safety evaluation (always-on; spec §6 rules 1-4) ──────────
+    if inp.confidence < cfg.low_confidence_threshold:
+        safety.append(SAFETY_LOW_CONFIDENCE)
+    if inp.catch_all_reason is not None:
+        safety.append(SAFETY_CATCH_ALL)
+    if _has_missing_required_slots(inp):
+        safety.append(SAFETY_MISSING_SLOTS)
+    if (
+        inp.live_verified_status is False
+        and not cfg.allow_unverified_providers
+    ):
+        safety.append(SAFETY_UNVERIFIED_PROVIDER)
+
+    # Any safety flag → warn_only with the flags recorded.
+    if safety:
+        return PolicyDecision(
+            decision_id=decision_id,
+            mode="dry_run",
+            intent_class=inp.intent_class,
+            confidence=inp.confidence,
+            action=ACTION_WARN_ONLY,
+            warning_message=_warning_message(safety),
+            decision_reason=_safety_reason(safety),
+            safety_flags=tuple(safety),
+        )
+
+    # ── No safety flags. Pick a suggestion priority order. ────────
+    # The Phase 2.1 directive uses singular ``action``; multi-action
+    # decisions are the spec's 2.4+ shape. Priority order:
+    #   suggest_route  >  suggest_compression_profile
+    #                  >  suggest_cache_policy
+    #                  >  suggest_delivery_policy
+    #                  >  observe_only
+    if cfg.allow_auto_routing:
+        # In dry-run, "suggest_route" is purely observational —
+        # recommended_provider / model carry the engine's hint, but
+        # the dispatcher is unaware of this field in 2.1.
+        return PolicyDecision(
+            decision_id=decision_id,
+            mode="dry_run",
+            intent_class=inp.intent_class,
+            confidence=inp.confidence,
+            action=ACTION_SUGGEST_ROUTE,
+            recommended_provider=inp.provider,
+            recommended_model=inp.model,
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+
+    compression = _COMPRESSION_HEURISTIC.get(inp.intent_class)
+    if compression is not None:
+        return PolicyDecision(
+            decision_id=decision_id,
+            mode="dry_run",
+            intent_class=inp.intent_class,
+            confidence=inp.confidence,
+            action=ACTION_SUGGEST_COMPRESSION_PROFILE,
+            compression_profile=compression,
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+
+    if _has_cache_capability(inp):
+        return PolicyDecision(
+            decision_id=decision_id,
+            mode="dry_run",
+            intent_class=inp.intent_class,
+            confidence=inp.confidence,
+            action=ACTION_SUGGEST_CACHE_POLICY,
+            cache_strategy=_cache_strategy_for(inp),
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+
+    delivery = _DELIVERY_HEURISTIC.get(inp.intent_class)
+    if delivery is not None:
+        return PolicyDecision(
+            decision_id=decision_id,
+            mode="dry_run",
+            intent_class=inp.intent_class,
+            confidence=inp.confidence,
+            action=ACTION_SUGGEST_DELIVERY_POLICY,
+            delivery_strategy=delivery,
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+
+    # Default: observe_only. No suggestion fired.
+    return PolicyDecision(
+        decision_id=decision_id,
+        mode="dry_run",
+        intent_class=inp.intent_class,
+        confidence=inp.confidence,
+        action=ACTION_OBSERVE_ONLY,
+        decision_reason=REASON_DEFAULT_OBSERVE_ONLY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def _has_missing_required_slots(inp: PolicyInput) -> bool:
+    if not inp.required_slots:
+        return False
+    missing = set(inp.slots_missing)
+    return any(slot in missing for slot in inp.required_slots)
+
+
+def _has_cache_capability(inp: PolicyInput) -> bool:
+    return any(c.startswith("tip.cache.") for c in inp.adapter_capabilities)
+
+
+def _cache_strategy_for(inp: PolicyInput) -> str:
+    if "tip.cache.proxy-managed" in inp.adapter_capabilities:
+        return "proxy_managed"
+    if "tip.cache.provider-observer" in inp.adapter_capabilities:
+        return "client_observed"
+    return "bypass"
+
+
+def _warning_message(flags: list[str]) -> str:
+    """Build a templated warning string. NEVER includes prompt text.
+
+    The ``flags`` argument is the engine-built safety-flag tuple;
+    no caller-supplied substrings reach this string. Tests under
+    Phase 2.1 §9 enforce this with the sentinel-substring pattern.
+    """
+    if not flags:
+        return ""
+    body = ", ".join(sorted(flags))
+    return (
+        f"Intent policy: routing-affecting actions suppressed by safety "
+        f"rules ({body}). Decision is informational only (dry-run)."
+    )
+
+
+def _safety_reason(flags: list[str]) -> str:
+    """Map a safety-flag list to a single ``decision_reason``.
+
+    Priority when multiple flags trip: low_confidence >
+    catch_all > missing_slots > unverified_provider. This matches
+    the Phase 2 spec §5 reason taxonomy ordering.
+    """
+    if SAFETY_LOW_CONFIDENCE in flags:
+        return REASON_LOW_CONFIDENCE_BLOCKED_ROUTING
+    if SAFETY_CATCH_ALL in flags:
+        return REASON_CATCH_ALL_BLOCKED_ROUTING
+    if SAFETY_MISSING_SLOTS in flags:
+        return REASON_MISSING_SLOTS_BLOCKED_ROUTING
+    if SAFETY_UNVERIFIED_PROVIDER in flags:
+        return REASON_UNVERIFIED_PROVIDER_BLOCKED
+    return REASON_ROUTING_DISABLED_BY_CONFIG
+
+
+__all__ = [
+    "ACTIONS_PHASE_2_1",
+    "ACTION_FLAG_BUDGET_RISK",
+    "ACTION_OBSERVE_ONLY",
+    "ACTION_SUGGEST_CACHE_POLICY",
+    "ACTION_SUGGEST_COMPRESSION_PROFILE",
+    "ACTION_SUGGEST_DELIVERY_POLICY",
+    "ACTION_SUGGEST_ROUTE",
+    "ACTION_WARN_ONLY",
+    "PolicyDecision",
+    "PolicyEngineConfig",
+    "PolicyInput",
+    "REASON_CATCH_ALL_BLOCKED_ROUTING",
+    "REASON_DEFAULT_OBSERVE_ONLY",
+    "REASON_DRY_RUN_SUGGEST",
+    "REASON_LOW_CONFIDENCE_BLOCKED_ROUTING",
+    "REASON_MISSING_SLOTS_BLOCKED_ROUTING",
+    "REASON_ROUTING_DISABLED_BY_CONFIG",
+    "REASON_UNVERIFIED_PROVIDER_BLOCKED",
+    "SAFETY_CATCH_ALL",
+    "SAFETY_LOW_CONFIDENCE",
+    "SAFETY_MISSING_SLOTS",
+    "SAFETY_UNVERIFIED_PROVIDER",
+    "evaluate_policy",
+    "load_default_config",
+    "make_decision_id",
+]

--- a/tokenpak/proxy/intent_policy_preview.py
+++ b/tokenpak/proxy/intent_policy_preview.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.1 — ``tokenpak intent policy-preview`` renderers.
+
+Read-only. Mirrors :mod:`tokenpak.proxy.intent_doctor` in shape so
+operators running both back-to-back get a coherent reading.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+def collect_latest() -> Optional[Dict[str, Any]]:
+    """Return the most recent ``intent_policy_decisions`` row.
+
+    Returns ``None`` when no decision has been recorded yet.
+    """
+    from tokenpak.proxy.intent_policy_telemetry import get_default_policy_store
+
+    return get_default_policy_store().fetch_latest()
+
+
+def render_human(payload: Optional[Dict[str, Any]] = None) -> str:
+    p = payload if payload is not None else collect_latest()
+    if p is None:
+        return (
+            "\nTOKENPAK  |  Intent policy preview (Phase 2.1 dry-run)\n"
+            "──────────────────────────────\n"
+            "\n"
+            "  No policy decisions yet.\n"
+            "\n"
+            "  The dry-run engine writes one row per classified request.\n"
+            "  Send a request via `tokenpak proxy` and re-run this command.\n"
+            "  See `tokenpak doctor --intent` for activation state.\n"
+        )
+
+    lines: List[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Intent policy preview (Phase 2.1 dry-run)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+    lines.append(f"  decision_id:               {p.get('decision_id')}")
+    lines.append(f"  request_id:                {p.get('request_id')}")
+    lines.append(f"  contract_id:               {p.get('contract_id')}")
+    lines.append(f"  timestamp:                 {p.get('timestamp')}")
+    lines.append("")
+    lines.append(f"  mode:                      {p.get('mode')}")
+    lines.append(f"  intent_class:              {p.get('intent_class')}")
+    lines.append(f"  confidence:                {p.get('intent_confidence', 0.0):.4f}")
+    lines.append(f"  action:                    {p.get('action')}")
+    lines.append(f"  decision_reason:           {p.get('decision_reason')}")
+    flags = p.get("safety_flags") or []
+    flags_str = ", ".join(flags) if flags else "(none)"
+    lines.append(f"  safety_flags:              {flags_str}")
+    lines.append("")
+    suggestion_block: List[str] = []
+    if p.get("recommended_provider"):
+        suggestion_block.append(
+            f"  recommended_provider:      {p['recommended_provider']}"
+        )
+    if p.get("recommended_model"):
+        suggestion_block.append(
+            f"  recommended_model:         {p['recommended_model']}"
+        )
+    if p.get("compression_profile"):
+        suggestion_block.append(
+            f"  compression_profile:       {p['compression_profile']}"
+        )
+    if p.get("cache_strategy"):
+        suggestion_block.append(
+            f"  cache_strategy:            {p['cache_strategy']}"
+        )
+    if p.get("delivery_strategy"):
+        suggestion_block.append(
+            f"  delivery_strategy:         {p['delivery_strategy']}"
+        )
+    if p.get("budget_action"):
+        suggestion_block.append(
+            f"  budget_action:             {p['budget_action']}"
+        )
+    if suggestion_block:
+        lines.append("  Suggestion fields:")
+        lines.extend(suggestion_block)
+        lines.append("")
+    if p.get("warning_message"):
+        lines.append(f"  warning_message:           {p['warning_message']}")
+        lines.append("")
+    lines.append("  Config snapshot at decision time:")
+    lines.append(f"    mode:                      {p.get('config_mode')}")
+    lines.append(f"    dry_run:                   {p.get('config_dry_run')}")
+    lines.append(f"    allow_auto_routing:        {p.get('config_allow_auto_routing')}")
+    lines.append(f"    allow_unverified_providers: {p.get('config_allow_unverified_providers')}")
+    lines.append(f"    low_confidence_threshold:  {p.get('config_low_confidence_threshold')}")
+    lines.append("")
+    lines.append("  Phase 2.1 is dry-run. Decisions are observational only;")
+    lines.append("  no routing, no model swap, no body mutation. See")
+    lines.append("  docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md")
+    lines.append("  for the rollout plan.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(payload: Optional[Dict[str, Any]] = None) -> str:
+    p = payload if payload is not None else collect_latest()
+    if p is None:
+        return json.dumps({"decision": None}, indent=2)
+    return json.dumps(p, indent=2, sort_keys=True, default=str)
+
+
+__all__ = ["collect_latest", "render_human", "render_json"]

--- a/tokenpak/proxy/intent_policy_telemetry.py
+++ b/tokenpak/proxy/intent_policy_telemetry.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.1 — SQLite store for ``intent_policy_decisions`` rows.
+
+Separate file from :mod:`intent_contract` so policy concerns don't
+bleed into Phase 0's classifier surface. Same DB
+(``~/.tokenpak/telemetry.db``) so a single backup captures
+everything.
+
+Schema is **strictly hashes / ids / aggregate-safe fields**. No raw
+prompt text, no per-row content. Each row links to the
+``intent_events`` row (Phase 0) via ``contract_id`` so the operator
+can join the two tables to see "what intent → what policy decision"
+without exposing the underlying prompt body.
+
+Privacy contract (asserted in
+``tests/test_intent_policy_engine_phase21.py::TestPrivacyContract``):
+
+  - The schema has no column named after raw content.
+  - The writer never accepts a string with prompt content; only
+    structured fields from :class:`PolicyDecision`.
+  - The ``warning_message`` column carries the engine's templated
+    string only; no caller substring reaches it.
+
+Best-effort write contract (mirrors :class:`IntentTelemetryStore`):
+exceptions are swallowed at the writer boundary so a misbehaving
+disk never breaks a request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from tokenpak.proxy.intent_policy_engine import PolicyDecision
+
+_DEFAULT_DB_PATH = Path(
+    os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak"))
+) / "telemetry.db"
+
+
+_INTENT_POLICY_DECISIONS_DDL = """\
+CREATE TABLE IF NOT EXISTS intent_policy_decisions (
+    decision_id              TEXT PRIMARY KEY,
+    request_id               TEXT,
+    contract_id              TEXT,
+    timestamp                TEXT NOT NULL,
+    mode                     TEXT NOT NULL,
+    intent_class             TEXT NOT NULL,
+    intent_confidence        REAL NOT NULL,
+    action                   TEXT NOT NULL,
+    decision_reason          TEXT NOT NULL,
+    safety_flags             TEXT NOT NULL,    -- JSON list
+    recommended_provider     TEXT,
+    recommended_model        TEXT,
+    budget_action            TEXT,
+    compression_profile      TEXT,
+    cache_strategy           TEXT,
+    delivery_strategy        TEXT,
+    warning_message          TEXT,
+    requires_user_confirmation INTEGER NOT NULL,
+    config_mode              TEXT,
+    config_dry_run           INTEGER,
+    config_allow_auto_routing INTEGER,
+    config_allow_unverified_providers INTEGER,
+    config_low_confidence_threshold REAL
+);
+CREATE INDEX IF NOT EXISTS idx_policy_decisions_contract
+    ON intent_policy_decisions (contract_id);
+CREATE INDEX IF NOT EXISTS idx_policy_decisions_action
+    ON intent_policy_decisions (action, timestamp);
+CREATE INDEX IF NOT EXISTS idx_policy_decisions_reason
+    ON intent_policy_decisions (decision_reason);
+"""
+
+
+@dataclass
+class IntentPolicyDecisionRow:
+    """One row of the ``intent_policy_decisions`` table.
+
+    ``decision`` is the engine output; the row also carries the
+    request-side correlation ids and the config snapshot so a
+    future replay can rebuild the inputs verbatim.
+    """
+
+    request_id: str
+    contract_id: str
+    timestamp: str
+    decision: PolicyDecision
+    config_mode: Optional[str] = None
+    config_dry_run: Optional[bool] = None
+    config_allow_auto_routing: Optional[bool] = None
+    config_allow_unverified_providers: Optional[bool] = None
+    config_low_confidence_threshold: Optional[float] = None
+
+
+class IntentPolicyDecisionStore:
+    """Per-host SQLite writer for the ``intent_policy_decisions`` table.
+
+    Lazy-init (creates the table on first :meth:`write`). Single
+    connection guarded by a process-wide lock — Phase 2.1 traffic is
+    low; Phase 2.2+ may switch to the existing async writer once the
+    schema lift is complete.
+    """
+
+    _LOCK = threading.Lock()
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.executescript(_INTENT_POLICY_DECISIONS_DDL)
+            conn.commit()
+            self._conn = conn
+        return self._conn
+
+    def write(self, row: IntentPolicyDecisionRow) -> None:
+        """Insert one row. Best-effort — never raises on caller path."""
+        d = row.decision
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO intent_policy_decisions (
+                        decision_id, request_id, contract_id, timestamp,
+                        mode, intent_class, intent_confidence,
+                        action, decision_reason, safety_flags,
+                        recommended_provider, recommended_model,
+                        budget_action, compression_profile,
+                        cache_strategy, delivery_strategy,
+                        warning_message, requires_user_confirmation,
+                        config_mode, config_dry_run,
+                        config_allow_auto_routing,
+                        config_allow_unverified_providers,
+                        config_low_confidence_threshold
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        d.decision_id,
+                        row.request_id,
+                        row.contract_id,
+                        row.timestamp,
+                        d.mode,
+                        d.intent_class,
+                        d.confidence,
+                        d.action,
+                        d.decision_reason,
+                        json.dumps(list(d.safety_flags)),
+                        d.recommended_provider,
+                        d.recommended_model,
+                        d.budget_action,
+                        d.compression_profile,
+                        d.cache_strategy,
+                        d.delivery_strategy,
+                        d.warning_message,
+                        1 if d.requires_user_confirmation else 0,
+                        row.config_mode,
+                        _bool_to_int(row.config_dry_run),
+                        _bool_to_int(row.config_allow_auto_routing),
+                        _bool_to_int(row.config_allow_unverified_providers),
+                        row.config_low_confidence_threshold,
+                    ),
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001 — best-effort; never propagate
+            return
+
+    def fetch_latest(self) -> Optional[dict[str, Any]]:
+        """Return the most recent row as a dict, or ``None``.
+
+        Read path used by ``tokenpak intent policy-preview --last``.
+        Returns ``None`` when the DB doesn't exist, the table
+        doesn't exist, or no rows have been written.
+        """
+        if not self._db_path.is_file():
+            return None
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_policy_decisions'"
+                ).fetchone()
+                if exists is None:
+                    return None
+                row = conn.execute(
+                    "SELECT * FROM intent_policy_decisions "
+                    "ORDER BY timestamp DESC LIMIT 1"
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return None
+        if row is None:
+            return None
+        out = {k: row[k] for k in row.keys()}
+        # JSON-decode the safety flags column for caller convenience.
+        try:
+            out["safety_flags"] = json.loads(out.get("safety_flags") or "[]")
+        except (TypeError, json.JSONDecodeError):
+            out["safety_flags"] = []
+        # Re-cast bool-ish columns.
+        for col in (
+            "requires_user_confirmation",
+            "config_dry_run",
+            "config_allow_auto_routing",
+            "config_allow_unverified_providers",
+        ):
+            if col in out and out[col] is not None:
+                out[col] = bool(out[col])
+        return out
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+_DEFAULT_STORE: Optional[IntentPolicyDecisionStore] = None
+
+
+def get_default_policy_store() -> IntentPolicyDecisionStore:
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = IntentPolicyDecisionStore()
+    return _DEFAULT_STORE
+
+
+def set_default_policy_store(store: Optional[IntentPolicyDecisionStore]) -> None:
+    """Test hook — swap the default writer (e.g. for an in-memory DB)."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+def _bool_to_int(v: Optional[bool]) -> Optional[int]:
+    if v is None:
+        return None
+    return 1 if v else 0
+
+
+__all__ = [
+    "IntentPolicyDecisionRow",
+    "IntentPolicyDecisionStore",
+    "get_default_policy_store",
+    "set_default_policy_store",
+]

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1527,6 +1527,69 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 # Side-channel; never break the request on telemetry failures.
                 pass
 
+        # ── Intent Layer Phase 2.1 — dry-run policy engine ─────────
+        # Pure evaluation over the Phase 0 contract + request
+        # context. No mutation of fwd_headers, body, or any dispatch
+        # state — Phase 2.1 is observational only. Decision lands
+        # in the intent_policy_decisions table; later sub-phases
+        # add CLI explain + dashboard preview + opt-in suggest.
+        if _intent_contract is not None:
+            try:
+                from tokenpak.proxy.intent_policy_engine import (
+                    PolicyInput as _I21Input,
+                )
+                from tokenpak.proxy.intent_policy_engine import (
+                    evaluate_policy as _i21_evaluate,
+                )
+                from tokenpak.proxy.intent_policy_engine import (
+                    load_default_config as _i21_config,
+                )
+                from tokenpak.proxy.intent_policy_telemetry import (
+                    IntentPolicyDecisionRow as _I21Row,
+                )
+                from tokenpak.proxy.intent_policy_telemetry import (
+                    get_default_policy_store as _i21_store,
+                )
+
+                _i21_cfg = _i21_config()
+                _i21_input = _I21Input(
+                    intent_class=_intent_contract.intent_class,
+                    confidence=_intent_contract.confidence,
+                    slots_present=_intent_contract.slots_present,
+                    slots_missing=_intent_contract.slots_missing,
+                    catch_all_reason=_intent_contract.catch_all_reason,
+                    provider=_resolved_provider or "",
+                    model=model or "",
+                    estimated_cost_usd=None,
+                    adapter_capabilities=(
+                        request_adapter.capabilities
+                        if request_adapter is not None
+                        else frozenset()
+                    ),
+                    delivery_target_capabilities=frozenset(),
+                    live_verified_status=None,
+                    required_slots=(),
+                )
+                _i21_decision = _i21_evaluate(_i21_input, _i21_cfg)
+                _i21_store().write(
+                    _I21Row(
+                        request_id=_req_id,
+                        contract_id=_intent_contract.contract_id,
+                        timestamp=datetime.now().isoformat(timespec="seconds"),
+                        decision=_i21_decision,
+                        config_mode=_i21_cfg.mode,
+                        config_dry_run=_i21_cfg.dry_run,
+                        config_allow_auto_routing=_i21_cfg.allow_auto_routing,
+                        config_allow_unverified_providers=_i21_cfg.allow_unverified_providers,
+                        config_low_confidence_threshold=_i21_cfg.low_confidence_threshold,
+                    )
+                )
+            except Exception:
+                # Side-channel — never break the request on engine /
+                # telemetry failures. Phase 2.1 is observation-only;
+                # if the engine misbehaves, the proxy continues.
+                pass
+
         try:
             pool = self.server.proxy_server._connection_pool  # type: ignore[attr-defined]
             _cb_success = False  # track whether request succeeded for circuit breaker


### PR DESCRIPTION
## Summary

Phase 2 spec sub-phase 2.1 — first code-shipping step on the Phase 2 rollout path. Pure-function engine over the Phase 0 IntentContract + request context; emits one of seven Phase 2.1 actions per decision; writes to a separate `intent_policy_decisions` SQLite table linked to `intent_events` by `contract_id`.

**Dry-run only.** No request mutation. No body / header / target_url changes anywhere in the dispatch path. Default config is `observe_only / dry_run=true / no auto-routing / no unverified providers` — a host that hasn't configured anything sees zero behavior change vs. Phase 1.1.

## Changes

- **`tokenpak/proxy/intent_policy_engine.py`** — pure engine. Frozen `PolicyInput` / `PolicyDecision` / `PolicyEngineConfig` dataclasses. Seven-action enum (`observe_only`, `warn_only`, `suggest_route`, `suggest_compression_profile`, `suggest_cache_policy`, `suggest_delivery_policy`, `flag_budget_risk` — last reserved for 2.6). Decision-reason + safety-flag string constants. `evaluate_policy(input, config) -> PolicyDecision` is a pure function; no I/O during evaluation; safe from any thread.
- **`tokenpak/proxy/intent_policy_telemetry.py`** — SQLite store for `intent_policy_decisions`. Schema is **IDs / hashes / aggregate-safe fields only**. Best-effort writer contract (mirrors Phase 0). `fetch_latest()` for the read-side preview.
- **`tokenpak/proxy/intent_policy_preview.py`** — CLI renderers consumed by the new `tokenpak intent policy-preview` subcommand. Shape mirrors `tokenpak doctor --explain-last` for visual coherence.
- **`tokenpak/proxy/server.py`** — call site inserted after the Phase 0 telemetry write. Wraps every step in a try/except that swallows errors; the engine is a side-channel.
- **`tokenpak/cli/_impl.py`** — `tokenpak intent policy-preview [--last] [--json]` subcommand. Read-only.
- **`tests/test_intent_policy_engine_phase21.py`** — 38 tests across 12 classes; one class per directive bullet plus three cross-cutting (decision shape, telemetry round-trip, CLI smoke).
- **`docs/reference/intent-policy-preview.md`** — operator-facing doc covering engine semantics, the seven actions, four safety rules, default config, CLI surface, telemetry schema, and what NOT to infer from dry-run decisions.
- **`docs/reference/cli.md`** — regenerated.

## Acceptance

- [x] Policy engine exists (pure function; frozen dataclasses).
- [x] Engine runs in dry-run / observe_only mode by default.
- [x] No routing behavior changes (zero edits to forward / dispatch paths beyond the new telemetry-side call).
- [x] No classifier behavior changes (`intent_classifier.py` untouched).
- [x] No request mutation (`TestNoRouteMutation` enforces — frozen dataclass, input unchanged after call).
- [x] No provider/model switching.
- [x] Policy decisions are explainable — `render_human`, `render_json`, JSON columns expose every field; `safety_flags` + `decision_reason` map back to spec §6 rules.
- [x] Privacy-safe — `TestPrivacyContract` pins the sentinel-substring contract end-to-end.
- [x] `ruff check` clean.
- [x] `cli-docs-in-sync --check` clean.
- [x] **1083 passing** (was 1045 baseline, +38), 0 regressions.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no scaffold renderer expansion, **no classifier behavior changes**, **no production intent-based routing decisions**.