### PR TITLE
feat(proxy,cli): Phase 2.4.1 — PolicySuggestion builder + telemetry

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -616,14 +616,16 @@ options:
 Intent Layer observation + reporting (read-only)
 
 ```
-usage: tokenpak intent [-h] {report,policy-preview} ...
+usage: tokenpak intent [-h] {report,policy-preview,suggestions} ...
 
 positional arguments:
-  {report,policy-preview}
+  {report,policy-preview,suggestions}
     report              Summarize the intent_events telemetry over a window.
                         Read-only; never reads or emits raw prompt text.
     policy-preview      Show the latest intent policy decision (Phase 2.1 dry-
                         run; read-only).
+    suggestions         Show the latest dry-run policy suggestion (Phase
+                        2.4.1; internal/dev inspector; read-only).
 
 options:
   -h, --help            show this help message and exit

--- a/tests/test_intent_suggestion_phase24_1.py
+++ b/tests/test_intent_suggestion_phase24_1.py
@@ -1,0 +1,751 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.1 — PolicySuggestion builder + telemetry test suite.
+
+Thirteen directive-mandated test categories:
+
+  - eligible suggestion generated
+  - low-confidence no suggestion
+  - catch_all no suggestion
+  - missing slots no suggestion (constructive variant fires only
+    on warn_only/missing_slots; main types suppressed)
+  - live_verified=False no suggestion by default
+  - adapter capability suggestion (constructive fallback)
+  - budget warning suggestion
+  - wording forbidden-list enforcement
+  - no prompt text or secrets
+  - no classifier mutation
+  - no request mutation
+  - no routing mutation
+  - deterministic suggestion_id behavior
+
+Read-only against production telemetry; uses the production
+builder + telemetry store so the schema stays a single source of
+truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import build_contract
+from tokenpak.proxy.intent_policy_engine import (
+    ACTION_FLAG_BUDGET_RISK,
+    ACTION_OBSERVE_ONLY,
+    ACTION_SUGGEST_CACHE_POLICY,
+    ACTION_SUGGEST_COMPRESSION_PROFILE,
+    ACTION_SUGGEST_DELIVERY_POLICY,
+    ACTION_SUGGEST_ROUTE,
+    ACTION_WARN_ONLY,
+    REASON_DEFAULT_OBSERVE_ONLY,
+    REASON_DRY_RUN_SUGGEST,
+    SAFETY_LOW_CONFIDENCE,
+    SAFETY_MISSING_SLOTS,
+    PolicyDecision,
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+    make_decision_id,
+)
+from tokenpak.proxy.intent_suggestion import (
+    DRY_RUN_DISCLAIMER,
+    FORBIDDEN_PHRASES,
+    SOURCE_INTENT_POLICY_V0,
+    SUGGESTION_ADAPTER_CAPABILITY,
+    SUGGESTION_BUDGET_WARNING,
+    SUGGESTION_COMPRESSION,
+    SUGGESTION_MISSING_SLOT,
+    SUGGESTION_PROVIDER_MODEL,
+    SUGGESTION_TYPES,
+    SuggestionBuilderContext,
+    SuggestionWordingError,
+    build_suggestions,
+    make_suggestion_id,
+)
+from tokenpak.proxy.intent_suggestion_telemetry import (
+    IntentSuggestionRow,
+    IntentSuggestionStore,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _classification(intent_class="summarize", confidence=0.9,
+                    slots_present=("period",), slots_missing=(),
+                    catch_all_reason=None):
+    return IntentClassification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+
+
+def _safe_input(**over) -> PolicyInput:
+    kw = dict(
+        intent_class="summarize",
+        confidence=0.9,
+        slots_present=("period",),
+        slots_missing=(),
+        catch_all_reason=None,
+        provider="tokenpak-test",
+        model="test-model",
+        live_verified_status=True,
+        required_slots=(),
+    )
+    kw.update(over)
+    return PolicyInput(**kw)
+
+
+def _safe_contract(*, prompt="summarize the vault", **kw):
+    cls = _classification(**kw)
+    return build_contract(classification=cls, raw_prompt=prompt)
+
+
+def _ctx(*, capabilities=frozenset({"tip.compression.v1"}),
+         provider_verified=None, required_slots=(),
+         allow_unverified=False, threshold=0.65):
+    return SuggestionBuilderContext(
+        config=PolicyEngineConfig(
+            allow_unverified_providers=allow_unverified,
+            low_confidence_threshold=threshold,
+        ),
+        adapter_capabilities=capabilities,
+        provider_verified=provider_verified,
+        required_slots=required_slots,
+    )
+
+
+# ── 1. Eligible suggestion generated ──────────────────────────────────
+
+
+class TestEligibleSuggestion:
+
+    def test_high_confidence_summarize_emits_compression(self):
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert len(suggestions) == 1
+        s = suggestions[0]
+        assert s.suggestion_type == SUGGESTION_COMPRESSION
+        assert s.confidence == contract.confidence
+        assert s.requires_confirmation is False
+        assert s.source == SOURCE_INTENT_POLICY_V0
+        assert s.user_visible is False  # 2.4.3 wires this on
+        assert s.recommended_action  # not None
+        # Disclaimer present in message.
+        assert DRY_RUN_DISCLAIMER in s.message
+
+    def test_suggestion_links_decision_and_contract(self):
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert suggestions[0].decision_id == decision.decision_id
+        assert suggestions[0].contract_id == contract.contract_id
+
+
+# ── 2. Low-confidence no suggestion ───────────────────────────────────
+
+
+class TestLowConfidenceNoSuggestion:
+
+    def test_below_threshold_emits_nothing(self):
+        # Even with a clean intent, low confidence blocks all
+        # suggestion types.
+        contract = _safe_contract(confidence=0.4)
+        # Build a decision via the engine — it'll emit warn_only
+        # with low_confidence flag.
+        decision = evaluate_policy(_safe_input(confidence=0.4), PolicyEngineConfig())
+        assert decision.action == ACTION_WARN_ONLY
+        assert SAFETY_LOW_CONFIDENCE in decision.safety_flags
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert suggestions == []
+
+
+# ── 3. Catch-all no suggestion ────────────────────────────────────────
+
+
+class TestCatchAllNoSuggestion:
+
+    def test_catch_all_emits_nothing(self):
+        contract = _safe_contract(intent_class="query", confidence=0.0,
+                                   slots_present=(), slots_missing=(),
+                                   catch_all_reason="empty_prompt")
+        # Construct a hand-crafted suggest_compression decision to
+        # bypass the engine (which would itself block routing on
+        # catch-all). The builder MUST also block.
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="query",
+            confidence=0.0,
+            action=ACTION_SUGGEST_COMPRESSION_PROFILE,
+            compression_profile="aggressive",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert suggestions == []
+
+
+# ── 4. Missing slots no suggestion (main types suppressed) ────────────
+
+
+class TestMissingSlotsNoSuggestion:
+
+    def test_main_types_suppressed_when_required_slot_missing(self):
+        contract = _safe_contract(slots_missing=("target",))
+        # Pretend the engine wants to suggest compression even with
+        # missing required slots.
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_COMPRESSION_PROFILE,
+            compression_profile="aggressive",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(required_slots=("target",)),
+        )
+        # No compression suggestion when required slots missing.
+        # Constructive missing_slot_improvement only fires when the
+        # decision itself is warn_only/missing_slots.
+        assert suggestions == []
+
+    def test_warn_only_missing_slots_emits_constructive(self):
+        contract = _safe_contract(slots_missing=("target",))
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_WARN_ONLY,
+            decision_reason="missing_slots_blocked_routing",
+            safety_flags=(SAFETY_MISSING_SLOTS,),
+        )
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(required_slots=("target",)),
+        )
+        assert len(suggestions) == 1
+        s = suggestions[0]
+        assert s.suggestion_type == SUGGESTION_MISSING_SLOT
+        assert "target" in s.message
+        assert s.safety_flags == (SAFETY_MISSING_SLOTS,)
+
+
+# ── 5. live_verified=False no suggestion by default ───────────────────
+
+
+class TestLiveVerifiedFalseNoSuggestion:
+
+    def test_unverified_blocks_provider_recommendation(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_ROUTE,
+            recommended_provider="tokenpak-unverified",
+            recommended_model="m",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(provider_verified=False, allow_unverified=False),
+        )
+        assert suggestions == []
+
+    def test_unverified_emits_when_allowed(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_ROUTE,
+            recommended_provider="tokenpak-unverified",
+            recommended_model="m",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(provider_verified=False, allow_unverified=True),
+        )
+        assert len(suggestions) == 1
+        assert suggestions[0].suggestion_type == SUGGESTION_PROVIDER_MODEL
+
+
+# ── 6. Adapter capability suggestion (constructive fallback) ──────────
+
+
+class TestAdapterCapabilitySuggestion:
+
+    def test_compression_falls_back_when_capability_absent(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_COMPRESSION_PROFILE,
+            compression_profile="aggressive",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        # Adapter has SOMETHING (passes rule e) but not tip.compression.v1.
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(capabilities=frozenset({"tip.security.dlp-redaction"})),
+        )
+        assert len(suggestions) == 1
+        s = suggestions[0]
+        assert s.suggestion_type == SUGGESTION_ADAPTER_CAPABILITY
+        assert "tip.compression.v1" in s.message
+
+    def test_cache_falls_back_when_no_cache_capability(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_CACHE_POLICY,
+            cache_strategy="proxy_managed",
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision,
+            contract=contract,
+            ctx=_ctx(capabilities=frozenset({"tip.compression.v1"})),
+        )
+        assert len(suggestions) == 1
+        assert suggestions[0].suggestion_type == SUGGESTION_ADAPTER_CAPABILITY
+
+
+# ── 7. Budget warning suggestion ──────────────────────────────────────
+
+
+class TestBudgetWarningSuggestion:
+
+    def test_flag_budget_risk_emits_warning(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_FLAG_BUDGET_RISK,
+            decision_reason=REASON_DRY_RUN_SUGGEST,
+        )
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert len(suggestions) == 1
+        s = suggestions[0]
+        assert s.suggestion_type == SUGGESTION_BUDGET_WARNING
+        assert s.recommended_action is None  # observation only
+
+    def test_observe_only_emits_nothing(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="status",
+            confidence=0.9,
+            action=ACTION_OBSERVE_ONLY,
+            decision_reason=REASON_DEFAULT_OBSERVE_ONLY,
+        )
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert suggestions == []
+
+
+# ── 8. Wording forbidden-list enforcement ─────────────────────────────
+
+
+class TestWordingGuardrail:
+
+    def test_forbidden_phrases_constant_pinned(self):
+        # The directive enumerates exactly these eight phrases.
+        # Any future change requires explicit ratification.
+        assert "applied" in FORBIDDEN_PHRASES
+        assert "changed" in FORBIDDEN_PHRASES
+        assert "routed to" in FORBIDDEN_PHRASES
+        assert "switched to" in FORBIDDEN_PHRASES
+        assert "now using" in FORBIDDEN_PHRASES
+        assert "updated" in FORBIDDEN_PHRASES
+        assert "will route" in FORBIDDEN_PHRASES
+        assert "will switch" in FORBIDDEN_PHRASES
+
+    def test_no_emitted_string_contains_forbidden_phrase(self):
+        # Build one suggestion of every type that fires from a
+        # decision in 2.4.1, and check every string field against
+        # the forbidden regex.
+        contract = _safe_contract()
+
+        cases = [
+            (ACTION_SUGGEST_COMPRESSION_PROFILE, "tip.compression.v1"),
+            (ACTION_SUGGEST_CACHE_POLICY, "tip.cache.proxy-managed"),
+            (ACTION_SUGGEST_DELIVERY_POLICY, "tip.compression.v1"),  # delivery not capability-gated
+            (ACTION_FLAG_BUDGET_RISK, "tip.compression.v1"),
+        ]
+        forbidden_re = re.compile(
+            r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+            re.IGNORECASE,
+        )
+        for action, capability in cases:
+            decision = PolicyDecision(
+                decision_id=make_decision_id(),
+                mode="dry_run",
+                intent_class="summarize",
+                confidence=0.9,
+                action=action,
+                compression_profile="aggressive" if action == ACTION_SUGGEST_COMPRESSION_PROFILE else None,
+                cache_strategy="proxy_managed" if action == ACTION_SUGGEST_CACHE_POLICY else None,
+                delivery_strategy="non_streaming" if action == ACTION_SUGGEST_DELIVERY_POLICY else None,
+                decision_reason=REASON_DRY_RUN_SUGGEST,
+            )
+            suggestions = build_suggestions(
+                decision=decision, contract=contract,
+                ctx=_ctx(capabilities=frozenset({capability})),
+            )
+            for s in suggestions:
+                for text in (s.title, s.message, s.recommended_action or ""):
+                    assert forbidden_re.search(text) is None, (
+                        f"forbidden phrase in {s.suggestion_type}: {text!r}"
+                    )
+
+    def test_dry_run_disclaimer_in_message(self):
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        for s in suggestions:
+            assert DRY_RUN_DISCLAIMER in s.message
+
+    def test_wording_guardrail_raises_on_forbidden(self):
+        # Direct test of the guardrail function. Hitting any
+        # forbidden phrase in any field raises
+        # SuggestionWordingError. This is the contract a future
+        # template change relies on — a regression in
+        # _check_wording would let bad wording through.
+        #
+        # Re-imported from sys.modules at call time to survive
+        # the module-reload pollution from tests/deprecations/
+        # (which pops tokenpak.proxy.* modules and rebinds the
+        # exception class identity).
+        from tokenpak.proxy.intent_suggestion import _check_wording
+
+        def _expect_raise(*args):
+            try:
+                _check_wording(*args)
+            except Exception as exc:  # noqa: BLE001
+                assert type(exc).__name__ == "SuggestionWordingError", (
+                    f"unexpected exception type: {type(exc).__name__}"
+                )
+                return
+            pytest.fail(f"expected SuggestionWordingError for {args!r}")
+
+        for phrase in FORBIDDEN_PHRASES:
+            _expect_raise(f"This was {phrase} successfully")
+            _expect_raise("title", f"message that has {phrase} in it", None)
+            _expect_raise("title", "msg", f"action with {phrase}")
+
+    def test_wording_guardrail_passes_safe_strings(self):
+        from tokenpak.proxy.intent_suggestion import _check_wording
+
+        # Allowed wording from spec §8.1 must pass the guard.
+        for phrase in (
+            "Recommended", "Consider", "Could improve", "Suggested",
+            "May help", "Eligible for",
+        ):
+            _check_wording(f"This is a {phrase} suggestion.")
+            _check_wording("title", "msg", f"{phrase} action")
+
+
+# ── 9. No prompt text or secrets ──────────────────────────────────────
+
+
+class TestPrivacyContract:
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-2-4-1"
+
+    def test_sentinel_absent_from_suggestion(self):
+        contract = _safe_contract(prompt=f"summarize the vault {self.SENTINEL}")
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        for s in suggestions:
+            payload = json.dumps(s.to_dict())
+            assert self.SENTINEL not in payload
+
+    def test_sentinel_absent_from_persisted_row(self, tmp_path: Path):
+        contract = _safe_contract(prompt=f"summarize the vault {self.SENTINEL}")
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        store = IntentSuggestionStore(db_path=tmp_path / "t.db")
+        for s in suggestions:
+            store.write(IntentSuggestionRow(suggestion=s, timestamp="t"))
+        store.close()
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM intent_suggestions").fetchall()
+        conn.close()
+        for row in rows:
+            for col in row.keys():
+                v = row[col]
+                if v is not None:
+                    assert self.SENTINEL not in str(v), (
+                        f"sentinel leaked into column {col!r}"
+                    )
+
+
+# ── 10. No classifier mutation ────────────────────────────────────────
+
+
+class TestNoClassifierMutation:
+    """The Phase 2.4 spec §11 rule: intent_classifier.py MUST NOT
+    be edited in any 2.4.x PR. Structural test on the file
+    contents — the §11 list of canonical-intent keywords + the
+    classify_intent function signature must remain stable.
+    """
+
+    def test_classify_threshold_unchanged_from_phase_0(self):
+        from tokenpak.proxy.intent_classifier import (
+            CLASSIFY_THRESHOLD,
+            INTENT_SOURCE_V0,
+        )
+        assert CLASSIFY_THRESHOLD == 0.4
+        assert INTENT_SOURCE_V0 == "rule_based_v0"
+
+
+# ── 11. No request mutation ───────────────────────────────────────────
+
+
+class TestNoRequestMutation:
+
+    def test_builder_does_not_mutate_inputs(self):
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        ctx = _ctx()
+        # Capture pre-call state (frozen dataclasses; capture
+        # attribute identities).
+        before_decision = decision
+        before_contract = contract
+        before_caps = ctx.adapter_capabilities
+        build_suggestions(decision=decision, contract=contract, ctx=ctx)
+        # Frozen dataclasses; reference equality is strict equality.
+        assert before_decision is decision
+        assert before_contract is contract
+        assert before_caps is ctx.adapter_capabilities
+
+    def test_suggestion_is_frozen(self):
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        with pytest.raises(Exception):
+            suggestions[0].title = "spoofed"  # type: ignore[misc]
+
+
+# ── 12. No routing mutation ───────────────────────────────────────────
+
+
+class TestNoRoutingMutation:
+    """Structural: the suggestion + telemetry modules MUST NOT
+    import dispatch / forward primitives.
+    """
+
+    def test_suggestion_module_does_not_import_forward_path(self):
+        import tokenpak.proxy.intent_suggestion as m
+
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src, (
+                f"suggestion module references dispatch primitive: {forbidden!r}"
+            )
+
+    def test_telemetry_module_does_not_import_forward_path(self):
+        import tokenpak.proxy.intent_suggestion_telemetry as m
+
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src, (
+                f"telemetry module references dispatch primitive: {forbidden!r}"
+            )
+
+
+# ── 13. Deterministic suggestion_id ───────────────────────────────────
+
+
+class TestSuggestionIdShape:
+    """suggestion_id is opaque + sortable. Each call returns a
+    distinct id; the shape (29 hex chars: 13 ms + 16 random) is
+    pinned.
+    """
+
+    def test_id_shape(self):
+        sid = make_suggestion_id()
+        assert len(sid) == 29
+        int(sid, 16)  # all hex
+
+    def test_ids_unique(self):
+        a = make_suggestion_id()
+        b = make_suggestion_id()
+        assert a != b
+
+    def test_suggestion_type_enum_has_seven(self):
+        assert len(SUGGESTION_TYPES) == 7
+
+
+# ── 14. Telemetry round-trip + CLI smoke (cross-cutting) ──────────────
+
+
+class TestTelemetryRoundTrip:
+
+    def test_table_created_on_first_write(self, tmp_path: Path):
+        store = IntentSuggestionStore(db_path=tmp_path / "t.db")
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        for s in build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        ):
+            store.write(IntentSuggestionRow(suggestion=s, timestamp="t"))
+        store.close()
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='intent_suggestions'"
+        )
+        assert cur.fetchone() is not None
+
+    def test_fetch_latest_round_trip(self, tmp_path: Path):
+        store = IntentSuggestionStore(db_path=tmp_path / "t.db")
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        for s in build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        ):
+            store.write(IntentSuggestionRow(suggestion=s, timestamp="2026-04-26T12:00:00"))
+        latest = store.fetch_latest()
+        assert latest is not None
+        assert latest["suggestion_type"] == SUGGESTION_COMPRESSION
+        assert isinstance(latest["safety_flags"], list)
+        assert latest["requires_confirmation"] is False
+        assert latest["user_visible"] is False
+
+    def test_fetch_for_decision(self, tmp_path: Path):
+        store = IntentSuggestionStore(db_path=tmp_path / "t.db")
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        for s in build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        ):
+            store.write(IntentSuggestionRow(suggestion=s, timestamp="t"))
+        rows = store.fetch_for_decision(decision.decision_id)
+        assert len(rows) == 1
+        assert rows[0]["decision_id"] == decision.decision_id
+
+    def test_writer_does_not_raise_on_unwritable_path(self):
+        bad = Path("/proc/this-cannot-be-a-real-file.db")
+        store = IntentSuggestionStore(db_path=bad)
+        contract = _safe_contract()
+        decision = evaluate_policy(_safe_input(), PolicyEngineConfig())
+        for s in build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        ):
+            # Best-effort contract — never propagates.
+            store.write(IntentSuggestionRow(suggestion=s, timestamp="t"))
+
+
+class TestCliInspector:
+
+    def test_help_includes_suggestions(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "suggestions", "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--last" in result.stdout
+        assert "--json" in result.stdout
+
+    def test_runs_without_error(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "suggestions"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+
+    def test_json_mode_returns_json(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "suggestions", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        json.loads(result.stdout)
+
+
+# ── 15. Eligibility shape pinned (cross-cutting) ──────────────────────
+
+
+class TestEligibilityPinned:
+    """Pin the seven types + the seven gates. A future spec change
+    requires explicit ratification.
+    """
+
+    def test_seven_types_match_spec(self):
+        assert SUGGESTION_TYPES == frozenset({
+            "provider_model_recommendation",
+            "compression_profile_recommendation",
+            "cache_policy_recommendation",
+            "delivery_strategy_recommendation",
+            "budget_warning",
+            "missing_slot_improvement",
+            "adapter_capability_recommendation",
+        })
+
+    def test_decision_with_unknown_reason_emits_nothing(self):
+        contract = _safe_contract()
+        decision = PolicyDecision(
+            decision_id=make_decision_id(),
+            mode="dry_run",
+            intent_class="summarize",
+            confidence=0.9,
+            action=ACTION_SUGGEST_COMPRESSION_PROFILE,
+            compression_profile="aggressive",
+            decision_reason="some_future_reason_not_in_taxonomy",
+        )
+        suggestions = build_suggestions(
+            decision=decision, contract=contract, ctx=_ctx(),
+        )
+        assert suggestions == []

--- a/tests/test_intent_suggestion_phase24_1.py
+++ b/tests/test_intent_suggestion_phase24_1.py
@@ -65,7 +65,6 @@ from tokenpak.proxy.intent_suggestion import (
     SUGGESTION_PROVIDER_MODEL,
     SUGGESTION_TYPES,
     SuggestionBuilderContext,
-    SuggestionWordingError,
     build_suggestions,
     make_suggestion_id,
 )

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -553,6 +553,74 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def cmd_intent_suggestions(args) -> None:
+    """Phase 2.4.1 — show the latest dry-run policy suggestion.
+
+    Read-only over ``intent_suggestions``. Minimal internal /
+    dev-facing inspector; broad surfaces (CLI report, dashboard
+    panel, API) are Phase 2.4.2 deliverables.
+    """
+    import json as _json
+
+    from tokenpak.proxy.intent_suggestion_telemetry import (
+        get_default_suggestion_store,
+    )
+
+    payload = get_default_suggestion_store().fetch_latest()
+    if getattr(args, "suggestions_json", False):
+        print(_json.dumps(payload if payload is not None else None, indent=2, sort_keys=True, default=str))
+        sys.exit(0)
+
+    if payload is None:
+        print(
+            "\nTOKENPAK  |  Intent suggestions (Phase 2.4.1 dry-run inspector)\n"
+            "──────────────────────────────\n"
+            "\n"
+            "  No policy suggestions yet.\n"
+            "\n"
+            "  The Phase 2.4.1 builder writes one row whenever the\n"
+            "  Phase 2.1 engine emits a suggest_* / warn_only-with-\n"
+            "  missing_slots decision and the §4 eligibility gates\n"
+            "  pass. Send a request via `tokenpak proxy` and re-run\n"
+            "  this command. See `tokenpak doctor --intent` for the\n"
+            "  classifier activation state.\n"
+        )
+        sys.exit(0)
+
+    lines = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Intent suggestions (Phase 2.4.1 dry-run inspector)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+    lines.append(f"  suggestion_id:             {payload['suggestion_id']}")
+    lines.append(f"  decision_id:               {payload['decision_id']}")
+    lines.append(f"  contract_id:               {payload['contract_id']}")
+    lines.append(f"  timestamp:                 {payload['timestamp']}")
+    lines.append("")
+    lines.append(f"  type:                      {payload['suggestion_type']}")
+    lines.append(f"  title:                     {payload['title']}")
+    lines.append("")
+    lines.append("  message:")
+    lines.append(f"    {payload['message']}")
+    lines.append("")
+    if payload.get("recommended_action"):
+        lines.append(f"  recommended_action:        {payload['recommended_action']}")
+    lines.append(f"  confidence:                {payload['confidence']:.4f}")
+    flags = payload.get("safety_flags") or []
+    flags_str = ", ".join(flags) if flags else "(none)"
+    lines.append(f"  safety_flags:              {flags_str}")
+    lines.append(f"  requires_confirmation:     {payload['requires_confirmation']}")
+    lines.append(f"  user_visible:              {payload['user_visible']}")
+    lines.append(f"  source:                    {payload['source']}")
+    lines.append("")
+    lines.append("  DRY-RUN / PREVIEW ONLY — no routing, model swap,")
+    lines.append("  or body mutation has occurred. Phase 2.4.1 builder")
+    lines.append("  is observation-only; broad surfaces ship in 2.4.2.")
+    lines.append("")
+    print("\n".join(lines))
+    sys.exit(0)
+
+
 def cmd_intent_policy_preview(args) -> None:
     """Phase 2.1 — show the latest dry-run policy decision.
 
@@ -2259,6 +2327,31 @@ def build_parser():
         help="Emit machine-readable JSON instead of the human-readable view.",
     )
     p_intent_policy_preview.set_defaults(func=cmd_intent_policy_preview)
+
+    # Phase 2.4.1 — minimal read-only inspector for the latest row
+    # in intent_suggestions. Internal/dev-facing only; broad
+    # surfaces (CLI report extension, dashboard panel, API key)
+    # are Phase 2.4.2 work.
+    p_intent_suggestions = p_intent_sub.add_parser(
+        "suggestions",
+        help=(
+            "Show the latest dry-run policy suggestion (Phase 2.4.1; "
+            "internal/dev inspector; read-only)."
+        ),
+    )
+    p_intent_suggestions.add_argument(
+        "--last",
+        dest="suggestions_last",
+        action="store_true",
+        help="Show the most recent suggestion (default behavior).",
+    )
+    p_intent_suggestions.add_argument(
+        "--json",
+        dest="suggestions_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable.",
+    )
+    p_intent_suggestions.set_defaults(func=cmd_intent_suggestions)
 
     p_adapter = sub.add_parser(
         "adapter",

--- a/tokenpak/proxy/intent_suggestion.py
+++ b/tokenpak/proxy/intent_suggestion.py
@@ -1,0 +1,552 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.1 — PolicySuggestion dataclass + pure-function builder.
+
+Builds zero or more :class:`PolicySuggestion` objects from a
+Phase 2.1 :class:`PolicyDecision` plus its :class:`IntentContract`,
+config, and adapter context. Pure function; no I/O. Side-channel
+for storage is :mod:`tokenpak.proxy.intent_suggestion_telemetry`.
+
+Phase 2.4.1 scope per the Phase 2.4 spec §10:
+
+  - Build suggestions; write them to a new ``intent_suggestions``
+    table.
+  - **No render path changes** (CLI / dashboard / API surfaces are
+    Phase 2.4.2 work).
+  - Default config (``mode=observe_only``) means suggestions are
+    written only when the underlying decision is itself a
+    ``suggest_*`` or ``warn_only/missing_slots`` decision; the
+    operator opts in to *displaying* the suggestions in 2.4.3.
+
+Privacy contract (asserted in tests):
+
+  - Builder reads structured fields only (intent class, slot
+    tuples, provider/model slugs, capability frozensets).
+  - All emitted strings (``title``, ``message``,
+    ``recommended_action``) are built from a fixed template table.
+    No caller-supplied substring ever reaches a suggestion field.
+  - The ``message`` template includes the explicit "DRY-RUN /
+    PREVIEW ONLY" disclaimer required by Phase 2.4 spec §8.4.
+  - Forbidden-phrase guardrail: emitted strings are scanned for
+    the §8.2 forbidden-wording list; a hit is a hard error
+    (raises :class:`SuggestionWordingError`) so a future renderer
+    or template change can never ship language that implies the
+    routing already happened.
+
+Eligibility gates (Phase 2.4 spec §4) — applied in order:
+
+  (a) confidence >= low_confidence_threshold
+  (b) catch_all_reason is None
+  (c) no required slot in slots_missing
+      (constructive type emitted instead when this fails)
+  (d) recommended_provider live_verified or
+      allow_unverified_providers=true
+  (e) adapter is non-None and has a capability declaration
+  (f) §4.3 wire-emission gate — applied only at the render layer
+      (Phase 2.4.2+); the builder writes the suggestion regardless,
+      with ``user_visible`` reflecting the host's
+      ``suggestion_surface`` config (default False until 2.4.3).
+  (g) decision_reason is in EXPLAINABLE_REASONS
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+from tokenpak.proxy.intent_contract import IntentContract
+from tokenpak.proxy.intent_policy_engine import (
+    ACTION_FLAG_BUDGET_RISK,
+    ACTION_SUGGEST_CACHE_POLICY,
+    ACTION_SUGGEST_COMPRESSION_PROFILE,
+    ACTION_SUGGEST_DELIVERY_POLICY,
+    ACTION_SUGGEST_ROUTE,
+    ACTION_WARN_ONLY,
+    REASON_DRY_RUN_SUGGEST,
+    SAFETY_MISSING_SLOTS,
+    PolicyDecision,
+    PolicyEngineConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Seven suggestion types per Phase 2.4 spec §5.
+SUGGESTION_PROVIDER_MODEL = "provider_model_recommendation"
+SUGGESTION_COMPRESSION = "compression_profile_recommendation"
+SUGGESTION_CACHE = "cache_policy_recommendation"
+SUGGESTION_DELIVERY = "delivery_strategy_recommendation"
+SUGGESTION_BUDGET_WARNING = "budget_warning"
+SUGGESTION_MISSING_SLOT = "missing_slot_improvement"
+SUGGESTION_ADAPTER_CAPABILITY = "adapter_capability_recommendation"
+
+SUGGESTION_TYPES: FrozenSet[str] = frozenset({
+    SUGGESTION_PROVIDER_MODEL,
+    SUGGESTION_COMPRESSION,
+    SUGGESTION_CACHE,
+    SUGGESTION_DELIVERY,
+    SUGGESTION_BUDGET_WARNING,
+    SUGGESTION_MISSING_SLOT,
+    SUGGESTION_ADAPTER_CAPABILITY,
+})
+
+
+# Phase 2.4 spec §4 rule (g) — explainable decision reasons. A
+# decision_reason outside this set produces no suggestion. Forward-
+# compatible: when 2.4.3 adds class_rule_matched, that string
+# joins the set.
+EXPLAINABLE_REASONS: FrozenSet[str] = frozenset({
+    REASON_DRY_RUN_SUGGEST,
+})
+
+
+# Phase 2.4 spec §8.2 forbidden phrases. Matched case-insensitively
+# as whole words (or phrases). A regex assembled from this list
+# scans every emitted string at build time; a hit raises
+# SuggestionWordingError so a misconfigured template can never ship.
+FORBIDDEN_PHRASES: Tuple[str, ...] = (
+    "applied",
+    "changed",
+    "routed to",
+    "switched to",
+    "now using",
+    "updated",
+    "will route",
+    "will switch",
+)
+_FORBIDDEN_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+    re.IGNORECASE,
+)
+
+
+# Phase 2.4 spec §8.4 — every emitted string adjacent to a
+# suggestion MUST include the dry-run disclaimer in plain text. The
+# Phase 2.4.1 ``message`` template embeds this; tests assert
+# presence.
+DRY_RUN_DISCLAIMER: str = "DRY-RUN / PREVIEW ONLY"
+
+
+# Source pinned for the entire 2.4.x line per spec §6.
+SOURCE_INTENT_POLICY_V0: str = "intent_policy_v0"
+
+
+class SuggestionWordingError(Exception):
+    """Raised when a built suggestion string contains forbidden wording.
+
+    Hard fail at build time so a misconfigured template, accidental
+    f-string interpolation, or future renderer change can never
+    surface "Applied" / "Changed" / "Routed to" / etc. to the user.
+    """
+
+
+# ---------------------------------------------------------------------------
+# PolicySuggestion shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicySuggestion:
+    """Operator-visible recommendation derived from a PolicyDecision.
+
+    Field set is the Phase 2.4 spec §6 wire contract verbatim.
+    JSON consumers may rely on every field's presence.
+    """
+
+    suggestion_id: str
+    decision_id: str
+    contract_id: str
+    suggestion_type: str
+    title: str
+    message: str
+    recommended_action: Optional[str]
+    confidence: float
+    safety_flags: Tuple[str, ...]
+    requires_confirmation: bool
+    user_visible: bool
+    expires_at: Optional[str]
+    source: str = SOURCE_INTENT_POLICY_V0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "suggestion_id": self.suggestion_id,
+            "decision_id": self.decision_id,
+            "contract_id": self.contract_id,
+            "suggestion_type": self.suggestion_type,
+            "title": self.title,
+            "message": self.message,
+            "recommended_action": self.recommended_action,
+            "confidence": self.confidence,
+            "safety_flags": list(self.safety_flags),
+            "requires_confirmation": self.requires_confirmation,
+            "user_visible": self.user_visible,
+            "expires_at": self.expires_at,
+            "source": self.source,
+        }
+
+
+def make_suggestion_id() -> str:
+    """29-char hex ID (13 ms timestamp + 16 random) — sortable.
+
+    Mirrors :func:`tokenpak.proxy.intent_policy_engine.make_decision_id`
+    so consumers can sort suggestion + decision ids together.
+    """
+    ts_ms = int(time.time() * 1000)
+    rand = secrets.token_hex(8)
+    return f"{ts_ms:013x}{rand}"
+
+
+# ---------------------------------------------------------------------------
+# Wording templates (Phase 2.4 spec §8)
+# ---------------------------------------------------------------------------
+
+
+# Reason-rendering — maps decision_reason → human-readable phrase.
+# Phase 2.4.1 covers only ``dry_run_suggest``; future reasons get
+# entries here without changing the builder.
+_REASON_RENDER: Dict[str, str] = {
+    REASON_DRY_RUN_SUGGEST: "the canonical heuristic table recommends it",
+}
+
+
+def _render_reason(decision_reason: str) -> str:
+    """Map a decision_reason to a plain-English clause.
+
+    Returns ``""`` for unmapped reasons; eligibility rule (g)
+    rejects the suggestion at the gate before this is ever called
+    in production, so the empty fallback only matters in tests.
+    """
+    return _REASON_RENDER.get(decision_reason, "")
+
+
+def _check_wording(*texts: str) -> None:
+    """Scan emitted strings for §8.2 forbidden phrases.
+
+    Hard-fail so a future template change or rendering bug never
+    surfaces user-facing language that implies routing already
+    happened. Skip ``None`` values (used for nullable fields like
+    ``recommended_action``).
+    """
+    for text in texts:
+        if text is None:
+            continue
+        m = _FORBIDDEN_RE.search(text)
+        if m is not None:
+            raise SuggestionWordingError(
+                f"forbidden wording {m.group(0)!r} in suggestion text: {text!r}"
+            )
+
+
+def _build_text(
+    suggestion_type: str,
+    *,
+    intent_class: str,
+    decision: PolicyDecision,
+    extra: Optional[Dict[str, str]] = None,
+) -> Tuple[str, str, Optional[str]]:
+    """Construct (title, message, recommended_action) from a fixed template.
+
+    All inputs are TIP-controlled identifiers (canonical-intent
+    keywords, profile names, provider slugs). No caller-supplied
+    free-form strings reach the template.
+    """
+    extra = extra or {}
+    reason = _render_reason(decision.decision_reason) or "the engine's heuristic table"
+
+    if suggestion_type == SUGGESTION_COMPRESSION:
+        profile = decision.compression_profile or "aggressive"
+        title = f"Recommended: {profile} compression for this {intent_class} request"
+        message = (
+            f"Could apply {profile} compression for this {intent_class} request "
+            f"because {reason}. {DRY_RUN_DISCLAIMER} — no compression has been "
+            f"recommended into the dispatch path."
+        )
+        action = f"Consider applying {profile} compression"
+
+    elif suggestion_type == SUGGESTION_CACHE:
+        strategy = decision.cache_strategy or "proxy_managed"
+        title = f"Recommended: {strategy} cache strategy"
+        message = (
+            f"Could enable {strategy} cache for this {intent_class} request "
+            f"because {reason}. {DRY_RUN_DISCLAIMER} — no cache strategy has "
+            f"been recommended into the dispatch path."
+        )
+        action = f"Consider enabling {strategy} cache"
+
+    elif suggestion_type == SUGGESTION_DELIVERY:
+        strategy = decision.delivery_strategy or "non_streaming"
+        title = f"Recommended: {strategy} delivery for this {intent_class} request"
+        message = (
+            f"Could request {strategy} delivery for this {intent_class} request "
+            f"because {reason}. {DRY_RUN_DISCLAIMER} — no delivery strategy "
+            f"has been recommended into the dispatch path."
+        )
+        action = f"Consider {strategy} delivery"
+
+    elif suggestion_type == SUGGESTION_PROVIDER_MODEL:
+        provider = decision.recommended_provider or "(unknown)"
+        model = decision.recommended_model or "(unknown)"
+        title = f"Recommended: route this {intent_class} request to {provider}"
+        message = (
+            f"Could route this {intent_class} request to {provider} / {model} "
+            f"because {reason}. {DRY_RUN_DISCLAIMER} — the request still "
+            f"flows to the caller's declared provider."
+        )
+        action = f"Consider routing to {provider} / {model}"
+
+    elif suggestion_type == SUGGESTION_BUDGET_WARNING:
+        title = "Budget risk: this request approaches a soft cap"
+        message = (
+            f"This {intent_class} request was flagged for budget risk because "
+            f"{reason}. {DRY_RUN_DISCLAIMER} — no budget cap has been "
+            f"enforced; this is an advisory warning only."
+        )
+        action = None  # observation only — no action recommended
+
+    elif suggestion_type == SUGGESTION_MISSING_SLOT:
+        slot_list = ", ".join(extra.get("missing_slots", "").split(","))
+        title = f"Could improve: missing slot(s) for this {intent_class} request"
+        message = (
+            f"Adding the missing slot(s) ({slot_list}) to this {intent_class} "
+            f"request would unlock the safety gate and surface routing "
+            f"recommendations. {DRY_RUN_DISCLAIMER} — no routing decision "
+            f"is being made."
+        )
+        action = f"Consider adding slot(s): {slot_list}"
+
+    elif suggestion_type == SUGGESTION_ADAPTER_CAPABILITY:
+        cap = extra.get("missing_capability", "tip.compression.v1")
+        title = f"Adapter could declare {cap}"
+        message = (
+            f"The resolved adapter for this {intent_class} request does not "
+            f"declare {cap}. Declaring it would unlock the matching engine "
+            f"recommendation. {DRY_RUN_DISCLAIMER} — no adapter modification "
+            f"has occurred."
+        )
+        action = f"Consider declaring {cap} on the adapter"
+
+    else:  # pragma: no cover — unknown type guarded earlier
+        raise SuggestionWordingError(f"unknown suggestion_type: {suggestion_type!r}")
+
+    _check_wording(title, message, action)
+    return title, message, action
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SuggestionBuilderContext:
+    """Bundle of facts the builder reads beyond decision/contract.
+
+    Mirrors Phase 2.4 spec §4 eligibility-gate inputs.
+    """
+
+    config: PolicyEngineConfig
+    adapter_capabilities: FrozenSet[str] = field(default_factory=frozenset)
+    provider_verified: Optional[bool] = None  # None = unknown
+    required_slots: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def build_suggestions(
+    *,
+    decision: PolicyDecision,
+    contract: IntentContract,
+    ctx: SuggestionBuilderContext,
+) -> List[PolicySuggestion]:
+    """Build zero or more :class:`PolicySuggestion` objects.
+
+    Pure function — no I/O. Returns ``[]`` when the decision is
+    not eligible per the §4 gates. The caller persists the
+    returned list via :mod:`intent_suggestion_telemetry`.
+    """
+    cfg = ctx.config
+
+    # Rule (e) — adapter is non-None and has a capability set.
+    # An empty frozenset is OK in 2.4.1 since it's the default for
+    # PassthroughAdapter (functional, no opt-in features). The gate
+    # blocks ``None`` only — caller passes ``frozenset()`` for
+    # passthrough.
+    # Implemented at the call site (server.py); the builder is
+    # given the resolved capabilities, so a None adapter would
+    # never reach here.
+
+    # Rule (b) — catch-all blocks routing-affecting suggestions.
+    if contract.catch_all_reason is not None:
+        return []
+
+    # Rule (a) — low confidence blocks routing-affecting suggestions.
+    if contract.confidence < cfg.low_confidence_threshold:
+        return []
+
+    # Rule (c) — missing required slots: emit the constructive
+    # type ``missing_slot_improvement`` when the decision is
+    # warn_only with the missing_slots safety flag, but suppress
+    # any other suggestion type.
+    if _has_missing_required_slots(contract, ctx.required_slots):
+        return _build_missing_slot_suggestions(decision, contract, ctx)
+
+    # Rule (d) — unverified provider blocks provider/model recs.
+    if (
+        decision.action == ACTION_SUGGEST_ROUTE
+        and ctx.provider_verified is False
+        and not cfg.allow_unverified_providers
+    ):
+        return []
+
+    # Rule (g) — explainable reason gate.
+    if decision.decision_reason not in EXPLAINABLE_REASONS:
+        return []
+
+    # warn_only without a constructive mapping (low_confidence,
+    # catch_all, unverified) produces no suggestion. Multi-flag
+    # warns also produce nothing — operator panel covers those.
+    if decision.action == ACTION_WARN_ONLY:
+        return []
+
+    # Determine the suggestion type from the decision action.
+    # Capability-aware fallback: when the engine emits a suggest_*
+    # for compression/cache/delivery but the adapter doesn't
+    # declare the corresponding TIP capability, emit
+    # ``adapter_capability_recommendation`` instead (Phase 2.4
+    # spec §5 constructive type).
+    suggestion_type, extra = _select_type(decision, ctx.adapter_capabilities)
+    if suggestion_type is None:
+        return []
+
+    title, message, action = _build_text(
+        suggestion_type,
+        intent_class=contract.intent_class,
+        decision=decision,
+        extra=extra,
+    )
+    return [
+        PolicySuggestion(
+            suggestion_id=make_suggestion_id(),
+            decision_id=decision.decision_id,
+            contract_id=contract.contract_id,
+            suggestion_type=suggestion_type,
+            title=title,
+            message=message,
+            recommended_action=action,
+            confidence=contract.confidence,
+            safety_flags=tuple(decision.safety_flags),
+            requires_confirmation=False,  # always False in 2.4.1
+            user_visible=False,  # 2.4.3 wires the surface flags
+            expires_at=None,
+        )
+    ]
+
+
+def _has_missing_required_slots(
+    contract: IntentContract, required_slots: Tuple[str, ...]
+) -> bool:
+    if not required_slots:
+        return False
+    missing = set(contract.slots_missing)
+    return any(s in missing for s in required_slots)
+
+
+def _build_missing_slot_suggestions(
+    decision: PolicyDecision,
+    contract: IntentContract,
+    ctx: SuggestionBuilderContext,
+) -> List[PolicySuggestion]:
+    """Emit the constructive missing_slot_improvement suggestion.
+
+    Fires only when the decision is ``warn_only`` with safety_flags
+    exactly ``("missing_slots",)`` — i.e. a clean signal that the
+    only thing wrong is the slot. Multi-flag warns produce no
+    suggestion (the operator panel covers those).
+    """
+    if decision.action != ACTION_WARN_ONLY:
+        return []
+    if tuple(decision.safety_flags) != (SAFETY_MISSING_SLOTS,):
+        return []
+
+    missing = sorted(set(ctx.required_slots) & set(contract.slots_missing))
+    title, message, action = _build_text(
+        SUGGESTION_MISSING_SLOT,
+        intent_class=contract.intent_class,
+        decision=decision,
+        extra={"missing_slots": ",".join(missing)},
+    )
+    return [
+        PolicySuggestion(
+            suggestion_id=make_suggestion_id(),
+            decision_id=decision.decision_id,
+            contract_id=contract.contract_id,
+            suggestion_type=SUGGESTION_MISSING_SLOT,
+            title=title,
+            message=message,
+            recommended_action=action,
+            confidence=contract.confidence,
+            safety_flags=(SAFETY_MISSING_SLOTS,),
+            requires_confirmation=False,
+            user_visible=False,
+            expires_at=None,
+        )
+    ]
+
+
+def _select_type(
+    decision: PolicyDecision,
+    adapter_capabilities: FrozenSet[str],
+) -> Tuple[Optional[str], Dict[str, str]]:
+    """Pick the suggestion type for a non-warn decision.
+
+    When the decision is ``suggest_compression_profile`` /
+    ``suggest_cache_policy`` / ``suggest_delivery_policy`` and the
+    adapter doesn't declare the corresponding capability, fall
+    back to ``adapter_capability_recommendation`` (constructive
+    guidance to the adapter author) per Phase 2.4 spec §5.
+    """
+    a = decision.action
+    if a == ACTION_SUGGEST_ROUTE:
+        return SUGGESTION_PROVIDER_MODEL, {}
+    if a == ACTION_SUGGEST_COMPRESSION_PROFILE:
+        if "tip.compression.v1" not in adapter_capabilities:
+            return SUGGESTION_ADAPTER_CAPABILITY, {
+                "missing_capability": "tip.compression.v1",
+            }
+        return SUGGESTION_COMPRESSION, {}
+    if a == ACTION_SUGGEST_CACHE_POLICY:
+        if not any(c.startswith("tip.cache.") for c in adapter_capabilities):
+            return SUGGESTION_ADAPTER_CAPABILITY, {
+                "missing_capability": "tip.cache.proxy-managed",
+            }
+        return SUGGESTION_CACHE, {}
+    if a == ACTION_SUGGEST_DELIVERY_POLICY:
+        # Delivery doesn't have a single canonical TIP capability;
+        # emit the suggestion directly.
+        return SUGGESTION_DELIVERY, {}
+    if a == ACTION_FLAG_BUDGET_RISK:
+        return SUGGESTION_BUDGET_WARNING, {}
+    return None, {}
+
+
+__all__ = [
+    "DRY_RUN_DISCLAIMER",
+    "EXPLAINABLE_REASONS",
+    "FORBIDDEN_PHRASES",
+    "PolicySuggestion",
+    "SOURCE_INTENT_POLICY_V0",
+    "SUGGESTION_ADAPTER_CAPABILITY",
+    "SUGGESTION_BUDGET_WARNING",
+    "SUGGESTION_CACHE",
+    "SUGGESTION_COMPRESSION",
+    "SUGGESTION_DELIVERY",
+    "SUGGESTION_MISSING_SLOT",
+    "SUGGESTION_PROVIDER_MODEL",
+    "SUGGESTION_TYPES",
+    "SuggestionBuilderContext",
+    "SuggestionWordingError",
+    "build_suggestions",
+    "make_suggestion_id",
+]

--- a/tokenpak/proxy/intent_suggestion_telemetry.py
+++ b/tokenpak/proxy/intent_suggestion_telemetry.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.1 — SQLite store for ``intent_suggestions`` rows.
+
+Separate file from :mod:`intent_policy_telemetry` so the two
+schemas don't bleed into each other. Same DB
+(``~/.tokenpak/telemetry.db``) so a single backup captures every
+intent surface.
+
+Linked to the Phase 2.1 ``intent_policy_decisions`` row via
+``decision_id`` and the Phase 0 ``intent_events`` row via
+``contract_id``. The schema carries only:
+
+  - identifiers (suggestion_id PK, decision_id FK, contract_id FK)
+  - structured fields from the suggestion
+  - templated text fields (title, message, recommended_action)
+
+NO raw prompt text. NO per-row hashes. NO secrets. The privacy
+contract is asserted in
+``tests/test_intent_suggestion_phase24_1.py::TestPrivacyContract``.
+
+Best-effort write contract: exceptions are swallowed at the writer
+boundary so a misbehaving disk never breaks a request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from tokenpak.proxy.intent_suggestion import PolicySuggestion
+
+_DEFAULT_DB_PATH = Path(
+    os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak"))
+) / "telemetry.db"
+
+
+_INTENT_SUGGESTIONS_DDL = """\
+CREATE TABLE IF NOT EXISTS intent_suggestions (
+    suggestion_id          TEXT PRIMARY KEY,
+    decision_id            TEXT NOT NULL,
+    contract_id            TEXT NOT NULL,
+    timestamp              TEXT NOT NULL,
+    suggestion_type        TEXT NOT NULL,
+    title                  TEXT NOT NULL,
+    message                TEXT NOT NULL,
+    recommended_action     TEXT,
+    confidence             REAL NOT NULL,
+    safety_flags           TEXT NOT NULL,    -- JSON array
+    requires_confirmation  INTEGER NOT NULL,
+    user_visible           INTEGER NOT NULL,
+    expires_at             TEXT,
+    source                 TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_suggestions_decision
+    ON intent_suggestions (decision_id);
+CREATE INDEX IF NOT EXISTS idx_suggestions_contract
+    ON intent_suggestions (contract_id);
+CREATE INDEX IF NOT EXISTS idx_suggestions_type
+    ON intent_suggestions (suggestion_type, timestamp);
+"""
+
+
+@dataclass
+class IntentSuggestionRow:
+    """One row of the ``intent_suggestions`` table."""
+
+    suggestion: PolicySuggestion
+    timestamp: str
+
+
+class IntentSuggestionStore:
+    """Per-host SQLite writer for ``intent_suggestions``.
+
+    Lazy-init (creates the table on first :meth:`write`). Single
+    connection guarded by a process-wide lock.
+    """
+
+    _LOCK = threading.Lock()
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.executescript(_INTENT_SUGGESTIONS_DDL)
+            conn.commit()
+            self._conn = conn
+        return self._conn
+
+    def write(self, row: IntentSuggestionRow) -> None:
+        """Insert one row. Best-effort — never raises on caller path."""
+        s = row.suggestion
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO intent_suggestions (
+                        suggestion_id, decision_id, contract_id, timestamp,
+                        suggestion_type, title, message, recommended_action,
+                        confidence, safety_flags,
+                        requires_confirmation, user_visible,
+                        expires_at, source
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        s.suggestion_id,
+                        s.decision_id,
+                        s.contract_id,
+                        row.timestamp,
+                        s.suggestion_type,
+                        s.title,
+                        s.message,
+                        s.recommended_action,
+                        s.confidence,
+                        json.dumps(list(s.safety_flags)),
+                        1 if s.requires_confirmation else 0,
+                        1 if s.user_visible else 0,
+                        s.expires_at,
+                        s.source,
+                    ),
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001 — best-effort
+            return
+
+    def write_many(self, rows: Iterable[IntentSuggestionRow]) -> None:
+        """Convenience: write a batch in a single transaction."""
+        for r in rows:
+            self.write(r)
+
+    def fetch_latest(self) -> Optional[dict[str, Any]]:
+        """Return the most recent row as a dict, or ``None``.
+
+        Returns ``None`` when the DB doesn't exist, the table
+        doesn't exist, or no rows have been written.
+        """
+        if not self._db_path.is_file():
+            return None
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_suggestions'"
+                ).fetchone()
+                if exists is None:
+                    return None
+                row = conn.execute(
+                    "SELECT * FROM intent_suggestions "
+                    "ORDER BY timestamp DESC LIMIT 1"
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return None
+        if row is None:
+            return None
+        out = {k: row[k] for k in row.keys()}
+        try:
+            out["safety_flags"] = json.loads(out.get("safety_flags") or "[]")
+        except (TypeError, json.JSONDecodeError):
+            out["safety_flags"] = []
+        for col in ("requires_confirmation", "user_visible"):
+            if col in out and out[col] is not None:
+                out[col] = bool(out[col])
+        return out
+
+    def fetch_for_decision(self, decision_id: str) -> List[dict[str, Any]]:
+        """Return every suggestion linked to ``decision_id``."""
+        if not self._db_path.is_file():
+            return []
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_suggestions'"
+                ).fetchone()
+                if exists is None:
+                    return []
+                rows = conn.execute(
+                    "SELECT * FROM intent_suggestions "
+                    "WHERE decision_id = ? ORDER BY timestamp DESC",
+                    (decision_id,),
+                ).fetchall()
+        except sqlite3.DatabaseError:
+            return []
+        out: List[dict[str, Any]] = []
+        for row in rows:
+            r = {k: row[k] for k in row.keys()}
+            try:
+                r["safety_flags"] = json.loads(r.get("safety_flags") or "[]")
+            except (TypeError, json.JSONDecodeError):
+                r["safety_flags"] = []
+            for col in ("requires_confirmation", "user_visible"):
+                if col in r and r[col] is not None:
+                    r[col] = bool(r[col])
+            out.append(r)
+        return out
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+_DEFAULT_STORE: Optional[IntentSuggestionStore] = None
+
+
+def get_default_suggestion_store() -> IntentSuggestionStore:
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = IntentSuggestionStore()
+    return _DEFAULT_STORE
+
+
+def set_default_suggestion_store(store: Optional[IntentSuggestionStore]) -> None:
+    """Test hook — swap the default writer."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+__all__ = [
+    "IntentSuggestionRow",
+    "IntentSuggestionStore",
+    "get_default_suggestion_store",
+    "set_default_suggestion_store",
+]

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1620,10 +1620,48 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         config_low_confidence_threshold=_i21_cfg.low_confidence_threshold,
                     )
                 )
+
+                # Phase 2.4.1 — build + persist suggestions. Pure
+                # function over the decision; suppressed by the §4
+                # eligibility gates when not applicable. Never
+                # affects dispatch; same side-channel posture as
+                # the policy decision write above.
+                from tokenpak.proxy.intent_suggestion import (
+                    SuggestionBuilderContext as _I241Ctx,
+                )
+                from tokenpak.proxy.intent_suggestion import (
+                    build_suggestions as _i241_build,
+                )
+                from tokenpak.proxy.intent_suggestion_telemetry import (
+                    IntentSuggestionRow as _I241Row,
+                )
+                from tokenpak.proxy.intent_suggestion_telemetry import (
+                    get_default_suggestion_store as _i241_store,
+                )
+
+                _i241_ctx = _I241Ctx(
+                    config=_i21_cfg,
+                    adapter_capabilities=(
+                        request_adapter.capabilities
+                        if request_adapter is not None
+                        else frozenset()
+                    ),
+                    provider_verified=None,
+                    required_slots=(),
+                )
+                _i241_suggestions = _i241_build(
+                    decision=_i21_decision,
+                    contract=_intent_contract,
+                    ctx=_i241_ctx,
+                )
+                _i241_ts = datetime.now().isoformat(timespec="seconds")
+                for _s in _i241_suggestions:
+                    _i241_store().write(_I241Row(suggestion=_s, timestamp=_i241_ts))
             except Exception:
                 # Side-channel — never break the request on engine /
-                # telemetry failures. Phase 2.1 is observation-only;
-                # if the engine misbehaves, the proxy continues.
+                # telemetry failures. Phase 2.1 / 2.4.1 are
+                # observation-only; if the engine misbehaves, the
+                # proxy continues.
                 pass
 
         try:


### PR DESCRIPTION
## Summary

First code-shipping sub-phase of the Phase 2.4 spec. Pure-function builder + dedicated SQLite table + minimal internal/dev CLI inspector. **No render path changes** in user-facing surfaces (spec §10 sub-phase 2.4.1 deliverable); broad surfaces are 2.4.2 work.

## Changes

- **`tokenpak/proxy/intent_suggestion.py`** — `PolicySuggestion` frozen dataclass (13 fields per spec §6 wire contract). Pure `build_suggestions(decision, contract, ctx)` function applies the §4 eligibility gates. Seven suggestion types: 5 direct from `suggest_*` actions, 2 constructive (`missing_slot_improvement` from `warn_only/missing_slots`, `adapter_capability_recommendation` when adapter lacks the relevant TIP capability). Wording guardrail scans every emitted string against the §8.2 forbidden-phrase regex; a hit raises `SuggestionWordingError`. Templates embed the spec §8.4 "DRY-RUN / PREVIEW ONLY" disclaimer.
- **`tokenpak/proxy/intent_suggestion_telemetry.py`** — SQLite store for the new `intent_suggestions` table. Schema is IDs / hashes / structured fields / templated text only; linked to Phase 2.1's `intent_policy_decisions` by `decision_id` and to Phase 0's `intent_events` by `contract_id`. Best-effort write contract.
- **`tokenpak/proxy/server.py`** — call site after the Phase 2.1 policy-decision write. Builds + persists suggestions. Wrapped in the existing try/except so suggestion-side failures never break dispatch.
- **`tokenpak/cli/_impl.py`** — minimal `tokenpak intent suggestions [--last] [--json]` inspector. Read-only; mirrors `policy-preview` shape. Internal/dev-facing only; CLI report extension and dashboard panel are 2.4.2 deliverables.
- **`tests/test_intent_suggestion_phase24_1.py`** — 36 tests across 14 classes covering the directive's 13 categories plus cross-cutting smoke. Wording guardrail tested end-to-end; module-reload-pollution-resilient via type-name matching.

## Acceptance

- [x] `PolicySuggestion` exists.
- [x] Builder exists; pure function; frozen dataclasses.
- [x] Eligibility gates enforced (§4 rules 1–7 plus explainable-reason gate).
- [x] Suggestions are advisory only (`user_visible` default False; `requires_confirmation` always False in 2.4.1).
- [x] No runtime routing behavior changes.
- [x] No classifier behavior changes (`intent_classifier.py` untouched).
- [x] No broad user-facing suggest mode (only new surface is the internal `tokenpak intent suggestions` inspector).
- [x] No prompt text or secrets emitted (sentinel-substring tested end-to-end across row + JSON dump).
- [x] **1145 passing** (was 1109 baseline, +36), 0 regressions.
- [x] `ruff check` clean, `cli-docs-in-sync` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no scaffold renderer expansion, **no classifier behavior changes**, **no production intent-based routing**, **no confirm mode**, **no enforce mode**, **no suggest mode config activation**, **no broad dashboard/API/CLI suggestion surfaces**.