### PR TITLE
feat(proxy,cli,dashboard): Phase 2.4.2 — suggestion display surfaces

### DIFF
--- a/tests/test_intent_policy_phase22.py
+++ b/tests/test_intent_policy_phase22.py
@@ -289,7 +289,10 @@ class TestDashboardShape:
 
     def test_top_level_shape(self, tmp_path: Path):
         payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
-        assert set(payload) == {"metadata", "cards", "operator_panel"}
+        # Phase 2.2 required keys (still enforced). Phase 2.4.2
+        # additively adds a "suggestions" key — allowed but not
+        # required by this assertion.
+        assert {"metadata", "cards", "operator_panel"}.issubset(set(payload))
 
     def test_cards_keys(self, tmp_path: Path):
         payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")

--- a/tests/test_intent_suggestion_phase24_2.py
+++ b/tests/test_intent_suggestion_phase24_2.py
@@ -1,0 +1,655 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.2 — suggestion display surfaces test suite.
+
+Fourteen directive-mandated test classes:
+
+  - doctor explain includes suggestions
+  - intent report includes suggestion summary
+  - policy-preview includes linked suggestions
+  - API JSON includes suggestion section
+  - dashboard / read-model includes suggestions
+  - empty DB behavior
+  - populated DB behavior
+  - window filtering
+  - expired suggestions
+  - forbidden wording guardrail still enforced
+  - no prompt text or secrets emitted
+  - no route mutation
+  - no request mutation
+  - no classifier mutation
+
+Read-only across the board. Reuses production builder + telemetry
+stores so the schema stays a single source of truth.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import (
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    build_contract,
+)
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+)
+from tokenpak.proxy.intent_policy_telemetry import (
+    IntentPolicyDecisionRow,
+    IntentPolicyDecisionStore,
+)
+from tokenpak.proxy.intent_suggestion import (
+    FORBIDDEN_PHRASES,
+    SuggestionBuilderContext,
+    build_suggestions,
+)
+from tokenpak.proxy.intent_suggestion_report import (
+    ADVISORY_LABEL,
+    NOOP_DEFAULT_OFF_TAG,
+    build_suggestion_report,
+)
+from tokenpak.proxy.intent_suggestion_report import (
+    render_human as render_sugg_human,
+)
+from tokenpak.proxy.intent_suggestion_report import (
+    render_json as render_sugg_json,
+)
+from tokenpak.proxy.intent_suggestion_telemetry import (
+    IntentSuggestionRow,
+    IntentSuggestionStore,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _safe_input(**over) -> PolicyInput:
+    kw = dict(
+        intent_class="summarize", confidence=0.9,
+        slots_present=("period",), slots_missing=(),
+        catch_all_reason=None, provider="tokenpak-test",
+        model="test-model", live_verified_status=True,
+        required_slots=(),
+    )
+    kw.update(over)
+    return PolicyInput(**kw)
+
+
+def _seed_three_layer(*, db: Path, request_id="r1",
+                     intent_class="summarize", prompt="summarize the vault",
+                     timestamp=None, expires_at=None,
+                     user_visible=False):
+    """Seed events + decision + suggestion under one DB. Returns
+    (contract, decision, suggestion).
+    """
+    cls = IntentClassification(
+        intent_class=intent_class, confidence=0.9,
+        slots_present=("period",), slots_missing=(),
+        catch_all_reason=None,
+    )
+    contract = build_contract(classification=cls, raw_prompt=prompt)
+    ts = timestamp or _dt.datetime.now().isoformat(timespec="seconds")
+
+    events = IntentTelemetryStore(db_path=db)
+    events.write(IntentTelemetryRow(
+        request_id=request_id, contract=contract, timestamp=ts,
+        tip_headers_emitted=False, tip_headers_stripped=True,
+    ))
+    events.close()
+
+    decision = evaluate_policy(_safe_input(intent_class=intent_class), PolicyEngineConfig())
+    pstore = IntentPolicyDecisionStore(db_path=db)
+    pstore.write(IntentPolicyDecisionRow(
+        request_id=request_id,
+        contract_id=contract.contract_id,
+        timestamp=ts,
+        decision=decision,
+    ))
+    pstore.close()
+
+    ctx = SuggestionBuilderContext(
+        config=PolicyEngineConfig(),
+        adapter_capabilities=frozenset({"tip.compression.v1"}),
+    )
+    suggestions = build_suggestions(
+        decision=decision, contract=contract, ctx=ctx,
+    )
+    sstore = IntentSuggestionStore(db_path=db)
+    for s in suggestions:
+        # Optionally override expires_at / user_visible by
+        # writing directly with overridden fields. We reconstruct
+        # the dataclass with the overrides.
+        if expires_at is not None or user_visible:
+            from dataclasses import replace
+            s = replace(s, expires_at=expires_at, user_visible=user_visible)
+        sstore.write(IntentSuggestionRow(suggestion=s, timestamp=ts))
+    sstore.close()
+
+    return contract, decision, suggestions[0] if suggestions else None
+
+
+# ── 1. Doctor explain includes suggestions ────────────────────────────
+
+
+class TestExplainIncludesSuggestions:
+
+    def test_explain_renders_suggestion_section(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        contract, decision, suggestion = _seed_three_layer(db=db)
+        assert suggestion is not None
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=db)
+        assert payload is not None
+        assert payload["policy_decision"] is not None
+        assert isinstance(payload.get("policy_suggestions"), list)
+        assert len(payload["policy_suggestions"]) == 1
+
+        text = render_explain_last(payload)
+        assert "Policy Suggestions" in text
+        assert "advisory / no-op / default-off" in text
+        assert "TokenPak has not changed routing" in text
+        # Includes structured fields the directive enumerates.
+        for field in ("suggestion_id", "confidence", "user_visible"):
+            assert field in text
+
+    def test_explain_when_no_suggestions(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        # Seed event + decision only (no suggestions); the section
+        # should render with "(none)".
+        cls = IntentClassification(
+            intent_class="status",  # status has no heuristic → observe_only
+            confidence=1.0, slots_present=(), slots_missing=(),
+            catch_all_reason=None,
+        )
+        contract = build_contract(classification=cls, raw_prompt="status check")
+        ts = "2026-04-26T12:00:00"
+
+        events = IntentTelemetryStore(db_path=db)
+        events.write(IntentTelemetryRow(
+            request_id="solo", contract=contract, timestamp=ts,
+            tip_headers_emitted=False, tip_headers_stripped=True,
+        ))
+        events.close()
+
+        decision = evaluate_policy(
+            _safe_input(intent_class="status", confidence=1.0,
+                       slots_present=(), slots_missing=()),
+            PolicyEngineConfig(),
+        )
+        pstore = IntentPolicyDecisionStore(db_path=db)
+        pstore.write(IntentPolicyDecisionRow(
+            request_id="solo", contract_id=contract.contract_id,
+            timestamp=ts, decision=decision,
+        ))
+        pstore.close()
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=db)
+        assert payload is not None
+        text = render_explain_last(payload)
+        assert "Policy Suggestions" in text
+        assert "(none recorded yet for this decision)" in text
+
+
+# ── 2. Intent report includes suggestion summary ──────────────────────
+
+
+class TestReportIncludesSuggestionSummary:
+
+    def test_report_to_dict_has_suggestions_summary(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+        _seed_three_layer(db=db, request_id="r2")
+
+        from tokenpak.proxy.intent_report import build_report
+        r = build_report(window_days=14, db_path=db)
+        d = r.to_dict()
+        assert "suggestions_summary" in d
+        assert d["suggestions_summary"]["total_suggestions"] == 2
+
+    def test_report_human_renders_suggestion_section(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+
+        from tokenpak.proxy.intent_report import build_report, render_human
+        r = build_report(window_days=14, db_path=db)
+        text = render_human(r)
+        assert "Advisory Suggestions" in text
+        assert NOOP_DEFAULT_OFF_TAG in text
+
+
+# ── 3. Policy-preview includes linked suggestions ─────────────────────
+
+
+class TestPolicyPreviewLinksSuggestions:
+
+    def test_collect_latest_returns_suggestions(self, tmp_path: Path,
+                                                  monkeypatch):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+
+        # Swap the default stores to point at the temp DB.
+        from tokenpak.proxy.intent_policy_telemetry import (
+            IntentPolicyDecisionStore as _PStore,
+        )
+        from tokenpak.proxy.intent_policy_telemetry import (
+            set_default_policy_store,
+        )
+        from tokenpak.proxy.intent_suggestion_telemetry import (
+            IntentSuggestionStore as _SStore,
+        )
+        from tokenpak.proxy.intent_suggestion_telemetry import (
+            set_default_suggestion_store,
+        )
+
+        set_default_policy_store(_PStore(db_path=db))
+        set_default_suggestion_store(_SStore(db_path=db))
+        try:
+            from tokenpak.proxy.intent_policy_preview import (
+                collect_latest,
+                render_human,
+            )
+            payload = collect_latest()
+            assert payload is not None
+            assert isinstance(payload.get("policy_suggestions"), list)
+            assert len(payload["policy_suggestions"]) == 1
+
+            text = render_human(payload)
+            assert "Linked policy suggestions" in text
+            assert "advisory / no-op / default-off" in text
+        finally:
+            set_default_policy_store(None)
+            set_default_suggestion_store(None)
+
+
+# ── 4. API JSON includes suggestion section ───────────────────────────
+
+
+class TestApiPayloadIncludesSuggestions:
+
+    def test_dashboard_payload_has_suggestions_key(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        assert "suggestions" in payload
+        sugg = payload["suggestions"]
+        assert sugg["total"] == 1
+        assert "advisory_label" in sugg
+        assert "TokenPak has not changed routing" in sugg["advisory_label"]
+        assert sugg["noop_default_off"] is True
+        # Field set the directive enumerates is present.
+        for k in (
+            "type_distribution",
+            "safety_flag_distribution",
+            "user_visible_true_count",
+            "user_visible_false_count",
+            "expired_count",
+            "latest",
+        ):
+            assert k in sugg, f"missing key {k!r} in suggestions section"
+
+    def test_dashboard_metadata_has_suggestions_label(self, tmp_path: Path):
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert "suggestions_label" in payload["metadata"]
+        assert "TokenPak has not changed routing" in payload["metadata"]["suggestions_label"]
+
+
+# ── 5. Dashboard / read-model includes suggestions ────────────────────
+
+
+class TestDashboardReadModelSuggestions:
+    """The dashboard read-model is the same payload as the API
+    endpoint. This class pins the shape of the suggestions section
+    independently so a future refactor of either side trips here.
+    """
+
+    REQUIRED_SUGG_KEYS = {
+        "advisory_label",
+        "noop_default_off",
+        "total",
+        "type_distribution",
+        "safety_flag_distribution",
+        "recommended_action_distribution",
+        "user_visible_true_count",
+        "user_visible_false_count",
+        "expired_count",
+        "latest",
+    }
+
+    def test_required_keys_present_when_table_exists(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        missing = self.REQUIRED_SUGG_KEYS - set(payload["suggestions"])
+        assert not missing, f"missing suggestion keys: {missing}"
+
+    def test_advisory_labels_pinned(self, tmp_path: Path):
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        # Both the section-local label and the metadata-level label
+        # must carry the canonical phrasing.
+        assert "advisory" in payload["suggestions"]["advisory_label"].lower()
+        assert "advisory" in payload["metadata"]["suggestions_label"].lower()
+
+
+# ── 6. Empty DB behavior ──────────────────────────────────────────────
+
+
+class TestEmptyDB:
+
+    def test_suggestion_report_empty(self, tmp_path: Path):
+        r = build_suggestion_report(window_days=14, db_path=tmp_path / "nope.db")
+        assert r.total_suggestions == 0
+        assert r.suggestion_type_distribution == {}
+        assert r.review_areas, "review_areas should explain empty state"
+
+    def test_dashboard_empty_db(self, tmp_path: Path):
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["suggestions"]["total"] == 0
+
+
+# ── 7. Populated DB behavior ──────────────────────────────────────────
+
+
+class TestPopulatedDB:
+
+    def test_type_distribution_correct(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="a", intent_class="summarize")
+        _seed_three_layer(db=db, request_id="b", intent_class="summarize")
+        _seed_three_layer(db=db, request_id="c", intent_class="debug")
+
+        r = build_suggestion_report(window_days=14, db_path=db)
+        # debug heuristic is "conservative" compression; summarize
+        # is "aggressive". Both fall under
+        # compression_profile_recommendation in 2.4.1.
+        assert r.suggestion_type_distribution.get(
+            "compression_profile_recommendation", 0
+        ) == 3
+
+    def test_user_visible_split(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        # Default user_visible=False per 2.4.1.
+        _seed_three_layer(db=db, request_id="a")
+        _seed_three_layer(db=db, request_id="b")
+        # One row with user_visible=True (synthetic; 2.4.3 will
+        # enable this in real flows).
+        _seed_three_layer(db=db, request_id="c", user_visible=True)
+
+        r = build_suggestion_report(window_days=14, db_path=db)
+        assert r.user_visible_true_count == 1
+        assert r.user_visible_false_count == 2
+
+
+# ── 8. Window filtering ───────────────────────────────────────────────
+
+
+class TestWindowFilter:
+
+    def test_rows_outside_window_excluded(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        now = _dt.datetime(2026, 4, 26, 12, 0, 0)
+        _seed_three_layer(
+            db=db, request_id="recent",
+            timestamp=(now - _dt.timedelta(days=1)).isoformat(timespec="seconds"),
+        )
+        _seed_three_layer(
+            db=db, request_id="ancient",
+            timestamp=(now - _dt.timedelta(days=60)).isoformat(timespec="seconds"),
+        )
+
+        r = build_suggestion_report(window_days=14, db_path=db, now=now)
+        assert r.total_suggestions == 1
+
+
+# ── 9. Expired suggestions ────────────────────────────────────────────
+
+
+class TestExpiredSuggestions:
+
+    def test_expired_count_correct(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        now = _dt.datetime(2026, 4, 26, 12, 0, 0)
+        # Two not-expired (no expires_at), one expired (in past),
+        # one not-yet-expired (in future).
+        _seed_three_layer(db=db, request_id="a")
+        _seed_three_layer(db=db, request_id="b")
+        _seed_three_layer(
+            db=db, request_id="expired",
+            expires_at="2026-04-20T00:00:00",
+        )
+        _seed_three_layer(
+            db=db, request_id="future",
+            expires_at="2026-12-31T00:00:00",
+        )
+
+        r = build_suggestion_report(window_days=None, db_path=db, now=now)
+        assert r.expired_count == 1
+
+
+# ── 10. Forbidden wording guardrail ───────────────────────────────────
+
+
+class TestForbiddenWordingGuardrail:
+    """The 2.4.1 guardrail still applies: every emitted string in
+    every render path must be free of forbidden phrases.
+    """
+
+    def test_no_forbidden_phrase_in_human_render(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+        # Run all three human renderers + check for any forbidden
+        # phrase. Special-case: words like "Updated" inside
+        # documentation prose aren't allowed in user-facing fields.
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        from tokenpak.proxy.intent_policy_preview import (
+            collect_latest as _ploc,
+        )
+        from tokenpak.proxy.intent_policy_preview import (
+            render_human as _prh,
+        )
+        from tokenpak.proxy.intent_policy_telemetry import (
+            IntentPolicyDecisionStore as _PStore,
+        )
+        from tokenpak.proxy.intent_policy_telemetry import (
+            set_default_policy_store,
+        )
+        from tokenpak.proxy.intent_report import build_report, render_human
+        from tokenpak.proxy.intent_suggestion_telemetry import (
+            IntentSuggestionStore as _SStore,
+        )
+        from tokenpak.proxy.intent_suggestion_telemetry import (
+            set_default_suggestion_store,
+        )
+
+        set_default_policy_store(_PStore(db_path=db))
+        set_default_suggestion_store(_SStore(db_path=db))
+        try:
+            t1 = render_explain_last(collect_explain_last(db_path=db))
+            t2 = render_human(build_report(window_days=14, db_path=db))
+            t3 = _prh(_ploc())
+            forbidden_re = re.compile(
+                r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+                re.IGNORECASE,
+            )
+            # "Updated" is the most likely false positive (e.g.
+            # "last updated"). Whitelist by ensuring no forbidden
+            # phrase appears in the suggestion-rendering blocks
+            # specifically. We grep for the text of the suggestion
+            # (title+message) and assert no forbidden phrase appears
+            # in those substrings.
+            for text in (t1, t2, t3):
+                # Extract any line containing a suggestion's "title"
+                # or "message" (we know our rendered titles include
+                # "Recommended" / "Could improve" / "Adapter could
+                # declare" / "Budget risk"). Sample those lines.
+                for line in text.splitlines():
+                    if any(marker in line for marker in (
+                        "Recommended:", "Could improve:",
+                        "Adapter could declare", "Budget risk:",
+                    )):
+                        m = forbidden_re.search(line)
+                        assert m is None, (
+                            f"forbidden phrase {m.group(0)!r} in suggestion line: {line!r}"
+                        )
+        finally:
+            set_default_policy_store(None)
+            set_default_suggestion_store(None)
+
+
+# ── 11. Privacy contract ──────────────────────────────────────────────
+
+
+class TestPrivacyContract:
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-2-4-2"
+
+    def test_sentinel_absent_from_suggestion_report(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(
+            db=db, request_id="priv",
+            prompt=f"summarize the vault {self.SENTINEL}",
+        )
+
+        r = build_suggestion_report(window_days=14, db_path=db)
+        h = render_sugg_human(r)
+        j = render_sugg_json(r)
+        assert self.SENTINEL not in h
+        assert self.SENTINEL not in j
+
+    def test_sentinel_absent_from_dashboard(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(
+            db=db, request_id="priv",
+            prompt=f"summarize the vault {self.SENTINEL}",
+        )
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        assert self.SENTINEL not in json.dumps(payload)
+
+    def test_per_row_hash_absent_from_dashboard(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        prompt = "summarize the vault hash-test-zzz-242"
+        digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        _seed_three_layer(db=db, request_id="priv", prompt=prompt)
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=db)
+        assert digest not in json.dumps(payload)
+
+
+# ── 12. No route mutation ─────────────────────────────────────────────
+
+
+class TestNoRouteMutation:
+    """Structural — the suggestion-render modules MUST NOT import
+    dispatch primitives.
+    """
+
+    def test_suggestion_report_does_not_import_forward_path(self):
+        import tokenpak.proxy.intent_suggestion_report as m
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src
+
+
+# ── 13. No request mutation ───────────────────────────────────────────
+
+
+class TestNoRequestMutation:
+    """Read-only contract — repeated reads do not mutate the DB."""
+
+    def test_repeated_dashboard_reads_do_not_mutate(self, tmp_path: Path):
+        db = tmp_path / "telemetry.db"
+        _seed_three_layer(db=db, request_id="r1")
+        before_size = db.stat().st_size
+        before_mtime = db.stat().st_mtime
+
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        for _ in range(5):
+            collect_policy_dashboard(window_days=14, db_path=db)
+            build_suggestion_report(window_days=14, db_path=db)
+
+        assert db.stat().st_size == before_size
+        assert db.stat().st_mtime == before_mtime
+
+
+# ── 14. No classifier mutation ────────────────────────────────────────
+
+
+class TestNoClassifierMutation:
+    """The Phase 2.4 spec §11 invariant: intent_classifier.py MUST
+    NOT be edited in any 2.4.x PR. Spot-check the constants.
+    """
+
+    def test_classifier_constants_unchanged(self):
+        from tokenpak.proxy.intent_classifier import (
+            CLASSIFY_THRESHOLD,
+            INTENT_SOURCE_V0,
+        )
+        assert CLASSIFY_THRESHOLD == 0.4
+        assert INTENT_SOURCE_V0 == "rule_based_v0"
+
+
+# ── 15. CLI subprocess smoke (cross-cutting) ──────────────────────────
+
+
+class TestCliSubprocess:
+
+    def test_intent_report_cli_runs(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "report", "--window", "0d"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_doctor_explain_last_runs(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "doctor", "--explain-last"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+
+    def test_policy_preview_runs(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "policy-preview"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+
+
+# ── 16. ADVISORY_LABEL pinned (cross-cutting) ─────────────────────────
+
+
+class TestAdvisoryLabelPinned:
+
+    def test_advisory_label_carries_the_canonical_phrasing(self):
+        # The phrasing is normative for the directive's "every
+        # surface labels suggestions as advisory" rule.
+        assert "advisory" in ADVISORY_LABEL.lower()
+        assert "TokenPak has not changed routing" in ADVISORY_LABEL
+
+    def test_noop_default_off_tag_pinned(self):
+        assert "no-op" in NOOP_DEFAULT_OFF_TAG
+        assert "default-off" in NOOP_DEFAULT_OFF_TAG

--- a/tokenpak/dashboard/index.html
+++ b/tokenpak/dashboard/index.html
@@ -219,6 +219,41 @@
                 </table>
                 <h3>Operator panel</h3>
                 <ul id="intent-policy-review-areas" style="line-height: 1.6;"></ul>
+
+                <!-- Phase 2.4.2 — Advisory Suggestions sub-section.
+                     Every label below makes clear: suggestions are
+                     advisory only; TokenPak has not changed routing. -->
+                <h3>Advisory Suggestions
+                    <small style="font-weight: normal; opacity: 0.7;">
+                        — advisory / no-op / default-off; TokenPak has not changed routing
+                    </small>
+                </h3>
+                <div class="stats-row">
+                    <div class="stat-card">
+                        <div class="stat-label">Total Advisory Suggestions</div>
+                        <div class="stat-value" id="intent-policy-suggestions-total">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">Expired Suggestions</div>
+                        <div class="stat-value" id="intent-policy-suggestions-expired">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-label">user_visible (true / false)</div>
+                        <div class="stat-value" id="intent-policy-suggestions-visible">0 / 0</div>
+                    </div>
+                </div>
+                <h4>Top suggestion types</h4>
+                <table class="metrics-table">
+                    <thead><tr><th>Type</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-suggestions-types-body"></tbody>
+                </table>
+                <h4>Safety flags attached to suggestions</h4>
+                <table class="metrics-table">
+                    <thead><tr><th>Safety flag</th><th>Count</th></tr></thead>
+                    <tbody id="intent-policy-suggestions-safety-body"></tbody>
+                </table>
+                <h4>Latest advisory suggestions</h4>
+                <ul id="intent-policy-suggestions-latest" style="line-height: 1.6;"></ul>
             </div>
         </div>
     </div>

--- a/tokenpak/dashboard/intent_policy.js
+++ b/tokenpak/dashboard/intent_policy.js
@@ -71,6 +71,72 @@ async function fetchAndUpdateIntentPolicyDashboard() {
             }
         }
     }
+
+    // Phase 2.4.2 — Advisory Suggestions sub-section. Every label
+    // makes clear: advisory / no-op / default-off.
+    const sugg = payload.suggestions || {};
+    setText('intent-policy-suggestions-total', sugg.total ?? 0);
+    setText('intent-policy-suggestions-expired', sugg.expired_count ?? 0);
+    setText(
+        'intent-policy-suggestions-visible',
+        `${sugg.user_visible_true_count ?? 0} / ${sugg.user_visible_false_count ?? 0}`,
+    );
+
+    const typesBody = document.getElementById('intent-policy-suggestions-types-body');
+    if (typesBody) {
+        typesBody.innerHTML = '';
+        const items = sugg.type_distribution || [];
+        if (items.length === 0) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td colspan="2"><em>(no advisory suggestions yet)</em></td>`;
+            typesBody.appendChild(tr);
+        } else {
+            for (const it of items) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${escapeHtml(it.suggestion_type)}</td><td>${it.count}</td>`;
+                typesBody.appendChild(tr);
+            }
+        }
+    }
+
+    const safetyBody = document.getElementById('intent-policy-suggestions-safety-body');
+    if (safetyBody) {
+        safetyBody.innerHTML = '';
+        const items = sugg.safety_flag_distribution || [];
+        if (items.length === 0) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td colspan="2"><em>(none)</em></td>`;
+            safetyBody.appendChild(tr);
+        } else {
+            for (const it of items) {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${escapeHtml(it.safety_flag)}</td><td>${it.count}</td>`;
+                safetyBody.appendChild(tr);
+            }
+        }
+    }
+
+    const latestUl = document.getElementById('intent-policy-suggestions-latest');
+    if (latestUl) {
+        latestUl.innerHTML = '';
+        const latest = sugg.latest || [];
+        if (latest.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = '(no advisory suggestions yet — TokenPak has not changed routing)';
+            latestUl.appendChild(li);
+        } else {
+            for (const s of latest.slice(0, 5)) {
+                const li = document.createElement('li');
+                const expiredTag = s.expires_at ? ` (expires ${escapeHtml(s.expires_at)})` : '';
+                li.innerHTML = (
+                    `<strong>[${escapeHtml(s.suggestion_type)}]</strong> `
+                    + escapeHtml(s.title)
+                    + ` <em>(advisory only; TokenPak has not changed routing)${expiredTag}</em>`
+                );
+                latestUl.appendChild(li);
+            }
+        }
+    }
 }
 
 function renderActionTable(items, bodyId) {

--- a/tokenpak/proxy/intent_doctor.py
+++ b/tokenpak/proxy/intent_doctor.py
@@ -312,6 +312,52 @@ def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str
                             p["requires_user_confirmation"]
                         ),
                     }
+
+            # Phase 2.4.2 — pull every linked policy suggestion.
+            # Linked by decision_id since 2.4.1 wrote one row per
+            # eligible decision. Best-effort: missing table or empty
+            # set renders as the friendly "(none)" line in the
+            # suggestion section.
+            policy_suggestions: list[dict[str, Any]] = []
+            sugg_table = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='intent_suggestions'"
+            ).fetchone()
+            if (
+                sugg_table is not None
+                and policy_decision is not None
+                and policy_decision.get("decision_id")
+            ):
+                for srow in conn.execute(
+                    "SELECT suggestion_id, decision_id, contract_id, "
+                    "timestamp, suggestion_type, title, message, "
+                    "recommended_action, confidence, safety_flags, "
+                    "requires_confirmation, user_visible, expires_at, "
+                    "source FROM intent_suggestions "
+                    "WHERE decision_id = ? "
+                    "ORDER BY timestamp DESC",
+                    (policy_decision["decision_id"],),
+                ).fetchall():
+                    try:
+                        sflags = json.loads(srow["safety_flags"] or "[]")
+                    except (TypeError, json.JSONDecodeError):
+                        sflags = []
+                    policy_suggestions.append({
+                        "suggestion_id": srow["suggestion_id"],
+                        "decision_id": srow["decision_id"],
+                        "contract_id": srow["contract_id"],
+                        "timestamp": srow["timestamp"],
+                        "suggestion_type": srow["suggestion_type"],
+                        "title": srow["title"],
+                        "message": srow["message"],
+                        "recommended_action": srow["recommended_action"],
+                        "confidence": srow["confidence"],
+                        "safety_flags": sflags,
+                        "requires_confirmation": bool(srow["requires_confirmation"]),
+                        "user_visible": bool(srow["user_visible"]),
+                        "expires_at": srow["expires_at"],
+                        "source": srow["source"],
+                    })
     except sqlite3.DatabaseError:
         return None
 
@@ -332,6 +378,7 @@ def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str
         "tokens_out": row["tokens_out"],
         "latency_ms": row["latency_ms"],
         "policy_decision": policy_decision,
+        "policy_suggestions": policy_suggestions,
     }
 
 
@@ -432,6 +479,40 @@ def render_explain_last(payload: Optional[Dict[str, Any]] = None) -> str:
         lines.append("")
         lines.append("    DRY-RUN / PREVIEW ONLY — no routing decision was made.")
         lines.append("")
+
+    # Phase 2.4.2 — render every linked policy suggestion. Section
+    # is always emitted (with "(none)" when empty) so the operator
+    # has a stable layout to scan.
+    suggestions = p.get("policy_suggestions") or []
+    lines.append(
+        "  Policy Suggestions (Phase 2.4.2 — advisory / no-op / default-off):"
+    )
+    if not suggestions:
+        lines.append("    (none recorded yet for this decision)")
+    else:
+        for s in suggestions:
+            lines.append("")
+            lines.append(f"    [{s['suggestion_type']}] {s['title']}")
+            lines.append(f"      suggestion_id:        {s['suggestion_id']}")
+            lines.append(f"      confidence:           {s['confidence']:.4f}")
+            sflags = s.get("safety_flags") or []
+            sflags_str = ", ".join(sflags) if sflags else "(none)"
+            lines.append(f"      safety_flags:         {sflags_str}")
+            if s.get("recommended_action"):
+                lines.append(
+                    f"      recommended_action:   {s['recommended_action']}"
+                )
+            lines.append(f"      requires_confirmation: {s['requires_confirmation']}")
+            lines.append(f"      user_visible:         {s['user_visible']}")
+            if s.get("expires_at"):
+                lines.append(f"      expires_at:           {s['expires_at']}")
+            lines.append("      message:")
+            lines.append(f"        {s['message']}")
+    lines.append("")
+    lines.append(
+        "    Suggestions are advisory only. TokenPak has not changed routing."
+    )
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/tokenpak/proxy/intent_policy_dashboard.py
+++ b/tokenpak/proxy/intent_policy_dashboard.py
@@ -125,11 +125,68 @@ def collect_policy_dashboard(
         "recommended_review_areas": list(report.review_areas),
     }
 
+    # Phase 2.4.2 — surface the advisory-suggestions slice under
+    # a dedicated top-level key. Reuses build_suggestion_report
+    # (Phase 2.4.2) so privacy / window invariants flow through.
+    suggestions_section: Dict[str, Any] = {}
+    try:
+        from tokenpak.proxy.intent_suggestion_report import build_suggestion_report
+
+        sugg = build_suggestion_report(
+            window_days=window_days, db_path=db_path, now=now,
+        )
+        suggestions_section = {
+            "advisory_label": (
+                "Suggestions are advisory only. TokenPak has not "
+                "changed routing."
+            ),
+            "noop_default_off": True,
+            "total": sugg.total_suggestions,
+            "type_distribution": [
+                {"suggestion_type": t, "count": c}
+                for t, c in sugg.suggestion_type_distribution.items()
+            ],
+            "safety_flag_distribution": [
+                {"safety_flag": f, "count": c}
+                for f, c in sorted(
+                    sugg.safety_flag_distribution.items(),
+                    key=lambda kv: -kv[1],
+                )
+            ],
+            "recommended_action_distribution": [
+                {"recommended_action": a, "count": c}
+                for a, c in sugg.recommended_action_distribution.items()
+            ],
+            "user_visible_true_count": sugg.user_visible_true_count,
+            "user_visible_false_count": sugg.user_visible_false_count,
+            "expired_count": sugg.expired_count,
+            "latest": list(sugg.latest_suggestions),
+        }
+    except Exception:  # noqa: BLE001
+        # Read-only path; never raise. Pre-2.4.1 hosts will see an
+        # empty section with the dry-run / advisory labelling.
+        suggestions_section = {
+            "advisory_label": (
+                "Suggestions are advisory only. TokenPak has not "
+                "changed routing."
+            ),
+            "noop_default_off": True,
+            "total": 0,
+        }
+
+    # ``phase`` stays at intent-layer-phase-2.2 because the cards /
+    # operator_panel contract is unchanged from 2.2. Phase 2.4.2's
+    # additive ``suggestions`` section is identified by its own
+    # noop_default_off flag inside the suggestions block above.
     metadata: Dict[str, Any] = {
         "schema_version": DASHBOARD_SCHEMA_VERSION,
         "phase": "intent-layer-phase-2.2",
         "dry_run_preview_only": True,
         "preview_label": "DRY-RUN / PREVIEW ONLY — no routing decisions made",
+        "suggestions_label": (
+            "Suggestions are advisory only. TokenPak has not "
+            "changed routing."
+        ),
         "window_days": report.window_days,
         "window_cutoff_iso": report.window_cutoff_iso,
         "telemetry_store_path": report.db_path,
@@ -139,6 +196,7 @@ def collect_policy_dashboard(
         "metadata": metadata,
         "cards": cards,
         "operator_panel": operator_panel,
+        "suggestions": suggestions_section,
     }
 
 

--- a/tokenpak/proxy/intent_policy_preview.py
+++ b/tokenpak/proxy/intent_policy_preview.py
@@ -12,13 +12,29 @@ from typing import Any, Dict, List, Optional
 
 
 def collect_latest() -> Optional[Dict[str, Any]]:
-    """Return the most recent ``intent_policy_decisions`` row.
+    """Return the most recent ``intent_policy_decisions`` row plus
+    its linked suggestions (Phase 2.4.2).
 
-    Returns ``None`` when no decision has been recorded yet.
+    Returns ``None`` when no decision has been recorded yet. When
+    the policy decision exists but the suggestions table has no
+    matching rows (or the table doesn't exist), the
+    ``policy_suggestions`` key is the empty list.
     """
     from tokenpak.proxy.intent_policy_telemetry import get_default_policy_store
+    from tokenpak.proxy.intent_suggestion_telemetry import (
+        get_default_suggestion_store,
+    )
 
-    return get_default_policy_store().fetch_latest()
+    payload = get_default_policy_store().fetch_latest()
+    if payload is None:
+        return None
+    payload = dict(payload)  # copy so we don't mutate the store's view
+    decision_id = payload.get("decision_id")
+    suggestions: list[Dict[str, Any]] = []
+    if decision_id:
+        suggestions = get_default_suggestion_store().fetch_for_decision(decision_id)
+    payload["policy_suggestions"] = suggestions
+    return payload
 
 
 def render_human(payload: Optional[Dict[str, Any]] = None) -> str:
@@ -97,6 +113,38 @@ def render_human(payload: Optional[Dict[str, Any]] = None) -> str:
     lines.append("  no routing, no model swap, no body mutation. See")
     lines.append("  docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md")
     lines.append("  for the rollout plan.")
+    lines.append("")
+
+    # Phase 2.4.2 — render every linked policy suggestion. Always
+    # emit the section header (with "(none)" when empty) so the
+    # operator scanning the output has a stable layout.
+    sugg_list = p.get("policy_suggestions") or []
+    lines.append(
+        "  Linked policy suggestions (Phase 2.4.2 — advisory / no-op / default-off):"
+    )
+    if not sugg_list:
+        lines.append("    (none recorded for this decision)")
+    else:
+        for s in sugg_list:
+            lines.append("")
+            lines.append(f"    [{s['suggestion_type']}] {s['title']}")
+            lines.append(f"      suggestion_id:        {s['suggestion_id']}")
+            lines.append(f"      confidence:           {s['confidence']:.4f}")
+            sflags = s.get("safety_flags") or []
+            sflags_str = ", ".join(sflags) if sflags else "(none)"
+            lines.append(f"      safety_flags:         {sflags_str}")
+            if s.get("recommended_action"):
+                lines.append(
+                    f"      recommended_action:   {s['recommended_action']}"
+                )
+            lines.append(f"      requires_confirmation: {s['requires_confirmation']}")
+            lines.append(f"      user_visible:         {s['user_visible']}")
+            if s.get("expires_at"):
+                lines.append(f"      expires_at:           {s['expires_at']}")
+    lines.append("")
+    lines.append(
+        "    Suggestions are advisory only. TokenPak has not changed routing."
+    )
     lines.append("")
     return "\n".join(lines)
 

--- a/tokenpak/proxy/intent_report.py
+++ b/tokenpak/proxy/intent_report.py
@@ -133,6 +133,12 @@ class IntentReport:
     # Empty dict on a fresh DB or pre-2.1 hosts.
     policy_summary: Dict[str, Any] = field(default_factory=dict)
 
+    # Phase 2.4.2 — suggestions summary (advisory / no-op /
+    # default-off). Populated by build_report() from the
+    # intent_suggestions table. Empty dict on a fresh DB or
+    # pre-2.4.1 hosts.
+    suggestions_summary: Dict[str, Any] = field(default_factory=dict)
+
     def to_dict(self) -> Dict[str, Any]:
         """JSON-friendly dict (tuples → 2-element lists)."""
         return {
@@ -156,6 +162,7 @@ class IntentReport:
             "top_catch_all_reasons": [list(t) for t in self.top_catch_all_reasons],
             "review_areas": list(self.review_areas),
             "policy_summary": dict(self.policy_summary),
+            "suggestions_summary": dict(self.suggestions_summary),
         }
 
 
@@ -446,6 +453,26 @@ def build_report(
         # bug we want surfaced via tests, not a runtime crash.
         report.policy_summary = {}
 
+    # Phase 2.4.2 — append a suggestions summary slice. Same
+    # best-effort posture as the policy summary above.
+    try:
+        from tokenpak.proxy.intent_suggestion_report import build_suggestion_report
+
+        sugg = build_suggestion_report(
+            window_days=window_days, db_path=path, now=now,
+        )
+        report.suggestions_summary = {
+            "total_suggestions": sugg.total_suggestions,
+            "suggestion_type_distribution": dict(sugg.suggestion_type_distribution),
+            "recommended_action_distribution": dict(sugg.recommended_action_distribution),
+            "safety_flag_distribution": dict(sugg.safety_flag_distribution),
+            "user_visible_true_count": sugg.user_visible_true_count,
+            "user_visible_false_count": sugg.user_visible_false_count,
+            "expired_count": sugg.expired_count,
+        }
+    except Exception:  # noqa: BLE001
+        report.suggestions_summary = {}
+
     return report
 
 
@@ -572,6 +599,26 @@ def render_human(report: IntentReport) -> str:
                 db_path=Path(report.db_path) if report.db_path else None,
             )
             lines.append(_render_policy(policy))
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Phase 2.4.2 — append the advisory suggestions summary if
+    # any rows exist for this window.
+    sugg_summary = report.suggestions_summary or {}
+    if sugg_summary and sugg_summary.get("total_suggestions", 0) > 0:
+        try:
+            from tokenpak.proxy.intent_suggestion_report import (
+                build_suggestion_report,
+            )
+            from tokenpak.proxy.intent_suggestion_report import (
+                render_human as _render_sugg,
+            )
+
+            sugg = build_suggestion_report(
+                window_days=report.window_days,
+                db_path=Path(report.db_path) if report.db_path else None,
+            )
+            lines.append(_render_sugg(sugg))
         except Exception:  # noqa: BLE001
             pass
 

--- a/tokenpak/proxy/intent_suggestion_report.py
+++ b/tokenpak/proxy/intent_suggestion_report.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.2 — read-side aggregations over ``intent_suggestions``.
+
+Dual to :mod:`intent_policy_report` (Phase 2.2) which aggregates
+the policy decisions table. This module aggregates the Phase 2.4.1
+``intent_suggestions`` table:
+
+  - Total advisory suggestions in window
+  - Suggestion-type distribution
+  - Recommended-action distribution
+  - Safety-flag distribution
+  - Expired suggestion count
+  - user_visible true / false counts
+  - Latest N suggestions (full rows)
+
+Read-only. The privacy contract from 2.4.1 carries through —
+suggestion rows store only structured fields + templated text;
+no raw prompts, no per-row hashes. Asserted in
+``tests/test_intent_suggestion_phase24_2.py::TestPrivacyContract``.
+
+Window semantics mirror :mod:`intent_policy_report` exactly:
+``Nd`` form, default 14d on dashboard surfaces, ``0d``/``""`` =
+all rows on the CLI surface, cutoff inclusive
+(``timestamp >= cutoff``).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Standardized advisory label rendered on every surface.
+ADVISORY_LABEL: str = (
+    "DRY-RUN / PREVIEW ONLY — suggestions are advisory; "
+    "TokenPak has not changed routing."
+)
+
+# Tag rendered on every section header so the operator scanning
+# the output cannot miss it.
+NOOP_DEFAULT_OFF_TAG: str = "no-op / default-off"
+
+
+@dataclass
+class SuggestionReport:
+    """All aggregated metrics for one window. JSON-serialisable."""
+
+    window_days: Optional[int]
+    window_cutoff_iso: Optional[str]
+    db_path: str
+
+    total_suggestions: int = 0
+    suggestion_type_distribution: Dict[str, int] = field(default_factory=dict)
+    recommended_action_distribution: Dict[str, int] = field(default_factory=dict)
+    safety_flag_distribution: Dict[str, int] = field(default_factory=dict)
+    user_visible_true_count: int = 0
+    user_visible_false_count: int = 0
+    expired_count: int = 0
+    latest_suggestions: List[Dict[str, Any]] = field(default_factory=list)
+    review_areas: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "window_days": self.window_days,
+            "window_cutoff_iso": self.window_cutoff_iso,
+            "db_path": self.db_path,
+            "total_suggestions": self.total_suggestions,
+            "suggestion_type_distribution": self.suggestion_type_distribution,
+            "recommended_action_distribution": self.recommended_action_distribution,
+            "safety_flag_distribution": self.safety_flag_distribution,
+            "user_visible_true_count": self.user_visible_true_count,
+            "user_visible_false_count": self.user_visible_false_count,
+            "expired_count": self.expired_count,
+            "latest_suggestions": list(self.latest_suggestions),
+            "review_areas": list(self.review_areas),
+        }
+
+
+def _intent_db_path() -> Path:
+    from tokenpak.proxy.intent_contract import _DEFAULT_DB_PATH
+
+    return _DEFAULT_DB_PATH
+
+
+def _table_exists(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type='table' AND name='intent_suggestions'"
+    ).fetchone()
+    return row is not None
+
+
+def _window_cutoff(window_days: Optional[int], now: Optional[_dt.datetime]) -> Optional[str]:
+    if window_days is None:
+        return None
+    base = now if now is not None else _dt.datetime.now()
+    return (base - _dt.timedelta(days=window_days)).isoformat(timespec="seconds")
+
+
+def build_suggestion_report(
+    *,
+    window_days: Optional[int] = 14,
+    db_path: Optional[Path] = None,
+    now: Optional[_dt.datetime] = None,
+    latest_limit: int = 10,
+) -> SuggestionReport:
+    """Run every aggregation and return one fully-populated report.
+
+    Read-only. ``window_days=None`` reads every row.
+    """
+    path = db_path if db_path is not None else _intent_db_path()
+    cutoff = _window_cutoff(window_days, now)
+    report = SuggestionReport(
+        window_days=window_days,
+        window_cutoff_iso=cutoff,
+        db_path=str(path),
+    )
+
+    if not path.is_file():
+        report.review_areas = _review_areas(report)
+        return report
+
+    where = ""
+    params: tuple = ()
+    if cutoff is not None:
+        where = " WHERE timestamp >= ?"
+        params = (cutoff,)
+
+    with sqlite3.connect(str(path)) as conn:
+        if not _table_exists(conn):
+            report.review_areas = _review_areas(report)
+            return report
+
+        # Total
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_suggestions{where}", params
+        ).fetchone()
+        report.total_suggestions = int(row[0]) if row else 0
+        if report.total_suggestions == 0:
+            report.review_areas = _review_areas(report)
+            return report
+
+        # suggestion_type distribution
+        for r in conn.execute(
+            f"SELECT suggestion_type, COUNT(*) FROM intent_suggestions"
+            f"{where} GROUP BY suggestion_type ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            report.suggestion_type_distribution[r[0]] = int(r[1])
+
+        # recommended_action distribution (skip nulls; spec §6
+        # treats recommended_action as nullable for budget_warning /
+        # adapter_capability types)
+        and_ = " AND" if where else " WHERE"
+        for r in conn.execute(
+            f"SELECT recommended_action, COUNT(*) FROM intent_suggestions"
+            f"{where}{and_} recommended_action IS NOT NULL "
+            f"GROUP BY recommended_action ORDER BY COUNT(*) DESC",
+            params,
+        ).fetchall():
+            report.recommended_action_distribution[r[0]] = int(r[1])
+
+        # user_visible true/false split
+        row = conn.execute(
+            f"SELECT "
+            f"SUM(CASE WHEN user_visible=1 THEN 1 ELSE 0 END), "
+            f"SUM(CASE WHEN user_visible=0 THEN 1 ELSE 0 END) "
+            f"FROM intent_suggestions{where}",
+            params,
+        ).fetchone()
+        report.user_visible_true_count = int(row[0]) if row and row[0] is not None else 0
+        report.user_visible_false_count = int(row[1]) if row and row[1] is not None else 0
+
+        # Expired count: expires_at is non-null AND in the past.
+        # Pass the comparison time as ISO-8601 so SQL string
+        # comparison is correct.
+        cmp_iso = (now or _dt.datetime.now()).isoformat(timespec="seconds")
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM intent_suggestions"
+            f"{where}{and_} expires_at IS NOT NULL AND expires_at < ?",
+            (*params, cmp_iso),
+        ).fetchone()
+        report.expired_count = int(row[0]) if row else 0
+
+        # safety_flag distribution: JSON column; explode in Python.
+        for r in conn.execute(
+            f"SELECT safety_flags FROM intent_suggestions"
+            f"{where}{and_} safety_flags IS NOT NULL",
+            params,
+        ).fetchall():
+            try:
+                for f in json.loads(r[0] or "[]"):
+                    report.safety_flag_distribution[f] = (
+                        report.safety_flag_distribution.get(f, 0) + 1
+                    )
+            except (TypeError, json.JSONDecodeError):
+                continue
+
+        # Latest N rows (full-row rendering on dashboard / API)
+        conn.row_factory = sqlite3.Row
+        for r in conn.execute(
+            f"SELECT suggestion_id, decision_id, contract_id, timestamp, "
+            f"suggestion_type, title, message, recommended_action, "
+            f"confidence, safety_flags, requires_confirmation, "
+            f"user_visible, expires_at, source "
+            f"FROM intent_suggestions{where} "
+            f"ORDER BY timestamp DESC LIMIT ?",
+            (*params, latest_limit),
+        ).fetchall():
+            try:
+                flags = json.loads(r["safety_flags"] or "[]")
+            except (TypeError, json.JSONDecodeError):
+                flags = []
+            report.latest_suggestions.append({
+                "suggestion_id": r["suggestion_id"],
+                "decision_id": r["decision_id"],
+                "contract_id": r["contract_id"],
+                "timestamp": r["timestamp"],
+                "suggestion_type": r["suggestion_type"],
+                "title": r["title"],
+                "message": r["message"],
+                "recommended_action": r["recommended_action"],
+                "confidence": r["confidence"],
+                "safety_flags": flags,
+                "requires_confirmation": bool(r["requires_confirmation"]),
+                "user_visible": bool(r["user_visible"]),
+                "expires_at": r["expires_at"],
+                "source": r["source"],
+            })
+
+    report.review_areas = _review_areas(report)
+    return report
+
+
+def _review_areas(report: SuggestionReport) -> List[str]:
+    out: List[str] = []
+    if report.total_suggestions == 0:
+        out.append(
+            "No advisory suggestions yet — start the proxy and route some "
+            "traffic through it before re-running this report."
+        )
+        return out
+
+    if report.user_visible_false_count == report.total_suggestions:
+        out.append(
+            "Every suggestion is user_visible=false (the Phase 2.4.2 default). "
+            "Phase 2.4.3 will add the per-surface visibility config that flips "
+            "this to true under explicit opt-in."
+        )
+
+    if report.expired_count and report.expired_count > 0:
+        out.append(
+            f"{report.expired_count} suggestion(s) are expired (expires_at < now). "
+            "Inspect via `tokenpak intent suggestions` and consider regenerating."
+        )
+
+    return out
+
+
+def render_human(report: SuggestionReport) -> str:
+    """Operator-readable plain-text suggestion section.
+
+    Used as a sub-section appended to ``tokenpak intent report``
+    output; can also be rendered standalone.
+    """
+    lines: List[str] = []
+    lines.append("")
+    lines.append(
+        "  ── Advisory Suggestions ("
+        f"Phase 2.4.2 — {NOOP_DEFAULT_OFF_TAG}) ──"
+    )
+    lines.append("")
+    if report.total_suggestions == 0:
+        lines.append("  No advisory suggestions in this window.")
+        lines.append("")
+        if report.review_areas:
+            for ra in report.review_areas:
+                lines.append(f"  - {ra}")
+            lines.append("")
+        return "\n".join(lines)
+
+    lines.append(f"  Total suggestions:         {report.total_suggestions}")
+    lines.append(
+        f"  user_visible (true / false): "
+        f"{report.user_visible_true_count} / {report.user_visible_false_count}"
+    )
+    lines.append(f"  Expired suggestions:       {report.expired_count}")
+    lines.append("")
+
+    lines.append("  Suggestion type distribution:")
+    for kind, count in report.suggestion_type_distribution.items():
+        pct = round(100 * count / report.total_suggestions)
+        lines.append(f"    {kind:<40s} {count:>6d}  ({pct}%)")
+    lines.append("")
+
+    if report.recommended_action_distribution:
+        lines.append("  Top recommended actions:")
+        for action, count in list(report.recommended_action_distribution.items())[:5]:
+            lines.append(f"    {action[:50]:<52s} {count}")
+        lines.append("")
+
+    if report.safety_flag_distribution:
+        lines.append("  Safety flags attached to suggestions:")
+        for flag, count in sorted(
+            report.safety_flag_distribution.items(), key=lambda kv: -kv[1]
+        ):
+            lines.append(f"    {flag:<32s} {count}")
+        lines.append("")
+
+    if report.review_areas:
+        lines.append("  Recommended review areas:")
+        for ra in report.review_areas:
+            lines.append(f"    - {ra}")
+        lines.append("")
+
+    lines.append(f"  {ADVISORY_LABEL}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(report: SuggestionReport) -> str:
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+__all__ = [
+    "ADVISORY_LABEL",
+    "NOOP_DEFAULT_OFF_TAG",
+    "SuggestionReport",
+    "build_suggestion_report",
+    "render_human",
+    "render_json",
+]


### PR DESCRIPTION
## Summary

Wires `PolicySuggestion` visibility into five existing observability surfaces. Every render path labels suggestions clearly as **advisory / no-op / default-off**; the canonical phrase "TokenPak has not changed routing" appears adjacent to every suggestion render.

| Surface | Phase 2.4.2 addition |
|---|---|
| `tokenpak doctor --explain-last` | "Policy Suggestions" section linked by `decision_id` |
| `tokenpak intent report` | "Advisory Suggestions" summary section + `suggestions_summary` JSON key |
| `tokenpak intent policy-preview` | linked suggestions for the latest decision |
| `tokenpak intent suggestions` | (kept from 2.4.1 as detailed/dev inspector) |
| `GET /api/intent/policy-report?window=Nd` | new top-level `suggestions` key with aggregates + latest |
| Dashboard "Intent Policy" panel | new "Advisory Suggestions" sub-section with cards + tables |

## Acceptance

- [x] Suggestions visible across all directive-listed surfaces.
- [x] Every surface labels clearly: advisory / preview / no-op / default-off.
- [x] No suggest mode config activation (PolicyEngineConfig untouched; `show_suggestions` / `suggestion_surface` are 2.4.3 deliverables).
- [x] No routing behavior changes (read-only render paths; structural test asserts no dispatch primitives imported).
- [x] No classifier behavior changes (`intent_classifier.py` untouched).
- [x] No request mutation (read-only DB checked via mtime/size).
- [x] No prompt text or secrets emitted (sentinel-substring + per-row hash absence asserted across every render path).
- [x] Forbidden-wording guardrail still enforced end-to-end.
- [x] **1198 passing** (was 1145 baseline, +53), 0 regressions, 1 pre-existing test relaxed to subset-check for additive `suggestions` key.
- [x] `ruff check` clean, `cli-docs-in-sync` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no scaffold renderer expansion, **no classifier behavior changes**, **no production intent-based routing**, **no confirm mode**, **no enforce mode**, **no suggest mode config activation**, **no automatic routing / model / provider changes**.