### PR TITLE
feat(proxy,cli): PI-1 — PromptPatch builder + intent_patches table

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -616,10 +616,11 @@ options:
 Intent Layer observation + reporting (read-only)
 
 ```
-usage: tokenpak intent [-h] {report,policy-preview,suggestions,config} ...
+usage: tokenpak intent [-h]
+                       {report,policy-preview,suggestions,config,patches} ...
 
 positional arguments:
-  {report,policy-preview,suggestions,config}
+  {report,policy-preview,suggestions,config,patches}
     report              Summarize the intent_events telemetry over a window.
                         Read-only; never reads or emits raw prompt text.
     policy-preview      Show the latest intent policy decision (Phase 2.1 dry-
@@ -628,6 +629,8 @@ positional arguments:
                         2.4.1; internal/dev inspector; read-only).
     config              Show or validate the intent_policy config (Phase
                         2.4.3; read-only).
+    patches             Show the latest dry-run prompt-patch (PI-1;
+                        internal/dev inspector; read-only; not applied).
 
 options:
   -h, --help            show this help message and exit

--- a/tests/test_intent_prompt_patch_phase_pi_1.py
+++ b/tests/test_intent_prompt_patch_phase_pi_1.py
@@ -1,0 +1,921 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase PI-1 — PromptPatch builder + telemetry test suite.
+
+Nineteen directive-mandated test categories:
+
+  1. PromptPatch object shape pinned
+  2. builder returns zero when disabled
+  3. builder returns patch when eligible
+  4. low confidence blocks patch
+  5. catch_all blocks patch
+  6. missing slots produce only ask_clarification, not guidance
+  7. byte-preserve locked blocks patch
+  8. target=user_message rejected
+  9. allow_byte_preserve_override clamped/blocked
+  10. expired suggestion blocks patch
+  11. patch text privacy guardrail
+  12. forbidden wording guardrail
+  13. no raw prompt stored
+  14. no secrets emitted
+  15. no request mutation
+  16. no route mutation
+  17. no classifier mutation
+  18. CLI inspector empty DB behavior + populated DB behavior
+  19. JSON shape
+
+Read-only against production telemetry. Reuses production
+classifier + contract + suggestion builder so the schema stays a
+single source of truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import build_contract
+from tokenpak.proxy.intent_policy_engine import (
+    REASON_DRY_RUN_SUGGEST,
+    SAFETY_MISSING_SLOTS,
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+)
+from tokenpak.proxy.intent_prompt_patch import (
+    ALL_MODES,
+    FORBIDDEN_PHRASES,
+    MODE_ASK_CLARIFICATION,
+    MODE_INJECT_GUIDANCE,
+    MODE_PREVIEW_ONLY,
+    MODE_REWRITE_PROMPT,
+    PATCH_TEXT_MAX_LEN,
+    PI_1_ADDITIONAL_FORBIDDEN,
+    PI_1_SUPPORTED_MODES,
+    SOURCE_PI,
+    TARGET_COMPANION_CONTEXT,
+    TARGET_SYSTEM,
+    TARGET_USER_MESSAGE,
+    PromptInterventionConfig,
+    PromptPatch,
+    PromptPatchBuilderContext,
+    build_patches,
+    make_patch_id,
+)
+from tokenpak.proxy.intent_prompt_patch_telemetry import (
+    IntentPatchRow,
+    IntentPatchStore,
+)
+from tokenpak.proxy.intent_suggestion import (
+    SuggestionBuilderContext,
+    build_suggestions,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _classification(intent_class="create", confidence=0.9,
+                    slots_present=("target",), slots_missing=(),
+                    catch_all_reason=None):
+    return IntentClassification(
+        intent_class=intent_class,
+        confidence=confidence,
+        slots_present=slots_present,
+        slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+
+
+def _safe_input(**over) -> PolicyInput:
+    kw = dict(
+        intent_class="create", confidence=0.9,
+        slots_present=("target",), slots_missing=(),
+        catch_all_reason=None, provider="tokenpak-test",
+        model="test-model", live_verified_status=True,
+        required_slots=(),
+    )
+    kw.update(over)
+    return PolicyInput(**kw)
+
+
+def _make_eligible_inputs(*, intent_class="create", confidence=0.9,
+                           slots_present=("target",), slots_missing=(),
+                           catch_all_reason=None,
+                           prompt="create a new file"):
+    """Build (suggestion, contract, decision) for an eligible case.
+
+    Goes through the production engine + suggestion builder so the
+    schema stays a single source of truth. Returns the triple.
+    """
+    cls = _classification(
+        intent_class=intent_class, confidence=confidence,
+        slots_present=slots_present, slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+    contract = build_contract(classification=cls, raw_prompt=prompt)
+
+    inp = _safe_input(
+        intent_class=intent_class, confidence=confidence,
+        slots_present=slots_present, slots_missing=slots_missing,
+        catch_all_reason=catch_all_reason,
+    )
+    decision = evaluate_policy(inp, PolicyEngineConfig())
+    sugg_ctx = SuggestionBuilderContext(
+        config=PolicyEngineConfig(),
+        adapter_capabilities=frozenset({"tip.compression.v1"}),
+    )
+    suggestions = build_suggestions(
+        decision=decision, contract=contract, ctx=sugg_ctx,
+    )
+    suggestion = suggestions[0] if suggestions else None
+    return suggestion, contract, decision
+
+
+def _builder_ctx(*, capabilities=frozenset({"tip.compression.v1"}),
+                 required_slots=()):
+    return PromptPatchBuilderContext(
+        config=PolicyEngineConfig(),
+        adapter_capabilities=capabilities,
+        required_slots=required_slots,
+    )
+
+
+def _pi(**over) -> PromptInterventionConfig:
+    kw = dict(
+        enabled=True,
+        mode=MODE_INJECT_GUIDANCE,
+        target=TARGET_COMPANION_CONTEXT,
+        require_confirmation=True,
+        allow_byte_preserve_override=False,
+    )
+    kw.update(over)
+    return PromptInterventionConfig(**kw)
+
+
+# ── 1. PromptPatch object shape pinned ────────────────────────────────
+
+
+class TestPromptPatchShape:
+
+    REQUIRED_FIELDS = {
+        "patch_id",
+        "contract_id",
+        "decision_id",
+        "suggestion_id",
+        "mode",
+        "target",
+        "original_hash",
+        "patch_text",
+        "reason",
+        "confidence",
+        "safety_flags",
+        "requires_confirmation",
+        "applied",
+        "source",
+    }
+
+    def test_to_dict_has_all_required_fields(self):
+        p = PromptPatch(
+            patch_id="pid", contract_id="cid", decision_id="did",
+            suggestion_id="sid", mode=MODE_PREVIEW_ONLY,
+            target=TARGET_COMPANION_CONTEXT, original_hash="h",
+            patch_text="<TokenPak Intent Guidance>x</TokenPak Intent Guidance>",
+            reason="r", confidence=0.9,
+        )
+        d = p.to_dict()
+        missing = self.REQUIRED_FIELDS - set(d)
+        assert not missing, f"missing fields: {missing}"
+
+    def test_default_values(self):
+        p = PromptPatch(
+            patch_id="pid", contract_id="cid", decision_id="did",
+            suggestion_id="sid", mode=MODE_PREVIEW_ONLY,
+            target=TARGET_COMPANION_CONTEXT, original_hash="h",
+            patch_text="x", reason="r", confidence=0.9,
+        )
+        assert p.applied is False
+        assert p.requires_confirmation is True
+        assert p.source == SOURCE_PI
+        assert p.safety_flags == ()
+
+    def test_patch_is_frozen(self):
+        p = PromptPatch(
+            patch_id="pid", contract_id="cid", decision_id="did",
+            suggestion_id="sid", mode=MODE_PREVIEW_ONLY,
+            target=TARGET_COMPANION_CONTEXT, original_hash="h",
+            patch_text="x", reason="r", confidence=0.9,
+        )
+        with pytest.raises(Exception):
+            p.applied = True  # type: ignore[misc]
+
+    def test_make_patch_id_shape(self):
+        pid = make_patch_id()
+        assert len(pid) == 29
+        int(pid, 16)
+
+
+# ── 2. builder returns zero when disabled ─────────────────────────────
+
+
+class TestDisabledReturnsZero:
+
+    def test_default_pi_config_is_disabled(self):
+        cfg = PromptInterventionConfig()
+        assert cfg.enabled is False
+
+    def test_builder_returns_empty_when_disabled(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        assert suggestion is not None
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=PromptInterventionConfig(enabled=False),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+    def test_builder_returns_patch_when_enabled_create(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create",
+        )
+        assert suggestion is not None
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert len(result) == 1
+
+
+# ── 3. builder returns patch when eligible ────────────────────────────
+
+
+class TestEligiblePatchEmitted:
+
+    def test_create_intent_emits_coding_template(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create",
+        )
+        assert suggestion is not None
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert len(result) == 1
+        p = result[0]
+        assert "preserve the user's original request" in p.patch_text
+        assert "<TokenPak Intent Guidance>" in p.patch_text
+        assert p.applied is False
+
+    def test_debug_intent_emits_debug_template(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="debug",
+        )
+        # The engine emits suggest_compression_profile for debug
+        # (heuristic table). The suggestion itself doesn't matter
+        # for the patch builder as long as decision_reason is in
+        # the explainable set; the builder selects the template
+        # by intent_class.
+        if suggestion is None:
+            pytest.skip("debug intent didn't produce a suggestion in this run")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert len(result) == 1
+        p = result[0]
+        assert "identify the failure path" in p.patch_text
+
+    def test_intent_without_template_returns_zero(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="status",
+        )
+        # status produces observe_only — no suggestion. Use the
+        # create-intent suggestion as the input but with status
+        # contract; the builder selects template by intent_class.
+        # Since status isn't in the coding set, no template.
+        if suggestion is None:
+            # Substitute manually.
+            cls_create = _classification(intent_class="create")
+            contract_create = build_contract(
+                classification=cls_create, raw_prompt="create something",
+            )
+            inp_create = _safe_input(intent_class="create")
+            decision_create = evaluate_policy(inp_create, PolicyEngineConfig())
+            sugg_ctx = SuggestionBuilderContext(
+                config=PolicyEngineConfig(),
+                adapter_capabilities=frozenset({"tip.compression.v1"}),
+            )
+            suggs = build_suggestions(
+                decision=decision_create, contract=contract_create,
+                ctx=sugg_ctx,
+            )
+            suggestion = suggs[0]
+        # Now use the suggestion with the status contract.
+        cls_status = _classification(intent_class="status")
+        contract_status = build_contract(
+            classification=cls_status, raw_prompt="check status",
+        )
+        # decision.decision_reason needs to be explainable; reuse
+        # the create decision's reason.
+        result = build_patches(
+            suggestion=suggestion, contract=contract_status, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 4. low confidence blocks patch ────────────────────────────────────
+
+
+class TestLowConfidenceBlocks:
+
+    def test_below_threshold_returns_empty(self):
+        # Build via the engine with low confidence — the engine
+        # itself emits warn_only, which doesn't produce a
+        # suggestion. We construct the inputs manually to test
+        # the builder gate independently.
+        cls = _classification(intent_class="create", confidence=0.4)
+        contract = build_contract(classification=cls, raw_prompt="create x")
+        decision = evaluate_policy(
+            _safe_input(intent_class="create", confidence=0.4),
+            PolicyEngineConfig(),
+        )
+        # Build a stub suggestion the builder can read.
+        from tokenpak.proxy.intent_suggestion import (
+            SUGGESTION_COMPRESSION,
+        )
+        from tokenpak.proxy.intent_suggestion import (
+            PolicySuggestion as _PS,
+        )
+        sugg = _PS(
+            suggestion_id="s1", decision_id=decision.decision_id,
+            contract_id=contract.contract_id,
+            suggestion_type=SUGGESTION_COMPRESSION,
+            title="t", message="m", recommended_action=None,
+            confidence=0.4, safety_flags=(),
+            requires_confirmation=False, user_visible=False,
+            expires_at=None,
+        )
+        # Force the decision's reason to be explainable so the
+        # only blocking gate is confidence.
+        decision = replace(decision, decision_reason=REASON_DRY_RUN_SUGGEST)
+        result = build_patches(
+            suggestion=sugg, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 5. catch_all blocks patch ─────────────────────────────────────────
+
+
+class TestCatchAllBlocks:
+
+    def test_catch_all_returns_empty(self):
+        suggestion, _, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline create-intent suggestion not produced")
+        # Now substitute a catch-all contract.
+        cls = _classification(
+            intent_class="query", confidence=0.0,
+            slots_present=(), slots_missing=(),
+            catch_all_reason="empty_prompt",
+        )
+        contract = build_contract(classification=cls, raw_prompt="")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 6. missing slots produce only ask_clarification, not guidance ─────
+
+
+class TestMissingSlotsAskClarification:
+
+    def test_inject_guidance_blocks_when_required_slot_missing(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create", slots_missing=("target",),
+        )
+        if suggestion is None:
+            pytest.skip("baseline create-intent suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(mode=MODE_INJECT_GUIDANCE),
+            ctx=_builder_ctx(required_slots=("target",)),
+        )
+        assert result == ()
+
+    def test_ask_clarification_emits_when_required_slot_missing(self):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create", slots_missing=("target",),
+        )
+        if suggestion is None:
+            pytest.skip("baseline create-intent suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(mode=MODE_ASK_CLARIFICATION),
+            ctx=_builder_ctx(required_slots=("target",)),
+        )
+        assert len(result) == 1
+        p = result[0]
+        assert "ask one clarifying question" in p.patch_text
+        # Safety flag carries through.
+        assert SAFETY_MISSING_SLOTS in p.safety_flags
+
+
+# ── 7. byte-preserve locked blocks patch ──────────────────────────────
+
+
+class TestByteReserveLocked:
+
+    def test_byte_preserve_blocks_when_target_not_companion_context(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(target=TARGET_SYSTEM),
+            ctx=_builder_ctx(
+                capabilities=frozenset({"tip.byte-preserved-passthrough"}),
+            ),
+        )
+        assert result == ()
+
+    def test_byte_preserve_allows_companion_context(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        # Companion-context is the explicit exception per spec §6.
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(target=TARGET_COMPANION_CONTEXT),
+            ctx=_builder_ctx(
+                capabilities=frozenset({
+                    "tip.byte-preserved-passthrough",
+                    "tip.compression.v1",
+                }),
+            ),
+        )
+        assert len(result) == 1
+
+
+# ── 8. target=user_message rejected ───────────────────────────────────
+
+
+class TestUserMessageTargetRejected:
+
+    def test_user_message_target_returns_empty(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(target=TARGET_USER_MESSAGE),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 9. allow_byte_preserve_override clamped/blocked ───────────────────
+
+
+class TestByteReserveOverrideBlocked:
+
+    def test_override_requested_blocks_in_pi_1(self):
+        # Even on a non-byte-preserved adapter, requesting the
+        # override hard-blocks in PI-1.
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(allow_byte_preserve_override=True),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 10. expired suggestion blocks patch ───────────────────────────────
+
+
+class TestExpiredSuggestionBlocked:
+
+    def test_past_expires_at_blocks(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        # Mutate the suggestion to have a past expires_at.
+        expired = replace(suggestion, expires_at="2020-01-01T00:00:00")
+        result = build_patches(
+            suggestion=expired, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 11. patch text privacy guardrail ──────────────────────────────────
+
+
+class TestPatchTextPrivacyGuardrail:
+
+    def test_templates_pass_privacy_check(self):
+        # The three templates ship clean. This is a regression
+        # test against any future template that accidentally
+        # interpolates a credential-shaped value.
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create",
+        )
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert len(result) == 1
+        # No credential-shaped substring.
+        p = result[0]
+        for cred_pattern in (
+            "sk-",
+            "sk-ant-",
+            "AKIA",
+            "github_pat_",
+            "BEGIN PRIVATE KEY",
+        ):
+            assert cred_pattern not in p.patch_text
+
+
+# ── 12. forbidden wording guardrail ───────────────────────────────────
+
+
+class TestForbiddenWordingGuardrail:
+
+    def test_pi_1_forbidden_phrases_pinned(self):
+        # The directive enumerates exactly these phrases on top of
+        # the Phase 2.4.1 list. Any future change requires
+        # explicit ratification.
+        for phrase in (
+            "injected",
+            "mutated",
+            "rewrote",
+            "inserted",
+            "will inject",
+            "will rewrite",
+        ):
+            assert phrase in [p.lower() for p in FORBIDDEN_PHRASES]
+        for phrase in PI_1_ADDITIONAL_FORBIDDEN:
+            assert phrase in FORBIDDEN_PHRASES
+
+    def test_template_strings_have_no_forbidden_phrase(self):
+        # Build one patch of each PI-1 supported template and
+        # scan the emitted text.
+        forbidden_re = re.compile(
+            r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+            re.IGNORECASE,
+        )
+        cases = [
+            ("create", MODE_INJECT_GUIDANCE),
+            ("debug", MODE_INJECT_GUIDANCE),
+            ("create", MODE_ASK_CLARIFICATION),
+        ]
+        for intent_class, mode in cases:
+            suggestion, contract, decision = _make_eligible_inputs(
+                intent_class=intent_class,
+                slots_missing=("target",) if mode == MODE_ASK_CLARIFICATION else (),
+            )
+            if suggestion is None:
+                continue
+            result = build_patches(
+                suggestion=suggestion, contract=contract, decision=decision,
+                pi_config=_pi(mode=mode),
+                ctx=_builder_ctx(
+                    required_slots=(("target",) if mode == MODE_ASK_CLARIFICATION else ()),
+                ),
+            )
+            for p in result:
+                for text in (p.patch_text, p.reason):
+                    m = forbidden_re.search(text)
+                    assert m is None, (
+                        f"forbidden phrase {m.group(0)!r} in PI-1 emit: {text!r}"
+                    )
+
+
+# ── 13 + 14. no raw prompt stored, no secrets emitted ─────────────────
+
+
+class TestPrivacyContract:
+    SENTINEL = "kevin-magic-prompt-marker-PI-1"
+
+    def test_sentinel_absent_from_patch(self):
+        # Inject the sentinel into the prompt; assert it appears
+        # nowhere in the emitted patch.
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create",
+            prompt=f"create a new file {self.SENTINEL}",
+        )
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert len(result) == 1
+        payload = json.dumps(result[0].to_dict())
+        assert self.SENTINEL not in payload
+
+    def test_sentinel_absent_from_persisted_row(self, tmp_path: Path):
+        suggestion, contract, decision = _make_eligible_inputs(
+            intent_class="create",
+            prompt=f"create a new file {self.SENTINEL}",
+        )
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        store = IntentPatchStore(db_path=tmp_path / "t.db")
+        for p in result:
+            store.write(IntentPatchRow(patch=p, created_at="t"))
+        store.close()
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM intent_patches").fetchall()
+        conn.close()
+        for row in rows:
+            for col in row.keys():
+                v = row[col]
+                if v is not None:
+                    assert self.SENTINEL not in str(v)
+
+
+# ── 15. no request mutation ───────────────────────────────────────────
+
+
+class TestNoRequestMutation:
+
+    def test_builder_does_not_mutate_inputs(self):
+        suggestion, contract, decision = _make_eligible_inputs()
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        # Capture refs (frozen dataclasses).
+        before = (suggestion, contract, decision)
+        build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        assert before == (suggestion, contract, decision)
+
+
+# ── 16. no route mutation ─────────────────────────────────────────────
+
+
+class TestNoRouteMutation:
+
+    def test_module_does_not_import_dispatch(self):
+        import tokenpak.proxy.intent_prompt_patch as m
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src
+
+    def test_telemetry_module_does_not_import_dispatch(self):
+        import tokenpak.proxy.intent_prompt_patch_telemetry as m
+        src = Path(m.__file__).read_text()
+        for forbidden in ("forward_headers", "pool.request", "pool.stream"):
+            assert forbidden not in src
+
+
+# ── 17. no classifier mutation ────────────────────────────────────────
+
+
+class TestNoClassifierMutation:
+
+    def test_classifier_constants_unchanged(self):
+        from tokenpak.proxy.intent_classifier import (
+            CLASSIFY_THRESHOLD,
+            INTENT_SOURCE_V0,
+        )
+        assert CLASSIFY_THRESHOLD == 0.4
+        assert INTENT_SOURCE_V0 == "rule_based_v0"
+
+    def test_pi_1_does_not_register_intent_classifier_path(self):
+        # Structural: the patch module + telemetry module MUST NOT
+        # import or invoke the classifier directly. They consume
+        # the contract / decision / suggestion that came out of
+        # the classifier upstream.
+        for modname in (
+            "tokenpak.proxy.intent_prompt_patch",
+            "tokenpak.proxy.intent_prompt_patch_telemetry",
+        ):
+            __import__(modname)
+            mod = sys.modules[modname]
+            src = Path(mod.__file__).read_text()
+            assert "classify_intent(" not in src
+            assert "extract_prompt_text(" not in src
+
+
+# ── 18. CLI inspector empty + populated ───────────────────────────────
+
+
+class TestCliInspector:
+
+    def test_help_includes_patches(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "patches", "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--last" in result.stdout
+        assert "--json" in result.stdout
+
+    def test_runs_without_error(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "patches"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        # The four directive labels MUST appear when the table is
+        # empty (which is the typical state for a fresh PI-1
+        # install).
+        for label in (
+            "PREVIEW ONLY",
+            "NOT APPLIED",
+            "NO PROMPT MUTATION",
+            "NO CLAUDE CODE INJECTION YET",
+        ):
+            assert label in result.stdout
+
+    def test_json_mode_returns_json(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "intent", "patches", "--json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        d = json.loads(result.stdout)
+        assert "labels" in d
+        for label in (
+            "PREVIEW ONLY",
+            "NOT APPLIED",
+            "NO PROMPT MUTATION",
+            "NO CLAUDE CODE INJECTION YET",
+        ):
+            assert label in d["labels"]
+
+
+# ── 19. JSON shape ────────────────────────────────────────────────────
+
+
+class TestJsonShape:
+
+    def test_to_dict_round_trip(self):
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        payload = json.loads(json.dumps(result[0].to_dict()))
+        assert payload["mode"] in PI_1_SUPPORTED_MODES
+        assert payload["target"] == TARGET_COMPANION_CONTEXT
+        assert payload["applied"] is False
+        assert payload["source"] == SOURCE_PI
+
+
+# ── 20. Mode validation (cross-cutting) ───────────────────────────────
+
+
+class TestModeValidation:
+    """Pin the PI-1 mode set + rejection of rewrite_prompt."""
+
+    def test_supported_modes_pinned(self):
+        assert PI_1_SUPPORTED_MODES == frozenset({
+            MODE_PREVIEW_ONLY,
+            MODE_INJECT_GUIDANCE,
+            MODE_ASK_CLARIFICATION,
+        })
+        assert MODE_REWRITE_PROMPT not in PI_1_SUPPORTED_MODES
+        assert MODE_REWRITE_PROMPT in ALL_MODES
+
+    def test_rewrite_prompt_returns_zero_in_pi_1(self):
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(mode=MODE_REWRITE_PROMPT),
+            ctx=_builder_ctx(),
+        )
+        assert result == ()
+
+
+# ── 21. Telemetry round-trip (cross-cutting) ──────────────────────────
+
+
+class TestTelemetryRoundTrip:
+
+    def test_table_created_on_first_write(self, tmp_path: Path):
+        store = IntentPatchStore(db_path=tmp_path / "t.db")
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        for p in result:
+            store.write(IntentPatchRow(patch=p, created_at="t"))
+        store.close()
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='intent_patches'"
+        )
+        assert cur.fetchone() is not None
+
+    def test_fetch_latest_round_trip(self, tmp_path: Path):
+        store = IntentPatchStore(db_path=tmp_path / "t.db")
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        for p in result:
+            store.write(IntentPatchRow(patch=p, created_at="2026-04-26T20:00:00"))
+        latest = store.fetch_latest()
+        assert latest is not None
+        assert latest["mode"] == MODE_INJECT_GUIDANCE
+        assert latest["target"] == TARGET_COMPANION_CONTEXT
+        assert latest["applied"] is False
+        assert latest["source"] == SOURCE_PI
+
+    def test_fetch_for_suggestion(self, tmp_path: Path):
+        store = IntentPatchStore(db_path=tmp_path / "t.db")
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        for p in result:
+            store.write(IntentPatchRow(patch=p, created_at="t"))
+        rows = store.fetch_for_suggestion(suggestion.suggestion_id)
+        assert len(rows) == 1
+
+    def test_writer_does_not_raise_on_unwritable_path(self):
+        bad = Path("/proc/this-cannot-be-a-real-file.db")
+        store = IntentPatchStore(db_path=bad)
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            return
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        for p in result:
+            store.write(IntentPatchRow(patch=p, created_at="t"))
+
+
+# ── 22. Patch text length cap (cross-cutting) ─────────────────────────
+
+
+class TestPatchTextLengthCap:
+
+    def test_patch_text_length_within_cap(self):
+        suggestion, contract, decision = _make_eligible_inputs(intent_class="create")
+        if suggestion is None:
+            pytest.skip("baseline suggestion not produced")
+        result = build_patches(
+            suggestion=suggestion, contract=contract, decision=decision,
+            pi_config=_pi(),
+            ctx=_builder_ctx(),
+        )
+        for p in result:
+            assert len(p.patch_text) <= PATCH_TEXT_MAX_LEN

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -553,6 +553,104 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def cmd_intent_patches(args) -> None:
+    """Phase PI-1 — internal/dev inspector for intent_patches.
+
+    Read-only. The four directive-mandated labels appear in every
+    render path:
+
+      - PREVIEW ONLY
+      - NOT APPLIED
+      - NO PROMPT MUTATION
+      - NO CLAUDE CODE INJECTION YET
+    """
+    import json as _json
+
+    from tokenpak.proxy.intent_prompt_patch_telemetry import (
+        get_default_patch_store,
+    )
+
+    payload = get_default_patch_store().fetch_latest()
+    if getattr(args, "patches_json", False):
+        if payload is None:
+            print(_json.dumps({"patch": None, "labels": [
+                "PREVIEW ONLY",
+                "NOT APPLIED",
+                "NO PROMPT MUTATION",
+                "NO CLAUDE CODE INJECTION YET",
+            ]}, indent=2, sort_keys=True))
+        else:
+            payload = dict(payload)
+            payload["labels"] = [
+                "PREVIEW ONLY",
+                "NOT APPLIED",
+                "NO PROMPT MUTATION",
+                "NO CLAUDE CODE INJECTION YET",
+            ]
+            print(_json.dumps(payload, indent=2, sort_keys=True, default=str))
+        sys.exit(0)
+
+    if payload is None:
+        print(
+            "\nTOKENPAK  |  Intent patches (PI-1 internal inspector)\n"
+            "──────────────────────────────\n"
+            "\n"
+            "  PREVIEW ONLY  ·  NOT APPLIED  ·  NO PROMPT MUTATION  ·  NO CLAUDE CODE INJECTION YET\n"
+            "\n"
+            "  No prompt patches yet.\n"
+            "\n"
+            "  PI-1 ships the PromptPatch builder + intent_patches table\n"
+            "  + this internal inspector. There is no production write\n"
+            "  path in PI-1 — the builder is library code that PI-2 will\n"
+            "  integrate into operator-facing surfaces, and PI-3 will\n"
+            "  integrate into the Claude Code Companion injection path.\n"
+        )
+        sys.exit(0)
+
+    lines: list[str] = []
+    lines.append("")
+    lines.append("TOKENPAK  |  Intent patches (PI-1 internal inspector)")
+    lines.append("──────────────────────────────")
+    lines.append("")
+    lines.append("  PREVIEW ONLY  ·  NOT APPLIED  ·  NO PROMPT MUTATION  ·  NO CLAUDE CODE INJECTION YET")
+    lines.append("")
+    lines.append(f"  patch_id:                  {payload['patch_id']}")
+    lines.append(f"  contract_id:               {payload['contract_id']}")
+    lines.append(f"  decision_id:               {payload['decision_id']}")
+    lines.append(f"  suggestion_id:             {payload['suggestion_id']}")
+    lines.append(f"  created_at:                {payload['created_at']}")
+    lines.append("")
+    lines.append(f"  mode:                      {payload['mode']}")
+    lines.append(f"  target:                    {payload['target']}")
+    lines.append(f"  applied:                   {payload['applied']}  (always False in PI-1)")
+    lines.append(f"  requires_confirmation:     {payload['requires_confirmation']}")
+    lines.append(f"  source:                    {payload['source']}")
+    lines.append("")
+    lines.append(f"  confidence:                {payload['confidence']:.4f}")
+    flags = payload.get("safety_flags") or []
+    flags_str = ", ".join(flags) if flags else "(none)"
+    lines.append(f"  safety_flags:              {flags_str}")
+    lines.append(f"  reason:                    {payload['reason']}")
+    lines.append(f"  original_hash:             {payload['original_hash']}")
+    lines.append("")
+    lines.append("  patch_text (preview, would be inserted into target if PI-3 applied it):")
+    for line in payload["patch_text"].splitlines():
+        lines.append(f"    {line}")
+    lines.append("")
+    lines.append(
+        "  This is a preview only. Phase PI-1 has no production write"
+    )
+    lines.append(
+        "  path; this row was constructed by tests / future-phase wiring."
+    )
+    lines.append(
+        "  No prompt has been mutated. No Claude Code injection has occurred."
+    )
+    lines.append("")
+    print("\n".join(lines))
+    sys.exit(0)
+
+
 def cmd_intent_config(args) -> None:
     """Phase 2.4.3 — show / validate the intent_policy config.
 
@@ -2470,6 +2568,31 @@ def build_parser():
         help="Emit machine-readable JSON instead of human-readable.",
     )
     p_intent_config.set_defaults(func=cmd_intent_config)
+
+    # Phase PI-1 — internal/dev inspector for the latest row in
+    # intent_patches. Read-only. Builder + table exist; this CLI
+    # is the only PI-1 surface. Broader surfaces are PI-2 work;
+    # actual application is PI-3 / PI-4 (companion-side, opt-in).
+    p_intent_patches = p_intent_sub.add_parser(
+        "patches",
+        help=(
+            "Show the latest dry-run prompt-patch (PI-1; "
+            "internal/dev inspector; read-only; not applied)."
+        ),
+    )
+    p_intent_patches.add_argument(
+        "--last",
+        dest="patches_last",
+        action="store_true",
+        help="Show the most recent patch (default behavior).",
+    )
+    p_intent_patches.add_argument(
+        "--json",
+        dest="patches_json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable.",
+    )
+    p_intent_patches.set_defaults(func=cmd_intent_patches)
 
     p_adapter = sub.add_parser(
         "adapter",

--- a/tokenpak/proxy/intent_prompt_patch.py
+++ b/tokenpak/proxy/intent_prompt_patch.py
@@ -1,0 +1,611 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase PI-1 — PromptPatch dataclass + pure-function builder.
+
+Builds zero or one :class:`PromptPatch` from an existing
+``PolicySuggestion`` plus its linked contract / decision / config /
+adapter context. **Pure function; no I/O. Side-channel for storage
+is :mod:`tokenpak.proxy.intent_prompt_patch_telemetry`.**
+
+PI-1 scope (per the PI-0 spec § 10 sub-phase 1 deliverable):
+
+  - Define :class:`PromptPatch` (frozen).
+  - Build patches in three modes: ``preview_only`` /
+    ``inject_guidance`` / ``ask_clarification``. **NOT
+    ``rewrite_prompt``** — that mode is PI-4 deliverable; the
+    builder rejects it in PI-1.
+  - Persist to a new ``intent_patches`` SQLite table.
+  - **No surface changes; no application; no companion
+    integration; no server.py call site.** PI-2 wires surfaces;
+    PI-3 wires companion injection.
+
+Eligibility gates (always-on; cannot be relaxed by any config):
+
+  (a) ``prompt_intervention.enabled`` is ``True``.
+  (b) Mode is one of the three PI-1 modes; ``rewrite_prompt`` is
+      rejected.
+  (c) ``target`` is not ``user_message`` (reserved indefinitely).
+  (d) ``allow_byte_preserve_override`` is **not requested** —
+      PI-1 hard-blocks even when the host config sets the flag
+      true. The override capability is reserved for a future
+      ratification past PI-1.
+  (e) Confidence ≥ ``low_confidence_threshold`` (carry from 2.4).
+  (f) ``catch_all_reason is None`` (carry from 2.4).
+  (g) Resolved adapter is not byte-preserve locked **OR**
+      ``target == "companion_context"`` (companion runs
+      pre-bytes; byte-fidelity rule preserved by construction).
+  (h) For modes other than ``ask_clarification``: no required
+      slot is missing (carry from 2.4).
+  (i) Underlying suggestion is not expired (``expires_at`` null
+      or in the future).
+  (j) ``decision_reason`` is in
+      :data:`EXPLAINABLE_REASONS` (Phase 2.4.1 carry-through).
+  (k) An applicable template exists for ``(mode, intent_class)``;
+      no template ⇒ no patch (silent no-op, not an error).
+  (l) Built ``patch_text`` passes the §8 wording guardrail (no
+      forbidden phrase implying application has happened).
+  (m) Built ``patch_text`` passes the privacy guardrail (no
+      sentinel-style substring that could be a leaked secret;
+      reuses the scaffold ``_guardrails`` regex set).
+
+Privacy contract (asserted in tests):
+
+  - Builder reads structured fields only (intent class, slot
+    tuples, provider/model slugs, capability frozensets,
+    suggestion text). No raw prompt content is an input.
+  - Emitted ``patch_text`` is **always** a fixed-template string
+    parameterized only by intent_class. No caller-supplied
+    substring reaches the field.
+  - Emitted ``reason`` reuses the Phase 2.4.1 reason-rendering
+    table; no caller-supplied substring reaches that field
+    either.
+  - The ``original_hash`` field is sha256-hex of the
+    suggestion's ``contract_id || message`` digest — NEVER the
+    raw prompt body. (PI-2 / PI-3 callers may pass a real
+    prompt-equivalent string when they need genuine staleness
+    detection; for PI-1 builder-only flows, the suggestion-
+    derived digest suffices.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Optional, Tuple
+
+from tokenpak.proxy.intent_contract import IntentContract
+from tokenpak.proxy.intent_policy_engine import (
+    REASON_DRY_RUN_SUGGEST,
+    SAFETY_MISSING_SLOTS,
+    PolicyDecision,
+    PolicyEngineConfig,
+    SuggestionSurfaceConfig,
+)
+from tokenpak.proxy.intent_suggestion import (
+    FORBIDDEN_PHRASES as _BASE_FORBIDDEN_PHRASES,
+)
+from tokenpak.proxy.intent_suggestion import (
+    SOURCE_INTENT_POLICY_V0,
+    PolicySuggestion,
+    SuggestionWordingError,
+)
+
+# ---------------------------------------------------------------------------
+# Constants / enums
+# ---------------------------------------------------------------------------
+
+
+# PI-1 modes. Spec PI-0 § 5 enumerates four; PI-1 supports three
+# of them. ``rewrite_prompt`` is reserved for PI-4 and rejected
+# at the eligibility gate.
+MODE_PREVIEW_ONLY = "preview_only"
+MODE_INJECT_GUIDANCE = "inject_guidance"
+MODE_ASK_CLARIFICATION = "ask_clarification"
+MODE_REWRITE_PROMPT = "rewrite_prompt"  # rejected in PI-1
+
+PI_1_SUPPORTED_MODES: FrozenSet[str] = frozenset({
+    MODE_PREVIEW_ONLY,
+    MODE_INJECT_GUIDANCE,
+    MODE_ASK_CLARIFICATION,
+})
+
+ALL_MODES: FrozenSet[str] = PI_1_SUPPORTED_MODES | frozenset({MODE_REWRITE_PROMPT})
+
+
+# Spec PI-0 § 6: PI-1 / PI-2 / PI-3 limit ``target`` to
+# ``companion_context``. ``system`` is PI-4-only. ``user_message``
+# is reserved indefinitely. The PI-1 builder rejects ``user_message``
+# at the eligibility gate; ``system`` is technically allowed by the
+# config schema but is gated on adapter capability + future
+# ratification.
+TARGET_COMPANION_CONTEXT = "companion_context"
+TARGET_SYSTEM = "system"
+TARGET_USER_MESSAGE = "user_message"  # rejected in PI-1
+
+PI_1_SUPPORTED_TARGETS: FrozenSet[str] = frozenset({
+    TARGET_COMPANION_CONTEXT,
+    TARGET_SYSTEM,
+})
+
+
+# Phase 2.4.1 carry-through.
+EXPLAINABLE_REASONS: FrozenSet[str] = frozenset({
+    REASON_DRY_RUN_SUGGEST,
+})
+
+
+# Forbidden-phrase set EXTENDS the Phase 2.4.1 list with PI-1-
+# specific application-implying verbs. Tests pin this set so any
+# future change requires explicit ratification.
+PI_1_ADDITIONAL_FORBIDDEN: Tuple[str, ...] = (
+    "injected",
+    "mutated",
+    "rewrote",
+    "inserted",
+    "will inject",
+    "will rewrite",
+)
+FORBIDDEN_PHRASES: Tuple[str, ...] = tuple(_BASE_FORBIDDEN_PHRASES) + PI_1_ADDITIONAL_FORBIDDEN
+_FORBIDDEN_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+    re.IGNORECASE,
+)
+
+
+# Source pinned for the PI-x line. The directive specifies
+# ``intent_policy_v0`` (matches Phase 2.4.1 PolicySuggestion) so
+# the entire Intent Layer shares one provenance namespace.
+SOURCE_PI: str = SOURCE_INTENT_POLICY_V0
+
+
+# Hard cap on patch_text length per PI-0 spec § 4.1.
+PATCH_TEXT_MAX_LEN: int = 1024
+
+
+class PatchModeError(Exception):
+    """Raised when an unknown / unsupported mode is requested."""
+
+
+class PatchTargetError(Exception):
+    """Raised when an unsupported / reserved target is requested."""
+
+
+class PatchPrivacyError(Exception):
+    """Raised when patch_text fails the privacy guardrail."""
+
+
+# ---------------------------------------------------------------------------
+# PromptPatch shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptPatch:
+    """One operator-visible prompt-patch candidate. Always advisory
+    in PI-1; surfaces decide visibility (PI-2); approval gates
+    application (PI-3 / PI-4).
+
+    Field set is the PI-0 spec § 4 wire contract verbatim.
+    """
+
+    # Identity
+    patch_id: str
+    contract_id: str
+    decision_id: str
+    suggestion_id: str
+
+    # What this patch IS
+    mode: str
+    target: str
+    original_hash: str
+    patch_text: str
+    reason: str
+
+    # Provenance / risk
+    confidence: float
+    safety_flags: Tuple[str, ...] = field(default_factory=tuple)
+
+    # Lifecycle
+    requires_confirmation: bool = True
+    applied: bool = False
+    source: str = SOURCE_PI
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "patch_id": self.patch_id,
+            "contract_id": self.contract_id,
+            "decision_id": self.decision_id,
+            "suggestion_id": self.suggestion_id,
+            "mode": self.mode,
+            "target": self.target,
+            "original_hash": self.original_hash,
+            "patch_text": self.patch_text,
+            "reason": self.reason,
+            "confidence": self.confidence,
+            "safety_flags": list(self.safety_flags),
+            "requires_confirmation": self.requires_confirmation,
+            "applied": self.applied,
+            "source": self.source,
+        }
+
+
+def make_patch_id() -> str:
+    """29-char hex ID (13 ms timestamp + 16 random) — sortable.
+
+    Mirrors :func:`tokenpak.proxy.intent_policy_engine.make_decision_id`
+    so consumers can sort patch + decision + suggestion ids
+    together.
+    """
+    ts_ms = int(time.time() * 1000)
+    rand = secrets.token_hex(8)
+    return f"{ts_ms:013x}{rand}"
+
+
+def _hash_original(suggestion: PolicySuggestion, contract: IntentContract) -> str:
+    """Compute the ``original_hash`` field.
+
+    PI-1 derives the hash from suggestion identity + contract_id
+    so a patch built against suggestion X is detectably stale if
+    suggestion X is later edited / superseded. PI-2 / PI-3 may
+    extend this to include the prompt-equivalent text the
+    companion would inject the patch into; for the builder-only
+    PI-1 flow, the suggestion-derived digest suffices.
+    """
+    seed = (
+        f"{contract.contract_id}|"
+        f"{suggestion.suggestion_id}|"
+        f"{suggestion.suggestion_type}"
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Templates (PI-0 spec § 4.1: fixed-template, parameterized only
+# by intent_class)
+# ---------------------------------------------------------------------------
+
+
+_TEMPLATE_CODING = (
+    "<TokenPak Intent Guidance>\n"
+    "Recommended: preserve the user's original request, make the smallest "
+    "safe change, identify touched files, and include verification steps "
+    "when practical.\n"
+    "</TokenPak Intent Guidance>"
+)
+
+_TEMPLATE_DEBUG = (
+    "<TokenPak Intent Guidance>\n"
+    "Recommended: identify the failure path, isolate the likely root cause, "
+    "propose the smallest fix, and include verification steps.\n"
+    "</TokenPak Intent Guidance>"
+)
+
+_TEMPLATE_CLARIFICATION = (
+    "<TokenPak Intent Guidance>\n"
+    "Recommended: ask one clarifying question before making assumptions "
+    "about target files, framework, or success criteria.\n"
+    "</TokenPak Intent Guidance>"
+)
+
+
+# Map intent_class → coding-template-applicable. The PI-0 spec
+# §6 directive's "coding intent" maps onto our 10 canonical
+# intents via the create / execute set (the two intents that
+# imply code-touching action).
+_CODING_INTENT_CLASSES: FrozenSet[str] = frozenset({"create", "execute"})
+
+
+def _select_template(intent_class: str, mode: str) -> Optional[str]:
+    """Pick the patch_text template.
+
+    Returns ``None`` when no applicable template — that's the
+    silent no-op case (eligibility rule (k)).
+    """
+    if mode == MODE_ASK_CLARIFICATION:
+        return _TEMPLATE_CLARIFICATION
+    if mode in (MODE_INJECT_GUIDANCE, MODE_PREVIEW_ONLY):
+        if intent_class == "debug":
+            return _TEMPLATE_DEBUG
+        if intent_class in _CODING_INTENT_CLASSES:
+            return _TEMPLATE_CODING
+    return None
+
+
+def _render_reason(decision_reason: str) -> str:
+    """Map decision_reason → templated plain-English clause.
+
+    Reuses the Phase 2.4.1 reason-rendering rule. Empty fallback
+    only triggers in tests (eligibility (j) blocks unknown
+    reasons in production).
+    """
+    if decision_reason == REASON_DRY_RUN_SUGGEST:
+        return "the canonical heuristic table recommends it"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Wording + privacy guardrails
+# ---------------------------------------------------------------------------
+
+
+def _check_wording(*texts: str) -> None:
+    """Scan emitted strings for the PI-1 forbidden-phrase set.
+
+    Hard-fail so a future template change can never ship language
+    that implies application has happened. Skips ``None``.
+    """
+    for text in texts:
+        if text is None:
+            continue
+        m = _FORBIDDEN_RE.search(text)
+        if m is not None:
+            raise SuggestionWordingError(
+                f"forbidden wording {m.group(0)!r} in patch text: {text!r}"
+            )
+
+
+def _check_privacy(text: str) -> None:
+    """Apply the scaffold-guardrail privacy regex set to patch_text.
+
+    Hard-fail when patch_text matches any credential / token / key
+    pattern the scaffold guard already pins. Belt-and-suspenders
+    against a future template that accidentally interpolates a
+    secret-shaped value.
+    """
+    try:
+        from tokenpak.scaffold import _guardrails as _sg
+
+        # Reuse the regex set the scaffold guardrail already pins
+        # (private import; same package). The scaffold side
+        # consumes the patterns from a module-level ``_CRED_PATTERNS``
+        # list — same regexes, same behavior.
+        for pattern in getattr(_sg, "_CRED_PATTERNS", ()):
+            if pattern.search(text):
+                raise PatchPrivacyError(
+                    f"patch_text matches secret pattern: {pattern.pattern!r}"
+                )
+    except ImportError:
+        # If the scaffold module isn't importable, fall through —
+        # tests will catch any regression.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptPatchBuilderContext:
+    """Bundle of facts the builder reads beyond suggestion / decision /
+    contract.
+
+    Mirrors the PI-0 spec § 7 eligibility-gate inputs.
+    """
+
+    config: PolicyEngineConfig
+    adapter_capabilities: FrozenSet[str] = field(default_factory=frozenset)
+    required_slots: Tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PromptInterventionConfig:
+    """Subset of the PI-0 spec § 8 ``intent_policy.prompt_intervention``
+    block. PI-1 mirrors only the fields the builder reads; PI-2 /
+    PI-3 / PI-4 wiring will load these from ``~/.tokenpak/policy.yaml``.
+
+    Default: all-off, ``preview_only`` mode, ``companion_context``
+    target, ``require_confirmation = True``,
+    ``allow_byte_preserve_override = False``.
+    """
+
+    enabled: bool = False
+    mode: str = MODE_PREVIEW_ONLY
+    target: str = TARGET_COMPANION_CONTEXT
+    require_confirmation: bool = True
+    allow_byte_preserve_override: bool = False
+
+
+def build_patches(
+    *,
+    suggestion: PolicySuggestion,
+    contract: IntentContract,
+    decision: PolicyDecision,
+    pi_config: PromptInterventionConfig,
+    ctx: PromptPatchBuilderContext,
+    now_ms: Optional[int] = None,
+) -> Tuple[PromptPatch, ...]:
+    """Pure function. Phase PI-1's only entry point.
+
+    Returns a tuple of zero or one patch. Tuple-of-zero is the
+    common case (eligibility blocks). The interface returns a
+    tuple instead of an Optional so PI-2 / PI-3 can extend
+    without breaking callers.
+
+    Never raises on:
+      - Unknown decision_reason → returns ``()``
+      - Missing template → returns ``()``
+      - Disabled config → returns ``()``
+
+    Raises only on:
+      - ``PatchModeError`` — caller passed an unknown mode
+      - ``PatchTargetError`` — caller passed an unknown target
+      - ``SuggestionWordingError`` — template contains a forbidden
+        phrase (template bug, never user input)
+      - ``PatchPrivacyError`` — template matches a secret pattern
+        (template bug, never user input)
+    """
+    cfg = pi_config
+
+    # Validate mode + target up-front. These raise so a caller
+    # using an undefined enum value gets a loud error.
+    if cfg.mode not in ALL_MODES:
+        raise PatchModeError(f"unknown mode: {cfg.mode!r}")
+    if cfg.target not in PI_1_SUPPORTED_TARGETS | frozenset({TARGET_USER_MESSAGE}):
+        raise PatchTargetError(f"unknown target: {cfg.target!r}")
+
+    # ── Eligibility gates ──────────────────────────────────────────
+    # (a) enabled flag
+    if not cfg.enabled:
+        return ()
+
+    # (b) mode is one of the PI-1 supported modes; rewrite_prompt
+    # rejected.
+    if cfg.mode not in PI_1_SUPPORTED_MODES:
+        return ()
+
+    # (c) target = user_message rejected
+    if cfg.target == TARGET_USER_MESSAGE:
+        return ()
+
+    # (d) allow_byte_preserve_override hard-blocked in PI-1
+    if cfg.allow_byte_preserve_override:
+        return ()
+
+    # (e) confidence ≥ threshold
+    if contract.confidence < ctx.config.low_confidence_threshold:
+        return ()
+
+    # (f) no catch-all
+    if contract.catch_all_reason is not None:
+        return ()
+
+    # (g) byte-preserve check, with companion_context exception
+    if (
+        "tip.byte-preserved-passthrough" in ctx.adapter_capabilities
+        and cfg.target != TARGET_COMPANION_CONTEXT
+    ):
+        return ()
+
+    # (h) missing required slots — ask_clarification bypasses
+    if cfg.mode != MODE_ASK_CLARIFICATION:
+        if _has_missing_required_slots(contract, ctx.required_slots):
+            return ()
+
+    # (i) suggestion expiration
+    if suggestion.expires_at:
+        # ISO-8601 string compare. Build-time comparison value can
+        # be overridden by callers via now_ms, but the typical
+        # path uses wall clock.
+        cur_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+        # expires_at is ISO-8601 in our schema; decode best-effort.
+        if _expires_in_past(suggestion.expires_at, cur_ms):
+            return ()
+
+    # (j) decision_reason explainable
+    if decision.decision_reason not in EXPLAINABLE_REASONS:
+        return ()
+
+    # (k) template selection
+    template = _select_template(contract.intent_class, cfg.mode)
+    if template is None:
+        return ()
+
+    # Build the patch_text. Bound length defensively.
+    patch_text = template.strip()
+    if len(patch_text) > PATCH_TEXT_MAX_LEN:
+        patch_text = patch_text[:PATCH_TEXT_MAX_LEN]
+
+    reason = _render_reason(decision.decision_reason)
+    if not reason:
+        # eligibility (j) above should have caught this; guard
+        # defensively against template drift.
+        return ()
+
+    # (l) wording guardrail
+    _check_wording(patch_text, reason)
+    # (m) privacy guardrail
+    _check_privacy(patch_text)
+    _check_privacy(reason)
+
+    # If we reach here, build the patch. ask_clarification carries
+    # the safety flag; other modes don't unless the underlying
+    # suggestion did.
+    safety_flags: Tuple[str, ...] = tuple(suggestion.safety_flags)
+    if cfg.mode == MODE_ASK_CLARIFICATION and SAFETY_MISSING_SLOTS not in safety_flags:
+        # Add the implicit reason flag so the explain surface can
+        # render "this clarification fires because slots are
+        # missing".
+        safety_flags = tuple(sorted(set(safety_flags) | {SAFETY_MISSING_SLOTS}))
+
+    patch = PromptPatch(
+        patch_id=make_patch_id(),
+        contract_id=contract.contract_id,
+        decision_id=decision.decision_id,
+        suggestion_id=suggestion.suggestion_id,
+        mode=cfg.mode,
+        target=cfg.target,
+        original_hash=_hash_original(suggestion, contract),
+        patch_text=patch_text,
+        reason=reason,
+        confidence=contract.confidence,
+        safety_flags=safety_flags,
+        requires_confirmation=cfg.require_confirmation,
+        applied=False,  # always False in PI-1
+        source=SOURCE_PI,
+    )
+    return (patch,)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def _has_missing_required_slots(
+    contract: IntentContract, required_slots: Tuple[str, ...]
+) -> bool:
+    if not required_slots:
+        return False
+    missing = set(contract.slots_missing)
+    return any(s in missing for s in required_slots)
+
+
+def _expires_in_past(iso_str: str, now_ms: int) -> bool:
+    """Best-effort expiry comparison.
+
+    The PolicySuggestion schema stores ``expires_at`` as ISO-8601
+    when set. Phase 2.4.1 builds with ``None`` by default; the
+    expiry path here exists for future PI-x writers that set a
+    non-null value.
+    """
+    if not iso_str:
+        return False
+    try:
+        # Compare ISO strings lexicographically — sound for
+        # ISO-8601 timestamp strings.
+        from datetime import datetime as _dt
+        cur = _dt.fromtimestamp(now_ms / 1000.0).isoformat(timespec="seconds")
+        return iso_str < cur
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "ALL_MODES",
+    "EXPLAINABLE_REASONS",
+    "FORBIDDEN_PHRASES",
+    "MODE_ASK_CLARIFICATION",
+    "MODE_INJECT_GUIDANCE",
+    "MODE_PREVIEW_ONLY",
+    "MODE_REWRITE_PROMPT",
+    "PATCH_TEXT_MAX_LEN",
+    "PI_1_ADDITIONAL_FORBIDDEN",
+    "PI_1_SUPPORTED_MODES",
+    "PI_1_SUPPORTED_TARGETS",
+    "PatchModeError",
+    "PatchPrivacyError",
+    "PatchTargetError",
+    "PromptInterventionConfig",
+    "PromptPatch",
+    "PromptPatchBuilderContext",
+    "SOURCE_PI",
+    "SuggestionSurfaceConfig",
+    "TARGET_COMPANION_CONTEXT",
+    "TARGET_SYSTEM",
+    "TARGET_USER_MESSAGE",
+    "build_patches",
+    "make_patch_id",
+]

--- a/tokenpak/proxy/intent_prompt_patch_telemetry.py
+++ b/tokenpak/proxy/intent_prompt_patch_telemetry.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase PI-1 — SQLite store for ``intent_patches`` rows.
+
+Same DB (``~/.tokenpak/telemetry.db``) so a single backup
+captures every Intent Layer surface. Schema is **strictly hashes
+/ IDs / templated text only** per PI-0 spec § 4.3 + § 9.
+
+Linked to the PI-x dependency chain by:
+
+  - ``contract_id`` → ``intent_events`` (Phase 0)
+  - ``decision_id`` → ``intent_policy_decisions`` (Phase 2.1)
+  - ``suggestion_id`` → ``intent_suggestions`` (Phase 2.4.1)
+
+NO raw prompt text. NO per-row hashes of prompt content. The
+``original_hash`` column is a sha256 of the suggestion's
+identity tuple (contract_id || suggestion_id ||
+suggestion_type) — explicitly NOT a hash of the user's prompt.
+
+Best-effort write contract: exceptions are swallowed at the
+writer boundary. PI-1 has no production write path (the builder
+is library code; PI-2+ surfaces will integrate it), so this
+contract is mostly forward-compat with the rest of the Intent
+Layer's telemetry stores.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+from tokenpak.proxy.intent_prompt_patch import PromptPatch
+
+_DEFAULT_DB_PATH = Path(
+    os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak"))
+) / "telemetry.db"
+
+
+_INTENT_PATCHES_DDL = """\
+CREATE TABLE IF NOT EXISTS intent_patches (
+    patch_id              TEXT PRIMARY KEY,
+    contract_id           TEXT NOT NULL,
+    decision_id           TEXT NOT NULL,
+    suggestion_id         TEXT NOT NULL,
+    created_at            TEXT NOT NULL,
+    mode                  TEXT NOT NULL,
+    target                TEXT NOT NULL,
+    original_hash         TEXT NOT NULL,
+    patch_text            TEXT NOT NULL,
+    reason                TEXT NOT NULL,
+    confidence            REAL NOT NULL,
+    safety_flags          TEXT NOT NULL,    -- JSON array
+    requires_confirmation INTEGER NOT NULL,
+    applied               INTEGER NOT NULL,
+    source                TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_patches_suggestion
+    ON intent_patches (suggestion_id);
+CREATE INDEX IF NOT EXISTS idx_patches_contract
+    ON intent_patches (contract_id);
+CREATE INDEX IF NOT EXISTS idx_patches_mode
+    ON intent_patches (mode, created_at);
+CREATE INDEX IF NOT EXISTS idx_patches_applied
+    ON intent_patches (applied, created_at);
+"""
+
+
+@dataclass
+class IntentPatchRow:
+    """One row of ``intent_patches``."""
+
+    patch: PromptPatch
+    created_at: str
+
+
+class IntentPatchStore:
+    """Per-host SQLite writer for ``intent_patches``.
+
+    Lazy-init; creates the table on first :meth:`write`. Single
+    connection guarded by a process-wide lock — PI-1 traffic is
+    zero by design (no production write path).
+    """
+
+    _LOCK = threading.Lock()
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.executescript(_INTENT_PATCHES_DDL)
+            conn.commit()
+            self._conn = conn
+        return self._conn
+
+    def write(self, row: IntentPatchRow) -> None:
+        """Insert one row. Best-effort — never raises on caller path."""
+        p = row.patch
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO intent_patches (
+                        patch_id, contract_id, decision_id, suggestion_id,
+                        created_at, mode, target,
+                        original_hash, patch_text, reason,
+                        confidence, safety_flags,
+                        requires_confirmation, applied, source
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        p.patch_id,
+                        p.contract_id,
+                        p.decision_id,
+                        p.suggestion_id,
+                        row.created_at,
+                        p.mode,
+                        p.target,
+                        p.original_hash,
+                        p.patch_text,
+                        p.reason,
+                        p.confidence,
+                        json.dumps(list(p.safety_flags)),
+                        1 if p.requires_confirmation else 0,
+                        1 if p.applied else 0,
+                        p.source,
+                    ),
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001
+            return
+
+    def write_many(self, rows: Iterable[IntentPatchRow]) -> None:
+        for r in rows:
+            self.write(r)
+
+    def fetch_latest(self) -> Optional[dict[str, Any]]:
+        """Return the most recent row as a dict, or ``None``."""
+        if not self._db_path.is_file():
+            return None
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_patches'"
+                ).fetchone()
+                if exists is None:
+                    return None
+                row = conn.execute(
+                    "SELECT * FROM intent_patches "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ).fetchone()
+        except sqlite3.DatabaseError:
+            return None
+        if row is None:
+            return None
+        out = {k: row[k] for k in row.keys()}
+        try:
+            out["safety_flags"] = json.loads(out.get("safety_flags") or "[]")
+        except (TypeError, json.JSONDecodeError):
+            out["safety_flags"] = []
+        for col in ("requires_confirmation", "applied"):
+            if col in out and out[col] is not None:
+                out[col] = bool(out[col])
+        return out
+
+    def fetch_for_suggestion(self, suggestion_id: str) -> List[dict[str, Any]]:
+        """Return every patch linked to ``suggestion_id``."""
+        if not self._db_path.is_file():
+            return []
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='intent_patches'"
+                ).fetchone()
+                if exists is None:
+                    return []
+                rows = conn.execute(
+                    "SELECT * FROM intent_patches "
+                    "WHERE suggestion_id = ? ORDER BY created_at DESC",
+                    (suggestion_id,),
+                ).fetchall()
+        except sqlite3.DatabaseError:
+            return []
+        out: List[dict[str, Any]] = []
+        for row in rows:
+            r = {k: row[k] for k in row.keys()}
+            try:
+                r["safety_flags"] = json.loads(r.get("safety_flags") or "[]")
+            except (TypeError, json.JSONDecodeError):
+                r["safety_flags"] = []
+            for col in ("requires_confirmation", "applied"):
+                if col in r and r[col] is not None:
+                    r[col] = bool(r[col])
+            out.append(r)
+        return out
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+_DEFAULT_STORE: Optional[IntentPatchStore] = None
+
+
+def get_default_patch_store() -> IntentPatchStore:
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = IntentPatchStore()
+    return _DEFAULT_STORE
+
+
+def set_default_patch_store(store: Optional[IntentPatchStore]) -> None:
+    """Test hook — swap the default writer."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+__all__ = [
+    "IntentPatchRow",
+    "IntentPatchStore",
+    "get_default_patch_store",
+    "set_default_patch_store",
+]


### PR DESCRIPTION
## Summary

First code-shipping sub-phase of the Intent Prompt Intervention spec (PI-0, merged `8bc31d8c`). Pure-function builder + dedicated SQLite table + minimal internal/dev CLI inspector.

**No production write path. No surface integration. No companion integration. No application.** PI-1 is library-only — PI-2 wires surfaces, PI-3 wires companion injection, PI-4 adds narrow rewrite mode. Each future sub-phase requires its own explicit ratification.

## Changes

- **`tokenpak/proxy/intent_prompt_patch.py`** — `PromptPatch` frozen dataclass (14 fields per PI-0 spec §4). Pure `build_patches(suggestion, contract, decision, pi_config, ctx)` function. 13 always-on eligibility gates (the spec's 11 plus mode validation + target validation). PI-1 hard-blocks `allow_byte_preserve_override=true` even when requested by config — override is reserved for a future ratification past PI-1. Three conservative templates (coding for `create`/`execute`, debug, clarification). Forbidden-wording guardrail extends Phase 2.4.1 list with PI-1-specific application-implying verbs (`injected`, `mutated`, `rewrote`, `inserted`, `will inject`, `will rewrite`). Privacy guardrail reuses scaffold `_CRED_PATTERNS` regex set.
- **`tokenpak/proxy/intent_prompt_patch_telemetry.py`** — SQLite store for `intent_patches`. Schema is IDs / hashes / templated text only. `original_hash` is sha256 of suggestion identity tuple — **never** a hash of the user's prompt body. Best-effort write contract.
- **`tokenpak/cli/_impl.py`** — `tokenpak intent patches [--last] [--json]` internal/dev inspector. Every render path includes the four directive labels: `PREVIEW ONLY · NOT APPLIED · NO PROMPT MUTATION · NO CLAUDE CODE INJECTION YET`.
- **`tests/test_intent_prompt_patch_phase_pi_1.py`** — 40 tests across 16 classes covering all 19 directive categories + cross-cutting.
- **`docs/reference/cli.md`** — regenerated.

## Acceptance

- [x] `PromptPatch` object exists (14 fields, frozen).
- [x] Builder exists; pure function; no I/O during evaluation.
- [x] `intent_patches` table exists (DDL via lazy connect).
- [x] Internal inspector exists with all four directive labels.
- [x] Patches are preview-only — every row has `applied = False`.
- [x] No Claude Code injection yet (`tokenpak/companion/` untouched).
- [x] No proxy mutation (`tokenpak/proxy/server.py` untouched — no PI-1 call site).
- [x] No request mutation (frozen dataclass; structural test).
- [x] No classifier behavior changes (`intent_classifier.py` untouched; pinned).
- [x] No routing behavior changes (structural test asserts no dispatch primitives imported).
- [x] No byte-preserve override (`allow_byte_preserve_override=true` hard-blocks).
- [x] No raw prompt text or secrets emitted (sentinel-substring + privacy guardrail + scaffold `_CRED_PATTERNS`).
- [x] **1248 passing** (was 1208 baseline, +40), 0 regressions.
- [x] `ruff check` clean, `cli-docs-in-sync` clean.
- [ ] CI green on all three workflows.

## Held per directive

No prompt application, no prompt mutation, no Claude Code injection, no proxy-level injection, no user_message rewriting, no routing changes, no classifier changes, no provider/model selection, no TIP wire header emission, no byte-preserve override, no companion prompt insertion, **no implementation of PI-2 / PI-3 / PI-4**.