### PR TITLE
feat(companion,proxy,cli,docs): PI-3 — Claude Code companion-side opt-in PromptPatch injection

### DIFF
--- a/docs/reference/claude-code-intent-injection.md
+++ b/docs/reference/claude-code-intent-injection.md
@@ -1,0 +1,205 @@
+# Claude Code Companion — Opt-in Intent Guidance Injection (PI-3)
+
+> Phase PI-3 is the **first phase** in which TokenPak may apply a `PromptPatch`. Application is **companion-side only**, **explicitly opt-in**, and limited to `target = companion_context`. The proxy path remains byte-preserved-passthrough; user messages are never rewritten; routing, classification, and provider/model selection are untouched. Default posture: **disabled**.
+
+## How to enable Claude Code companion guidance injection
+
+Add (or edit) `~/.tokenpak/policy.yaml` (or `$TOKENPAK_HOME/policy.yaml`):
+
+```yaml
+intent_policy:
+  mode: suggest
+  prompt_intervention:
+    enabled: true
+    mode: inject_guidance
+    target: companion_context
+    require_confirmation: false        # set true to keep PI-3 lib refusing auto-apply
+    allow_byte_preserve_override: false  # forced false; can't be flipped
+    surfaces:
+      claude_code_companion: true
+      proxy: false                     # forced false; can't be flipped
+```
+
+Reload by re-running any `tokenpak claude-code …` command. The CLI prints:
+
+```
+Prompt intervention is enabled for Claude Code companion context only.
+User messages are preserved.
+```
+
+When `enabled: false` (the default) the CLI prints:
+
+```
+Prompt intervention is disabled. Guidance is preview-only.
+```
+
+## What gets injected
+
+Only patches that satisfy **every** PI-1 eligibility gate AND every PI-3 application gate are eligible. The PI-1 builder writes `intent_patches` rows with `applied = false`, fixed-template `patch_text`, and forbidden-phrase-clean `reason`. PI-3 then validates at injection time:
+
+- `pi_config.enabled` is `true`
+- `pi_config.allow_byte_preserve_override` is `false` (force-clamped)
+- `pi_config.surfaces.proxy` is `false` (force-clamped)
+- `pi_config.surfaces.claude_code_companion` is `true`
+- `pi_config.mode == "inject_guidance"`
+- `pi_config.target == "companion_context"`
+- `pi_config.require_confirmation` is `false` (PI-3 ships no approval gesture; with `true` the library refuses to auto-apply)
+- `patch.applied` is `false`
+- `patch.mode == "inject_guidance"`
+- `patch.target == "companion_context"`
+- `patch.source == "intent_policy_v0"`
+- `patch.patch_text` re-passes the wording + privacy guardrails
+
+When all gates align, the library prepends the existing `<TokenPak Intent Guidance>…</TokenPak Intent Guidance>` block to the companion's context string (byte-for-byte; the original context follows unchanged).
+
+Example block:
+
+```
+<TokenPak Intent Guidance>
+Recommended: preserve the user's original request, make the smallest
+safe change, identify touched files, and include verification steps
+when practical.
+</TokenPak Intent Guidance>
+```
+
+## What never gets modified
+
+PI-3 has zero authority over:
+
+- **The user message** — `target = "user_message"` is rejected by the loader and refused by the runtime library.
+- **The proxy path** — `surfaces.proxy` is force-clamped to `false`; the AnthropicAdapter byte-preserved-passthrough invariant is unchanged.
+- **Provider / model / adapter selection** — the application library imports no routing primitives; structural tests pin this.
+- **TIP wire headers** — `tip.intent.contract-headers-v1` capability is unchanged; no header lands on the wire.
+- **Classifier behavior** — the same Phase 0 classifier path is used; no PI-3 code touches it.
+- **`patch_text` template content** — the PI-1 builder is the single source of truth for what the block says.
+
+## How to inspect applied patches
+
+```bash
+tokenpak claude-code patches              # human render
+tokenpak claude-code patches --json       # JSON
+```
+
+When the latest patch was successfully applied, the surface shows:
+
+- `applied: True`
+- `applied_at: <UTC ISO-8601>`
+- `applied_surface: claude_code_companion`
+- `application_mode: inject_guidance`
+- `application_id: <16-hex token>`
+
+And the label set swaps from PI-2's preview labels to:
+
+- `Claude Code Companion Intent Guidance`
+- `Applied for this one request`
+- `Injected into Claude Code companion context`
+- `User messages preserved`
+- `Proxy path remains byte-preserved-passthrough`
+- `Telemetry-only; no TIP intent headers emitted`
+
+For an unapplied patch (default behavior), the original PI-2 PREVIEW_LABELS still apply: `PREVIEW ONLY`, `NOT APPLIED`, `NO PROMPT MUTATION`, `NO CLAUDE CODE INJECTION YET`.
+
+## How to disable it
+
+Set `enabled: false` in the `prompt_intervention` block (or remove the block entirely):
+
+```yaml
+intent_policy:
+  prompt_intervention:
+    enabled: false
+```
+
+Removing the block is equivalent to the default (disabled). Already-applied rows are not retroactively reverted; the audit columns remain.
+
+## Why proxy-level mutation remains off
+
+The Anthropic adapter declares `tip.byte-preserved-passthrough` precisely because Claude Code's billing routing depends on byte fidelity (cache_control alignment, OAuth quota mode, prompt-prefix cache hit rates). Any proxy-side mutation would break that invariant for *every* downstream caller of the adapter — including non-Claude-Code clients. PI-3 keeps the proxy path off-limits by:
+
+1. The loader force-clamps `surfaces.proxy` to `false`.
+2. The runtime library has a defense-in-depth check that refuses to apply when `surfaces.proxy = true` (in case a caller hand-builds a config bypassing the loader).
+3. The application library lives entirely under `tokenpak/companion/`, with structural tests pinning that it imports no proxy dispatch primitives.
+
+The companion runs **pre-bytes**: the patch is composed into the companion's context string before that string ever becomes a request body, so the byte-preserved-passthrough invariant downstream is preserved by construction.
+
+## Why byte-preserve override remains blocked
+
+`allow_byte_preserve_override = true` is the single most dangerous knob in the prompt-intervention schema — it would let an operator bypass the byte-fidelity invariant on *any* adapter. PI-3 force-clamps it to `false` for the same reason PI-1 hard-blocks it: future ratification (with explicit Kevin sign-off + a separate phase) is required before the bit can be flipped, and even then only for non-byte-preserved adapters. The runtime library has a defense-in-depth refusal that returns `byte_preserve_override_blocked` even if a caller hand-builds a config with the flag set.
+
+## How application is performed
+
+The companion calls:
+
+```python
+from tokenpak.companion.intent_injection import (
+    apply_patch_to_companion_context,
+)
+from tokenpak.proxy.intent_policy_config_loader import (
+    load_prompt_intervention_config_safely,
+)
+from tokenpak.proxy.intent_prompt_patch_telemetry import (
+    get_default_patch_store,
+)
+
+cfg = load_prompt_intervention_config_safely()
+store = get_default_patch_store()
+patch = store.fetch_latest()  # or fetch_for_suggestion(...)
+
+result = apply_patch_to_companion_context(
+    patch_dict=patch,
+    pi_config=cfg,
+    existing_context=companion_context,
+    store=store,
+)
+
+if result.success:
+    companion_context = result.injected_context
+```
+
+`result.success` is `True` only when every gate aligned, the patch passed both guardrails, and the audit row was persisted. On failure, `result.reason` is one of the documented enum values (`disabled`, `claude_code_companion_disabled`, `wrong_mode`, `wrong_target`, `wrong_source`, `byte_preserve_override_blocked`, `proxy_surface_forced_off`, `requires_confirmation`, `patch_missing`, `already_applied`, `wording_guardrail_blocked`, `privacy_guardrail_blocked`, `persist_failed`).
+
+The library is **idempotent**: a second call on an already-applied row returns `already_applied` without persisting again. The audit columns (`applied_at`, `applied_surface`, `application_mode`, `application_id`) record the first successful application only.
+
+## Privacy contract
+
+Same as Phase 0 / 2.4 / PI-1 / PI-2:
+
+- Only structured fields cross the application boundary (IDs, hashes, templated text, numeric / boolean fields).
+- The patch_text template is fixed and parameterized only by `intent_class`; no caller-supplied substring reaches it.
+- The PI-3 library re-runs the privacy guardrail (scaffold credential-pattern regex set) against `patch_text` before injecting.
+- The library emits no `print()` and no `logger.info` / `logger.warning` lines that include patch content; the only side-effect is the SQLite update on the audit columns.
+
+The sentinel-substring privacy contract is asserted in `tests/test_intent_prompt_intervention_phase_pi_3.py::TestPrivacyContract`.
+
+## Forbidden wording — before vs after
+
+PI-1 / PI-2 hard-block these phrases inside `patch_text` and `reason` (PI-1 builder enforces at build time):
+
+- `applied`, `inserted`, `injected`, `mutated`, `rewrote`
+- `will inject`, `will rewrite`
+- `changed`, `routed to`, `switched to`, `now using`, `updated`, `will route`, `will switch`
+
+PI-3 keeps the same builder-side ban: `patch_text` continues to be a fixed template that contains none of these words. What PI-3 adds is an **operator-facing surface** that *may* render `Applied`, `Inserted`, `Injected` — but only on the audit columns of a row that has actually been applied. Pre-application, the CLI never says these words about the row; post-application, the labels include `Applied for this one request` and `Injected into Claude Code companion context`.
+
+The pre/post distinction is asserted in `tests/test_intent_prompt_intervention_phase_pi_3.py::TestForbiddenWordingBeforeApplication` and `::TestAppliedWordingAfterApplication`.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `tokenpak/companion/intent_injection.py` | application library + `ApplicationResult` |
+| `tokenpak/proxy/intent_policy_config_loader.py` | `prompt_intervention` block parser + `PromptInterventionRuntimeConfig` |
+| `tokenpak/proxy/intent_prompt_patch_telemetry.py` | `intent_patches` schema + `IntentPatchStore.mark_applied` |
+| `tokenpak/proxy/intent_claude_code_preview.py` | applied-state-aware label selection |
+| `tokenpak/cli/_impl.py` | CLI render of audit columns + intervention status banner |
+| `tests/test_intent_prompt_intervention_phase_pi_3.py` | 17-category test suite |
+| `docs/reference/claude-code-intent-injection.md` | this document |
+
+## Cross-references
+
+- `docs/reference/claude-code-intent-preview.md` — PI-2 read-only preview (predecessor)
+- `docs/internal/specs/intent-prompt-intervention-spec-2026-04-26.md` — PI-0 unified spec (§10 covers the rollout)
+- `docs/reference/intent-layer-phase-0.md` — Phase 0 fundamentals
+
+## What's next
+
+PI-4 is the next sub-phase that may extend the intervention scope (target = `system`, mode = `rewrite_prompt`). It requires explicit Kevin approval before any code lands; until then, both are rejected by the loader.

--- a/tests/test_intent_prompt_intervention_phase_pi_3.py
+++ b/tests/test_intent_prompt_intervention_phase_pi_3.py
@@ -1,0 +1,884 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase PI-3 — companion-side opt-in PromptPatch injection tests.
+
+Seventeen directive-mandated test categories:
+
+  1.  disabled config produces no injection
+  2.  enabled config injects into companion_context
+  3.  original user message preserved
+  4.  target=user_message rejected
+  5.  proxy injection remains disabled
+  6.  rewrite_prompt unsupported
+  7.  byte-preserve override blocked
+  8.  no TIP headers emitted
+  9.  no routing mutation
+  10. no classifier mutation
+  11. no provider/model switching
+  12. patch marked applied only after success
+  13. failed insertion leaves applied=false
+  14. no raw prompt text or secrets emitted
+  15. CLI shows applied state correctly
+  16. forbidden wording guardrail before application
+  17. applied wording allowed only after application
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from tokenpak.companion.intent_injection import (
+    APPLICATION_MODE_INJECT_GUIDANCE,
+    REASON_ALREADY_APPLIED,
+    REASON_BYTE_PRESERVE_OVERRIDE_BLOCKED,
+    REASON_CLAUDE_CODE_COMPANION_DISABLED,
+    REASON_DISABLED,
+    REASON_OK,
+    REASON_PERSIST_FAILED,
+    REASON_PROXY_FORCED_OFF,
+    REASON_WRONG_MODE,
+    REASON_WRONG_TARGET,
+    SURFACE_CLAUDE_CODE_COMPANION,
+    apply_patch_to_companion_context,
+)
+from tokenpak.proxy.intent_classifier import IntentClassification
+from tokenpak.proxy.intent_contract import (
+    IntentTelemetryRow,
+    IntentTelemetryStore,
+    build_contract,
+)
+from tokenpak.proxy.intent_policy_config_loader import (
+    PromptInterventionRuntimeConfig,
+    PromptInterventionSurfaces,
+    parse_prompt_intervention_block,
+)
+from tokenpak.proxy.intent_policy_engine import (
+    PolicyEngineConfig,
+    PolicyInput,
+    evaluate_policy,
+)
+from tokenpak.proxy.intent_policy_telemetry import (
+    IntentPolicyDecisionRow,
+    IntentPolicyDecisionStore,
+)
+from tokenpak.proxy.intent_prompt_patch import (
+    FORBIDDEN_PHRASES,
+    MODE_INJECT_GUIDANCE,
+    TARGET_COMPANION_CONTEXT,
+    PromptPatchBuilderContext,
+    build_patches,
+)
+from tokenpak.proxy.intent_prompt_patch import (
+    PromptInterventionConfig as BuilderPromptInterventionConfig,
+)
+from tokenpak.proxy.intent_prompt_patch_telemetry import (
+    IntentPatchRow,
+    IntentPatchStore,
+)
+from tokenpak.proxy.intent_suggestion import (
+    SuggestionBuilderContext,
+    build_suggestions,
+)
+from tokenpak.proxy.intent_suggestion_telemetry import (
+    IntentSuggestionRow,
+    IntentSuggestionStore,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _enabled_config() -> PromptInterventionRuntimeConfig:
+    """Fully-enabled PI-3 runtime config (companion only)."""
+    return PromptInterventionRuntimeConfig(
+        enabled=True,
+        mode="inject_guidance",
+        target="companion_context",
+        require_confirmation=False,
+        allow_byte_preserve_override=False,
+        surfaces=PromptInterventionSurfaces(
+            claude_code_companion=True,
+            proxy=False,
+        ),
+    )
+
+
+def _seed_eligible_patch(*, db: Path, prompt: str = "create a new file") -> dict:
+    """Seed a single eligible PI-1 patch row + return the dict view.
+
+    Returns the row as :meth:`IntentPatchStore.fetch_latest` would —
+    suitable for passing directly to
+    :func:`apply_patch_to_companion_context`.
+    """
+    cls = IntentClassification(
+        intent_class="create",
+        confidence=0.9,
+        slots_present=("target",),
+        slots_missing=(),
+        catch_all_reason=None,
+    )
+    contract = build_contract(classification=cls, raw_prompt=prompt)
+    ts = _dt.datetime.now().isoformat(timespec="seconds")
+
+    events = IntentTelemetryStore(db_path=db)
+    events.write(
+        IntentTelemetryRow(
+            request_id="pi3-r1",
+            contract=contract,
+            timestamp=ts,
+            tip_headers_emitted=False,
+            tip_headers_stripped=True,
+        )
+    )
+    events.close()
+
+    inp = PolicyInput(
+        intent_class="create",
+        confidence=0.9,
+        slots_present=("target",),
+        slots_missing=(),
+        catch_all_reason=None,
+        provider="tokenpak-claude-code",
+        model="claude-3-5-sonnet",
+        live_verified_status=True,
+    )
+    decision = evaluate_policy(inp, PolicyEngineConfig())
+    pstore = IntentPolicyDecisionStore(db_path=db)
+    pstore.write(
+        IntentPolicyDecisionRow(
+            request_id="pi3-r1",
+            contract_id=contract.contract_id,
+            timestamp=ts,
+            decision=decision,
+        )
+    )
+    pstore.close()
+
+    sugg_ctx = SuggestionBuilderContext(
+        config=PolicyEngineConfig(),
+        adapter_capabilities=frozenset({"tip.compression.v1"}),
+    )
+    suggestions = build_suggestions(
+        decision=decision, contract=contract, ctx=sugg_ctx
+    )
+    suggestion = suggestions[0]
+    sstore = IntentSuggestionStore(db_path=db)
+    sstore.write(IntentSuggestionRow(suggestion=suggestion, timestamp=ts))
+    sstore.close()
+
+    builder_ctx = PromptPatchBuilderContext(
+        config=PolicyEngineConfig(),
+        adapter_capabilities=frozenset(
+            {"tip.compression.v1", "tip.byte-preserved-passthrough"}
+        ),
+        required_slots=(),
+    )
+    patches = build_patches(
+        suggestion=suggestion,
+        contract=contract,
+        decision=decision,
+        pi_config=BuilderPromptInterventionConfig(
+            enabled=True,
+            mode=MODE_INJECT_GUIDANCE,
+            target=TARGET_COMPANION_CONTEXT,
+            require_confirmation=False,
+            allow_byte_preserve_override=False,
+        ),
+        ctx=builder_ctx,
+    )
+    patch = patches[0]
+    store = IntentPatchStore(db_path=db)
+    store.write(IntentPatchRow(patch=patch, created_at=ts))
+    return store.fetch_latest()
+
+
+# ── 1. disabled config produces no injection ─────────────────────────
+
+
+class TestDisabledConfigNoInjection:
+
+    def test_default_config_disabled(self):
+        cfg = PromptInterventionRuntimeConfig()
+        assert not cfg.enabled
+        assert not cfg.is_claude_code_companion_active()
+
+    def test_disabled_config_returns_disabled_reason(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=PromptInterventionRuntimeConfig(),
+            existing_context="orig context",
+            store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_DISABLED
+        # Persistence didn't happen.
+        latest = store.fetch_latest()
+        assert latest["applied"] is False
+        assert latest.get("applied_at") is None
+
+
+# ── 2. enabled config injects into companion_context ─────────────────
+
+
+class TestEnabledConfigInjects:
+
+    def test_eligible_patch_injects_block(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        original_context = "Companion context: prior memory capsules."
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context=original_context,
+            store=store,
+        )
+        assert result.success
+        assert result.reason == REASON_OK
+        assert result.injected_context is not None
+        assert "<TokenPak Intent Guidance>" in result.injected_context
+        assert "</TokenPak Intent Guidance>" in result.injected_context
+
+    def test_block_appears_before_existing_context(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        original = "ZZ_ORIGINAL_MARKER_ZZ"
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context=original,
+            store=store,
+        )
+        assert result.success
+        idx_block = result.injected_context.index("<TokenPak Intent Guidance>")
+        idx_orig = result.injected_context.index(original)
+        assert idx_block < idx_orig, (
+            "guidance block must precede original context"
+        )
+
+
+# ── 3. original user message preserved ───────────────────────────────
+
+
+class TestUserMessagePreserved:
+
+    def test_existing_context_is_substring_of_result(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        # Pretend the companion context already contains a verbatim
+        # user-input echo (companions sometimes include this).
+        original = (
+            "User message: Please add a CHANGELOG entry for v0.4.\n"
+            "Companion notes: previous commit 4bdf123."
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context=original,
+            store=store,
+        )
+        assert result.success
+        assert original in result.injected_context, (
+            "original user message must be byte-preserved within the "
+            "post-injection context"
+        )
+
+    def test_no_user_message_target_path_exists(self):
+        # The library only injects into companion_context. The
+        # config layer rejects target=user_message; the injection
+        # library has no code path that touches user_message.
+        from tokenpak.companion import intent_injection as ii
+        # Module-level constant — ensures the surface is bound to
+        # claude_code_companion only.
+        assert ii.SURFACE_CLAUDE_CODE_COMPANION == "claude_code_companion"
+
+
+# ── 4. target=user_message rejected ──────────────────────────────────
+
+
+class TestTargetUserMessageRejected:
+
+    def test_loader_rejects_user_message(self):
+        cfg, warnings = parse_prompt_intervention_block({
+            "enabled": True,
+            "mode": "inject_guidance",
+            "target": "user_message",
+            "require_confirmation": False,
+            "surfaces": {"claude_code_companion": True},
+        })
+        # Downgraded to the safe default.
+        assert cfg.target == "companion_context"
+        assert any("user_message" in w for w in warnings)
+
+    def test_runtime_rejects_user_message_target(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        # Hand-build a config with target=user_message even though
+        # the loader would reject it. The library must still refuse.
+        cfg = PromptInterventionRuntimeConfig(
+            enabled=True,
+            mode="inject_guidance",
+            target="user_message",
+            require_confirmation=False,
+            surfaces=PromptInterventionSurfaces(claude_code_companion=True),
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=cfg,
+            existing_context="orig",
+            store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_WRONG_TARGET
+
+
+# ── 5. proxy injection remains disabled ──────────────────────────────
+
+
+class TestProxyInjectionDisabled:
+
+    def test_loader_force_clamps_proxy_surface(self):
+        cfg, warnings = parse_prompt_intervention_block({
+            "enabled": True,
+            "mode": "inject_guidance",
+            "target": "companion_context",
+            "require_confirmation": False,
+            "surfaces": {
+                "claude_code_companion": True,
+                "proxy": True,  # operator tries to enable proxy injection
+            },
+        })
+        assert cfg.surfaces.proxy is False, "proxy surface must be force-clamped"
+        assert any("proxy" in w for w in warnings)
+
+    def test_runtime_refuses_proxy_surface(self, tmp_path):
+        # Hand-build a config with surfaces.proxy=True (bypassing the
+        # loader). The library refuses.
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        cfg = PromptInterventionRuntimeConfig(
+            enabled=True,
+            mode="inject_guidance",
+            target="companion_context",
+            require_confirmation=False,
+            surfaces=PromptInterventionSurfaces(
+                claude_code_companion=True, proxy=True
+            ),
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch, pi_config=cfg, existing_context="orig", store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_PROXY_FORCED_OFF
+
+    def test_companion_disabled_when_no_surface(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        cfg = PromptInterventionRuntimeConfig(
+            enabled=True,
+            mode="inject_guidance",
+            target="companion_context",
+            require_confirmation=False,
+            surfaces=PromptInterventionSurfaces(),  # all surfaces off
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch, pi_config=cfg, existing_context="orig", store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_CLAUDE_CODE_COMPANION_DISABLED
+
+
+# ── 6. rewrite_prompt unsupported ────────────────────────────────────
+
+
+class TestRewritePromptUnsupported:
+
+    def test_loader_downgrades_rewrite_prompt(self):
+        cfg, warnings = parse_prompt_intervention_block({
+            "enabled": True,
+            "mode": "rewrite_prompt",
+            "target": "companion_context",
+        })
+        assert cfg.mode == "preview_only"
+        assert any("rewrite_prompt" in w for w in warnings)
+
+    def test_runtime_rejects_rewrite_prompt_mode(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        cfg = PromptInterventionRuntimeConfig(
+            enabled=True,
+            mode="rewrite_prompt",
+            target="companion_context",
+            require_confirmation=False,
+            surfaces=PromptInterventionSurfaces(claude_code_companion=True),
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch, pi_config=cfg, existing_context="orig", store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_WRONG_MODE
+
+
+# ── 7. byte-preserve override blocked ────────────────────────────────
+
+
+class TestByteServeOverrideBlocked:
+
+    def test_loader_force_clamps_override(self):
+        cfg, warnings = parse_prompt_intervention_block({
+            "enabled": True,
+            "mode": "inject_guidance",
+            "target": "companion_context",
+            "allow_byte_preserve_override": True,
+            "surfaces": {"claude_code_companion": True},
+        })
+        assert cfg.allow_byte_preserve_override is False
+        assert any("byte_preserve" in w for w in warnings)
+
+    def test_runtime_refuses_override(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        cfg = PromptInterventionRuntimeConfig(
+            enabled=True,
+            mode="inject_guidance",
+            target="companion_context",
+            require_confirmation=False,
+            allow_byte_preserve_override=True,
+            surfaces=PromptInterventionSurfaces(claude_code_companion=True),
+        )
+        result = apply_patch_to_companion_context(
+            patch_dict=patch, pi_config=cfg, existing_context="orig", store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_BYTE_PRESERVE_OVERRIDE_BLOCKED
+
+
+# ── 8. no TIP headers emitted ────────────────────────────────────────
+
+
+class TestNoTipHeadersEmitted:
+
+    def test_module_does_not_emit_tip_headers(self):
+        # Structural test: companion/intent_injection.py has no
+        # reference to TIP intent header names.
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        text = path.read_text(encoding="utf-8")
+        # The module must not emit / construct any
+        # tip-prefix-named header. The source may *mention* the
+        # capability slug as a structural reference (we don't
+        # add this, but we don't rule it out).
+        assert "X-TIP-Intent" not in text
+        assert "x-tip-intent" not in text
+        assert "tip-intent-headers" not in text.lower()
+
+
+# ── 9. no routing mutation ───────────────────────────────────────────
+
+
+class TestNoRoutingMutation:
+
+    def test_module_does_not_import_dispatch_primitives(self):
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        text = path.read_text(encoding="utf-8")
+        # No dispatch-shaped primitive should be imported.
+        for forbidden in (
+            "forward_headers",
+            "from tokenpak.proxy.client import",
+            "pool.request",
+            "pool.stream",
+            "credential_injector",
+            "RoutingService",
+        ):
+            assert forbidden not in text, (
+                f"PI-3 module must not touch routing primitive: {forbidden}"
+            )
+
+
+# ── 10. no classifier mutation ───────────────────────────────────────
+
+
+class TestNoClassifierMutation:
+
+    def test_module_does_not_touch_classifier(self):
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        text = path.read_text(encoding="utf-8")
+        assert "intent_classifier" not in text
+        assert "IntentClassifier" not in text
+        assert "build_contract" not in text
+
+
+# ── 11. no provider/model switching ──────────────────────────────────
+
+
+class TestNoProviderModelSwitching:
+
+    def test_module_does_not_import_provider_selection(self):
+        # Scan imports only — docstrings may mention "provider"
+        # legitimately (e.g. to explain what we're NOT doing).
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        import ast
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                # No imports from routing / credential / provider
+                # subsystems.
+                forbidden_modules = (
+                    "tokenpak.services.routing_service",
+                    "tokenpak.routing",
+                    "tokenpak.proxy.client",
+                    "credential_injector",
+                    "credential_provider",
+                    "ProviderProfile",
+                    "ClientProfile",
+                )
+                for fm in forbidden_modules:
+                    assert fm not in mod, (
+                        f"PI-3 module imports forbidden routing surface: {mod}"
+                    )
+
+    def test_module_does_not_call_provider_apis(self):
+        # Verify no function calls into provider-selection APIs.
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        text = path.read_text(encoding="utf-8")
+        for forbidden in (
+            "select_provider(",
+            "resolve_provider(",
+            "set_provider(",
+            "switch_model(",
+            "set_model(",
+        ):
+            assert forbidden not in text, (
+                f"PI-3 module calls forbidden provider/model API: {forbidden}"
+            )
+
+
+# ── 12. patch marked applied only after success ──────────────────────
+
+
+class TestAppliedFlagOnSuccess:
+
+    def test_applied_columns_set(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert result.success
+        latest = store.fetch_latest()
+        assert latest["applied"] is True
+        assert latest["applied_at"] is not None
+        assert latest["applied_surface"] == SURFACE_CLAUDE_CODE_COMPANION
+        assert latest["application_mode"] == APPLICATION_MODE_INJECT_GUIDANCE
+        assert latest["application_id"] is not None
+
+    def test_applied_only_once_idempotent(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        first = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert first.success
+        # Re-fetch the now-applied row.
+        applied = store.fetch_latest()
+        # Re-apply: should refuse with already_applied.
+        second = apply_patch_to_companion_context(
+            patch_dict=applied,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert not second.success
+        assert second.reason == REASON_ALREADY_APPLIED
+
+
+# ── 13. failed insertion leaves applied=false ────────────────────────
+
+
+class TestFailedInsertionLeavesAppliedFalse:
+
+    def test_persist_failure_returns_persist_failed(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        # Build a store pointing at a non-existent path; the file
+        # is not yet created so mark_applied returns False (the
+        # ``self._db_path.is_file()`` guard at the top of the
+        # method).
+        store = IntentPatchStore(db_path=tmp_path / "missing.db")
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert not result.success
+        assert result.reason == REASON_PERSIST_FAILED
+
+    def test_eligibility_failure_does_not_touch_db(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=PromptInterventionRuntimeConfig(),  # disabled
+            existing_context="ctx",
+            store=store,
+        )
+        assert not result.success
+        latest = store.fetch_latest()
+        assert latest["applied"] is False
+
+
+# ── 14. no raw prompt text or secrets emitted ────────────────────────
+
+
+class TestPrivacyContract:
+
+    SENTINEL = "sentinel-magic-prompt-PI-3-NEVER-LEAK"
+
+    def test_sentinel_in_prompt_absent_from_injected_context(self, tmp_path):
+        # Seed with the sentinel inside the raw prompt — which
+        # never reaches patch_text by construction (PI-1 builder is
+        # template-only) — and assert post-injection context has no
+        # sentinel.
+        patch = _seed_eligible_patch(
+            db=tmp_path / "tel.db",
+            prompt=f"create a new file with marker {self.SENTINEL}",
+        )
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        result = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="prior context (no marker)",
+            store=store,
+        )
+        assert result.success
+        assert self.SENTINEL not in (result.injected_context or "")
+        # Also assert the persisted patch row has no sentinel
+        # leakage in any column.
+        applied = store.fetch_latest()
+        for v in applied.values():
+            if isinstance(v, str):
+                assert self.SENTINEL not in v
+
+    def test_module_has_no_print_logging_of_patch_text(self):
+        path = Path(
+            "tokenpak/companion/intent_injection.py"
+        ).resolve()
+        text = path.read_text(encoding="utf-8")
+        # The module must not print() patch_text or log it (so
+        # the operator's secret-shaped values don't end up in
+        # syslog / journalctl).
+        assert "print(" not in text or "print(patch" not in text
+        # No logger.info / logger.warning lines that include
+        # patch_text content (we keep telemetry only via the
+        # existing patch store).
+        assert "logger.info" not in text
+        assert "logger.warning" not in text
+
+
+# ── 15. CLI shows applied state correctly ────────────────────────────
+
+
+def _write_policy_yaml(tokenpak_home: Path, *, enabled: bool) -> None:
+    """Write a policy.yaml with an active or inactive
+    prompt_intervention block under ``tokenpak_home``.
+    """
+    tokenpak_home.mkdir(parents=True, exist_ok=True)
+    body = textwrap.dedent(
+        f"""
+        intent_policy:
+          mode: suggest
+          prompt_intervention:
+            enabled: {str(enabled).lower()}
+            mode: inject_guidance
+            target: companion_context
+            require_confirmation: false
+            surfaces:
+              claude_code_companion: {str(enabled).lower()}
+              proxy: false
+        """
+    ).lstrip()
+    (tokenpak_home / "policy.yaml").write_text(body, encoding="utf-8")
+
+
+class TestCliRendersAppliedState:
+
+    def test_intervention_status_disabled_default(self, tmp_path):
+        env = dict(os.environ)
+        env["TOKENPAK_HOME"] = str(tmp_path)  # no policy.yaml — disabled
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "claude-code", "patches"],
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        assert result.returncode == 0
+        assert "Prompt intervention is disabled" in result.stdout
+        assert "preview-only" in result.stdout
+
+    def test_intervention_status_enabled(self, tmp_path):
+        _write_policy_yaml(tmp_path, enabled=True)
+        env = dict(os.environ)
+        env["TOKENPAK_HOME"] = str(tmp_path)
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "claude-code", "patches"],
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        assert result.returncode == 0
+        assert (
+            "Prompt intervention is enabled for Claude Code companion "
+            "context only"
+        ) in result.stdout
+        assert "User messages are preserved" in result.stdout
+
+    def test_applied_patch_renders_audit_columns(self, tmp_path):
+        # Seed a patch + apply it under a dedicated TOKENPAK_HOME,
+        # then drive the CLI against the same telemetry.db.
+        _write_policy_yaml(tmp_path, enabled=True)
+        env = dict(os.environ)
+        env["TOKENPAK_HOME"] = str(tmp_path)
+
+        # Telemetry DB at $TOKENPAK_HOME/telemetry.db (mirrors
+        # _DEFAULT_DB_PATH).
+        db = tmp_path / "telemetry.db"
+        patch = _seed_eligible_patch(db=db)
+        store = IntentPatchStore(db_path=db)
+        result_lib = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert result_lib.success
+
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "claude-code", "patches",
+             "--json"],
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        assert result.returncode == 0
+        d = json.loads(result.stdout)
+        # JSON view exposes the audit columns.
+        p = d["patch"]
+        assert p["applied"] is True
+        assert p["applied_surface"] == SURFACE_CLAUDE_CODE_COMPANION
+        assert p["application_mode"] == APPLICATION_MODE_INJECT_GUIDANCE
+        assert p["applied_at"]
+        # APPLIED_LABELS take over.
+        assert "Applied for this one request" in d["labels"]
+        assert "Injected into Claude Code companion context" in d["labels"]
+        # PI-2 PREVIEW_LABELS are gone for this row.
+        assert "NOT APPLIED" not in d["labels"]
+        assert "NO PROMPT MUTATION" not in d["labels"]
+
+
+# ── 16. forbidden wording guardrail before application ───────────────
+
+
+class TestForbiddenWordingBeforeApplication:
+
+    def test_unapplied_patch_text_contains_no_forbidden_phrase(self, tmp_path):
+        patch = _seed_eligible_patch(db=tmp_path / "tel.db")
+        store = IntentPatchStore(db_path=tmp_path / "tel.db")
+        # Render the unapplied patch via the read model + CLI JSON
+        # surface; assert no forbidden phrase appears in patch_text.
+        from tokenpak.proxy.intent_claude_code_preview import (
+            collect_latest_patch_preview,
+        )
+        from tokenpak.proxy.intent_prompt_patch_telemetry import (
+            set_default_patch_store,
+        )
+
+        set_default_patch_store(store)
+        try:
+            payload = collect_latest_patch_preview()
+        finally:
+            set_default_patch_store(None)
+
+        forbidden_re = re.compile(
+            r"\b(?:" + "|".join(re.escape(p) for p in FORBIDDEN_PHRASES) + r")\b",
+            re.IGNORECASE,
+        )
+        text = payload["patch"]["patch_text"]
+        m = forbidden_re.search(text)
+        assert m is None, (
+            f"forbidden phrase {m.group(0)!r} appeared in unapplied patch_text"
+        )
+
+
+# ── 17. applied wording allowed only after application ───────────────
+
+
+class TestAppliedWordingAfterApplication:
+
+    def test_pre_application_cli_does_not_say_applied(self, tmp_path):
+        # On a fresh DB with an unapplied patch, the CLI must not
+        # render "Applied" / "Inserted" / "Injected" as a status
+        # statement about the row.
+        env = dict(os.environ)
+        env["TOKENPAK_HOME"] = str(tmp_path)
+        # Seed an unapplied patch under the alt TOKENPAK_HOME.
+        db = tmp_path / "telemetry.db"
+        _seed_eligible_patch(db=db)
+
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "claude-code", "patches"],
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        assert result.returncode == 0
+        # The PREVIEW labels are still active for this row.
+        assert "NOT APPLIED" in result.stdout
+        # The applied-only status string MUST NOT appear.
+        assert "Injected into Claude Code companion context" not in result.stdout
+        # The audit headers must not appear (we only render them
+        # when applied=True).
+        assert "applied_at:" not in result.stdout
+        assert "applied_surface:" not in result.stdout
+
+    def test_post_application_cli_says_injected(self, tmp_path):
+        env = dict(os.environ)
+        env["TOKENPAK_HOME"] = str(tmp_path)
+        db = tmp_path / "telemetry.db"
+        patch = _seed_eligible_patch(db=db)
+        store = IntentPatchStore(db_path=db)
+        result_lib = apply_patch_to_companion_context(
+            patch_dict=patch,
+            pi_config=_enabled_config(),
+            existing_context="ctx",
+            store=store,
+        )
+        assert result_lib.success
+
+        result = subprocess.run(
+            [sys.executable, "-m", "tokenpak", "claude-code", "patches"],
+            capture_output=True, text=True, timeout=15, env=env,
+        )
+        assert result.returncode == 0
+        # APPLIED_LABELS are now active.
+        assert "Applied for this one request" in result.stdout
+        assert "Injected into Claude Code companion context" in result.stdout
+        # Audit columns rendered.
+        assert "applied_at:" in result.stdout
+        assert (
+            f"applied_surface:         {SURFACE_CLAUDE_CODE_COMPANION}"
+            in result.stdout
+        )

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -553,37 +553,76 @@ def cmd_codex(args):
     launch_codex(extra_args=extra)
 
 
+def _intent_intervention_status_line() -> str:
+    """PI-3 operator-safety output. Reads
+    :func:`load_prompt_intervention_config_safely` and returns the
+    one-line status banner the directive § 6 mandates.
+    """
+    from tokenpak.proxy.intent_policy_config_loader import (
+        load_prompt_intervention_config_safely,
+    )
+
+    cfg = load_prompt_intervention_config_safely()
+    if cfg.is_claude_code_companion_active() and not cfg.require_confirmation:
+        return (
+            "Prompt intervention is enabled for Claude Code companion "
+            "context only. User messages are preserved."
+        )
+    return "Prompt intervention is disabled. Guidance is preview-only."
+
+
 def cmd_claude_code_intent(args) -> None:
     """PI-2 — Claude Code Companion intent preview (full chain).
 
     Renders the latest event + decision + suggestion + patch row
     chain with Claude-Code-specific identity labels. Read-only.
+    PI-3 extension: when the latest patch row is applied, the
+    label set swaps to :data:`APPLIED_LABELS` and the patch
+    section renders the four audit columns.
     """
     import json as _json
 
     from tokenpak.proxy.intent_claude_code_preview import (
-        PREVIEW_LABELS,
         collect_latest_preview,
+        labels_for_patch,
     )
 
     payload = collect_latest_preview()
     if getattr(args, "cc_intent_json", False):
         if payload is None:
+            from tokenpak.proxy.intent_claude_code_preview import (
+                PREVIEW_LABELS,
+            )
             print(_json.dumps({
                 "preview": None,
                 "labels": list(PREVIEW_LABELS),
+                "intervention_status": _intent_intervention_status_line(),
             }, indent=2, sort_keys=True))
         else:
-            print(_json.dumps(payload, indent=2, sort_keys=True, default=str))
+            payload_with_status = dict(payload)
+            payload_with_status["intervention_status"] = (
+                _intent_intervention_status_line()
+            )
+            print(_json.dumps(
+                payload_with_status, indent=2, sort_keys=True, default=str
+            ))
         sys.exit(0)
 
+    labels = (
+        labels_for_patch(payload.get("patch")) if payload else None
+    )
     lines: list[str] = []
     lines.append("")
     lines.append("TOKENPAK  |  Claude Code Companion Intent Preview (PI-2)")
     lines.append("──────────────────────────────")
     lines.append("")
-    for label in PREVIEW_LABELS:
+    if labels is None:
+        from tokenpak.proxy.intent_claude_code_preview import PREVIEW_LABELS
+        labels = PREVIEW_LABELS
+    for label in labels:
         lines.append(f"  · {label}")
+    lines.append("")
+    lines.append(f"  {_intent_intervention_status_line()}")
     lines.append("")
 
     if payload is None:
@@ -658,11 +697,29 @@ def cmd_claude_code_intent(args) -> None:
         lines.append("  prompt_intervention is disabled, the eligibility gates")
         lines.append("  rejected the case, or no template applied.")
     else:
-        lines.append("  Linked prompt patch (PI-1 preview):")
+        applied = bool(patch.get("applied"))
+        if applied:
+            lines.append("  Linked prompt patch (PI-3 — Applied):")
+        else:
+            lines.append("  Linked prompt patch (PI-1 preview):")
         lines.append(f"    patch_id:                {patch['patch_id']}")
         lines.append(f"    mode:                    {patch['mode']}")
         lines.append(f"    target:                  {patch['target']}")
-        lines.append(f"    applied:                 {patch['applied']}  (always False in PI-1/PI-2)")
+        lines.append(f"    applied:                 {patch['applied']}")
+        if applied:
+            lines.append(
+                f"    applied_at:              {patch.get('applied_at') or '(unknown)'}"
+            )
+            lines.append(
+                f"    applied_surface:         {patch.get('applied_surface') or '(unknown)'}"
+            )
+            lines.append(
+                f"    application_mode:        {patch.get('application_mode') or '(unknown)'}"
+            )
+            if patch.get("application_id"):
+                lines.append(
+                    f"    application_id:          {patch['application_id']}"
+                )
         lines.append(f"    confidence:              {patch['confidence']:.4f}")
         pflags = patch.get("safety_flags") or []
         lines.append(
@@ -670,14 +727,20 @@ def cmd_claude_code_intent(args) -> None:
         )
         lines.append(f"    reason:                  {patch['reason']}")
         lines.append("")
-        lines.append("    patch_text (preview, would be inserted into target if PI-3 applied it):")
+        if applied:
+            lines.append(
+                "    patch_text (Injected into Claude Code companion context):"
+            )
+        else:
+            lines.append(
+                "    patch_text (preview, would be inserted into target if PI-3 applied it):"
+            )
         for line in patch["patch_text"].splitlines():
             lines.append(f"      {line}")
     lines.append("")
-    lines.append("  This is a preview only. PI-2 has no application path; PI-3")
-    lines.append("  is the first sub-phase that will inject guidance into the")
-    lines.append("  Claude Code Companion's companion_context — and only on")
-    lines.append("  explicit opt-in via prompt_intervention config.")
+    lines.append("  PI-3 is the first sub-phase that may inject guidance into")
+    lines.append("  the Claude Code Companion's companion_context — and only")
+    lines.append("  on explicit opt-in via prompt_intervention config.")
     lines.append("")
     print("\n".join(lines))
     sys.exit(0)
@@ -687,13 +750,17 @@ def cmd_claude_code_patches(args) -> None:
     """PI-2 — Claude Code Companion patch-only preview.
 
     Renders the latest patch row tagged with Claude-Code-specific
-    identity labels. Read-only.
+    identity labels. Read-only. PI-3 extension: when the latest
+    patch row is applied, the label set swaps to
+    :data:`APPLIED_LABELS` and the four audit columns are
+    rendered.
     """
     import json as _json
 
     from tokenpak.proxy.intent_claude_code_preview import (
         PREVIEW_LABELS,
         collect_latest_patch_preview,
+        labels_for_patch,
     )
 
     payload = collect_latest_patch_preview()
@@ -702,9 +769,16 @@ def cmd_claude_code_patches(args) -> None:
             print(_json.dumps({
                 "patch": None,
                 "labels": list(PREVIEW_LABELS),
+                "intervention_status": _intent_intervention_status_line(),
             }, indent=2, sort_keys=True))
         else:
-            print(_json.dumps(payload, indent=2, sort_keys=True, default=str))
+            payload_with_status = dict(payload)
+            payload_with_status["intervention_status"] = (
+                _intent_intervention_status_line()
+            )
+            print(_json.dumps(
+                payload_with_status, indent=2, sort_keys=True, default=str
+            ))
         sys.exit(0)
 
     lines: list[str] = []
@@ -712,17 +786,20 @@ def cmd_claude_code_patches(args) -> None:
     lines.append("TOKENPAK  |  Claude Code Companion Patch Preview (PI-2)")
     lines.append("──────────────────────────────")
     lines.append("")
-    for label in PREVIEW_LABELS:
+    labels = labels_for_patch(payload["patch"]) if payload else PREVIEW_LABELS
+    for label in labels:
         lines.append(f"  · {label}")
+    lines.append("")
+    lines.append(f"  {_intent_intervention_status_line()}")
     lines.append("")
 
     if payload is None:
         lines.append("  No prompt patches yet.")
         lines.append("")
-        lines.append("  PI-2 surfaces a Claude-Code-shaped view over the")
-        lines.append("  intent_patches table. Run a Claude Code request through")
-        lines.append("  the proxy with prompt_intervention.enabled = true and")
-        lines.append("  re-run this command.")
+        lines.append("  Run a Claude Code request through the proxy with")
+        lines.append("  prompt_intervention.enabled = true and")
+        lines.append("  surfaces.claude_code_companion = true, then re-run")
+        lines.append("  this command.")
         lines.append("")
         print("\n".join(lines))
         sys.exit(0)
@@ -734,7 +811,11 @@ def cmd_claude_code_patches(args) -> None:
     lines.append(f"    wire_emission:           {payload['wire_emission']}")
     lines.append("")
     p = payload["patch"]
-    lines.append("  Latest patch:")
+    applied = bool(p.get("applied"))
+    if applied:
+        lines.append("  Latest patch (Applied):")
+    else:
+        lines.append("  Latest patch (preview):")
     lines.append(f"    patch_id:                {p['patch_id']}")
     lines.append(f"    contract_id:             {p['contract_id']}")
     lines.append(f"    decision_id:             {p['decision_id']}")
@@ -742,7 +823,21 @@ def cmd_claude_code_patches(args) -> None:
     lines.append(f"    created_at:              {p['created_at']}")
     lines.append(f"    mode:                    {p['mode']}")
     lines.append(f"    target:                  {p['target']}")
-    lines.append(f"    applied:                 {p['applied']}  (always False in PI-1/PI-2)")
+    lines.append(f"    applied:                 {p['applied']}")
+    if applied:
+        lines.append(
+            f"    applied_at:              {p.get('applied_at') or '(unknown)'}"
+        )
+        lines.append(
+            f"    applied_surface:         {p.get('applied_surface') or '(unknown)'}"
+        )
+        lines.append(
+            f"    application_mode:        {p.get('application_mode') or '(unknown)'}"
+        )
+        if p.get("application_id"):
+            lines.append(
+                f"    application_id:          {p['application_id']}"
+            )
     lines.append(f"    confidence:              {p['confidence']:.4f}")
     pflags = p.get("safety_flags") or []
     lines.append(
@@ -750,7 +845,14 @@ def cmd_claude_code_patches(args) -> None:
     )
     lines.append(f"    reason:                  {p['reason']}")
     lines.append("")
-    lines.append("  patch_text (preview, would be inserted into target if PI-3 applied it):")
+    if applied:
+        lines.append(
+            "  patch_text (Injected into Claude Code companion context):"
+        )
+    else:
+        lines.append(
+            "  patch_text (preview, would be inserted into target if PI-3 applied it):"
+        )
     for line in p["patch_text"].splitlines():
         lines.append(f"    {line}")
     lines.append("")

--- a/tokenpak/companion/intent_injection.py
+++ b/tokenpak/companion/intent_injection.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase PI-3 — companion-side opt-in PromptPatch injection.
+
+This is the **first phase where TokenPak may apply** PromptPatch
+guidance — but only through the Claude Code companion path, only
+when the operator explicitly opts in via
+``intent_policy.prompt_intervention``, only with
+``target = "companion_context"``, only with
+``mode = "inject_guidance"``, and only on patch rows the PI-1
+builder already emitted with ``applied = False``.
+
+What PI-3 explicitly does NOT do
+--------------------------------
+
+  - **No proxy-level injection.** ``surfaces.proxy`` is
+    force-clamped to ``False`` in the loader; the proxy path
+    remains byte-preserved-passthrough.
+  - **No user_message rewriting.** ``target = "user_message"``
+    is rejected by the loader.
+  - **No rewrite_prompt mode.** Rejected by the loader.
+  - **No routing changes.** The application library never
+    touches provider / model / adapter selection.
+  - **No classifier changes.** Same intent-classification path
+    that PI-1 / PI-2 use.
+  - **No TIP wire-header emission.** The ``tip.intent.contract-headers-v1``
+    capability is unchanged; no header lands on the wire.
+  - **No byte-preserve override.** Force-clamped.
+  - **No confirmation-mode execution.** When the host config
+    sets ``require_confirmation = True``, the library refuses to
+    auto-apply (PI-3 ships no approval gesture). The companion
+    must call this library only after its own confirmation
+    handshake — and even then, the library still validates that
+    the operator opted out of ``require_confirmation`` for the
+    auto-apply branch.
+
+Idempotency + audit
+-------------------
+
+The library calls
+:meth:`tokenpak.proxy.intent_prompt_patch_telemetry.IntentPatchStore.mark_applied`
+which is **idempotent**: it only flips ``applied = 0`` rows to
+``applied = 1`` and stamps the four audit columns. Calling
+``apply_patch_to_companion_context`` twice on the same patch row
+yields one application; the second call returns
+``ApplicationResult(success=False, reason="already_applied")``.
+
+Privacy contract
+----------------
+
+The library reads only the structured fields stored in
+``intent_patches`` — no raw prompt text, no secrets. The patch
+text is itself a fixed-template string the PI-1 builder emitted
+under the wording + privacy guardrails. The library re-runs the
+privacy guardrail before injecting.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+import secrets
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from tokenpak.proxy.intent_policy_config_loader import (
+    PromptInterventionRuntimeConfig,
+)
+from tokenpak.proxy.intent_prompt_patch import (
+    FORBIDDEN_PHRASES as _PATCH_FORBIDDEN_PHRASES,
+)
+from tokenpak.proxy.intent_prompt_patch import (
+    SOURCE_PI as _PATCH_SOURCE,
+)
+from tokenpak.proxy.intent_prompt_patch_telemetry import IntentPatchStore
+
+# ---------------------------------------------------------------------------
+# Constants — surface labels + reasons
+# ---------------------------------------------------------------------------
+
+
+SURFACE_CLAUDE_CODE_COMPANION: str = "claude_code_companion"
+APPLICATION_MODE_INJECT_GUIDANCE: str = "inject_guidance"
+
+# PI-3 reasons surfaced via :class:`ApplicationResult.reason`.
+REASON_OK: str = "ok"
+REASON_DISABLED: str = "disabled"
+REASON_CLAUDE_CODE_COMPANION_DISABLED: str = "claude_code_companion_disabled"
+REASON_PROXY_FORCED_OFF: str = "proxy_surface_forced_off"
+REASON_REQUIRES_CONFIRMATION: str = "requires_confirmation"
+REASON_PATCH_MISSING: str = "patch_missing"
+REASON_ALREADY_APPLIED: str = "already_applied"
+REASON_WRONG_MODE: str = "wrong_mode"
+REASON_WRONG_TARGET: str = "wrong_target"
+REASON_WRONG_SOURCE: str = "wrong_source"
+REASON_BYTE_PRESERVE_OVERRIDE_BLOCKED: str = "byte_preserve_override_blocked"
+REASON_PRIVACY_GUARDRAIL: str = "privacy_guardrail_blocked"
+REASON_WORDING_GUARDRAIL: str = "wording_guardrail_blocked"
+REASON_PERSIST_FAILED: str = "persist_failed"
+
+
+# Same forbidden-phrase regex the PI-1 builder uses. We re-run it
+# here so a patch row tampered with after the builder still gets
+# blocked at injection time.
+_FORBIDDEN_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(p) for p in _PATCH_FORBIDDEN_PHRASES) + r")\b",
+    re.IGNORECASE,
+)
+
+# Match the scaffold-side credential patterns. We import inside
+# the function so a missing scaffold module isn't a hard import
+# error here.
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApplicationResult:
+    """Outcome of one
+    :func:`apply_patch_to_companion_context` call."""
+
+    success: bool
+    reason: str
+    patch_id: Optional[str] = None
+    injected_context: Optional[str] = None
+    applied_at: Optional[str] = None
+    applied_surface: Optional[str] = None
+    application_mode: Optional[str] = None
+    application_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_application_id() -> str:
+    """Opaque caller-side application token. 16 hex chars."""
+    return secrets.token_hex(8)
+
+
+def _check_privacy_guardrail(text: str) -> bool:
+    """Re-run the scaffold credential-pattern regex set against
+    ``text``. Returns ``True`` when no pattern matches.
+    """
+    try:
+        from tokenpak.scaffold import _guardrails as _sg
+    except ImportError:
+        return True
+    for pattern in getattr(_sg, "_CRED_PATTERNS", ()):
+        if pattern.search(text):
+            return False
+    return True
+
+
+def _check_wording_guardrail(text: str) -> bool:
+    """Return ``True`` when ``text`` contains no forbidden phrase.
+
+    PI-3 still blocks ``Applied`` / ``Inserted`` / ``Injected`` in
+    the patch_text *itself* — those words become permitted only in
+    operator-facing surface text *after* an application succeeds
+    (see CLI render in :mod:`tokenpak.cli._impl`). The patch row's
+    ``patch_text`` continues to carry the PI-1 fixed template,
+    which is forbidden-phrase clean by construction.
+    """
+    return _FORBIDDEN_RE.search(text) is None
+
+
+def _build_block(patch_text: str) -> str:
+    """Return the ``<TokenPak Intent Guidance>`` block to inject.
+
+    The PI-1 builder already emits ``patch_text`` as a complete
+    ``<TokenPak Intent Guidance>...</TokenPak Intent Guidance>``
+    block, so the library returns it as-is. We do not wrap or
+    re-template — that would risk wording-guardrail drift.
+    """
+    return patch_text.strip()
+
+
+def _splice_into_context(existing_context: str, block: str) -> str:
+    """Prepend the guidance block to ``existing_context``.
+
+    Order matters: PI-3 places the guidance *first* so the model
+    reads operator-approved guidance before any prior companion
+    state. The original context is preserved byte-for-byte.
+    """
+    if not existing_context:
+        return block
+    sep = "\n\n" if not existing_context.startswith("\n") else "\n"
+    return block + sep + existing_context
+
+
+# ---------------------------------------------------------------------------
+# Eligibility
+# ---------------------------------------------------------------------------
+
+
+def _eligibility_check(
+    *,
+    patch_dict: Optional[Mapping[str, Any]],
+    pi_config: PromptInterventionRuntimeConfig,
+) -> Optional[str]:
+    """Return a reason string when the patch is **not** eligible,
+    otherwise ``None``."""
+    if not pi_config.enabled:
+        return REASON_DISABLED
+    if pi_config.allow_byte_preserve_override:
+        # Defense-in-depth — the loader force-clamps this to False,
+        # but if a caller hand-builds a config we still refuse.
+        return REASON_BYTE_PRESERVE_OVERRIDE_BLOCKED
+    if pi_config.surfaces.proxy:
+        # Same defense-in-depth as above.
+        return REASON_PROXY_FORCED_OFF
+    if not pi_config.surfaces.claude_code_companion:
+        return REASON_CLAUDE_CODE_COMPANION_DISABLED
+    if pi_config.mode != "inject_guidance":
+        return REASON_WRONG_MODE
+    if pi_config.target != "companion_context":
+        return REASON_WRONG_TARGET
+    if pi_config.require_confirmation:
+        # PI-3 ships no approval gesture; refuse auto-apply.
+        return REASON_REQUIRES_CONFIRMATION
+    if patch_dict is None:
+        return REASON_PATCH_MISSING
+    if patch_dict.get("applied"):
+        return REASON_ALREADY_APPLIED
+    if patch_dict.get("mode") != "inject_guidance":
+        return REASON_WRONG_MODE
+    if patch_dict.get("target") != "companion_context":
+        return REASON_WRONG_TARGET
+    if patch_dict.get("source") != _PATCH_SOURCE:
+        return REASON_WRONG_SOURCE
+    text = patch_dict.get("patch_text") or ""
+    if not _check_wording_guardrail(text):
+        return REASON_WORDING_GUARDRAIL
+    if not _check_privacy_guardrail(text):
+        return REASON_PRIVACY_GUARDRAIL
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def apply_patch_to_companion_context(
+    *,
+    patch_dict: Optional[Mapping[str, Any]],
+    pi_config: PromptInterventionRuntimeConfig,
+    existing_context: str,
+    store: Optional[IntentPatchStore] = None,
+    application_id: Optional[str] = None,
+    now_utc_iso: Optional[str] = None,
+) -> ApplicationResult:
+    """Inject a patch's guidance block into the Claude Code companion context.
+
+    Args:
+        patch_dict: A row from
+            :meth:`IntentPatchStore.fetch_latest` /
+            :meth:`fetch_for_suggestion` (already-decoded dict —
+            ``safety_flags`` as list, booleans as bool). May be
+            ``None`` to surface the empty-row failure mode.
+        pi_config: The active host's prompt-intervention config —
+            from :func:`load_prompt_intervention_config_safely`.
+        existing_context: The companion's current context string,
+            built by the rest of the companion (capsules / journal /
+            etc). Preserved byte-for-byte; the guidance block is
+            prepended.
+        store: The patch store the audit row gets persisted to.
+            Defaults to the process-wide default store.
+        application_id: Opaque caller-side token. Generated when
+            ``None``.
+        now_utc_iso: Override for :func:`_now_iso` (test hook).
+
+    Returns:
+        :class:`ApplicationResult` with ``success = True`` only
+        when every gate aligned, the patch_text passed both
+        guardrails, and the row was persisted with
+        ``applied = 1``.
+
+    The library never raises on the caller path; failures are
+    returned as ``ApplicationResult`` with the relevant
+    ``reason``.
+    """
+    reason = _eligibility_check(patch_dict=patch_dict, pi_config=pi_config)
+    if reason is not None:
+        patch_id = (
+            patch_dict.get("patch_id") if isinstance(patch_dict, Mapping) else None
+        )
+        return ApplicationResult(success=False, reason=reason, patch_id=patch_id)
+
+    assert patch_dict is not None  # narrowed by _eligibility_check
+    patch_id = patch_dict.get("patch_id")
+    text = patch_dict.get("patch_text") or ""
+
+    # Compose the new context. Pure-string — no I/O yet.
+    block = _build_block(text)
+    new_context = _splice_into_context(existing_context, block)
+
+    # Persist the audit columns. Only mark applied if the DB
+    # update succeeded; otherwise we surface persist_failed and
+    # the caller MUST NOT use new_context (the patch isn't
+    # auditable, so the operator-safety contract isn't met).
+    target_store = store if store is not None else _default_store()
+    app_id = application_id or _new_application_id()
+    applied_at = now_utc_iso or _now_iso()
+    ok = target_store.mark_applied(
+        patch_id=patch_id,
+        applied_surface=SURFACE_CLAUDE_CODE_COMPANION,
+        application_mode=APPLICATION_MODE_INJECT_GUIDANCE,
+        application_id=app_id,
+        applied_at=applied_at,
+    )
+    if not ok:
+        return ApplicationResult(
+            success=False,
+            reason=REASON_PERSIST_FAILED,
+            patch_id=patch_id,
+        )
+
+    return ApplicationResult(
+        success=True,
+        reason=REASON_OK,
+        patch_id=patch_id,
+        injected_context=new_context,
+        applied_at=applied_at,
+        applied_surface=SURFACE_CLAUDE_CODE_COMPANION,
+        application_mode=APPLICATION_MODE_INJECT_GUIDANCE,
+        application_id=app_id,
+    )
+
+
+def _default_store() -> IntentPatchStore:
+    """Lazy default store. Imported here so test hooks
+    (:func:`set_default_patch_store`) take effect.
+    """
+    from tokenpak.proxy.intent_prompt_patch_telemetry import (
+        get_default_patch_store,
+    )
+
+    return get_default_patch_store()
+
+
+__all__ = [
+    "APPLICATION_MODE_INJECT_GUIDANCE",
+    "ApplicationResult",
+    "REASON_ALREADY_APPLIED",
+    "REASON_BYTE_PRESERVE_OVERRIDE_BLOCKED",
+    "REASON_CLAUDE_CODE_COMPANION_DISABLED",
+    "REASON_DISABLED",
+    "REASON_OK",
+    "REASON_PATCH_MISSING",
+    "REASON_PERSIST_FAILED",
+    "REASON_PRIVACY_GUARDRAIL",
+    "REASON_PROXY_FORCED_OFF",
+    "REASON_REQUIRES_CONFIRMATION",
+    "REASON_WORDING_GUARDRAIL",
+    "REASON_WRONG_MODE",
+    "REASON_WRONG_SOURCE",
+    "REASON_WRONG_TARGET",
+    "SURFACE_CLAUDE_CODE_COMPANION",
+    "apply_patch_to_companion_context",
+]

--- a/tokenpak/proxy/intent_claude_code_preview.py
+++ b/tokenpak/proxy/intent_claude_code_preview.py
@@ -72,6 +72,33 @@ PREVIEW_LABELS = (
     "Telemetry-only; no TIP intent headers emitted",
 )
 
+# PI-3 — labels rendered on patch rows where ``applied = True``.
+# Replaces the PREVIEW_LABELS set per the PI-2 doc footer note:
+# "PI-3 will update the PI-2 surface labels (e.g. 'NOT APPLIED'
+# becomes 'Applied for this one request' only on the specific row
+# that was applied)."
+APPLIED_LABELS = (
+    "Claude Code Companion Intent Guidance",
+    "Applied for this one request",
+    "Injected into Claude Code companion context",
+    "User message preserved",
+    "Proxy path remains byte-preserved-passthrough",
+    "Telemetry-only; no TIP intent headers emitted",
+)
+
+
+def labels_for_patch(patch: Optional[Dict[str, Any]]) -> tuple:
+    """Pick :data:`APPLIED_LABELS` when the row records a successful
+    application, else fall back to :data:`PREVIEW_LABELS`.
+    """
+    if patch is None:
+        return PREVIEW_LABELS
+    if not patch.get("applied"):
+        return PREVIEW_LABELS
+    if patch.get("applied_surface") != "claude_code_companion":
+        return PREVIEW_LABELS
+    return APPLIED_LABELS
+
 
 def _intent_db_path() -> Path:
     """Resolved telemetry.db path. Mirrors :mod:`intent_contract`."""
@@ -197,12 +224,7 @@ def collect_latest_preview(
                 and _table_exists(conn, "intent_patches")
             ):
                 p = conn.execute(
-                    "SELECT patch_id, contract_id, decision_id, "
-                    "suggestion_id, created_at, mode, target, "
-                    "original_hash, patch_text, reason, "
-                    "confidence, safety_flags, "
-                    "requires_confirmation, applied, source "
-                    "FROM intent_patches "
+                    "SELECT * FROM intent_patches "
                     "WHERE suggestion_id = ? "
                     "ORDER BY created_at DESC LIMIT 1",
                     (suggestion["suggestion_id"],),
@@ -212,6 +234,7 @@ def collect_latest_preview(
                         pflags = json.loads(p["safety_flags"] or "[]")
                     except (TypeError, json.JSONDecodeError):
                         pflags = []
+                    p_keys = set(p.keys())
                     patch = {
                         "patch_id": p["patch_id"],
                         "contract_id": p["contract_id"],
@@ -230,6 +253,25 @@ def collect_latest_preview(
                         ),
                         "applied": bool(p["applied"]),
                         "source": p["source"],
+                        # PI-3 audit columns — None on pre-PI-3 rows.
+                        "applied_at": (
+                            p["applied_at"] if "applied_at" in p_keys else None
+                        ),
+                        "applied_surface": (
+                            p["applied_surface"]
+                            if "applied_surface" in p_keys
+                            else None
+                        ),
+                        "application_mode": (
+                            p["application_mode"]
+                            if "application_mode" in p_keys
+                            else None
+                        ),
+                        "application_id": (
+                            p["application_id"]
+                            if "application_id" in p_keys
+                            else None
+                        ),
                     }
     except sqlite3.DatabaseError:
         return None
@@ -245,8 +287,9 @@ def collect_latest_preview(
         "decision": decision,
         "suggestion": suggestion,
         "patch": patch,
-        # Directive-mandated label set
-        "labels": list(PREVIEW_LABELS),
+        # Directive-mandated label set; PI-3 swaps to APPLIED_LABELS
+        # for rows that were successfully applied.
+        "labels": list(labels_for_patch(patch)),
     }
 
 
@@ -303,11 +346,12 @@ def collect_latest_patch_preview(
         "credential_provider": CREDENTIAL_PROVIDER_CLAUDE_CODE,
         "wire_emission": WIRE_EMISSION_TELEMETRY_ONLY,
         "patch": p,
-        "labels": list(PREVIEW_LABELS),
+        "labels": list(labels_for_patch(p)),
     }
 
 
 __all__ = [
+    "APPLIED_LABELS",
     "CREDENTIAL_PROVIDER_CLAUDE_CODE",
     "FORMAT_ADAPTER_ANTHROPIC",
     "PREVIEW_LABELS",
@@ -315,4 +359,5 @@ __all__ = [
     "WIRE_EMISSION_TELEMETRY_ONLY",
     "collect_latest_patch_preview",
     "collect_latest_preview",
+    "labels_for_patch",
 ]

--- a/tokenpak/proxy/intent_policy_config_loader.py
+++ b/tokenpak/proxy/intent_policy_config_loader.py
@@ -23,12 +23,33 @@ Resolution order:
 
 The loader is read-only. It does not write to ``policy.yaml`` and
 never modifies any other on-disk state.
+
+Phase PI-3 extension
+--------------------
+
+The loader also parses the ``intent_policy.prompt_intervention``
+sub-block into a :class:`PromptInterventionRuntimeConfig`:
+
+  - ``enabled`` (default ``False``)
+  - ``mode`` — only ``"inject_guidance"``, ``"preview_only"``,
+    ``"ask_clarification"`` are accepted; ``"rewrite_prompt"`` is
+    rejected to ``preview_only``.
+  - ``target`` — only ``"companion_context"`` is accepted in
+    PI-3; ``"system"`` is downgraded with a warning;
+    ``"user_message"`` is rejected outright.
+  - ``require_confirmation`` (default ``True``)
+  - ``allow_byte_preserve_override`` — **forced** ``False``
+    (PI-3 § 1 invariant).
+  - ``surfaces.claude_code_companion`` (default ``False``)
+  - ``surfaces.proxy`` — **forced** ``False`` (PI-3 § 1
+    invariant; the proxy never injects in PI-3).
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -51,6 +72,61 @@ PERMITTED_MODES_2_4_3: Tuple[str, ...] = ("observe_only", "suggest")
 """Modes Phase 2.4.3 will accept as the resolved value. Anything
 else (including ``confirm`` / ``enforce``) is downgraded to
 ``observe_only`` with a warning."""
+
+
+# ---------------------------------------------------------------------------
+# Phase PI-3 — prompt_intervention sub-block
+# ---------------------------------------------------------------------------
+
+
+PI_3_VALID_MODES: Tuple[str, ...] = (
+    "preview_only",
+    "inject_guidance",
+    "ask_clarification",
+)
+"""``rewrite_prompt`` is intentionally absent — PI-4-only."""
+
+PI_3_VALID_TARGETS: Tuple[str, ...] = ("companion_context",)
+"""``system`` is reserved (PI-4 ratification); ``user_message`` is
+reserved indefinitely. PI-3 only accepts ``companion_context``."""
+
+
+@dataclass(frozen=True)
+class PromptInterventionSurfaces:
+    """Per-surface enable flags. ``proxy`` is forced ``False``."""
+
+    claude_code_companion: bool = False
+    proxy: bool = False  # forced False per PI-3 § 1
+
+
+@dataclass(frozen=True)
+class PromptInterventionRuntimeConfig:
+    """Resolved ``intent_policy.prompt_intervention`` block.
+
+    Mirrors :class:`tokenpak.proxy.intent_prompt_patch.PromptInterventionConfig`
+    but adds the ``surfaces`` sub-mapping that PI-3 introduces. Default is
+    all-off — same posture as the upstream PI-1 dataclass.
+    """
+
+    enabled: bool = False
+    mode: str = "preview_only"
+    target: str = "companion_context"
+    require_confirmation: bool = True
+    allow_byte_preserve_override: bool = False  # forced False
+    surfaces: PromptInterventionSurfaces = field(
+        default_factory=PromptInterventionSurfaces
+    )
+
+    def is_claude_code_companion_active(self) -> bool:
+        """True iff every gate aligns to allow companion-side injection."""
+        return (
+            self.enabled
+            and self.mode == "inject_guidance"
+            and self.target == "companion_context"
+            and self.surfaces.claude_code_companion
+            and not self.surfaces.proxy
+            and not self.allow_byte_preserve_override
+        )
 
 
 def _candidate_paths() -> List[Path]:
@@ -159,6 +235,123 @@ def _resolve_suggestion_surface(
         dashboard=dashboard,
         api=api,
         response_headers=False,  # forced
+    )
+
+
+def _resolve_prompt_intervention(
+    raw: Any, *, warnings_out: List[str]
+) -> PromptInterventionRuntimeConfig:
+    """Parse the ``prompt_intervention`` sub-block per PI-3 § 1.
+
+    Force-applied invariants:
+      - ``allow_byte_preserve_override`` → ``False``
+      - ``surfaces.proxy`` → ``False``
+      - ``target == "user_message"`` → reject (downgrade to default)
+      - ``mode == "rewrite_prompt"`` → reject (downgrade to ``preview_only``)
+    """
+    if raw is None:
+        return PromptInterventionRuntimeConfig()
+    if not isinstance(raw, dict):
+        warnings_out.append(
+            "intent_policy.prompt_intervention must be a mapping; "
+            "falling back to defaults (disabled)."
+        )
+        return PromptInterventionRuntimeConfig()
+
+    enabled = _safe_bool(raw.get("enabled"), False)
+
+    raw_mode = raw.get("mode", "preview_only")
+    if not isinstance(raw_mode, str):
+        warnings_out.append(
+            f"intent_policy.prompt_intervention.mode must be a string; got "
+            f"{type(raw_mode).__name__!r}; defaulting to preview_only."
+        )
+        mode = "preview_only"
+    elif raw_mode == "rewrite_prompt":
+        warnings_out.append(
+            "intent_policy.prompt_intervention.mode='rewrite_prompt' is "
+            "unsupported in PI-3; downgrading to preview_only."
+        )
+        mode = "preview_only"
+    elif raw_mode not in PI_3_VALID_MODES:
+        warnings_out.append(
+            f"intent_policy.prompt_intervention.mode={raw_mode!r} is not a "
+            f"known value; defaulting to preview_only."
+        )
+        mode = "preview_only"
+    else:
+        mode = raw_mode
+
+    raw_target = raw.get("target", "companion_context")
+    if not isinstance(raw_target, str):
+        warnings_out.append(
+            f"intent_policy.prompt_intervention.target must be a string; got "
+            f"{type(raw_target).__name__!r}; defaulting to companion_context."
+        )
+        target = "companion_context"
+    elif raw_target == "user_message":
+        warnings_out.append(
+            "intent_policy.prompt_intervention.target='user_message' is "
+            "reserved indefinitely; rejecting and defaulting to "
+            "companion_context."
+        )
+        target = "companion_context"
+    elif raw_target == "system":
+        warnings_out.append(
+            "intent_policy.prompt_intervention.target='system' is reserved "
+            "for PI-4; downgrading to companion_context."
+        )
+        target = "companion_context"
+    elif raw_target not in PI_3_VALID_TARGETS:
+        warnings_out.append(
+            f"intent_policy.prompt_intervention.target={raw_target!r} is not "
+            f"a known value; defaulting to companion_context."
+        )
+        target = "companion_context"
+    else:
+        target = raw_target
+
+    require_confirmation = _safe_bool(raw.get("require_confirmation"), True)
+
+    raw_byte_preserve = _safe_bool(
+        raw.get("allow_byte_preserve_override"), False
+    )
+    if raw_byte_preserve:
+        warnings_out.append(
+            "intent_policy.prompt_intervention.allow_byte_preserve_override "
+            "cannot be enabled in PI-3; forced to False."
+        )
+    allow_byte_preserve_override = False  # forced
+
+    raw_surfaces = raw.get("surfaces")
+    if raw_surfaces is None:
+        surfaces = PromptInterventionSurfaces()
+    elif not isinstance(raw_surfaces, dict):
+        warnings_out.append(
+            "intent_policy.prompt_intervention.surfaces must be a mapping; "
+            "falling back to defaults (all surfaces off)."
+        )
+        surfaces = PromptInterventionSurfaces()
+    else:
+        cc = _safe_bool(raw_surfaces.get("claude_code_companion"), False)
+        proxy_raw = _safe_bool(raw_surfaces.get("proxy"), False)
+        if proxy_raw:
+            warnings_out.append(
+                "intent_policy.prompt_intervention.surfaces.proxy cannot be "
+                "enabled in PI-3; forced to False."
+            )
+        surfaces = PromptInterventionSurfaces(
+            claude_code_companion=cc,
+            proxy=False,  # forced
+        )
+
+    return PromptInterventionRuntimeConfig(
+        enabled=enabled,
+        mode=mode,
+        target=target,
+        require_confirmation=require_confirmation,
+        allow_byte_preserve_override=allow_byte_preserve_override,
+        surfaces=surfaces,
     )
 
 
@@ -289,6 +482,50 @@ def resolve_active_config_path() -> Optional[Path]:
     return None
 
 
+def parse_prompt_intervention_block(
+    raw: Any,
+) -> Tuple[PromptInterventionRuntimeConfig, List[str]]:
+    """Public wrapper around :func:`_resolve_prompt_intervention`.
+
+    Pure function. Returns ``(config, warnings)``. Used by the
+    PI-3 application library and the CLI validator.
+    """
+    warnings_out: List[str] = []
+    cfg = _resolve_prompt_intervention(raw, warnings_out=warnings_out)
+    return cfg, warnings_out
+
+
+def load_prompt_intervention_config_safely(
+    *, candidate_path: Optional[Path] = None
+) -> PromptInterventionRuntimeConfig:
+    """Resolve + parse the active host's ``prompt_intervention`` block.
+
+    Always returns a :class:`PromptInterventionRuntimeConfig`; never
+    raises. ``candidate_path`` overrides the search path.
+    """
+    path = candidate_path
+    if path is None:
+        for cand in _candidate_paths():
+            if cand.is_file():
+                path = cand
+                break
+    if path is None or not path.is_file():
+        return PromptInterventionRuntimeConfig()
+
+    raw = _read_yaml_safely(path)
+    if raw is None:
+        return PromptInterventionRuntimeConfig()
+
+    intent_block = raw.get("intent_policy") if isinstance(raw, dict) else None
+    if not isinstance(intent_block, dict):
+        return PromptInterventionRuntimeConfig()
+    pi_block = intent_block.get("prompt_intervention")
+    cfg, warnings = parse_prompt_intervention_block(pi_block)
+    for w in warnings:
+        logger.warning("intent_policy_config_loader: %s", w)
+    return cfg
+
+
 # Helper used by surfaces (CLI / dashboard / API) to decide whether
 # to render the "Suggest mode active" badge for a given surface.
 def is_surface_active(cfg: PolicyEngineConfig, surface: str) -> bool:
@@ -313,9 +550,15 @@ def is_surface_active(cfg: PolicyEngineConfig, surface: str) -> bool:
 
 __all__ = [
     "PERMITTED_MODES_2_4_3",
+    "PI_3_VALID_MODES",
+    "PI_3_VALID_TARGETS",
+    "PromptInterventionRuntimeConfig",
+    "PromptInterventionSurfaces",
     "VALID_MODES",
     "is_surface_active",
     "load_policy_config_safely",
+    "load_prompt_intervention_config_safely",
     "parse_intent_policy_block",
+    "parse_prompt_intervention_block",
     "resolve_active_config_path",
 ]

--- a/tokenpak/proxy/intent_prompt_patch_telemetry.py
+++ b/tokenpak/proxy/intent_prompt_patch_telemetry.py
@@ -56,7 +56,11 @@ CREATE TABLE IF NOT EXISTS intent_patches (
     safety_flags          TEXT NOT NULL,    -- JSON array
     requires_confirmation INTEGER NOT NULL,
     applied               INTEGER NOT NULL,
-    source                TEXT NOT NULL
+    source                TEXT NOT NULL,
+    applied_at            TEXT,             -- PI-3: ISO-8601 when injection succeeded
+    applied_surface       TEXT,             -- PI-3: e.g. 'claude_code_companion'
+    application_mode      TEXT,             -- PI-3: 'inject_guidance' (PI-3 only mode)
+    application_id        TEXT              -- PI-3: opaque caller-side application token
 );
 CREATE INDEX IF NOT EXISTS idx_patches_suggestion
     ON intent_patches (suggestion_id);
@@ -66,7 +70,16 @@ CREATE INDEX IF NOT EXISTS idx_patches_mode
     ON intent_patches (mode, created_at);
 CREATE INDEX IF NOT EXISTS idx_patches_applied
     ON intent_patches (applied, created_at);
+CREATE INDEX IF NOT EXISTS idx_patches_applied_surface
+    ON intent_patches (applied_surface, applied_at);
 """
+
+_PI_3_ADDITIVE_COLUMNS = (
+    "applied_at",
+    "applied_surface",
+    "application_mode",
+    "application_id",
+)
 
 
 @dataclass
@@ -96,6 +109,18 @@ class IntentPatchStore:
             self._db_path.parent.mkdir(parents=True, exist_ok=True)
             conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
             conn.executescript(_INTENT_PATCHES_DDL)
+            # PI-3 additive migration: pre-PI-3 hosts have an
+            # intent_patches table without applied_at /
+            # applied_surface / application_mode / application_id.
+            # SQLite has no ADD COLUMN IF NOT EXISTS, so swallow
+            # the duplicate-column error per migration column.
+            for col in _PI_3_ADDITIVE_COLUMNS:
+                try:
+                    conn.execute(
+                        f"ALTER TABLE intent_patches ADD COLUMN {col} TEXT"
+                    )
+                except sqlite3.OperationalError:
+                    pass
             conn.commit()
             self._conn = conn
         return self._conn
@@ -141,6 +166,50 @@ class IntentPatchStore:
     def write_many(self, rows: Iterable[IntentPatchRow]) -> None:
         for r in rows:
             self.write(r)
+
+    def mark_applied(
+        self,
+        *,
+        patch_id: str,
+        applied_surface: str,
+        application_mode: str,
+        application_id: Optional[str],
+        applied_at: str,
+    ) -> bool:
+        """Flip ``applied = True`` and stamp PI-3 audit columns.
+
+        Returns ``True`` when exactly one row was updated. Returns
+        ``False`` on missing patch, already-applied patch, or any
+        SQLite error. Idempotent guard: refuses to flip a row that
+        is already ``applied = 1``.
+
+        PI-3 only — the only caller is
+        :func:`tokenpak.companion.intent_injection.apply_patch_to_companion_context`
+        on a successful insertion.
+        """
+        if not self._db_path.is_file():
+            return False
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                cur = conn.execute(
+                    "UPDATE intent_patches SET "
+                    "applied = 1, applied_at = ?, "
+                    "applied_surface = ?, application_mode = ?, "
+                    "application_id = ? "
+                    "WHERE patch_id = ? AND applied = 0",
+                    (
+                        applied_at,
+                        applied_surface,
+                        application_mode,
+                        application_id,
+                        patch_id,
+                    ),
+                )
+                conn.commit()
+                return cur.rowcount == 1
+        except sqlite3.DatabaseError:
+            return False
 
     def fetch_latest(self) -> Optional[dict[str, Any]]:
         """Return the most recent row as a dict, or ``None``."""


### PR DESCRIPTION
## Summary

PI-3 — **First approved phase** where TokenPak may apply PromptPatch guidance. Application is **companion-side only**, **explicitly opt-in**, and limited to `target = companion_context`.

**Default posture: disabled.** No prompt mutation happens unless the operator writes a `prompt_intervention` block in `~/.tokenpak/policy.yaml` and sets `surfaces.claude_code_companion: true` AND `require_confirmation: false`.

## Held throughout PI-3

- No proxy-level injection (`surfaces.proxy` force-clamped to `false`)
- No `user_message` rewriting (`target=user_message` rejected by loader + runtime)
- No `rewrite_prompt` mode (loader downgrades to `preview_only`)
- No routing changes (no dispatch primitives imported — structural test)
- No classifier changes (no `intent_classifier` touched — structural test)
- No provider/model switching (no `routing_service` imports — structural test)
- No TIP wire-header emission (capability set unchanged — structural test)
- No byte-preserve override (force-clamped + runtime defense-in-depth)
- No automatic confirmation-mode execution (`require_confirmation: true` refuses the auto-apply branch)
- No MCP auto-injection (companion library only)

## Schema migration

Additive ALTER TABLE for `intent_patches`:

| Column | Type | Purpose |
|---|---|---|
| `applied_at` | TEXT | UTC ISO-8601 when injection succeeded |
| `applied_surface` | TEXT | `claude_code_companion` |
| `application_mode` | TEXT | `inject_guidance` (PI-3 only mode) |
| `application_id` | TEXT | 16-hex caller-side application token |

Existing PI-1/PI-2 rows tolerate the migration (NULL columns).

## Application library

```python
from tokenpak.companion.intent_injection import (
    apply_patch_to_companion_context,
)
result = apply_patch_to_companion_context(
    patch_dict=patch,
    pi_config=cfg,
    existing_context=companion_context,
    store=store,
)
if result.success:
    companion_context = result.injected_context
```

Idempotent: second call returns `already_applied`. Returns one of 14 documented `reason` enums on failure.

## CLI extensions

```bash
tokenpak claude-code intent [--last] [--json]
tokenpak claude-code patches [--last] [--json]
```

- Operator-safety banner: \`Prompt intervention is disabled. Guidance is preview-only.\` (default) / \`Prompt intervention is enabled for Claude Code companion context only. User messages are preserved.\` (enabled)
- Audit columns rendered only when `applied = true`
- `APPLIED_LABELS` swap in for applied rows; PI-2's `PREVIEW_LABELS` still active for unapplied rows

## Forbidden wording — pre vs post

- `patch_text` continues to ban `Applied / Inserted / Injected / Mutated / Rewrote` (PI-1 builder enforces at write time)
- CLI surface renders those words **only** on rows where `applied=true` and `applied_surface=claude_code_companion`

Asserted in `tests/test_intent_prompt_intervention_phase_pi_3.py::TestForbiddenWordingBeforeApplication` + `::TestAppliedWordingAfterApplication`.

## Tests

32 new tests across 17 directive categories. Local suite: PI-1 (40) + PI-2 (24) + PI-3 (32) all green; pre-existing 4 failures in `test_first_request.py` / `test_ingest.py` confirmed identical on main (unrelated to PI-3).

## Test plan

- [x] \`pytest -q\` PI-1 + PI-2 + PI-3 — 96/96 green
- [x] \`ruff check tokenpak/ tests/\` clean
- [x] \`scripts/generate-cli-docs.py\` — in sync (no flag changes)
- [x] Structural test: companion library imports no routing primitives
- [x] Structural test: companion library imports no classifier primitives
- [x] Structural test: companion library does not emit TIP intent headers
- [x] Defense-in-depth: runtime refuses bypass even if config hand-built
- [x] Idempotency: second call returns already_applied
- [ ] CI green (17/17)

## Files

| Path | Purpose |
|---|---|
| `tokenpak/companion/intent_injection.py` | application library + ApplicationResult |
| `tokenpak/proxy/intent_policy_config_loader.py` | PromptInterventionRuntimeConfig + parser |
| `tokenpak/proxy/intent_prompt_patch_telemetry.py` | schema migration + mark_applied |
| `tokenpak/proxy/intent_claude_code_preview.py` | APPLIED_LABELS + audit-column projection |
| `tokenpak/cli/_impl.py` | audit columns + operator banner |
| `tests/test_intent_prompt_intervention_phase_pi_3.py` | 32 tests across 17 categories |
| `docs/reference/claude-code-intent-injection.md` | operator-facing doc |

## Cross-references

- `docs/reference/claude-code-intent-preview.md` — PI-2 read-only preview (predecessor)
- PR #59 (PI-2) — direct predecessor
- `docs/internal/specs/intent-prompt-intervention-spec-2026-04-26.md` — PI-0 unified spec

PI-4 (target=`system` + mode=`rewrite_prompt`) requires explicit Kevin approval before any code lands.