### PR TITLE
feat(proxy,cli,dashboard): Phase 2.2 — policy explain/report/dashboard preview

### DIFF
--- a/docs/reference/intent-policy-preview.md
+++ b/docs/reference/intent-policy-preview.md
@@ -1,6 +1,8 @@
-# Intent Layer — Policy Preview (Phase 2.1)
+# Intent Layer — Policy Preview (Phase 2.1 / 2.2)
 
-> Phase 2.1 ships a **dry-run** intent policy engine. It evaluates every classified request against a pure-function policy and writes the decision to a separate SQLite table (`intent_policy_decisions`). **Nothing about the request changes.** No routing, no model swap, no body mutation, no header injection. The decisions are observational only — what a future opt-in suggest mode (Phase 2.4 per the spec) might recommend.
+> The intent policy engine is **dry-run only** through Phase 2.x. It evaluates every classified request against a pure-function policy and writes the decision to a separate SQLite table (`intent_policy_decisions`). **Nothing about the request changes.** No routing, no model swap, no body mutation, no header injection. The decisions are observational only — what a future opt-in suggest mode (Phase 2.4 per the spec) might recommend.
+
+> **Phase 2.2 (this update)** adds explain / report / dashboard surfaces over the engine's output. Phase 2.1 (the underlying engine, merged in PR #49) is unchanged — Phase 2.2 is observability only.
 
 ## Engine semantics
 
@@ -70,16 +72,63 @@ A future Phase 2.2 will read `~/.tokenpak/policy.yaml` per the spec §7 schema. 
 
 ## CLI
 
+Three surfaces all read from the same `intent_policy_decisions` table:
+
 ```bash
 # Render the most recent decision (operator-readable plain text)
 tokenpak intent policy-preview
 tokenpak intent policy-preview --last      # alias for default behavior
-
-# Same row, machine-readable JSON
 tokenpak intent policy-preview --json
+
+# Phase 2.2: every request explain now also surfaces the matching
+# policy decision (linked by contract_id) when one exists.
+tokenpak doctor --explain-last
+tokenpak doctor --explain-last --json
+
+# Phase 2.2: tokenpak intent report now appends a "Policy summary"
+# section after the Phase 1 distributions. The JSON output gains a
+# top-level "policy_summary" key.
+tokenpak intent report
+tokenpak intent report --window 14d --json
 ```
 
 Returns a friendly "no decisions yet" message when the table is empty (fresh install).
+
+## API (Phase 2.2)
+
+The dashboard endpoint is read-only and aggregate-only:
+
+```http
+GET /api/intent/policy-report
+GET /api/intent/policy-report?window=14d
+GET /api/intent/policy-report?window=7d
+GET /api/intent/policy-report?window=0d        # all rows
+```
+
+Returns the dashboard payload — eight cards + four operator-panel slices + metadata. The metadata block includes `dry_run_preview_only: true` and a `preview_label: "DRY-RUN / PREVIEW ONLY — no routing decisions made"` so consumers can render the warning clearly. Schema version: `intent-policy-dashboard-v1`.
+
+Errors:
+
+- `400 bad_request` — malformed `window` parameter.
+- `500 intent_policy_dashboard_failed` — internal failure (rare, defensive).
+
+Read-only. The endpoint never writes to the telemetry store, never invokes a provider, never mutates adapter state.
+
+## Dashboard panel
+
+The local dashboard at `/dashboard/` (served by the proxy when running) renders an "Intent Policy" section below the Phase 1.1 "Intent Layer" panel. Same data, UI shape:
+
+- Total dry-run decisions (the headline number)
+- Budget risk flags (reserved in 2.1; counted forward-compatibly)
+- Top recommended actions (with percentages)
+- Top safety flags
+- Suggested compression profiles
+- Suggested cache policies
+- Suggested delivery policies
+- Auto-routing blocked reasons
+- Operator review areas
+
+The window badge always reads `DRY-RUN / PREVIEW ONLY — no routing decisions made` so an operator scanning the dashboard never confuses the preview with enforcement.
 
 ## Telemetry
 

--- a/tests/test_intent_policy_phase22.py
+++ b/tests/test_intent_policy_phase22.py
@@ -1,0 +1,569 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.2 — explain / report / dashboard policy-preview tests.
+
+Eleven directive-mandated test classes:
+
+  - CLI explain includes latest policy decision
+  - CLI report includes policy summary
+  - JSON output shape (CLI + API)
+  - dashboard / API output shape
+  - empty DB behavior
+  - populated DB behavior
+  - window filtering
+  - no raw prompt content
+  - no secrets emitted
+  - no request mutation
+  - no route mutation
+
+All tests read-only; reuse the production engine + telemetry
+store + report builders so the schema remains a single source of
+truth.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import (
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    build_contract,
+)
+from tokenpak.proxy.intent_policy_dashboard import (
+    DASHBOARD_SCHEMA_VERSION,
+    collect_policy_dashboard,
+)
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+)
+from tokenpak.proxy.intent_policy_report import (
+    build_policy_report,
+)
+from tokenpak.proxy.intent_policy_report import (
+    render_human as render_policy_human,
+)
+from tokenpak.proxy.intent_policy_report import (
+    render_json as render_policy_json,
+)
+from tokenpak.proxy.intent_policy_telemetry import (
+    IntentPolicyDecisionRow,
+    IntentPolicyDecisionStore,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _classification(intent_class="summarize", confidence=0.9,
+                    slots_present=("period",), slots_missing=(),
+                    catch_all_reason=None):
+    return IntentClassification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+
+
+def _seed_intent_event(store, *, request_id, contract,
+                       prompt="summarize the vault", emitted=False, stripped=True,
+                       timestamp=None):
+    """Seed one intent_events row tied to a contract."""
+    ts = timestamp or _dt.datetime.now().isoformat(timespec="seconds")
+    store.write(IntentTelemetryRow(
+        request_id=request_id,
+        contract=contract,
+        timestamp=ts,
+        tip_headers_emitted=emitted,
+        tip_headers_stripped=stripped,
+    ))
+
+
+def _seed_pair(events_store, policy_store, *, request_id="r1",
+               intent_class="summarize", confidence=0.9,
+               slots_present=("period",), slots_missing=(),
+               catch_all_reason=None,
+               provider="tokenpak-test", model="m",
+               cfg=None, prompt="summarize the vault",
+               timestamp=None):
+    """Seed one intent_events row and the matching policy decision.
+
+    Returns (contract, decision).
+    """
+    cls = _classification(
+        intent_class=intent_class, confidence=confidence,
+        slots_present=slots_present, slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+    contract = build_contract(classification=cls, raw_prompt=prompt)
+    _seed_intent_event(
+        events_store, request_id=request_id, contract=contract,
+        prompt=prompt, timestamp=timestamp,
+    )
+    pi = PolicyInput(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+        provider=provider,
+        model=model,
+        live_verified_status=True,
+    )
+    decision = evaluate_policy(pi, cfg or PolicyEngineConfig())
+    ts = timestamp or _dt.datetime.now().isoformat(timespec="seconds")
+    policy_store.write(IntentPolicyDecisionRow(
+        request_id=request_id,
+        contract_id=contract.contract_id,
+        timestamp=ts,
+        decision=decision,
+    ))
+    return contract, decision
+
+
+# ── 1. CLI explain includes latest policy decision ────────────────────
+
+
+class TestExplainShowsPolicyDecision:
+    """tokenpak doctor --explain-last MUST surface the linked
+    policy decision when one exists.
+    """
+
+    def test_render_explain_renders_policy_section(self, tmp_path: Path):
+        # Seed both tables under a single DB.
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        _seed_pair(events, policy, request_id="explain-1")
+        events.close()
+        policy.close()
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=db)
+        assert payload is not None
+        assert payload["policy_decision"] is not None
+        text = render_explain_last(payload)
+        # Contract row + policy row both present.
+        assert "Linked policy decision" in text
+        assert "DRY-RUN / PREVIEW ONLY" in text
+        # The 14 directive-mandated fields surface.
+        for field in (
+            "decision_id",
+            "mode",
+            "action",
+            "decision_reason",
+            "safety_flags",
+        ):
+            assert field in text, f"explain output missing {field!r}"
+
+    def test_explain_when_policy_missing(self, tmp_path: Path):
+        # Seed only the events row; no policy row exists.
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        cls = _classification()
+        contract = build_contract(classification=cls, raw_prompt="hello")
+        _seed_intent_event(events, request_id="lone", contract=contract)
+        events.close()
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=db)
+        assert payload is not None
+        assert payload["policy_decision"] is None
+        text = render_explain_last(payload)
+        assert "(none recorded yet)" in text
+
+
+# ── 2. CLI report includes policy summary ─────────────────────────────
+
+
+class TestReportIncludesPolicySummary:
+
+    def test_intent_report_appends_policy_summary(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        _seed_pair(events, policy, request_id="r1")
+        _seed_pair(events, policy, request_id="r2", intent_class="debug")
+        events.close()
+        policy.close()
+
+        from tokenpak.proxy.intent_report import build_report, render_human
+        r = build_report(window_days=14, db_path=db)
+        # Phase 2.2 — new field on the report.
+        assert "policy_summary" in r.to_dict()
+        assert r.policy_summary["total_decisions"] == 2
+        # Renderer appends the policy section.
+        text = render_human(r)
+        assert "Policy summary (Phase 2.2 dry-run / preview only)" in text
+
+
+# ── 3. JSON output shape ──────────────────────────────────────────────
+
+
+class TestJsonShape:
+    """Both the CLI report and the policy-report API endpoint
+    serialize cleanly. Required keys are pinned.
+    """
+
+    REQUIRED_POLICY_REPORT_KEYS = {
+        "window_days",
+        "window_cutoff_iso",
+        "db_path",
+        "total_decisions",
+        "action_distribution",
+        "decision_reason_distribution",
+        "safety_flag_distribution",
+        "recommendations_by_intent_class",
+        "low_confidence_blocked",
+        "low_confidence_safe_handled",
+        "catch_all_safe_handled",
+        "unverified_provider_blocked",
+        "missing_slots_blocked",
+        "budget_risk_flags",
+        "compression_profile_distribution",
+        "cache_strategy_distribution",
+        "delivery_strategy_distribution",
+        "review_areas",
+    }
+
+    def test_policy_report_required_keys(self, tmp_path: Path):
+        r = build_policy_report(window_days=14, db_path=tmp_path / "nope.db")
+        payload = json.loads(render_policy_json(r))
+        missing = self.REQUIRED_POLICY_REPORT_KEYS - set(payload)
+        assert not missing, f"missing keys: {missing}"
+
+    def test_intent_report_to_dict_has_policy_summary(self, tmp_path: Path):
+        from tokenpak.proxy.intent_report import build_report
+        r = build_report(window_days=14, db_path=tmp_path / "nope.db")
+        d = r.to_dict()
+        assert "policy_summary" in d
+
+
+# ── 4. Dashboard / API output shape ───────────────────────────────────
+
+
+class TestDashboardShape:
+    REQUIRED_CARD_KEYS = {
+        "total_dry_run_decisions",
+        "top_recommended_actions",
+        "top_safety_flags",
+        "budget_risk_flags",
+        "suggested_compression_profiles",
+        "suggested_cache_policies",
+        "suggested_delivery_policies",
+        "auto_routing_blocked_reasons",
+    }
+
+    REQUIRED_OPERATOR_PANEL_KEYS = {
+        "top_recommended_actions",
+        "top_safety_flags",
+        "top_blocked_reasons",
+        "recommended_review_areas",
+    }
+
+    REQUIRED_METADATA_KEYS = {
+        "schema_version",
+        "phase",
+        "dry_run_preview_only",
+        "preview_label",
+        "window_days",
+        "window_cutoff_iso",
+        "telemetry_store_path",
+    }
+
+    def test_top_level_shape(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert set(payload) == {"metadata", "cards", "operator_panel"}
+
+    def test_cards_keys(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_CARD_KEYS - set(payload["cards"])
+        assert not missing, f"missing card keys: {missing}"
+
+    def test_operator_panel_keys(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_OPERATOR_PANEL_KEYS - set(payload["operator_panel"])
+        assert not missing, f"missing panel keys: {missing}"
+
+    def test_metadata_keys(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        missing = self.REQUIRED_METADATA_KEYS - set(payload["metadata"])
+        assert not missing, f"missing metadata keys: {missing}"
+
+    def test_dry_run_preview_only_flag(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["metadata"]["dry_run_preview_only"] is True
+        assert "DRY-RUN" in payload["metadata"]["preview_label"]
+        assert payload["metadata"]["phase"] == "intent-layer-phase-2.2"
+
+    def test_schema_version_pinned(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["metadata"]["schema_version"] == DASHBOARD_SCHEMA_VERSION
+        assert payload["metadata"]["schema_version"] == "intent-policy-dashboard-v1"
+
+
+# ── 5. Empty DB behavior ──────────────────────────────────────────────
+
+
+class TestEmptyDB:
+
+    def test_policy_report_empty_db(self, tmp_path: Path):
+        r = build_policy_report(window_days=14, db_path=tmp_path / "nope.db")
+        assert r.total_decisions == 0
+        assert r.action_distribution == {}
+        assert r.review_areas, "review_areas should explain empty state"
+
+    def test_dashboard_empty_db(self, tmp_path: Path):
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["cards"]["total_dry_run_decisions"]["value"] == 0
+        assert payload["cards"]["top_recommended_actions"]["items"] == []
+
+    def test_table_missing_returns_zero(self, tmp_path: Path):
+        # File exists, no schema.
+        db = tmp_path / "telemetry.db"
+        sqlite3.connect(str(db)).close()
+        r = build_policy_report(window_days=14, db_path=db)
+        assert r.total_decisions == 0
+
+
+# ── 6. Populated DB behavior ──────────────────────────────────────────
+
+
+class TestPopulatedDB:
+
+    def test_action_distribution(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        # 3 summarize (compression suggestion); 2 status (observe);
+        # 1 query w/ catch-all (warn_only).
+        for i in range(3):
+            _seed_pair(events, policy, request_id=f"a{i}",
+                       intent_class="summarize")
+        for i in range(2):
+            _seed_pair(events, policy, request_id=f"b{i}",
+                       intent_class="status")
+        _seed_pair(events, policy, request_id="c0",
+                   intent_class="query", confidence=0.0,
+                   catch_all_reason="empty_prompt")
+        events.close()
+        policy.close()
+
+        r = build_policy_report(window_days=14, db_path=db)
+        assert r.total_decisions == 6
+        # The catch-all entry trips low_confidence (0.0 < 0.65) so
+        # warn_only fires for it; the catch_all reason is masked
+        # by low_confidence in the priority-ordered taxonomy.
+        assert r.action_distribution["suggest_compression_profile"] == 3
+        assert r.action_distribution["observe_only"] == 2
+        assert r.action_distribution["warn_only"] == 1
+        # safety_flag distribution surfaces all flags that tripped.
+        assert "low_confidence" in r.safety_flag_distribution
+        assert "catch_all" in r.safety_flag_distribution
+
+    def test_dashboard_pcts_computed(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        for i in range(2):
+            _seed_pair(events, policy, request_id=f"a{i}", intent_class="summarize")
+        events.close()
+        policy.close()
+
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        items = payload["cards"]["top_recommended_actions"]["items"]
+        assert items[0]["count"] == 2
+        assert items[0]["pct"] == 100.0
+
+
+# ── 7. Window filtering ───────────────────────────────────────────────
+
+
+class TestWindowFilter:
+
+    def test_rows_outside_window_excluded(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        now = _dt.datetime(2026, 4, 26, 12, 0, 0)
+        _seed_pair(events, policy, request_id="recent",
+                   timestamp=(now - _dt.timedelta(days=1)).isoformat(timespec="seconds"))
+        _seed_pair(events, policy, request_id="ancient",
+                   timestamp=(now - _dt.timedelta(days=60)).isoformat(timespec="seconds"))
+        events.close()
+        policy.close()
+
+        r = build_policy_report(window_days=14, db_path=db, now=now)
+        assert r.total_decisions == 1
+
+
+# ── 8 + 9. Privacy: no raw prompt content / secrets emitted ──────────
+
+
+class TestPrivacyContract:
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-2-2"
+
+    def test_sentinel_absent_from_policy_report(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        _seed_pair(events, policy, request_id="priv1",
+                   prompt=f"summarize the vault {self.SENTINEL}")
+        events.close()
+        policy.close()
+
+        r = build_policy_report(window_days=14, db_path=db)
+        s_human = render_policy_human(r)
+        s_json = render_policy_json(r)
+        assert self.SENTINEL not in s_human, (
+            "raw prompt content leaked into policy human render"
+        )
+        assert self.SENTINEL not in s_json, (
+            "raw prompt content leaked into policy JSON render"
+        )
+
+    def test_sentinel_absent_from_dashboard(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        _seed_pair(events, policy, request_id="priv2",
+                   prompt=f"summarize the vault {self.SENTINEL}")
+        events.close()
+        policy.close()
+
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        assert self.SENTINEL not in json.dumps(payload)
+
+    def test_per_row_hash_absent_from_policy_dashboard(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        prompt = "summarize the vault hash-test-zzz"
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        _seed_pair(events, policy, request_id="priv3", prompt=prompt)
+        events.close()
+        policy.close()
+
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        assert digest not in json.dumps(payload)
+
+
+# ── 10. No request mutation ───────────────────────────────────────────
+
+
+class TestNoRequestMutation:
+    """Phase 2.2 only adds READ-side surfaces. Verify by inspecting
+    the engine + telemetry contract: the engine's input is unchanged
+    after a call, and the new endpoint is read-only.
+    """
+
+    def test_read_only_no_writes_during_dashboard_call(self, tmp_path: Path):
+        # Prepare a sealed DB and confirm dashboard call does not
+        # mutate it (mtime / size unchanged).
+        db = tmp_path / "telemetry.db"
+        events = IntentTelemetryStore(db_path=db)
+        policy = IntentPolicyDecisionStore(db_path=db)
+        _seed_pair(events, policy, request_id="ro1")
+        events.close()
+        policy.close()
+
+        before = db.stat().st_size
+        before_mtime = db.stat().st_mtime
+        # Multiple reads.
+        for _ in range(5):
+            collect_policy_dashboard(window_days=14, db_path=db)
+            build_policy_report(window_days=14, db_path=db)
+        after = db.stat().st_size
+        after_mtime = db.stat().st_mtime
+        assert after == before
+        assert after_mtime == before_mtime
+
+
+# ── 11. No route mutation ─────────────────────────────────────────────
+
+
+class TestNoRouteMutation:
+    """The Phase 2.2 read surfaces never call into the dispatch
+    path. Verify by assertion at the import level: the policy-report
+    + dashboard modules MUST NOT import server-side mutation
+    primitives.
+    """
+
+    def test_policy_report_does_not_import_forward_path(self):
+        import tokenpak.proxy.intent_policy_report as r
+
+        # The module's source must not reference dispatch / forwarding
+        # primitives. This is a structural test, not a behavioral
+        # one.
+        src = Path(r.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src, (
+                f"policy report module references dispatch primitive: {forbidden!r}"
+            )
+
+    def test_policy_dashboard_does_not_import_forward_path(self):
+        import tokenpak.proxy.intent_policy_dashboard as d
+
+        src = Path(d.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src, (
+                f"policy dashboard module references dispatch primitive: {forbidden!r}"
+            )
+
+
+# ── 12. CLI / API subprocess smoke (cross-cutting) ────────────────────
+
+
+class TestCliSubprocess:
+
+    def test_intent_report_cli_runs(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "report", "--window", "0d"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_intent_report_cli_json_includes_policy_summary(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "report",
+             "--window", "0d", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        d: Dict[str, Any] = json.loads(result.stdout)
+        assert "policy_summary" in d
+
+
+# ── 13. Empty DB doctor explain handles missing policy table ──────────
+
+
+class TestExplainEmptyDB:
+    """When neither table exists, the renderer prints the friendly
+    'no rows yet' message — no stack trace.
+    """
+
+    def test_explain_no_db(self, tmp_path: Path):
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=tmp_path / "absent.db")
+        assert payload is None
+        text = render_explain_last(payload)
+        assert "No intent_events rows yet" in text

--- a/tokenpak/dashboard/__init__.py
+++ b/tokenpak/dashboard/__init__.py
@@ -28,6 +28,9 @@ def get_dashboard_files():
         # Phase 1.1 — intent dashboard cards. Read-only; consumes
         # /api/intent/report?window=14d.
         "intent.js": DASHBOARD_DIR / "intent.js",
+        # Phase 2.2 — intent policy preview panel (dry-run only).
+        # Consumes /api/intent/policy-report?window=14d.
+        "intent_policy.js": DASHBOARD_DIR / "intent_policy.js",
         "styles.css": DASHBOARD_DIR / "styles.css",
     }
 

--- a/tokenpak/dashboard/index.html
+++ b/tokenpak/dashboard/index.html
@@ -168,6 +168,58 @@
                 <h3>Operator panel</h3>
                 <ul id="intent-review-areas" style="line-height: 1.6;"></ul>
             </div>
+
+            <!-- Intent Policy (Phase 2.2) — DRY-RUN / PREVIEW ONLY -->
+            <div class="chart-container">
+                <h2>Intent Policy
+                    <small id="intent-policy-window-badge"
+                           style="font-weight: normal; opacity: 0.7;">
+                        — last 14d (DRY-RUN / PREVIEW ONLY — no routing decisions made)
+                    </small>
+                </h2>
+                <div class="stats-row">
+                    <div class="stat-card">
+                        <div class="stat-label">Total Dry-Run Decisions</div>
+                        <div class="stat-value" id="intent-policy-total">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Budget Risk Flags</div>
+                        <div class="stat-value" id="intent-policy-budget-risk">0</div>
+                    </div>
+                </div>
+                <h3>Top recommended actions</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Action</th><th>Count</th><th>%</th></tr></thead>
+                    <tbody id="intent-policy-actions-body"></tbody>
+                </table>
+                <h3>Top safety flags</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Safety flag</th><th>Count</th><th>%</th></tr></thead>
+                    <tbody id="intent-policy-safety-body"></tbody>
+                </table>
+                <h3>Suggested compression profiles</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Profile</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-compression-body"></tbody>
+                </table>
+                <h3>Suggested cache policies</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Strategy</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-cache-body"></tbody>
+                </table>
+                <h3>Suggested delivery policies</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Strategy</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-delivery-body"></tbody>
+                </table>
+                <h3>Auto-routing blocked reasons</h3>
+                <table class="metrics-table">
+                    <thead><tr><th>Reason</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-blocked-body"></tbody>
+                </table>
+                <h3>Operator panel</h3>
+                <ul id="intent-policy-review-areas" style="line-height: 1.6;"></ul>
+            </div>
         </div>
     </div>
 
@@ -175,6 +227,7 @@
     <script src="charts.js"></script>
     <script src="goals.js"></script>
     <script src="intent.js"></script>
+    <script src="intent_policy.js"></script>
     <script>
         // Auto-refresh every 5 seconds
         setInterval(() => {
@@ -182,12 +235,18 @@
             if (typeof fetchAndUpdateIntentDashboard === "function") {
                 fetchAndUpdateIntentDashboard();
             }
+            if (typeof fetchAndUpdateIntentPolicyDashboard === "function") {
+                fetchAndUpdateIntentPolicyDashboard();
+            }
         }, 5000);
 
         // Initial load
         fetchAndUpdateMetrics();
         if (typeof fetchAndUpdateIntentDashboard === "function") {
             fetchAndUpdateIntentDashboard();
+        }
+        if (typeof fetchAndUpdateIntentPolicyDashboard === "function") {
+            fetchAndUpdateIntentPolicyDashboard();
         }
     </script>
 </body>

--- a/tokenpak/dashboard/intent_policy.js
+++ b/tokenpak/dashboard/intent_policy.js
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Intent Policy panel (Phase 2.2) — DRY-RUN / PREVIEW ONLY.
+//
+// Reads /api/intent/policy-report?window=14d. Renders eight cards
+// across stat-cards + tables. The window badge in index.html
+// already labels this as preview-only; this script keeps that
+// label in sync with the metadata.preview_label field.
+
+async function fetchAndUpdateIntentPolicyDashboard() {
+    let payload;
+    try {
+        const response = await fetch('/api/intent/policy-report?window=14d');
+        if (!response.ok) return;
+        payload = await response.json();
+    } catch (err) {
+        return;
+    }
+    if (!payload || !payload.cards) return;
+
+    const cards = payload.cards;
+    const panel = payload.operator_panel || {};
+    const meta = payload.metadata || {};
+
+    // Window badge — keeps the dry-run label visible.
+    const winBadge = document.getElementById('intent-policy-window-badge');
+    if (winBadge && meta.window_days != null) {
+        const label = meta.preview_label || 'DRY-RUN / PREVIEW ONLY';
+        winBadge.textContent = `— last ${meta.window_days}d (${label})`;
+    }
+
+    setText('intent-policy-total', cards.total_dry_run_decisions.value);
+    setText('intent-policy-budget-risk', cards.budget_risk_flags.value);
+
+    renderActionTable(cards.top_recommended_actions.items, 'intent-policy-actions-body');
+    renderSafetyTable(cards.top_safety_flags.items, 'intent-policy-safety-body');
+    renderProfileTable(
+        cards.suggested_compression_profiles.items,
+        'intent-policy-compression-body',
+        'compression_profile',
+    );
+    renderProfileTable(
+        cards.suggested_cache_policies.items,
+        'intent-policy-cache-body',
+        'cache_strategy',
+    );
+    renderProfileTable(
+        cards.suggested_delivery_policies.items,
+        'intent-policy-delivery-body',
+        'delivery_strategy',
+    );
+    renderProfileTable(
+        cards.auto_routing_blocked_reasons.items,
+        'intent-policy-blocked-body',
+        'decision_reason',
+    );
+
+    const ul = document.getElementById('intent-policy-review-areas');
+    if (ul) {
+        ul.innerHTML = '';
+        const areas = panel.recommended_review_areas || [];
+        if (areas.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = '(no flags raised by the heuristic — keep observing)';
+            ul.appendChild(li);
+        } else {
+            for (const area of areas) {
+                const li = document.createElement('li');
+                li.textContent = area;
+                ul.appendChild(li);
+            }
+        }
+    }
+}
+
+function renderActionTable(items, bodyId) {
+    const body = document.getElementById(bodyId);
+    if (!body) return;
+    body.innerHTML = '';
+    for (const item of items) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${escapeHtml(item.action)}</td>
+            <td>${item.count}</td>
+            <td>${(item.pct ?? 0).toFixed(1)}%</td>
+        `;
+        body.appendChild(row);
+    }
+}
+
+function renderSafetyTable(items, bodyId) {
+    const body = document.getElementById(bodyId);
+    if (!body) return;
+    body.innerHTML = '';
+    for (const item of items) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${escapeHtml(item.safety_flag)}</td>
+            <td>${item.count}</td>
+            <td>${(item.pct ?? 0).toFixed(1)}%</td>
+        `;
+        body.appendChild(row);
+    }
+}
+
+function renderProfileTable(items, bodyId, key) {
+    const body = document.getElementById(bodyId);
+    if (!body) return;
+    body.innerHTML = '';
+    for (const item of items) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${escapeHtml(item[key] ?? '')}</td>
+            <td>${item.count}</td>
+        `;
+        body.appendChild(row);
+    }
+}
+
+function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = String(value ?? 0);
+}
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/tokenpak/proxy/intent_doctor.py
+++ b/tokenpak/proxy/intent_doctor.py
@@ -229,10 +229,14 @@ def render_intent_view(view: Optional[Dict[str, Any]] = None) -> str:
 
 
 def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str, Any]]:
-    """Read the most recent ``intent_events`` row.
+    """Read the most recent ``intent_events`` row plus its linked
+    ``intent_policy_decisions`` row (Phase 2.2).
 
-    Returns ``None`` when the DB doesn't exist or the table is
-    empty. Caller renders the absent case with a clear message.
+    Returns ``None`` when the events DB doesn't exist or the events
+    table is empty. The policy-decision linkage is best-effort —
+    if the policy table doesn't exist or doesn't carry a row for
+    the same ``contract_id``, the returned dict has
+    ``policy_decision = None``.
     """
     path = db_path if db_path is not None else _intent_db_path()
     if not path.is_file():
@@ -258,9 +262,57 @@ def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str
                 "FROM intent_events "
                 "ORDER BY timestamp DESC LIMIT 1"
             ).fetchone()
+            if row is None:
+                return None
+            contract_id = row["contract_id"]
+
+            # Phase 2.2: pull the linked policy decision if present.
+            policy_decision: Optional[Dict[str, Any]] = None
+            policy_table = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='intent_policy_decisions'"
+            ).fetchone()
+            if policy_table is not None and contract_id:
+                p = conn.execute(
+                    "SELECT decision_id, request_id, contract_id, timestamp, "
+                    "mode, intent_class, intent_confidence, action, "
+                    "decision_reason, safety_flags, recommended_provider, "
+                    "recommended_model, budget_action, compression_profile, "
+                    "cache_strategy, delivery_strategy, warning_message, "
+                    "requires_user_confirmation "
+                    "FROM intent_policy_decisions "
+                    "WHERE contract_id = ? "
+                    "ORDER BY timestamp DESC LIMIT 1",
+                    (contract_id,),
+                ).fetchone()
+                if p is not None:
+                    try:
+                        flags = json.loads(p["safety_flags"] or "[]")
+                    except (TypeError, json.JSONDecodeError):
+                        flags = []
+                    policy_decision = {
+                        "decision_id": p["decision_id"],
+                        "request_id": p["request_id"],
+                        "contract_id": p["contract_id"],
+                        "timestamp": p["timestamp"],
+                        "mode": p["mode"],
+                        "intent_class": p["intent_class"],
+                        "intent_confidence": p["intent_confidence"],
+                        "action": p["action"],
+                        "decision_reason": p["decision_reason"],
+                        "safety_flags": flags,
+                        "recommended_provider": p["recommended_provider"],
+                        "recommended_model": p["recommended_model"],
+                        "budget_action": p["budget_action"],
+                        "compression_profile": p["compression_profile"],
+                        "cache_strategy": p["cache_strategy"],
+                        "delivery_strategy": p["delivery_strategy"],
+                        "warning_message": p["warning_message"],
+                        "requires_user_confirmation": bool(
+                            p["requires_user_confirmation"]
+                        ),
+                    }
     except sqlite3.DatabaseError:
-        return None
-    if row is None:
         return None
 
     return {
@@ -279,6 +331,7 @@ def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str
         "tokens_in": row["tokens_in"],
         "tokens_out": row["tokens_out"],
         "latency_ms": row["latency_ms"],
+        "policy_decision": policy_decision,
     }
 
 
@@ -340,6 +393,44 @@ def render_explain_last(payload: Optional[Dict[str, Any]] = None) -> str:
         lines.append(f"    tokens_in:               {p['tokens_in']}")
         lines.append(f"    tokens_out:              {p['tokens_out']}")
         lines.append(f"    latency_ms:              {p['latency_ms']}")
+        lines.append("")
+
+    # Phase 2.2 — linked policy decision (dry-run / preview only).
+    pd = p.get("policy_decision")
+    if pd is None:
+        lines.append("  Linked policy decision:    (none recorded yet)")
+        lines.append("    The Phase 2.1 dry-run engine writes one decision per")
+        lines.append("    classified request. If this row predates Phase 2.1, no")
+        lines.append("    linkage is expected.")
+        lines.append("")
+    else:
+        lines.append("  Linked policy decision (Phase 2.2 dry-run / preview only):")
+        lines.append(f"    decision_id:               {pd['decision_id']}")
+        lines.append(f"    mode:                      {pd['mode']}")
+        lines.append(f"    action:                    {pd['action']}")
+        lines.append(f"    decision_reason:           {pd['decision_reason']}")
+        flags = pd.get("safety_flags") or []
+        flags_str = ", ".join(flags) if flags else "(none)"
+        lines.append(f"    safety_flags:              {flags_str}")
+        if pd.get("recommended_provider"):
+            lines.append(f"    recommended_provider:      {pd['recommended_provider']}")
+        if pd.get("recommended_model"):
+            lines.append(f"    recommended_model:         {pd['recommended_model']}")
+        if pd.get("budget_action"):
+            lines.append(f"    budget_action:             {pd['budget_action']}")
+        if pd.get("compression_profile"):
+            lines.append(f"    compression_profile:       {pd['compression_profile']}")
+        if pd.get("cache_strategy"):
+            lines.append(f"    cache_strategy:            {pd['cache_strategy']}")
+        if pd.get("delivery_strategy"):
+            lines.append(f"    delivery_strategy:         {pd['delivery_strategy']}")
+        lines.append(
+            f"    requires_user_confirmation: {pd['requires_user_confirmation']}"
+        )
+        if pd.get("warning_message"):
+            lines.append(f"    warning_message:           {pd['warning_message']}")
+        lines.append("")
+        lines.append("    DRY-RUN / PREVIEW ONLY — no routing decision was made.")
         lines.append("")
     return "\n".join(lines)
 

--- a/tokenpak/proxy/intent_policy_dashboard.py
+++ b/tokenpak/proxy/intent_policy_dashboard.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.2 — dashboard-shaped read-model for the policy preview.
+
+A thin UI-friendly view over :func:`build_policy_report`. The wire
+shape produced by :func:`collect_policy_dashboard` is the **stable
+API contract** consumed by:
+
+  - ``GET /api/intent/policy-report?window=Nd``
+  - The dashboard's "Intent Policy" panel
+    (``tokenpak/dashboard/intent_policy.js``)
+  - Any third-party tool that wants the policy aggregations
+    programmatically
+
+Three sections in the returned dict:
+
+  - ``cards`` — eight numeric / list cards the dashboard panel
+    renders. **Each card is dry-run / preview only** — the
+    metadata block carries this label explicitly.
+  - ``operator_panel`` — narrative slices (top recommended
+    actions, top safety flags, etc.).
+  - ``metadata`` — schema version, window identity, store path,
+    plus the explicit ``dry_run_preview_only=true`` flag that
+    consumers should display alongside the data.
+
+Read-only. Reuses :func:`build_policy_report` so all privacy /
+window / never-raises invariants flow through unchanged.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+DASHBOARD_SCHEMA_VERSION: str = "intent-policy-dashboard-v1"
+
+
+def _pct(numer: int, denom: int) -> float:
+    if denom <= 0:
+        return 0.0
+    return round(100.0 * numer / denom, 1)
+
+
+def _top_pairs(d: Dict[str, int], top_n: int = 5) -> List[Tuple[str, int]]:
+    return sorted(d.items(), key=lambda kv: -kv[1])[:top_n]
+
+
+def collect_policy_dashboard(
+    *,
+    window_days: Optional[int] = 14,
+    db_path: Optional[Path] = None,
+    now: Optional[_dt.datetime] = None,
+    top_n: int = 5,
+) -> Dict[str, Any]:
+    """Run :func:`build_policy_report` and reshape for dashboard consumers."""
+    from tokenpak.proxy.intent_policy_report import build_policy_report
+
+    report = build_policy_report(
+        window_days=window_days, db_path=db_path, now=now,
+    )
+    total = report.total_decisions
+
+    action_items = [
+        {"action": a, "count": c, "pct": _pct(c, total)}
+        for a, c in report.action_distribution.items()
+    ]
+    safety_items = [
+        {"safety_flag": f, "count": c, "pct": _pct(c, total)}
+        for f, c in sorted(
+            report.safety_flag_distribution.items(), key=lambda kv: -kv[1]
+        )
+    ]
+    compression_items = [
+        {"compression_profile": p, "count": c}
+        for p, c in report.compression_profile_distribution.items()
+    ]
+    cache_items = [
+        {"cache_strategy": s, "count": c}
+        for s, c in report.cache_strategy_distribution.items()
+    ]
+    delivery_items = [
+        {"delivery_strategy": s, "count": c}
+        for s, c in report.delivery_strategy_distribution.items()
+    ]
+    blocked_reason_items = [
+        {"decision_reason": r, "count": c}
+        for r, c in sorted(
+            report.decision_reason_distribution.items(), key=lambda kv: -kv[1]
+        )
+        if r.endswith("_blocked_routing") or r == "unverified_provider_blocked"
+    ]
+
+    cards: Dict[str, Any] = {
+        # Card 1: total
+        "total_dry_run_decisions": {"value": total},
+        # Card 2: top recommended actions
+        "top_recommended_actions": {"items": action_items[:top_n]},
+        # Card 3: top safety flags
+        "top_safety_flags": {"items": safety_items[:top_n]},
+        # Card 4: budget risk flags (reserved in 2.1 — counted here)
+        "budget_risk_flags": {
+            "value": report.budget_risk_flags,
+            "pct_of_total": _pct(report.budget_risk_flags, total),
+        },
+        # Card 5: suggested compression profiles
+        "suggested_compression_profiles": {"items": compression_items},
+        # Card 6: suggested cache policies
+        "suggested_cache_policies": {"items": cache_items},
+        # Card 7: suggested delivery policies
+        "suggested_delivery_policies": {"items": delivery_items},
+        # Card 8: auto-routing blocked reasons
+        "auto_routing_blocked_reasons": {"items": blocked_reason_items},
+    }
+
+    operator_panel: Dict[str, Any] = {
+        "top_recommended_actions": [list(t) for t in _top_pairs(report.action_distribution, top_n)],
+        "top_safety_flags": [list(t) for t in _top_pairs(report.safety_flag_distribution, top_n)],
+        "top_blocked_reasons": [list(t) for t in _top_pairs(
+            {
+                k: v for k, v in report.decision_reason_distribution.items()
+                if k.endswith("_blocked_routing") or k == "unverified_provider_blocked"
+            },
+            top_n,
+        )],
+        "recommended_review_areas": list(report.review_areas),
+    }
+
+    metadata: Dict[str, Any] = {
+        "schema_version": DASHBOARD_SCHEMA_VERSION,
+        "phase": "intent-layer-phase-2.2",
+        "dry_run_preview_only": True,
+        "preview_label": "DRY-RUN / PREVIEW ONLY — no routing decisions made",
+        "window_days": report.window_days,
+        "window_cutoff_iso": report.window_cutoff_iso,
+        "telemetry_store_path": report.db_path,
+    }
+
+    return {
+        "metadata": metadata,
+        "cards": cards,
+        "operator_panel": operator_panel,
+    }
+
+
+def parse_window_or_default(spec: Optional[str]) -> Optional[int]:
+    """Validate ``spec``. Default 14 days when missing.
+
+    Mirrors :func:`tokenpak.proxy.intent_dashboard.parse_window_or_default`
+    so the two API endpoints share window semantics.
+    """
+    from tokenpak.proxy.intent_report import parse_window
+
+    if spec is None or spec == "":
+        return 14
+    return parse_window(spec)
+
+
+__all__ = [
+    "DASHBOARD_SCHEMA_VERSION",
+    "collect_policy_dashboard",
+    "parse_window_or_default",
+]

--- a/tokenpak/proxy/intent_policy_report.py
+++ b/tokenpak/proxy/intent_policy_report.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.2 — read-side aggregations over ``intent_policy_decisions``.
+
+Dual to :mod:`tokenpak.proxy.intent_report` (Phase 1) which
+aggregates the ``intent_events`` table. This module aggregates the
+Phase 2.1 ``intent_policy_decisions`` table:
+
+  - Total dry-run decisions in window
+  - Action distribution
+  - Safety-flag distribution
+  - Decision-reason distribution
+  - Per-intent-class recommendation counts (cross-tab of
+    ``intent_class`` × ``action``)
+  - Low-confidence: blocked vs safe-handled counts
+  - Catch-all: safe-handled count
+  - ``live_verified=False`` recommendation blocks
+  - Budget-risk flag count (reserved in 2.1 — included for
+    forward-compatibility with 2.6)
+  - Compression / cache / delivery suggestion distributions
+
+Read-only. Reads ``raw_prompt_hash`` at most (not even that — the
+policy table doesn't carry that column). The privacy contract is
+asserted in
+``tests/test_intent_policy_phase22.py::TestPrivacyContract``.
+
+Window semantics mirror :mod:`intent_report` exactly: ``Nd`` form,
+default 14d on the dashboard surface, ``0d``/``""`` = all rows on
+the CLI surface, cutoff is inclusive (``timestamp >= cutoff``).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class PolicyReport:
+    """All aggregated metrics for one window. JSON-serialisable."""
+
+    window_days: Optional[int]
+    window_cutoff_iso: Optional[str]
+    db_path: str
+
+    total_decisions: int = 0
+    action_distribution: Dict[str, int] = field(default_factory=dict)
+    decision_reason_distribution: Dict[str, int] = field(default_factory=dict)
+    safety_flag_distribution: Dict[str, int] = field(default_factory=dict)
+
+    # Cross-tab: intent_class -> {action -> count}.
+    recommendations_by_intent_class: Dict[str, Dict[str, int]] = field(
+        default_factory=dict
+    )
+
+    # Safety summaries.
+    low_confidence_blocked: int = 0
+    low_confidence_safe_handled: int = 0
+    catch_all_safe_handled: int = 0
+    unverified_provider_blocked: int = 0
+    missing_slots_blocked: int = 0
+
+    # Reserved for 2.6; counted now so the schema is forward-compatible.
+    budget_risk_flags: int = 0
+
+    # Suggestion distributions.
+    compression_profile_distribution: Dict[str, int] = field(default_factory=dict)
+    cache_strategy_distribution: Dict[str, int] = field(default_factory=dict)
+    delivery_strategy_distribution: Dict[str, int] = field(default_factory=dict)
+
+    review_areas: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "window_days": self.window_days,
+            "window_cutoff_iso": self.window_cutoff_iso,
+            "db_path": self.db_path,
+            "total_decisions": self.total_decisions,
+            "action_distribution": self.action_distribution,
+            "decision_reason_distribution": self.decision_reason_distribution,
+            "safety_flag_distribution": self.safety_flag_distribution,
+            "recommendations_by_intent_class": self.recommendations_by_intent_class,
+            "low_confidence_blocked": self.low_confidence_blocked,
+            "low_confidence_safe_handled": self.low_confidence_safe_handled,
+            "catch_all_safe_handled": self.catch_all_safe_handled,
+            "unverified_provider_blocked": self.unverified_provider_blocked,
+            "missing_slots_blocked": self.missing_slots_blocked,
+            "budget_risk_flags": self.budget_risk_flags,
+            "compression_profile_distribution": self.compression_profile_distribution,
+            "cache_strategy_distribution": self.cache_strategy_distribution,
+            "delivery_strategy_distribution": self.delivery_strategy_distribution,
+            "review_areas": list(self.review_areas),
+        }
+
+
+def _intent_db_path() -> Path:
+    from tokenpak.proxy.intent_contract import _DEFAULT_DB_PATH
+
+    return _DEFAULT_DB_PATH
+
+
+def _table_exists(conn: sqlite3.Connection, name: str = "intent_policy_decisions") -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _window_cutoff(window_days: Optional[int], now: Optional[_dt.datetime]) -> Optional[str]:
+    if window_days is None:
+        return None
+    base = now if now is not None else _dt.datetime.now()
+    return (base - _dt.timedelta(days=window_days)).isoformat(timespec="seconds")
+
+
+def build_policy_report(
+    *,
+    window_days: Optional[int] = 14,
+    db_path: Optional[Path] = None,
+    now: Optional[_dt.datetime] = None,
+) -> PolicyReport:
+    """Run every aggregation and return one fully-populated report.
+
+    Read-only. ``window_days=None`` reads every row.
+    """
+    path = db_path if db_path is not None else _intent_db_path()
+    cutoff = _window_cutoff(window_days, now)
+    report = PolicyReport(
+        window_days=window_days,
+        window_cutoff_iso=cutoff,
+        db_path=str(path),
+    )
+
+    if not path.is_file():
+        report.review_areas = _review_areas(report)
+        return report
+
+    where = ""
+    params: Tuple[Any, ...] = ()
+    if cutoff is not None:
+        where = " WHERE timestamp >= ?"
+        params = (cutoff,)
+
+    with sqlite3.connect(str(path)) as conn:
+        if not _table_exists(conn):
+            report.review_areas = _review_areas(report)
+            return report
+
+        # Total
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_policy_decisions{where}", params
+        ).fetchone()
+        report.total_decisions = int(row[0]) if row else 0
+        if report.total_decisions == 0:
+            report.review_areas = _review_areas(report)
+            return report
+
+        # Action distribution
+        for r in conn.execute(
+            f"SELECT action, COUNT(*) FROM intent_policy_decisions"
+            f"{where} GROUP BY action ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            report.action_distribution[r[0]] = int(r[1])
+
+        # Decision-reason distribution
+        for r in conn.execute(
+            f"SELECT decision_reason, COUNT(*) FROM intent_policy_decisions"
+            f"{where} GROUP BY decision_reason ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            report.decision_reason_distribution[r[0]] = int(r[1])
+
+        # Per-intent-class × action cross-tab
+        for r in conn.execute(
+            f"SELECT intent_class, action, COUNT(*) FROM intent_policy_decisions"
+            f"{where} GROUP BY intent_class, action",
+            params,
+        ).fetchall():
+            cls = r[0]
+            action = r[1]
+            count = int(r[2])
+            report.recommendations_by_intent_class.setdefault(cls, {})[action] = count
+
+        # Suggestion distributions (only over non-null rows)
+        for col, target in (
+            ("compression_profile", report.compression_profile_distribution),
+            ("cache_strategy", report.cache_strategy_distribution),
+            ("delivery_strategy", report.delivery_strategy_distribution),
+        ):
+            and_ = " AND" if where else " WHERE"
+            for r in conn.execute(
+                f"SELECT {col}, COUNT(*) FROM intent_policy_decisions"
+                f"{where}{and_} {col} IS NOT NULL "
+                f"GROUP BY {col} ORDER BY COUNT(*) DESC",
+                params,
+            ).fetchall():
+                target[r[0]] = int(r[1])
+
+        # Safety-flag distribution. ``safety_flags`` is a JSON array
+        # column; aggregate by exploding in Python so SQL stays
+        # portable. Read only the column to keep the prompt-content
+        # locality contract intact.
+        and_ = " AND" if where else " WHERE"
+        for r in conn.execute(
+            f"SELECT safety_flags FROM intent_policy_decisions"
+            f"{where}{and_} safety_flags IS NOT NULL",
+            params,
+        ).fetchall():
+            try:
+                for f in json.loads(r[0] or "[]"):
+                    report.safety_flag_distribution[f] = (
+                        report.safety_flag_distribution.get(f, 0) + 1
+                    )
+            except (TypeError, json.JSONDecodeError):
+                continue
+
+        # Safety summaries derived from decision_reason +
+        # safety_flag presence. Each is a separate count to keep the
+        # report explainable.
+        report.low_confidence_blocked = report.decision_reason_distribution.get(
+            "low_confidence_blocked_routing", 0
+        )
+        # low_confidence_safe_handled: rows where the row's confidence
+        # column itself is below the engine's CLASSIFY_THRESHOLD
+        # (Phase 0 default 0.4) AND the decision is NOT in the
+        # routing-affecting blocked set. This is the symmetric
+        # "we observed low confidence and the engine handled it
+        # safely" counter. Use the engine's threshold for symmetry.
+        try:
+            from tokenpak.proxy.intent_policy_engine import PolicyEngineConfig
+
+            threshold = PolicyEngineConfig().low_confidence_threshold
+        except Exception:  # noqa: BLE001
+            threshold = 0.65
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_policy_decisions"
+            f"{where}{and_} intent_confidence < ? "
+            f"AND decision_reason != 'low_confidence_blocked_routing'",
+            (*params, threshold),
+        ).fetchone()
+        report.low_confidence_safe_handled = int(row[0]) if row else 0
+
+        report.catch_all_safe_handled = report.decision_reason_distribution.get(
+            "catch_all_blocked_routing", 0
+        )
+        report.unverified_provider_blocked = report.decision_reason_distribution.get(
+            "unverified_provider_blocked", 0
+        )
+        report.missing_slots_blocked = report.decision_reason_distribution.get(
+            "missing_slots_blocked_routing", 0
+        )
+        report.budget_risk_flags = report.action_distribution.get(
+            "flag_budget_risk", 0
+        )
+
+    report.review_areas = _review_areas(report)
+    return report
+
+
+def _review_areas(report: PolicyReport) -> List[str]:
+    """Operator-narrative recommendations. Heuristic, not authoritative."""
+    out: List[str] = []
+    if report.total_decisions == 0:
+        out.append(
+            "No dry-run policy decisions yet — start the proxy and route some "
+            "traffic through it before re-running this report."
+        )
+        return out
+
+    warn_count = report.action_distribution.get("warn_only", 0)
+    if warn_count and warn_count / report.total_decisions > 0.5:
+        pct = round(100 * warn_count / report.total_decisions)
+        out.append(
+            f"warn_only is {pct}% of policy decisions — investigate which "
+            f"safety flag dominates and whether it's calibrated correctly."
+        )
+
+    observe_count = report.action_distribution.get("observe_only", 0)
+    if observe_count == report.total_decisions and report.total_decisions > 0:
+        out.append(
+            "Every decision is observe_only — the per-intent heuristic table "
+            "may need broader entries before a future Phase 2.4 suggest mode "
+            "becomes useful."
+        )
+
+    if report.unverified_provider_blocked:
+        out.append(
+            f"{report.unverified_provider_blocked} request(s) hit "
+            f"unverified_provider_blocked; confirm provider live_verified "
+            f"flags are set correctly in credential_injector."
+        )
+
+    return out
+
+
+def render_human(report: PolicyReport) -> str:
+    """Operator-readable plain-text policy report.
+
+    Used as a section appended to ``tokenpak intent report`` output;
+    can also be rendered standalone.
+    """
+    lines: List[str] = []
+    lines.append("")
+    lines.append("  ── Policy summary (Phase 2.2 dry-run / preview only) ──")
+    lines.append("")
+    if report.total_decisions == 0:
+        lines.append("  No dry-run policy decisions in this window.")
+        lines.append("")
+        if report.review_areas:
+            for ra in report.review_areas:
+                lines.append(f"  - {ra}")
+            lines.append("")
+        return "\n".join(lines)
+
+    lines.append(f"  Total dry-run decisions:   {report.total_decisions}")
+    lines.append("")
+    lines.append("  Action distribution:")
+    for action, count in report.action_distribution.items():
+        pct = round(100 * count / report.total_decisions)
+        lines.append(f"    {action:<32s} {count:>6d}  ({pct}%)")
+    lines.append("")
+
+    if report.safety_flag_distribution:
+        lines.append("  Safety flags raised:")
+        for flag, count in sorted(
+            report.safety_flag_distribution.items(),
+            key=lambda kv: -kv[1],
+        ):
+            lines.append(f"    {flag:<32s} {count}")
+        lines.append("")
+
+    lines.append("  Safety summary:")
+    lines.append(f"    low_confidence_blocked:     {report.low_confidence_blocked}")
+    lines.append(f"    low_confidence_safe_handled:{report.low_confidence_safe_handled}")
+    lines.append(f"    catch_all_safe_handled:     {report.catch_all_safe_handled}")
+    lines.append(f"    unverified_provider_blocked:{report.unverified_provider_blocked}")
+    lines.append(f"    missing_slots_blocked:      {report.missing_slots_blocked}")
+    lines.append(f"    budget_risk_flags:          {report.budget_risk_flags}")
+    lines.append("")
+
+    if report.compression_profile_distribution:
+        lines.append("  Suggested compression profiles:")
+        for profile, count in report.compression_profile_distribution.items():
+            lines.append(f"    {profile:<24s} {count}")
+        lines.append("")
+    if report.cache_strategy_distribution:
+        lines.append("  Suggested cache strategies:")
+        for strat, count in report.cache_strategy_distribution.items():
+            lines.append(f"    {strat:<24s} {count}")
+        lines.append("")
+    if report.delivery_strategy_distribution:
+        lines.append("  Suggested delivery strategies:")
+        for strat, count in report.delivery_strategy_distribution.items():
+            lines.append(f"    {strat:<24s} {count}")
+        lines.append("")
+
+    if report.review_areas:
+        lines.append("  Recommended review areas:")
+        for ra in report.review_areas:
+            lines.append(f"    - {ra}")
+        lines.append("")
+
+    lines.append("  Phase 2.2 is observation only. No routing decisions made.")
+    lines.append("  See docs/reference/intent-policy-preview.md for what NOT")
+    lines.append("  to infer from these aggregations.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(report: PolicyReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+__all__ = [
+    "PolicyReport",
+    "build_policy_report",
+    "render_human",
+    "render_json",
+]

--- a/tokenpak/proxy/intent_report.py
+++ b/tokenpak/proxy/intent_report.py
@@ -128,6 +128,11 @@ class IntentReport:
     top_catch_all_reasons: List[Tuple[str, int]] = field(default_factory=list)
     review_areas: List[str] = field(default_factory=list)
 
+    # Phase 2.2 — policy summary (dry-run / preview only). Populated
+    # by build_report() from the intent_policy_decisions table.
+    # Empty dict on a fresh DB or pre-2.1 hosts.
+    policy_summary: Dict[str, Any] = field(default_factory=dict)
+
     def to_dict(self) -> Dict[str, Any]:
         """JSON-friendly dict (tuples → 2-element lists)."""
         return {
@@ -150,6 +155,7 @@ class IntentReport:
             "top_missing_slots": [list(t) for t in self.top_missing_slots],
             "top_catch_all_reasons": [list(t) for t in self.top_catch_all_reasons],
             "review_areas": list(self.review_areas),
+            "policy_summary": dict(self.policy_summary),
         }
 
 
@@ -406,6 +412,40 @@ def build_report(
         (k, v) for k, v in list(report.catch_all_reason_distribution.items())[:top_n]
     ]
     report.review_areas = _review_areas(report)
+
+    # Phase 2.2 — append a policy-summary slice. Best-effort: if the
+    # policy table is empty / missing / mid-migration, the summary
+    # is an empty dict and the renderer prints "no decisions yet".
+    try:
+        from tokenpak.proxy.intent_policy_report import build_policy_report
+
+        policy = build_policy_report(
+            window_days=window_days, db_path=path, now=now,
+        )
+        report.policy_summary = {
+            "total_decisions": policy.total_decisions,
+            "action_distribution": dict(policy.action_distribution),
+            "safety_flag_distribution": dict(policy.safety_flag_distribution),
+            "decision_reason_distribution": dict(policy.decision_reason_distribution),
+            "low_confidence_blocked": policy.low_confidence_blocked,
+            "low_confidence_safe_handled": policy.low_confidence_safe_handled,
+            "catch_all_safe_handled": policy.catch_all_safe_handled,
+            "unverified_provider_blocked": policy.unverified_provider_blocked,
+            "missing_slots_blocked": policy.missing_slots_blocked,
+            "budget_risk_flags": policy.budget_risk_flags,
+            "compression_profile_distribution": dict(
+                policy.compression_profile_distribution
+            ),
+            "cache_strategy_distribution": dict(policy.cache_strategy_distribution),
+            "delivery_strategy_distribution": dict(
+                policy.delivery_strategy_distribution
+            ),
+        }
+    except Exception:  # noqa: BLE001
+        # Read-side; never raise. An import failure here is a build
+        # bug we want surfaced via tests, not a runtime crash.
+        report.policy_summary = {}
+
     return report
 
 
@@ -514,6 +554,27 @@ def render_human(report: IntentReport) -> str:
     lines.append("  Phase 1 is observation-only. No user-facing behavior changes.")
     lines.append("  See docs/reference/intent-reporting.md for what NOT to infer.")
     lines.append("")
+
+    # Phase 2.2 — append the policy summary section if any decisions
+    # have been recorded.
+    summary = report.policy_summary or {}
+    if summary:
+        try:
+            from tokenpak.proxy.intent_policy_report import (
+                build_policy_report,
+            )
+            from tokenpak.proxy.intent_policy_report import (
+                render_human as _render_policy,
+            )
+
+            policy = build_policy_report(
+                window_days=report.window_days,
+                db_path=Path(report.db_path) if report.db_path else None,
+            )
+            lines.append(_render_policy(policy))
+        except Exception:  # noqa: BLE001
+            pass
+
     return "\n".join(lines)
 
 

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -496,6 +496,42 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             except Exception as e:
                 self._send_json({"error": str(e)})
             return
+        if path.startswith("/api/intent/policy-report"):
+            # Phase 2.2 — observation-only dashboard / read-model
+            # surface over the intent_policy_decisions store. Reuses
+            # build_policy_report; never reads or emits raw prompt
+            # content. Default window 14d (matches /api/intent/report).
+            # MUST be checked before /api/intent/report below since
+            # both share the prefix.
+            from urllib.parse import parse_qs as _pqs
+            from urllib.parse import urlparse as _purl
+
+            from tokenpak.proxy.intent_policy_dashboard import (
+                collect_policy_dashboard as _i22_collect,
+            )
+            from tokenpak.proxy.intent_policy_dashboard import (
+                parse_window_or_default as _i22_window,
+            )
+
+            parsed_path = _purl(path)
+            qs = _pqs(parsed_path.query)
+            raw_window = (qs.get("window") or [""])[0]
+            try:
+                days = _i22_window(raw_window)
+            except ValueError as exc:
+                self._send_json_error(400, "bad_request", str(exc))
+                return
+            try:
+                payload = _i22_collect(window_days=days)
+            except Exception as exc:  # noqa: BLE001
+                self._send_json_error(
+                    500,
+                    "intent_policy_dashboard_failed",
+                    f"intent policy dashboard failed: {exc!r}",
+                )
+                return
+            self._send_json(payload)
+            return
         if path.startswith("/api/intent/report"):
             # Phase 1.1 — observation-only dashboard / read-model
             # surface over the Phase 0 intent_events store. Reuses


### PR DESCRIPTION
## Summary

Observation-only Phase 2.2 surfaces over the Phase 2.1 dry-run policy engine. Three independent read paths, all sharing one query layer (`build_policy_report`):

| Surface | Where |
|---|---|
| `tokenpak doctor --explain-last` | extended with linked policy decision |
| `tokenpak intent report` | new "Policy summary" section + `policy_summary` JSON key |
| `GET /api/intent/policy-report?window=Nd` | new endpoint, dashboard-shaped JSON |
| Dashboard "Intent Policy" panel | new UI section, 8 cards + tables + operator panel |

**All surfaces clearly labeled DRY-RUN / PREVIEW ONLY.** Default behavior remains `observe_only`. No routing changes. No classifier changes. No request mutation.

## Changes

- **`tokenpak/proxy/intent_policy_report.py`** — read-side aggregations over `intent_policy_decisions`. `PolicyReport` dataclass with all 18 metrics + per-intent-class × action cross-tab. `build_policy_report` reuses the engine's `CLASSIFY_THRESHOLD` for the safe-handled count.
- **`tokenpak/proxy/intent_policy_dashboard.py`** — UI-shaped read-model. Pre-computed percentages. Schema version `intent-policy-dashboard-v1`. Metadata carries `dry_run_preview_only=true` + `preview_label`.
- **`tokenpak/proxy/intent_doctor.py`** — `collect_explain_last` joins to `intent_policy_decisions` by `contract_id`; `render_explain_last` surfaces every directive-mandated field.
- **`tokenpak/proxy/intent_report.py`** — `IntentReport` gains a `policy_summary` field; renderer appends a "Policy summary" section.
- **`tokenpak/proxy/server.py`** — new `GET /api/intent/policy-report?window=Nd` handler.
- **`tokenpak/dashboard/{index.html, intent_policy.js, __init__.py}`** — new "Intent Policy" panel polled every 5 s.
- **`tests/test_intent_policy_phase22.py`** — 26 tests across 13 classes (one per directive bullet + three cross-cutting).
- **`docs/reference/intent-policy-preview.md`** — extended with the new surfaces.

## Acceptance

- [x] Policy decisions visible in CLI explain (linked by `contract_id`) + `tokenpak intent report` (policy summary).
- [x] Policy preview visible in dashboard panel + API + read-model.
- [x] All output clearly labeled dry-run / preview.
- [x] Default behavior remains `observe_only` (engine + config untouched from 2.1).
- [x] No routing behavior changes.
- [x] No classifier behavior changes.
- [x] No prompt content / per-row hashes in any output (sentinel-substring + hash absence asserted across CLI / API / dashboard).
- [x] **1109 passing** (was 1083 baseline, +26), 0 regressions.
- [x] `ruff check` clean, `cli-docs-in-sync` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no scaffold renderer expansion, **no classifier behavior changes**, **no production intent-based routing decisions**, **no opt-in suggest/confirm/enforce behavior**.