### PR TITLE
feat(proxy,cli,dashboard): Phase 2.4.3 — opt-in suggest mode config

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -616,16 +616,18 @@ options:
 Intent Layer observation + reporting (read-only)
 
 ```
-usage: tokenpak intent [-h] {report,policy-preview,suggestions} ...
+usage: tokenpak intent [-h] {report,policy-preview,suggestions,config} ...
 
 positional arguments:
-  {report,policy-preview,suggestions}
+  {report,policy-preview,suggestions,config}
     report              Summarize the intent_events telemetry over a window.
                         Read-only; never reads or emits raw prompt text.
     policy-preview      Show the latest intent policy decision (Phase 2.1 dry-
                         run; read-only).
     suggestions         Show the latest dry-run policy suggestion (Phase
                         2.4.1; internal/dev inspector; read-only).
+    config              Show or validate the intent_policy config (Phase
+                        2.4.3; read-only).
 
 options:
   -h, --help            show this help message and exit

--- a/docs/reference/intent-suggest-mode.md
+++ b/docs/reference/intent-suggest-mode.md
@@ -1,0 +1,129 @@
+# Intent Layer — Suggest Mode (Phase 2.4.3)
+
+> Phase 2.4.3 lets a host **opt in** to suggest mode. The opt-in only changes labeling — every render path now badges decisions with "Suggest mode active" when the config flips on. **Nothing about request handling changes.** No routing, no model swap, no body mutation, no header injection. Suggestions are advisory only.
+
+## How to enable suggest mode
+
+Create or edit `~/.tokenpak/policy.yaml` (or `$TOKENPAK_HOME/policy.yaml`):
+
+```yaml
+intent_policy:
+  mode: suggest
+  # All other fields use safe defaults; you only need this one
+  # line to opt in.
+```
+
+Then verify the active config:
+
+```bash
+tokenpak intent config --show
+tokenpak intent config --validate
+tokenpak intent config --json
+```
+
+The CLI prints the active config + a "Suggest mode active" line when the opt-in is honored. The `--validate` flag re-parses the file and reports any safety overrides applied.
+
+## Default vs. suggest
+
+| Behavior | `mode: observe_only` (default) | `mode: suggest` (opt-in) |
+|---|---|---|
+| Engine generates `PolicyDecision` per request | yes | yes |
+| Engine generates `PolicySuggestion` rows when eligible | yes | yes |
+| Suggestion data appears in CLI / API / dashboard | yes (Phase 2.4.2) | yes |
+| Surfaces badge "Suggest mode active" | no | **yes** |
+| Wire-side `X-TokenPak-Suggestion-*` headers attached | **no (locked)** | **no (locked)** |
+| Routing / model / provider switching | **no** | **no** |
+| Body mutation | **no** | **no** |
+
+The only observable difference between the two modes is the **labeling** on the operator-facing surfaces. The engine, the writer, the gates — all unchanged.
+
+## Why `dry_run` remains true
+
+The Phase 2.4 spec §10 sub-phase plan explicitly keeps `dry_run = true` through every Phase 2.4.x sub-sub-phase. Phase 2.5 will reintroduce a synchronous pause point (confirmation mode); Phase 2.6 will introduce limited budget-cap enforcement. Until those land, every request — regardless of `mode` — flows exactly as it did in Phase 2.2.
+
+The loader **forces** `dry_run = True` regardless of what the config file says. A user who tries to flip it sees a warning logged but the runtime stays safe. This is an intentional safety invariant.
+
+## Why `allow_auto_routing` remains false
+
+Same reasoning. Auto-routing is gated for Phase 2.6+ ratification. The loader forces `allow_auto_routing = False` and warns on attempted overrides. Even when the engine emits `suggest_route` decisions and downstream code sees a `recommended_provider`, the dispatcher does NOT read those fields in 2.4.x.
+
+## Why `response_headers` are disabled
+
+The `suggestion_surface.response_headers` flag stays locked at `False`. Two reasons:
+
+1. **Adapter capability gate.** Wire-side `X-TokenPak-Suggestion-*` emission would still need to flow through Standard #23 §4.3 — the adapter has to declare `tip.intent.contract-headers-v1`. No first-party adapter does today (Phase 0 default; verified in `tests/test_intent_layer_phase0.py`).
+2. **Byte-fidelity rule.** Architecture §5.1 keeps non-TIP providers byte-stable. Sending unsolicited TIP headers risks observable side-effects — billing routing on Anthropic OAuth, signature mismatches on SigV4 — that the Phase 2.4 spec explicitly rules out.
+
+The loader forces `response_headers = False` and warns on attempted overrides.
+
+## Per-surface visibility flags
+
+```yaml
+intent_policy:
+  mode: suggest
+  show_suggestions: true     # auto-set when mode = suggest
+  suggestion_surface:
+    cli: true                # default true; set false to hide CLI badging
+    dashboard: true          # default true; set false to hide dashboard badging
+    api: true                # default true; set false to hide API badging
+    response_headers: false  # locked False in 2.4.3
+```
+
+Each flag controls **only** whether that surface adds the "Suggest mode active" badge. The underlying suggestion data still shows on every surface that already showed it in Phase 2.4.2 (with the standard "advisory / no-op / default-off" labeling). The flags add an additional active-mode badge, not a kill-switch on the data.
+
+## What comes later in confirm mode
+
+Phase 2.5 will introduce `mode: confirm`. With confirm mode:
+
+- The engine still emits `PolicyDecision` + `PolicySuggestion` (same as 2.4.x).
+- Decisions carrying `requires_confirmation = true` will pause the request synchronously.
+- A new SDK / CLI surface presents the decision to the user; the request resumes only after the user accepts (default) or rejects (skips the suggested action).
+- `dry_run` is still locked `True` until Phase 2.6.
+
+Phase 2.6 will introduce `mode: enforce` for budget caps only:
+
+- `flag_budget_risk` decisions will be honored — request blocked, downsized, or downgraded based on budget config.
+- Auto-routing remains locked off.
+- Provider switching remains locked off.
+
+The current spec for both is `docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md`. Each gets its own ratification before any code lands.
+
+## Operator commands
+
+```bash
+# Inspect the active config
+tokenpak intent config --show
+tokenpak intent config --json
+
+# Re-parse the file and surface warnings (safety overrides applied,
+# invalid values, reserved-mode rejections)
+tokenpak intent config --validate
+
+# Same config snapshot also surfaces in:
+tokenpak doctor --intent
+tokenpak doctor --explain-last
+```
+
+## Privacy
+
+Same contract as Phase 2.4.1 / 2.4.2: no raw prompt content, no secrets, no full credentials. The config snapshot rendered on each surface contains only the boolean / numeric / mode-name fields documented above. The loader is read-only; it never writes to disk.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/proxy/intent_policy_engine.py` | `PolicyEngineConfig` dataclass extended with `show_suggestions` + `suggestion_surface` |
+| `tokenpak/proxy/intent_policy_config_loader.py` | YAML loader, safety overrides, warnings list |
+| `tokenpak/cli/_impl.py::cmd_intent_config` | `tokenpak intent config` entry point |
+| `tokenpak/proxy/intent_doctor.py` | doctor `--intent` / `--explain-last` config snapshot |
+| `tokenpak/proxy/intent_policy_dashboard.py` | dashboard payload `metadata.active_policy_config` + `suggest_mode_active` |
+| `~/.tokenpak/policy.yaml` (operator-edited) | the config file |
+| `docs/reference/intent-suggest-mode.md` | this document |
+
+## Cross-references
+
+- Phase 2 spec (parent): `docs/internal/specs/phase2-intent-policy-engine-spec-2026-04-25.md`
+- Phase 2.4 sub-spec: `docs/internal/specs/phase2.4-suggest-mode-spec-2026-04-26.md` (§3 covers the schema; §10 covers the rollout plan)
+- Standard #23 §4.3 — wire-emission capability gate
+- Architecture §5.1 — byte-fidelity rule
+- Architecture §7.1 — prompt-locality rule

--- a/tests/test_intent_suggest_mode_phase24_3.py
+++ b/tests/test_intent_suggest_mode_phase24_3.py
@@ -1,0 +1,445 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.3 — opt-in suggest mode config test suite.
+
+Twelve directive-mandated test classes:
+
+  - default config = observe_only
+  - explicit suggest config loads
+  - invalid mode fails closed
+  - dry_run cannot be disabled yet
+  - allow_auto_routing cannot be enabled yet
+  - response_headers cannot be enabled yet
+  - CLI/dashboard/API obey suggestion_surface flags
+  - doctor shows config state
+  - no route mutation
+  - no request mutation
+  - no classifier mutation
+  - no prompt text/secrets emitted
+
+Read-only across the board.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_policy_config_loader import (
+    PERMITTED_MODES_2_4_3,
+    is_surface_active,
+    load_policy_config_safely,
+    parse_intent_policy_block,
+    resolve_active_config_path,
+)
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyEngineConfig,
+    SuggestionSurfaceConfig,
+    load_default_config,
+)
+
+# ── 1. Default config = observe_only ──────────────────────────────────
+
+
+class TestDefaultConfig:
+
+    def test_default_is_observe_only(self):
+        cfg, warns = parse_intent_policy_block(None)
+        assert cfg.mode == "observe_only"
+        assert cfg.dry_run is True
+        assert cfg.allow_auto_routing is False
+        assert cfg.show_suggestions is False
+        assert cfg.suggestion_surface.response_headers is False
+        assert warns == []
+
+    def test_load_safely_returns_policy_engine_config(self, tmp_path: Path,
+                                                       monkeypatch):
+        # Point the loader at a non-existent file; expect default.
+        cfg = load_policy_config_safely(candidate_path=tmp_path / "nope.yaml")
+        assert isinstance(cfg, PolicyEngineConfig)
+        assert cfg.mode == "observe_only"
+
+    def test_default_loader_imports_cleanly(self):
+        cfg = load_default_config()
+        assert cfg.mode == "observe_only"
+
+
+# ── 2. Explicit suggest config loads ──────────────────────────────────
+
+
+class TestSuggestConfigLoads:
+
+    def test_explicit_suggest_mode(self):
+        cfg, warns = parse_intent_policy_block({"mode": "suggest"})
+        assert cfg.mode == "suggest"
+        assert cfg.is_suggest_mode() is True
+        # show_suggestions auto-enabled when mode = suggest.
+        assert cfg.show_suggestions is True
+        assert warns == []
+
+    def test_suggest_mode_with_explicit_surface_overrides(self):
+        cfg, warns = parse_intent_policy_block({
+            "mode": "suggest",
+            "suggestion_surface": {"cli": False, "dashboard": True, "api": True},
+        })
+        assert cfg.mode == "suggest"
+        assert cfg.suggestion_surface.cli is False
+        assert cfg.suggestion_surface.dashboard is True
+
+    def test_suggest_active_helper(self):
+        cfg, _ = parse_intent_policy_block({"mode": "suggest"})
+        assert is_surface_active(cfg, "cli") is True
+        assert is_surface_active(cfg, "dashboard") is True
+        assert is_surface_active(cfg, "api") is True
+        # response_headers always False.
+        assert is_surface_active(cfg, "response_headers") is False
+
+    def test_suggest_with_show_suggestions_explicit_false(self):
+        # Even if mode = suggest, an explicit show_suggestions=false
+        # turns off the suggest-mode badging.
+        cfg, _ = parse_intent_policy_block({
+            "mode": "suggest", "show_suggestions": False,
+        })
+        assert cfg.mode == "suggest"
+        assert cfg.show_suggestions is False
+        assert is_surface_active(cfg, "cli") is False
+
+
+# ── 3. Invalid mode fails closed ──────────────────────────────────────
+
+
+class TestInvalidModeFailsClosed:
+
+    def test_unknown_mode_string(self):
+        cfg, warns = parse_intent_policy_block({"mode": "tornado"})
+        assert cfg.mode == "observe_only"
+        assert any("not a known value" in w for w in warns)
+
+    def test_reserved_modes_fall_back(self):
+        for reserved in ("confirm", "enforce"):
+            cfg, warns = parse_intent_policy_block({"mode": reserved})
+            assert cfg.mode == "observe_only", (
+                f"reserved mode {reserved!r} should fall back to observe_only"
+            )
+            assert any("reserved" in w for w in warns)
+
+    def test_non_string_mode(self):
+        for raw in (123, True, [], {}):
+            cfg, warns = parse_intent_policy_block({"mode": raw})
+            assert cfg.mode == "observe_only"
+
+    def test_permitted_modes_pinned(self):
+        # Future change to PERMITTED_MODES_2_4_3 requires explicit
+        # ratification — the current permitted set is exactly two
+        # values.
+        assert set(PERMITTED_MODES_2_4_3) == {"observe_only", "suggest"}
+
+
+# ── 4. dry_run cannot be disabled ─────────────────────────────────────
+
+
+class TestDryRunForcedTrue:
+
+    def test_explicit_false_overridden(self):
+        cfg, warns = parse_intent_policy_block({
+            "mode": "suggest", "dry_run": False,
+        })
+        assert cfg.dry_run is True
+        assert any("dry_run" in w and "forced to True" in w for w in warns)
+
+    def test_dry_run_string_false_overridden(self):
+        cfg, _ = parse_intent_policy_block({
+            "mode": "suggest", "dry_run": "false",
+        })
+        assert cfg.dry_run is True
+
+
+# ── 5. allow_auto_routing cannot be enabled ───────────────────────────
+
+
+class TestAllowAutoRoutingForcedFalse:
+
+    def test_explicit_true_overridden(self):
+        cfg, warns = parse_intent_policy_block({
+            "mode": "suggest", "allow_auto_routing": True,
+        })
+        assert cfg.allow_auto_routing is False
+        assert any("allow_auto_routing" in w and "forced to False" in w for w in warns)
+
+    def test_string_yes_overridden(self):
+        cfg, _ = parse_intent_policy_block({
+            "mode": "suggest", "allow_auto_routing": "yes",
+        })
+        assert cfg.allow_auto_routing is False
+
+
+# ── 6. response_headers cannot be enabled ─────────────────────────────
+
+
+class TestResponseHeadersForcedFalse:
+
+    def test_explicit_true_in_surface_overridden(self):
+        cfg, warns = parse_intent_policy_block({
+            "mode": "suggest",
+            "suggestion_surface": {"response_headers": True},
+        })
+        assert cfg.suggestion_surface.response_headers is False
+        assert any("response_headers" in w for w in warns)
+
+    def test_response_headers_default_false_in_default_config(self):
+        cfg, _ = parse_intent_policy_block(None)
+        assert cfg.suggestion_surface.response_headers is False
+
+
+# ── 7. CLI/dashboard/API obey suggestion_surface flags ────────────────
+
+
+class TestSurfaceFlagsObeyed:
+
+    def test_individual_surface_flips(self):
+        for surface_name in ("cli", "dashboard", "api"):
+            cfg, _ = parse_intent_policy_block({
+                "mode": "suggest",
+                "suggestion_surface": {surface_name: False},
+            })
+            # Other surfaces stay True; the flipped one is False.
+            for other in ("cli", "dashboard", "api"):
+                expected = other != surface_name
+                actual = is_surface_active(cfg, other)
+                assert actual is expected, (
+                    f"surface {other!r} active={actual} when {surface_name} flipped off"
+                )
+
+    def test_observe_only_mode_no_surface_active(self):
+        cfg, _ = parse_intent_policy_block({"mode": "observe_only"})
+        for surface in ("cli", "dashboard", "api"):
+            assert is_surface_active(cfg, surface) is False, (
+                f"observe_only must not activate any surface; got {surface}=True"
+            )
+
+
+# ── 8. Doctor shows config state ──────────────────────────────────────
+
+
+class TestDoctorShowsConfig:
+
+    def test_intent_view_carries_policy_config(self):
+        from tokenpak.proxy.intent_doctor import collect_intent_view
+        view = collect_intent_view()
+        assert "policy_config" in view
+        cfg = view["policy_config"]
+        assert isinstance(cfg, dict)
+        assert cfg.get("mode") in ("observe_only", "suggest")
+        assert cfg.get("dry_run") is True
+        assert cfg.get("allow_auto_routing") is False
+        # response_headers locked False.
+        assert cfg["suggestion_surface"]["response_headers"] is False
+
+    def test_intent_view_render_includes_config_section(self):
+        from tokenpak.proxy.intent_doctor import (
+            collect_intent_view,
+            render_intent_view,
+        )
+        text = render_intent_view(collect_intent_view())
+        assert "Active policy config (Phase 2.4.3)" in text
+        assert "dry_run:" in text
+        assert "(locked True in 2.4.3)" in text
+        assert "TokenPak has not changed routing" in text
+
+    def test_explain_last_carries_policy_config_when_present(self, tmp_path: Path):
+        # Even on an empty DB, the explain payload renders the
+        # "no rows yet" text — config snapshot is only populated
+        # when a row exists. Pass: assert no crash on empty.
+        from tokenpak.proxy.intent_doctor import (
+            collect_explain_last,
+            render_explain_last,
+        )
+        payload = collect_explain_last(db_path=tmp_path / "nope.db")
+        assert payload is None  # no rows
+        text = render_explain_last(payload)
+        assert "No intent_events rows yet" in text
+
+
+# ── 9. No route mutation ──────────────────────────────────────────────
+
+
+class TestNoRouteMutation:
+
+    def test_loader_does_not_import_dispatch_path(self):
+        import tokenpak.proxy.intent_policy_config_loader as m
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src, (
+                f"loader references dispatch primitive: {forbidden!r}"
+            )
+
+
+# ── 10. No request mutation ───────────────────────────────────────────
+
+
+class TestNoRequestMutation:
+
+    def test_repeated_loads_do_not_create_files(self, tmp_path: Path):
+        before = sorted(p.name for p in tmp_path.iterdir())
+        for _ in range(5):
+            load_policy_config_safely(candidate_path=tmp_path / "nope.yaml")
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert before == after, "loader created files; must be read-only"
+
+    def test_config_dataclass_is_frozen(self):
+        cfg = PolicyEngineConfig()
+        with pytest.raises(Exception):
+            cfg.mode = "suggest"  # type: ignore[misc]
+
+    def test_surface_dataclass_is_frozen(self):
+        s = SuggestionSurfaceConfig()
+        with pytest.raises(Exception):
+            s.cli = False  # type: ignore[misc]
+
+
+# ── 11. No classifier mutation ────────────────────────────────────────
+
+
+class TestNoClassifierMutation:
+
+    def test_classifier_constants_unchanged(self):
+        from tokenpak.proxy.intent_classifier import (
+            CLASSIFY_THRESHOLD,
+            INTENT_SOURCE_V0,
+        )
+        assert CLASSIFY_THRESHOLD == 0.4
+        assert INTENT_SOURCE_V0 == "rule_based_v0"
+
+
+# ── 12. Privacy contract ──────────────────────────────────────────────
+
+
+class TestPrivacyContract:
+    SENTINEL = "kevin-magic-prompt-marker-PHASE-2-4-3"
+
+    def test_no_sentinel_in_config_snapshot(self):
+        # The config loader / engine read no caller-supplied
+        # strings; planting a sentinel in the YAML's mode field
+        # should fall back to observe_only and surface a warning,
+        # NOT propagate the sentinel to any rendered output.
+        cfg, warns = parse_intent_policy_block({"mode": self.SENTINEL})
+        assert cfg.mode == "observe_only"
+        # The warning may name the offending value — that's fine; it
+        # comes from the loader, not from a prompt. But the rendered
+        # config dict MUST NOT carry the sentinel.
+        d = cfg.to_dict()
+        assert self.SENTINEL not in json.dumps(d)
+
+    def test_doctor_render_does_not_leak_sentinel(self, tmp_path: Path,
+                                                   monkeypatch):
+        # Create a malformed YAML containing the sentinel + ensure
+        # the doctor render doesn't echo it. We point the loader at
+        # the temp file via TOKENPAK_HOME.
+        cfg_path = tmp_path / "policy.yaml"
+        cfg_path.write_text(
+            f"intent_policy:\n  mode: {self.SENTINEL}\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path))
+
+        from tokenpak.proxy.intent_doctor import (
+            collect_intent_view,
+            render_intent_view,
+        )
+        view = collect_intent_view()
+        text = render_intent_view(view)
+        # The mode field should have fallen back to observe_only;
+        # no sentinel substring should appear in the rendered view.
+        assert self.SENTINEL not in text
+        # Rendered mode is the safe fallback.
+        assert "mode:                      observe_only" in text
+
+
+# ── 13. Dashboard payload exposes config (cross-cutting) ──────────────
+
+
+class TestDashboardPayloadConfig:
+
+    def test_metadata_includes_active_policy_config(self, tmp_path: Path):
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        meta = payload["metadata"]
+        assert "active_policy_config" in meta
+        assert "suggest_mode_active" in meta
+        # Default state: not active.
+        assert meta["suggest_mode_active"] is False
+
+    def test_metadata_suggest_mode_active_when_config_opts_in(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        cfg_path = tmp_path / "policy.yaml"
+        cfg_path.write_text(
+            "intent_policy:\n  mode: suggest\n", encoding="utf-8",
+        )
+        monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path))
+
+        from tokenpak.proxy.intent_policy_dashboard import collect_policy_dashboard
+        payload = collect_policy_dashboard(window_days=14, db_path=tmp_path / "nope.db")
+        assert payload["metadata"]["suggest_mode_active"] is True
+        cfg = payload["metadata"]["active_policy_config"]
+        assert cfg["mode"] == "suggest"
+        assert cfg["dry_run"] is True
+        assert cfg["allow_auto_routing"] is False
+        assert cfg["suggestion_surface"]["response_headers"] is False
+
+
+# ── 14. CLI subprocess smoke ──────────────────────────────────────────
+
+
+class TestCliSmoke:
+
+    def test_intent_config_show_runs(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "config", "--show"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "Intent policy config (Phase 2.4.3)" in result.stdout
+        assert "dry_run:" in result.stdout
+
+    def test_intent_config_validate_runs(self):
+        # Validate exits 0 even on hosts with no config file.
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "config", "--validate"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+
+    def test_intent_config_json_parses(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "config", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        d = json.loads(result.stdout)
+        assert "active_config" in d
+        assert "suggest_mode_active" in d
+
+
+# ── 15. resolve_active_config_path (cross-cutting) ────────────────────
+
+
+class TestResolvePath:
+
+    def test_returns_none_when_no_file(self, monkeypatch, tmp_path: Path):
+        # Point HOME at an empty dir so the default path doesn't
+        # accidentally hit the real ~/.tokenpak/policy.yaml.
+        monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path))
+        # Also override HOME so ~/.tokenpak/policy.yaml resolution
+        # falls inside tmp_path.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert resolve_active_config_path() is None
+
+    def test_returns_path_when_file_exists(self, monkeypatch, tmp_path: Path):
+        cfg_path = tmp_path / "policy.yaml"
+        cfg_path.write_text("intent_policy:\n  mode: suggest\n", encoding="utf-8")
+        monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path))
+        resolved = resolve_active_config_path()
+        assert resolved == cfg_path

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -553,6 +553,93 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def cmd_intent_config(args) -> None:
+    """Phase 2.4.3 — show / validate the intent_policy config.
+
+    Read-only over ``~/.tokenpak/policy.yaml`` (or
+    ``$TOKENPAK_HOME/policy.yaml``). Always exits 0 — a missing
+    file is a valid state (host runs the default observe_only
+    config). Exits non-zero only when ``--validate`` cannot read
+    a file that DOES exist.
+    """
+    import json as _json
+
+    from tokenpak.proxy.intent_policy_config_loader import (
+        load_policy_config_safely,
+        parse_intent_policy_block,
+        resolve_active_config_path,
+    )
+
+    cfg_path = resolve_active_config_path()
+    cfg = load_policy_config_safely()
+
+    # Re-parse to surface warnings (the load function logs but
+    # doesn't return them; for the CLI we want the list).
+    warnings: list[str] = []
+    if getattr(args, "config_validate", False) and cfg_path is not None:
+        try:
+            import yaml
+
+            with cfg_path.open("r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f) or {}
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[intent config] error: failed to read {cfg_path}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        block = raw.get("intent_policy") if isinstance(raw, dict) else None
+        _, warnings = parse_intent_policy_block(block)
+
+    if getattr(args, "config_json", False):
+        payload = {
+            "config_path": str(cfg_path) if cfg_path else None,
+            "active_config": cfg.to_dict(),
+            "warnings": warnings,
+            "suggest_mode_active": cfg.is_suggest_mode() and cfg.show_suggestions,
+        }
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        sys.exit(0)
+
+    lines: list[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Intent policy config (Phase 2.4.3)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+    lines.append(f"  config_path:               {cfg_path or '(none — using defaults)'}")
+    lines.append(f"  mode:                      {cfg.mode}")
+    if cfg.is_suggest_mode() and cfg.show_suggestions:
+        lines.append("    → Suggest mode active. Suggestions are advisory only;")
+        lines.append("      TokenPak has not changed routing.")
+    else:
+        lines.append("    → observe_only (default). No suggest-mode badging.")
+    lines.append(f"  dry_run:                   {cfg.dry_run}  (locked True in 2.4.3)")
+    lines.append(f"  allow_auto_routing:        {cfg.allow_auto_routing}  (locked False in 2.4.3)")
+    lines.append(f"  allow_unverified_providers:{cfg.allow_unverified_providers}")
+    lines.append(f"  show_suggestions:          {cfg.show_suggestions}")
+    lines.append("  suggestion_surface:")
+    lines.append(f"    cli:                     {cfg.suggestion_surface.cli}")
+    lines.append(f"    dashboard:               {cfg.suggestion_surface.dashboard}")
+    lines.append(f"    api:                     {cfg.suggestion_surface.api}")
+    lines.append(
+        f"    response_headers:        {cfg.suggestion_surface.response_headers}  "
+        f"(locked False in 2.4.3)"
+    )
+    lines.append(f"  low_confidence_threshold:  {cfg.low_confidence_threshold}")
+    lines.append("")
+    if warnings:
+        lines.append("  Warnings (safety overrides + invalid values):")
+        for w in warnings:
+            lines.append(f"    ! {w}")
+        lines.append("")
+    lines.append("  Safety posture: dry_run=True, allow_auto_routing=False,")
+    lines.append("  response_headers=False — no routing / model / provider /")
+    lines.append("  request mutation regardless of mode.")
+    lines.append("")
+    print("\n".join(lines))
+    sys.exit(0)
+
+
 def cmd_intent_suggestions(args) -> None:
     """Phase 2.4.1 — show the latest dry-run policy suggestion.
 
@@ -2352,6 +2439,37 @@ def build_parser():
         help="Emit machine-readable JSON instead of human-readable.",
     )
     p_intent_suggestions.set_defaults(func=cmd_intent_suggestions)
+
+    # Phase 2.4.3 — minimal config inspector / validator. Read-only.
+    p_intent_config = p_intent_sub.add_parser(
+        "config",
+        help=(
+            "Show or validate the intent_policy config "
+            "(Phase 2.4.3; read-only)."
+        ),
+    )
+    p_intent_config.add_argument(
+        "--show",
+        dest="config_show",
+        action="store_true",
+        help="Show the active policy config (default behavior).",
+    )
+    p_intent_config.add_argument(
+        "--validate",
+        dest="config_validate",
+        action="store_true",
+        help=(
+            "Re-parse the config file and report safety overrides + "
+            "warnings. Exits non-zero only on file-read errors."
+        ),
+    )
+    p_intent_config.add_argument(
+        "--json",
+        dest="config_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable.",
+    )
+    p_intent_config.set_defaults(func=cmd_intent_config)
 
     p_adapter = sub.add_parser(
         "adapter",

--- a/tokenpak/proxy/intent_doctor.py
+++ b/tokenpak/proxy/intent_doctor.py
@@ -91,6 +91,9 @@ def collect_intent_view() -> Dict[str, Any]:
         "would_emit_headers": False,
         "intent_events_db": {"path": None, "row_count": None},
         "errors": [],
+        # Phase 2.4.3 — active policy config snapshot.
+        "policy_config": None,
+        "policy_config_path": None,
     }
 
     try:
@@ -131,6 +134,20 @@ def collect_intent_view() -> Dict[str, Any]:
         out["would_emit_headers"] = any(a["declares_label"] for a in adapters)
     except Exception as exc:  # noqa: BLE001
         out["errors"].append(f"adapter registry unreachable: {exc!r}")
+
+    # Phase 2.4.3 — active policy config snapshot.
+    try:
+        from tokenpak.proxy.intent_policy_config_loader import (
+            resolve_active_config_path,
+        )
+        from tokenpak.proxy.intent_policy_engine import load_default_config
+
+        cfg = load_default_config()
+        out["policy_config"] = cfg.to_dict()
+        cpath = resolve_active_config_path()
+        out["policy_config_path"] = str(cpath) if cpath is not None else None
+    except Exception as exc:  # noqa: BLE001
+        out["errors"].append(f"policy config unreachable: {exc!r}")
 
     try:
         db_path = _intent_db_path()
@@ -216,6 +233,35 @@ def render_intent_view(view: Optional[Dict[str, Any]] = None) -> str:
         for e in v["errors"]:
             lines.append(f"    ! {e}")
         lines.append("")
+
+    # Phase 2.4.3 — active config snapshot.
+    cfg = v.get("policy_config")
+    cpath = v.get("policy_config_path")
+    lines.append("  Active policy config (Phase 2.4.3):")
+    lines.append(f"    config_path:               {cpath or '(none — using defaults)'}")
+    if cfg:
+        surface = cfg.get("suggestion_surface", {})
+        active_label = (
+            "Suggest mode active"
+            if cfg.get("mode") == "suggest"
+            else "observe_only (default)"
+        )
+        lines.append(f"    mode:                      {cfg.get('mode')}  ({active_label})")
+        lines.append(f"    dry_run:                   {cfg.get('dry_run')}  (locked True in 2.4.3)")
+        lines.append(f"    allow_auto_routing:        {cfg.get('allow_auto_routing')}  (locked False in 2.4.3)")
+        lines.append(f"    allow_unverified_providers:{cfg.get('allow_unverified_providers')}")
+        lines.append(f"    show_suggestions:          {cfg.get('show_suggestions')}")
+        lines.append(f"    suggestion_surface.cli:        {surface.get('cli')}")
+        lines.append(f"    suggestion_surface.dashboard:  {surface.get('dashboard')}")
+        lines.append(f"    suggestion_surface.api:        {surface.get('api')}")
+        lines.append(f"    suggestion_surface.response_headers: {surface.get('response_headers')}  (locked False in 2.4.3)")
+        lines.append(f"    low_confidence_threshold:  {cfg.get('low_confidence_threshold')}")
+    lines.append("")
+    lines.append("    Safety posture: dry_run=True, allow_auto_routing=False,")
+    lines.append("    response_headers=False — no routing / model / provider /")
+    lines.append("    request mutation regardless of mode.")
+    lines.append("    TokenPak has not changed routing.")
+    lines.append("")
 
     lines.append("  Run `tokenpak doctor --explain-last` to inspect the most")
     lines.append("  recent classification (full intent_events row).")
@@ -379,7 +425,22 @@ def collect_explain_last(*, db_path: Optional[Path] = None) -> Optional[Dict[str
         "latency_ms": row["latency_ms"],
         "policy_decision": policy_decision,
         "policy_suggestions": policy_suggestions,
+        "policy_config": _resolve_policy_config_snapshot(),
     }
+
+
+def _resolve_policy_config_snapshot() -> Optional[Dict[str, Any]]:
+    """Best-effort load of the active config for explain-last.
+
+    Pulled out so the explain return shape is stable — a config-
+    loader failure renders ``None`` instead of breaking the row.
+    """
+    try:
+        from tokenpak.proxy.intent_policy_engine import load_default_config
+
+        return load_default_config().to_dict()
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def render_explain_last(payload: Optional[Dict[str, Any]] = None) -> str:
@@ -513,6 +574,34 @@ def render_explain_last(payload: Optional[Dict[str, Any]] = None) -> str:
         "    Suggestions are advisory only. TokenPak has not changed routing."
     )
     lines.append("")
+
+    # Phase 2.4.3 — active config snapshot at the bottom of the
+    # explain output so the operator sees what gating was in effect
+    # for this row.
+    cfg = p.get("policy_config")
+    if cfg:
+        surface = cfg.get("suggestion_surface", {})
+        active = (
+            "Suggest mode active"
+            if cfg.get("mode") == "suggest"
+            else "observe_only (default)"
+        )
+        lines.append(
+            "  Active policy config snapshot (Phase 2.4.3):"
+        )
+        lines.append(f"    mode:                      {cfg.get('mode')}  ({active})")
+        lines.append(f"    show_suggestions:          {cfg.get('show_suggestions')}")
+        lines.append(
+            f"    suggestion surfaces enabled: cli={surface.get('cli')}, "
+            f"dashboard={surface.get('dashboard')}, api={surface.get('api')}"
+        )
+        lines.append(
+            f"    response_headers:          {surface.get('response_headers')}  "
+            f"(locked False in 2.4.3)"
+        )
+        lines.append(f"    dry_run:                   {cfg.get('dry_run')}  (locked True)")
+        lines.append(f"    allow_auto_routing:        {cfg.get('allow_auto_routing')}  (locked False)")
+        lines.append("")
     return "\n".join(lines)
 
 

--- a/tokenpak/proxy/intent_policy_config_loader.py
+++ b/tokenpak/proxy/intent_policy_config_loader.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase 2.4.3 — config loader for ``~/.tokenpak/policy.yaml``.
+
+Reads the ``intent_policy`` block (per Phase 2.4 spec §3 schema)
+into a :class:`PolicyEngineConfig`. Three safety invariants are
+**force-applied** regardless of what the file says:
+
+  1. ``dry_run`` is forced ``True``.
+  2. ``allow_auto_routing`` is forced ``False``.
+  3. ``suggestion_surface.response_headers`` is forced ``False``.
+
+A user who tries to flip any of these via config will see a
+``ConfigSafetyOverride`` warning logged but the runtime stays
+safe. The loader **never raises on caller paths** — a missing
+file, parse error, or unknown key falls back to the hard-coded
+default config.
+
+Resolution order:
+
+  1. ``$TOKENPAK_HOME/policy.yaml``
+  2. ``~/.tokenpak/policy.yaml``
+  3. (no fallback — return default config)
+
+The loader is read-only. It does not write to ``policy.yaml`` and
+never modifies any other on-disk state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyEngineConfig,
+    SuggestionSurfaceConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+VALID_MODES: Tuple[str, ...] = ("observe_only", "suggest", "confirm", "enforce")
+"""Modes the schema understands. ``confirm`` and ``enforce`` are
+reserved for Phase 2.5 / 2.6; loading them in 2.4.3 is treated as
+an invalid value and the loader falls back to ``observe_only`` per
+the directive's "fail closed" rule.
+"""
+
+PERMITTED_MODES_2_4_3: Tuple[str, ...] = ("observe_only", "suggest")
+"""Modes Phase 2.4.3 will accept as the resolved value. Anything
+else (including ``confirm`` / ``enforce``) is downgraded to
+``observe_only`` with a warning."""
+
+
+def _candidate_paths() -> List[Path]:
+    """Return ordered list of candidate config paths."""
+    out: List[Path] = []
+    home = os.environ.get("TOKENPAK_HOME")
+    if home:
+        out.append(Path(home) / "policy.yaml")
+    out.append(Path.home() / ".tokenpak" / "policy.yaml")
+    return out
+
+
+def _read_yaml_safely(path: Path) -> Optional[Dict[str, Any]]:
+    """Read + parse YAML from ``path``. Returns ``None`` on any failure."""
+    if not path.is_file():
+        return None
+    try:
+        # PyYAML is already a tokenpak dependency for slot
+        # definitions; no new dependency added.
+        import yaml  # noqa: I001 — local import keeps import cost off the hot path
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "intent_policy_config_loader: PyYAML unavailable; falling back to default config"
+        )
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "intent_policy_config_loader: failed to parse %s: %r — falling back to default",
+            path,
+            exc,
+        )
+        return None
+    if not isinstance(data, dict):
+        logger.warning(
+            "intent_policy_config_loader: %s did not parse to a mapping; falling back to default",
+            path,
+        )
+        return None
+    return data
+
+
+def _safe_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in {"true", "yes", "1", "on"}:
+            return True
+        if v in {"false", "no", "0", "off"}:
+            return False
+    return default
+
+
+def _resolve_mode(raw: Any, *, warnings_out: List[str]) -> str:
+    if not isinstance(raw, str):
+        if raw is not None:
+            warnings_out.append(
+                f"intent_policy.mode must be a string; got {type(raw).__name__!r}; "
+                f"defaulting to observe_only."
+            )
+        return "observe_only"
+    if raw not in PERMITTED_MODES_2_4_3:
+        if raw in VALID_MODES:
+            # confirm / enforce are reserved; fail closed.
+            warnings_out.append(
+                f"intent_policy.mode={raw!r} is reserved for a later sub-phase; "
+                f"falling back to observe_only."
+            )
+        else:
+            warnings_out.append(
+                f"intent_policy.mode={raw!r} is not a known value; falling back to "
+                f"observe_only."
+            )
+        return "observe_only"
+    return raw
+
+
+def _resolve_suggestion_surface(
+    raw: Any, *, warnings_out: List[str]
+) -> SuggestionSurfaceConfig:
+    """Parse the suggestion_surface block. response_headers always
+    resolved to False per the safety invariant.
+    """
+    if raw is None:
+        return SuggestionSurfaceConfig()
+    if not isinstance(raw, dict):
+        warnings_out.append(
+            "intent_policy.suggestion_surface must be a mapping; "
+            "falling back to defaults."
+        )
+        return SuggestionSurfaceConfig()
+    cli = _safe_bool(raw.get("cli"), True)
+    dashboard = _safe_bool(raw.get("dashboard"), True)
+    api = _safe_bool(raw.get("api"), True)
+    response_headers_raw = _safe_bool(raw.get("response_headers"), False)
+    if response_headers_raw:
+        warnings_out.append(
+            "intent_policy.suggestion_surface.response_headers cannot be "
+            "enabled in Phase 2.4.3; forced to False."
+        )
+    return SuggestionSurfaceConfig(
+        cli=cli,
+        dashboard=dashboard,
+        api=api,
+        response_headers=False,  # forced
+    )
+
+
+def parse_intent_policy_block(
+    block: Optional[Dict[str, Any]]
+) -> Tuple[PolicyEngineConfig, List[str]]:
+    """Parse the ``intent_policy`` mapping into a config + warnings list.
+
+    Pure function — no I/O. Used both by the file loader below and
+    by the ``tokenpak intent config --validate`` CLI to validate
+    arbitrary YAML strings.
+
+    Returns ``(config, warnings)``. ``warnings`` may be non-empty
+    even when the loader resolves successfully — every safety
+    override / invalid value emits exactly one warning string so
+    the caller can surface them to the operator.
+    """
+    warnings_out: List[str] = []
+    if block is None:
+        return PolicyEngineConfig(), warnings_out
+    if not isinstance(block, dict):
+        warnings_out.append(
+            "intent_policy block must be a mapping; falling back to default config."
+        )
+        return PolicyEngineConfig(), warnings_out
+
+    mode = _resolve_mode(block.get("mode"), warnings_out=warnings_out)
+
+    # dry_run — forced True per the safety invariant.
+    raw_dry_run = block.get("dry_run", True)
+    parsed_dry_run = _safe_bool(raw_dry_run, True)
+    if not parsed_dry_run:
+        warnings_out.append(
+            "intent_policy.dry_run cannot be disabled in Phase 2.4.3; forced to True."
+        )
+
+    # allow_auto_routing — forced False per the safety invariant.
+    raw_aar = block.get("allow_auto_routing", False)
+    parsed_aar = _safe_bool(raw_aar, False)
+    if parsed_aar:
+        warnings_out.append(
+            "intent_policy.allow_auto_routing cannot be enabled in Phase 2.4.3; "
+            "forced to False."
+        )
+
+    # allow_unverified_providers — caller-controlled (Phase 2.1
+    # already had it).
+    allow_unverified = _safe_bool(
+        block.get("allow_unverified_providers", False), False
+    )
+
+    # low_confidence_threshold — caller-controlled.
+    raw_thr = block.get("low_confidence_threshold", 0.65)
+    try:
+        threshold = float(raw_thr)
+    except (TypeError, ValueError):
+        warnings_out.append(
+            f"intent_policy.low_confidence_threshold={raw_thr!r} is not a number; "
+            f"defaulting to 0.65."
+        )
+        threshold = 0.65
+    if not (0.0 <= threshold <= 1.0):
+        warnings_out.append(
+            f"intent_policy.low_confidence_threshold={threshold} out of [0, 1]; "
+            f"defaulting to 0.65."
+        )
+        threshold = 0.65
+
+    # show_suggestions — defaults follow the directive: False
+    # except when mode == "suggest" (auto-on).
+    if mode == "suggest":
+        show_default = True
+    else:
+        show_default = False
+    show_suggestions = _safe_bool(
+        block.get("show_suggestions", show_default), show_default
+    )
+
+    surface = _resolve_suggestion_surface(
+        block.get("suggestion_surface"), warnings_out=warnings_out
+    )
+
+    cfg = PolicyEngineConfig(
+        mode=mode,
+        dry_run=True,  # forced
+        allow_auto_routing=False,  # forced
+        allow_unverified_providers=allow_unverified,
+        low_confidence_threshold=threshold,
+        show_suggestions=show_suggestions,
+        suggestion_surface=surface,
+    )
+    return cfg, warnings_out
+
+
+def load_policy_config_safely(
+    *, candidate_path: Optional[Path] = None
+) -> PolicyEngineConfig:
+    """Resolve + parse the active host config.
+
+    ``candidate_path`` overrides the search path (used in tests).
+    Always returns a :class:`PolicyEngineConfig`; never raises.
+    """
+    path = candidate_path
+    if path is None:
+        for cand in _candidate_paths():
+            if cand.is_file():
+                path = cand
+                break
+    if path is None or not path.is_file():
+        return PolicyEngineConfig()
+
+    raw = _read_yaml_safely(path)
+    if raw is None:
+        return PolicyEngineConfig()
+
+    block = raw.get("intent_policy") if isinstance(raw, dict) else None
+    cfg, warnings = parse_intent_policy_block(block)
+    for w in warnings:
+        logger.warning("intent_policy_config_loader: %s", w)
+    return cfg
+
+
+def resolve_active_config_path() -> Optional[Path]:
+    """Return the first candidate path that exists, or ``None``."""
+    for cand in _candidate_paths():
+        if cand.is_file():
+            return cand
+    return None
+
+
+# Helper used by surfaces (CLI / dashboard / API) to decide whether
+# to render the "Suggest mode active" badge for a given surface.
+def is_surface_active(cfg: PolicyEngineConfig, surface: str) -> bool:
+    """Return True when the host has opted in to suggest mode AND
+    the named surface flag is enabled.
+
+    Surface names: ``"cli"`` / ``"dashboard"`` / ``"api"`` /
+    ``"response_headers"``.
+    """
+    if not cfg.is_suggest_mode():
+        return False
+    if not cfg.show_suggestions:
+        return False
+    s = cfg.suggestion_surface
+    return {
+        "cli": s.cli,
+        "dashboard": s.dashboard,
+        "api": s.api,
+        "response_headers": s.response_headers,
+    }.get(surface, False)
+
+
+__all__ = [
+    "PERMITTED_MODES_2_4_3",
+    "VALID_MODES",
+    "is_surface_active",
+    "load_policy_config_safely",
+    "parse_intent_policy_block",
+    "resolve_active_config_path",
+]

--- a/tokenpak/proxy/intent_policy_dashboard.py
+++ b/tokenpak/proxy/intent_policy_dashboard.py
@@ -178,6 +178,17 @@ def collect_policy_dashboard(
     # operator_panel contract is unchanged from 2.2. Phase 2.4.2's
     # additive ``suggestions`` section is identified by its own
     # noop_default_off flag inside the suggestions block above.
+    # Phase 2.4.3 — active policy config snapshot for the
+    # dashboard. JS reads this to badge "Suggest mode active"
+    # when appropriate.
+    active_config: Dict[str, Any] = {}
+    try:
+        from tokenpak.proxy.intent_policy_engine import load_default_config
+
+        active_config = load_default_config().to_dict()
+    except Exception:  # noqa: BLE001
+        active_config = {}
+
     metadata: Dict[str, Any] = {
         "schema_version": DASHBOARD_SCHEMA_VERSION,
         "phase": "intent-layer-phase-2.2",
@@ -190,6 +201,12 @@ def collect_policy_dashboard(
         "window_days": report.window_days,
         "window_cutoff_iso": report.window_cutoff_iso,
         "telemetry_store_path": report.db_path,
+        # Phase 2.4.3 — active policy config snapshot.
+        "active_policy_config": active_config,
+        "suggest_mode_active": (
+            active_config.get("mode") == "suggest"
+            and bool(active_config.get("show_suggestions"))
+        ),
     }
 
     return {

--- a/tokenpak/proxy/intent_policy_engine.py
+++ b/tokenpak/proxy/intent_policy_engine.py
@@ -111,13 +111,35 @@ SAFETY_UNVERIFIED_PROVIDER: str = "unverified_provider"
 
 
 @dataclass(frozen=True)
+class SuggestionSurfaceConfig:
+    """Per-surface visibility flags for the Phase 2.4.3 suggest mode.
+
+    ``response_headers`` is **always forced False** by the loader
+    until a future ratification — wire-side ``X-TokenPak-
+    Suggestion-*`` emission stays gated by the Standard #23 §4.3
+    capability check on top of this flag and is not in 2.4.3 scope.
+    """
+
+    cli: bool = True
+    dashboard: bool = True
+    api: bool = True
+    response_headers: bool = False  # forced False; cannot be enabled in 2.4.3
+
+
+@dataclass(frozen=True)
 class PolicyEngineConfig:
     """Engine-side projection of the ``intent_policy`` config block.
 
-    Phase 2.1 covers exactly the five fields the directive
-    enumerates. The Phase 2 spec §7 defines additional fields
-    (``budget_caps``, ``class_rules``, ``class_groups``) that
-    later sub-phases will plumb in.
+    Phase 2.1 covered five fields; Phase 2.4.3 adds the suggest-
+    mode visibility controls (``show_suggestions``,
+    ``suggestion_surface``) per Phase 2.4 spec §3.
+
+    Three safety invariants enforced by the config loader (cannot
+    be disabled by user config):
+
+      - ``dry_run`` is forced ``True``.
+      - ``allow_auto_routing`` is forced ``False``.
+      - ``suggestion_surface.response_headers`` is forced ``False``.
     """
 
     mode: str = "observe_only"  # observe_only | suggest | confirm | enforce
@@ -126,20 +148,53 @@ class PolicyEngineConfig:
     allow_unverified_providers: bool = False
     low_confidence_threshold: float = 0.65
 
+    # Phase 2.4.3 — suggest mode visibility.
+    show_suggestions: bool = False
+    suggestion_surface: SuggestionSurfaceConfig = field(
+        default_factory=SuggestionSurfaceConfig
+    )
+
+    def is_suggest_mode(self) -> bool:
+        """True iff the host has explicitly opted in to suggest mode."""
+        return self.mode == "suggest"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serialisable view used by doctor / dashboard / API."""
+        return {
+            "mode": self.mode,
+            "dry_run": self.dry_run,
+            "allow_auto_routing": self.allow_auto_routing,
+            "allow_unverified_providers": self.allow_unverified_providers,
+            "low_confidence_threshold": self.low_confidence_threshold,
+            "show_suggestions": self.show_suggestions,
+            "suggestion_surface": {
+                "cli": self.suggestion_surface.cli,
+                "dashboard": self.suggestion_surface.dashboard,
+                "api": self.suggestion_surface.api,
+                "response_headers": self.suggestion_surface.response_headers,
+            },
+        }
+
 
 _DEFAULT_CONFIG: PolicyEngineConfig = PolicyEngineConfig()
 
 
 def load_default_config() -> PolicyEngineConfig:
-    """Return the Phase 2.1 default config.
+    """Return the active config for this host.
 
-    Phase 2.1 ships without a config-file loader; the directive
-    explicitly limits scope to the dry-run engine. The Phase 2.2
-    sub-phase will add ``~/.tokenpak/policy.yaml`` parsing per the
-    spec §7 schema. Until then, the default config is the only
-    config a host can have.
+    Phase 2.4.3 wires the loader: tries ``~/.tokenpak/policy.yaml``
+    via :mod:`tokenpak.proxy.intent_policy_config_loader`. Missing
+    file, parse error, or any safety-override violation falls back
+    to the hard-coded ``_DEFAULT_CONFIG`` (observe_only).
     """
-    return _DEFAULT_CONFIG
+    try:
+        from tokenpak.proxy.intent_policy_config_loader import (
+            load_policy_config_safely,
+        )
+
+        return load_policy_config_safely()
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_CONFIG
 
 
 # ---------------------------------------------------------------------------
@@ -452,6 +507,7 @@ __all__ = [
     "SAFETY_LOW_CONFIDENCE",
     "SAFETY_MISSING_SLOTS",
     "SAFETY_UNVERIFIED_PROVIDER",
+    "SuggestionSurfaceConfig",
     "evaluate_policy",
     "load_default_config",
     "make_decision_id",


### PR DESCRIPTION
## Summary

Final sub-sub-phase of the Phase 2.4 spec. Wires the config loader for `~/.tokenpak/policy.yaml`. Hosts opt in to suggest mode via:

```yaml
intent_policy:
  mode: suggest
```

Three safety invariants are **force-applied** by the loader regardless of what the file says:

| Invariant | Rule |
|---|---|
| `dry_run` | Forced `True`; warning logged on attempted override |
| `allow_auto_routing` | Forced `False`; same |
| `suggestion_surface.response_headers` | Forced `False`; same |

**Default config remains `observe_only`.** Suggest mode is advisory only — every surface that already showed suggestions in 2.4.2 keeps showing them; the only behavioral difference is the "Suggest mode active" badging on doctor / dashboard / API metadata.

## Changes

- **`tokenpak/proxy/intent_policy_engine.py`** — `PolicyEngineConfig` grows `show_suggestions` + `suggestion_surface` (with `SuggestionSurfaceConfig` dataclass). Both frozen. `is_suggest_mode()` + `to_dict()` helpers. `load_default_config()` now wires the loader.
- **`tokenpak/proxy/intent_policy_config_loader.py`** — pure parser + file loader + path resolver + per-surface `is_surface_active` helper. Reserved modes (`confirm`, `enforce`) fall back to `observe_only` with warning.
- **`tokenpak/proxy/intent_doctor.py`** — both views carry the active config snapshot; renderers print a "Active policy config" section.
- **`tokenpak/proxy/intent_policy_dashboard.py`** — metadata grows `active_policy_config` + `suggest_mode_active` boolean.
- **`tokenpak/cli/_impl.py`** — new `tokenpak intent config [--show] [--validate] [--json]` subcommand. Read-only.
- **`docs/reference/intent-suggest-mode.md`** — operator-facing doc.
- **`tests/test_intent_suggest_mode_phase24_3.py`** — 36 tests across 15 classes.

## Acceptance

- [x] Config supports explicit `mode = suggest`.
- [x] Default remains `observe_only`.
- [x] Suggest mode is advisory only.
- [x] `dry_run` remains `True` (forced; warning on override).
- [x] `allow_auto_routing` remains `False` (same).
- [x] `response_headers` remain disabled (same).
- [x] Surfaces respect `suggestion_surface` flags.
- [x] No routing behavior changes.
- [x] No classifier behavior changes (`intent_classifier.py` untouched).
- [x] No prompt text or secrets emitted (sentinel-substring tested across config snapshot + doctor render + dashboard payload).
- [x] **1208 passing** (was 1198 baseline, +36), 0 regressions.
- [x] `ruff check` clean, `cli-docs-in-sync` clean.
- [ ] CI green on all three workflows.

## Held per directive

No Bedrock generic, no Anthropic-on-Vertex, no IBM watsonx, no SigV4 / OAuth scaffolding, no `--llm-assist`, no scaffold renderer expansion, **no classifier behavior changes**, **no production intent-based routing**, **no confirm mode**, **no enforce mode**, **no automatic routing / model / provider changes**.