### PR TITLE
feat(ncp-1): Claude Code parity A/B test harness + operator protocol

### DIFF
--- a/docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md
+++ b/docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md
@@ -1,0 +1,363 @@
+# NCP-1 — Claude Code parity A/B test protocol
+
+**Date**: 2026-04-26
+**Status**: 🟡 **measurement-only** — no behavior changes proposed
+**Workstream**: NCP (Native Client Concurrency Parity)
+**Authors**: Sue (protocol) / Kevin (review)
+**Companion docs**:
+  - Standard proposal: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
+  - Diagnostic plan: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
+
+> **Goal:** settle hypotheses **H1 (cache prefix disruption)** and **H2 (session-id collapse)** from NCP-0 by running a side-by-side A/B test against the same Anthropic OAuth account, identical prompts, identical concurrency. Capture the 20-metric measurement contract from Standard #24 §3 (or mark unavailable with a documented reason). Produce a results report. **No code path is modified during the test run.**
+
+---
+
+## 0. Reading guide
+
+| § | Question |
+|---|---|
+| 1 | What hosts / accounts / tools are needed? |
+| 2 | Variant A — native Claude Code: how to capture |
+| 3 | Variant B — TokenPak-fronted: how to capture |
+| 4 | The 20-metric capture map (per metric: where to get it) |
+| 5 | Run order + timing |
+| 6 | Generating the diff report |
+| 7 | Results template (what to send back) |
+| 8 | Failure modes + reproducibility |
+| 9 | Out of scope |
+
+---
+
+## 1. Prerequisites
+
+| Item | Notes |
+|---|---|
+| Anthropic OAuth account | Same account for both variants. `~/.claude/.credentials.json` populated. |
+| `claude` CLI | Same version on both runs. Capture via `claude --version`. |
+| TokenPak | Built from `main` at or after PR #62 (NCP-0 closeout). `tokenpak --version` ≥ the version that includes commit `ccc1a3a259`. |
+| Optional: mitmproxy | For variant A. Used to capture upstream `Retry-After`, `anthropic-ratelimit-*` headers, and `usage` blocks on streaming responses. |
+| Telemetry DB | `~/.tokenpak/telemetry.db` — exists after first TokenPak invocation. The capture script reads from it. |
+| Disk | ~5 MB for two baselines + one diff report. |
+| Time | ~30 minutes for an unsaturated A/B. ~2–4 hours for a saturated A/B that triggers 429s. |
+
+**Test stage MUST be a clean shell session** (no leftover environment from prior runs). Set `TOKENPAK_HOME` to a fresh directory if you want to keep the parity telemetry separate from the operator's normal traffic:
+
+```bash
+export TOKENPAK_HOME=$HOME/.tokenpak-ncp1
+mkdir -p "$TOKENPAK_HOME"
+```
+
+---
+
+## 2. Variant A — native Claude Code (no TokenPak in path)
+
+The native CLI talks directly to `api.anthropic.com`. TokenPak is **not** in the path — its telemetry won't see this run. The operator captures observations out-of-band.
+
+### 2.1 Setup
+
+```bash
+unset ANTHROPIC_BASE_URL          # ensure no proxy redirect
+unset CLAUDE_BASE_URL
+which claude                      # verify the CLI binary
+claude --version                  # record the version
+```
+
+### 2.2 Two capture options
+
+#### Option A.1 — mitmproxy (recommended)
+
+```bash
+# In one terminal: start mitmproxy on 8080 with a recording log.
+mitmdump -p 8080 -w "$HOME/ncp1-native-$(date -u +%Y%m%dT%H%M%SZ).flow"
+
+# In another terminal: route the CLI through mitmproxy.
+export HTTPS_PROXY=http://localhost:8080
+export REQUESTS_CA_BUNDLE=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
+export SSL_CERT_FILE=$HOME/.mitmproxy/mitmproxy-ca-cert.pem
+claude  # run the workload (see §5)
+```
+
+Each captured request preserves: full headers (`Retry-After`, `anthropic-ratelimit-*`, `X-Claude-Code-Session-Id`), full response body (the `usage` block), wall-clock timing.
+
+After the run, post-process with a small jq / mitmproxy script (or by hand) to extract per-request: `session_id`, `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `Retry-After`, status code, latency.
+
+#### Option A.2 — `claude` CLI debug logging (lighter weight, less complete)
+
+```bash
+ANTHROPIC_LOG=debug claude  # workload
+```
+
+The CLI prints request + response logs to stderr. Capture to a file. **Note:** debug output may not include `usage` cache fields on streaming responses; mitmproxy is more reliable for cache-hit-ratio.
+
+### 2.3 Hand-fill the native baseline
+
+Use `scripts/capture_parity_baseline.py --label native` to seed an empty template, then hand-edit:
+
+```bash
+scripts/capture_parity_baseline.py \
+    --label native \
+    --window-days 1 \
+    --output tests/baselines/ncp-1-parity/native-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+Open the resulting JSON. For each metric in §4 you have data for, replace the `null` value. Leave metrics you couldn't capture as `null` — the diff script will flag them.
+
+The minimum fields to fill in for H1+H2 settling:
+
+- `metrics.cache_creation_tokens` (sum across the run)
+- `metrics.cache_read_tokens` (sum across the run)
+- `metrics.cache_hit_ratio` (= `cache_read_tokens / (cache_read_tokens + cache_creation_tokens)`)
+- `metrics.input_tokens`, `metrics.output_tokens`, `metrics.request_count`, `metrics.429_count` (for context)
+- `session.distinct_session_id_count` (count of distinct `X-Claude-Code-Session-Id` headers across the run)
+- `session.session_id_rotations_per_hour` (= `distinct_session_id_count / wall_clock_hours`)
+- `session.session_ids_truncated` (first 10 distinct ids — for sanity check that they're really different)
+
+---
+
+## 3. Variant B — TokenPak Companion Claude Code (proxy in path)
+
+The CLI talks to the local TokenPak proxy, which talks to `api.anthropic.com`. TokenPak telemetry sees every request; the capture script reads from `~/.tokenpak/telemetry.db`.
+
+### 3.1 Setup
+
+```bash
+# Start TokenPak (or verify it's already running).
+tokenpak serve &        # or however the operator normally starts it
+sleep 2
+curl -s http://127.0.0.1:8765/healthz   # sanity check
+
+# Point the CLI at TokenPak.
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8765
+unset HTTPS_PROXY                       # don't double-proxy
+claude                                  # run the workload (see §5)
+```
+
+### 3.2 Capture from telemetry.db
+
+After the run completes, run the capture script:
+
+```bash
+scripts/capture_parity_baseline.py \
+    --label tokenpak \
+    --window-days 1 \
+    --output tests/baselines/ncp-1-parity/tokenpak-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+Inspect the JSON. Metrics that are unavailable have a sibling `_unavailable` entry explaining why.
+
+---
+
+## 4. The 20-metric capture map
+
+This table maps each Standard #24 §3 metric to (a) where the operator captures it, (b) what to do if unavailable. Every row marked **AUTO** is filled in by `capture_parity_baseline.py` from existing telemetry. Every row marked **MANUAL** must be hand-filled or skipped.
+
+| # | Metric | Variant A (native) | Variant B (tokenpak) | Notes |
+|---|---|---|---|---|
+| 1 | `request_count` | MANUAL — count requests in mitmproxy log | AUTO — `tp_events` row count | — |
+| 2 | `retry_count` | MANUAL — count retried requests in mitmproxy | AUTO — `tp_events.error_class='retry'` (lower bound; current schema doesn't tag every retry) | NCP-1 limitation: TokenPak retry bookkeeping is incomplete; treat as lower bound |
+| 3 | `429_count` | MANUAL — count `429 Too Many Requests` in mitmproxy | AUTO — `tp_events.status='429'` | — |
+| 4 | `5xx_count` | MANUAL — count 500–599 in mitmproxy | AUTO — `tp_events.status` filter | — |
+| 5 | `latency_ms` (p50 / p95 / p99) | MANUAL — request timing in mitmproxy | AUTO — `tp_events.duration_ms` percentiles | — |
+| 6 | `time_to_first_token_ms` | MANUAL — first SSE chunk timestamp - request send timestamp | UNAVAILABLE — proxy stream layer doesn't record TTFT | NCP-1+ instrumentation phase will fix |
+| 7 | `input_tokens` | MANUAL — sum of `usage.input_tokens` from response bodies | AUTO — `tp_usage.input_billed` (or `input_est`) | — |
+| 8 | `output_tokens` | MANUAL — sum of `usage.output_tokens` | AUTO — `tp_usage.output_billed` | — |
+| 9 | `cache_creation_tokens` | MANUAL — sum of `usage.cache_creation_input_tokens` | AUTO — `tp_usage.cache_write` | **H1 critical** |
+| 10 | `cache_read_tokens` | MANUAL — sum of `usage.cache_read_input_tokens` | AUTO — `tp_usage.cache_read` | **H1 critical** |
+| 11 | `companion_added_chars` | N/A (no companion in path) | UNAVAILABLE — pre-send hook doesn't log additionalContext length | Set to `null` for both variants in NCP-1; capture in NCP-1+ instrumentation |
+| 12 | `companion_added_tokens_est` | N/A | UNAVAILABLE — derived from #11 | Same as #11 |
+| 13 | `vault_injection_chars` | N/A | UNAVAILABLE — vault retrieval doesn't log result-set length | Set to `null` for both; instrument in NCP-1+ |
+| 14 | `capsule_injection_chars` | N/A | UNAVAILABLE — capsule loader doesn't log loaded-bytes | Same |
+| 15 | `intent_guidance_chars` | N/A | AUTO — `intent_patches.patch_text` length (when PI-3 applied) | — |
+| 16 | `hook_triggered_calls` | N/A | UNAVAILABLE — companion hook dispatcher doesn't emit count | Logically zero by H8 |
+| 17 | `extra_background_calls` | N/A | AUTO = 0 (H8 ruled out) | — |
+| 18 | `retry_after_seconds` (per 429) | MANUAL — `Retry-After` header on 429 responses in mitmproxy | UNAVAILABLE — proxy doesn't parse `Retry-After` (H4) | NCP-5 will fix; capture native side via mitmproxy for H4 evidence |
+| 19 | `ratelimit_tokens_remaining` | MANUAL — `anthropic-ratelimit-tokens-remaining` from mitmproxy | UNAVAILABLE — proxy doesn't capture rate-limit headers | — |
+| 20 | `ratelimit_requests_remaining` | MANUAL — `anthropic-ratelimit-requests-remaining` from mitmproxy | UNAVAILABLE — same | — |
+
+### Session-block metrics
+
+| # | Metric | Variant A | Variant B | Notes |
+|---|---|---|---|---|
+| S1 | `distinct_session_id_count` | MANUAL — count distinct `X-Claude-Code-Session-Id` in mitmproxy | AUTO — `SELECT COUNT(DISTINCT session_id) FROM tp_events` | **H2 critical** |
+| S2 | `session_id_rotations_per_hour` | MANUAL — `distinct_session_id_count / wall_clock_hours` | AUTO — same formula | **H2 critical** |
+| S3 | `session_ids_truncated` (first 10) | MANUAL — copy from mitmproxy | AUTO — first 10 distinct ids | — |
+
+The H1 verdict is computed from #9 + #10. The H2 verdict is computed from S1 + S2. Both can be settled with the MANUAL-marked subset above; the `UNAVAILABLE` rows are useful but not required for NCP-1.
+
+---
+
+## 5. Run order + timing
+
+### 5.1 Quick (cache hit ratio test, settles H1)
+
+**Goal:** measure cache hit ratio with identical prompt sequences.
+
+**Workload:** 10 sequential identical prompts, single session, no concurrency. Total: ~3 minutes.
+
+1. **Native run.** `unset ANTHROPIC_BASE_URL` + start mitmproxy + `claude` + run the prompt sequence. Stop mitmproxy.
+2. **TokenPak run.** Start TokenPak proxy + `export ANTHROPIC_BASE_URL=http://127.0.0.1:8765` + `claude` + run the same prompt sequence. Stop the CLI.
+3. Wait 60 seconds (let TokenPak telemetry flush).
+4. Run both `capture_parity_baseline.py` invocations.
+5. Hand-fill the native JSON (see §2.3).
+6. Run `diff_parity_baselines.py`.
+
+### 5.2 Saturated (settles H2)
+
+**Goal:** measure 429 onset under N concurrent sessions.
+
+**Workload:** N parallel CLIs, each looping identical prompts every 5 seconds for 10 minutes. Recommended N: start with 5; if no 429s fire, double to 10.
+
+1. **Native:** spawn N parallel `claude` CLIs (each its own process, no shared session-id). Capture all via mitmproxy. Record the request count when the first 429 fires per CLI.
+2. **TokenPak:** spawn N parallel `claude` CLIs all pointed at the same TokenPak proxy. The proxy synthesizes one shared `X-Claude-Code-Session-Id`. Record total 429 count.
+3. Capture both baselines as in §5.1.
+4. Run the diff script.
+
+The H2 verdict surfaces as: "TokenPak's `session_id_rotations_per_hour` is < `1/H2_SESSION_ROTATION_RATIO_THRESHOLD` of native's" (default threshold ratio: 3×).
+
+### 5.3 Order matters — but cache state, not bucket state
+
+Run native FIRST, TokenPak SECOND when comparing cache hit ratio (so neither variant has a 'warmed up' cache from the other). For the saturated H2 test, run them with at least 1 hour of recovery time between (Anthropic's rate-limit windows reset on a sliding hourly basis).
+
+---
+
+## 6. Generating the diff report
+
+```bash
+scripts/diff_parity_baselines.py \
+    --native tests/baselines/ncp-1-parity/native-<TIMESTAMP>.json \
+    --tokenpak tests/baselines/ncp-1-parity/tokenpak-<TIMESTAMP>.json \
+    --output tests/baselines/ncp-1-parity/results-<TIMESTAMP>.md
+```
+
+The script emits a markdown report (or `--json` for the raw verdict). Every verdict is one of:
+
+- `supported` — the data clears the threshold (H1: cache_hit delta ≥ 0.30; H2: rotation ratio ≥ 3×)
+- `not_supported` — the data is within parity
+- `inconclusive` — at least one side has missing data (the diff script tells you which)
+
+The synthesis maps the (H1, H2) pair to a dominant cause:
+
+| H1 | H2 | Dominant cause | Confidence | NCP-x fix |
+|---|---|---|---|---|
+| supported | supported | H1+H2 both | high | NCP-2 (cache) + NCP-3 (session) |
+| supported | not_supported | H1 only | high | NCP-2 (cache) |
+| not_supported | supported | H2 only | high | NCP-3 (session) |
+| not_supported | not_supported | neither | medium | re-run with H3/H4 evidence |
+| any inconclusive | any | inconclusive | low | fill gap, re-run |
+
+---
+
+## 7. Results template
+
+Send this back to the workstream for NCP-2 ratification. Keep it short.
+
+```markdown
+# NCP-1 results — <YYYY-MM-DD>
+
+**Operator**: <name>
+**Anthropic account**: <account-handle>
+**TokenPak version**: <output of tokenpak --version>
+**Claude CLI version**: <output of claude --version>
+**Workload**: <one of: §5.1 quick / §5.2 saturated / custom>
+**Wall-clock window**: <ISO-8601 start> → <ISO-8601 end>
+
+## Verdicts
+
+- **H1 (cache prefix disruption)**: <supported | not_supported | inconclusive>
+  - native cache_hit_ratio: <0.0–1.0>
+  - tokenpak cache_hit_ratio: <0.0–1.0>
+  - delta: <number>
+- **H2 (session-id collapse)**: <supported | not_supported | inconclusive>
+  - native session_id_rotations_per_hour: <number>
+  - tokenpak session_id_rotations_per_hour: <number>
+  - ratio: <number>×
+
+## Dominant cause
+
+<copy-paste from the diff script's "Synthesis" block>
+
+## Confidence
+
+<copy-paste — high / medium / low>
+
+## Recommended NCP-2 / NCP-3 fix direction
+
+<copy-paste from the diff script's "Recommended next step" block>
+
+## Out-of-band observations
+
+<free-form: any anomalies the operator noticed during the run that
+the metrics don't capture — e.g. "request 47 of native run hit a
+500 from Anthropic; not counted in tokenpak side because TokenPak
+wasn't in the path">
+
+## Attached files
+
+- `tests/baselines/ncp-1-parity/native-<TIMESTAMP>.json`
+- `tests/baselines/ncp-1-parity/tokenpak-<TIMESTAMP>.json`
+- `tests/baselines/ncp-1-parity/results-<TIMESTAMP>.md`
+- (optional) raw mitmproxy capture file
+```
+
+---
+
+## 8. Failure modes + reproducibility
+
+### 8.1 Common gotchas
+
+- **`HTTPS_PROXY` left set across runs.** Set it for variant A, **unset** for variant B. The TokenPak proxy is reached via `ANTHROPIC_BASE_URL`, not `HTTPS_PROXY`.
+- **mitmproxy CA cert not installed.** Symptom: SSL handshake errors from the CLI. Run `mitmproxy --version` once to generate the CA, then point `REQUESTS_CA_BUNDLE` + `SSL_CERT_FILE` at it.
+- **Telemetry from prior runs polluting the window.** Use `--window-days <small>` to scope, or set a fresh `TOKENPAK_HOME` for the test.
+- **CLI session-id stability.** The `claude` CLI emits a new `X-Claude-Code-Session-Id` on every invocation. Native variant: kill + restart the CLI between sub-runs to force rotation. TokenPak variant: the proxy collapses to one id regardless.
+- **Anthropic rate-limit window.** If you hit a 429 in variant A, **wait an hour** before starting variant B, or the tokenpak side will be measuring against a depleted bucket.
+
+### 8.2 Reproducibility
+
+The protocol is reproducible when:
+
+- The two `*.json` baselines + the diff `*.md` are checked into `tests/baselines/ncp-1-parity/`.
+- The operator's command history is captured (e.g. `script(1)` recorded the shell session).
+- The workload script (the prompt sequence) is captured in the results.
+- The TokenPak version + Claude CLI version are pinned in the results.
+
+A second operator running the same workload with the same TokenPak / Claude versions should reach the same H1 / H2 verdicts (within the threshold's noise floor).
+
+---
+
+## 9. Out of scope for NCP-1
+
+- ❌ Implementing measurement instrumentation (NCP-1+ instrumentation phase). The directive says: capture or mark unavailable. NCP-1 marks 8 of 20 metrics unavailable.
+- ❌ Changing companion behavior (vault / capsule / intent injection unchanged).
+- ❌ Changing proxy behavior (failover, connection pool, retry, credential injection unchanged).
+- ❌ Changing session-id behavior (NCP-3 fix; NOT in NCP-1).
+- ❌ Changing cache placement (NCP-2 fix; NOT in NCP-1).
+- ❌ Implementing `tokenpak doctor --parity` CLI (NCP-1+ instrumentation phase).
+- ❌ Other interactive clients (Codex, Cursor) — the standard generalizes; the protocol is Claude Code only.
+
+NCP-1 is **strictly observational + operator-run.** No code path changes.
+
+---
+
+## 10. Cross-references
+
+- `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md` — the standard proposal whose §3 measurement contract this protocol exercises
+- `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md` — the diagnostic plan, including §5 A/B test methodology that this protocol concretizes
+- `scripts/capture_parity_baseline.py` — capture script
+- `scripts/diff_parity_baselines.py` — diff script
+- `tests/test_ncp1_parity_baseline.py` — unit tests for both scripts
+
+---
+
+## 11. Acceptance criteria
+
+NCP-1 is **complete** when:
+
+- [x] The capture script exists and reads existing telemetry without modifying it.
+- [x] The diff script exists and produces a results report from two baselines.
+- [x] The 20-metric measurement contract is enumerated; available metrics auto-fill from telemetry; unavailable metrics carry a documented reason.
+- [x] The protocol doc enumerates how to capture each metric for each variant.
+- [x] A results template exists.
+- [x] No runtime / classifier / routing / retry / cache-placement / session-id behavior changes.
+- [ ] CI green on the closeout PR.
+
+After NCP-1 is closed, the next step is the **operator running the §5.1 + §5.2 tests** and submitting the §7 results template. NCP-2 / NCP-3 implementation does not begin until those results are in.

--- a/docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md
+++ b/docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md
@@ -1,13 +1,15 @@
 # Standard #24 (proposal) — Native Client Concurrency Parity
 
-**Status**: 🟡 **proposal** — awaiting Kevin ratification
+**Status**: 🟡 **ratified in principle (2026-04-26)** — promotion to vault gated on NCP-1 data
 **Date**: 2026-04-26
 **Workstream**: NCP (Native Client Concurrency Parity) diagnostic
 **Authors**: Sue (draft) / Kevin (review)
-**Canonical home (when ratified)**: `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/24-native-client-concurrency-parity-standard.md`
-**Companion diagnostic plan**: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
+**Canonical home (when promoted)**: `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/24-native-client-concurrency-parity-standard.md`
+**Companion docs**:
+  - Diagnostic plan: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
+  - A/B test protocol: `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md`
 
-> This is a **proposal**. Until ratified, no code path is required to honour it. Once ratified, the standard is promoted to the vault and binds every TokenPak surface that fronts an interactive client (Claude Code, Codex, Cursor, etc.).
+> Kevin **ratified the five invariants and the fail-safe contract in principle on 2026-04-26**. Promotion to the canonical vault location is gated on NCP-1 data either confirming or adjusting the measurement thresholds (specifically the H1 cache-hit-delta threshold and H2 session-id rotation-ratio threshold). Until promoted, no code path is required to honour the standard, but the invariants ARE the design contract for any NCP-x implementation work.
 
 ---
 

--- a/scripts/capture_parity_baseline.py
+++ b/scripts/capture_parity_baseline.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-1 — capture a parity baseline from existing TokenPak telemetry.
+
+Read-only over ``~/.tokenpak/telemetry.db`` (or
+``$TOKENPAK_HOME/telemetry.db``) — joins ``tp_events`` + ``tp_usage``
++ ``intent_patches`` and projects the 20-metric measurement contract
+from Standard Proposal #24 §3.
+
+This script makes **no runtime behavior changes**. It only reads
+existing telemetry rows and emits a JSON snapshot. For metrics that
+the current telemetry layer does not capture, the snapshot uses
+``null`` and a sibling ``_unavailable`` field explains why and
+where the operator should capture the metric out-of-band (e.g. via
+mitmproxy on the native side).
+
+Usage:
+
+    scripts/capture_parity_baseline.py \\
+        --label tokenpak \\
+        --window-days 1 \\
+        --output tests/baselines/ncp-1-parity/tokenpak-2026-04-26.json
+
+For the native-side baseline, the operator records observations
+manually (see the NCP-1 A/B test protocol doc) and either:
+
+  - hand-edits a JSON file matching the same schema, or
+  - runs this script with ``--label native --from-stdin`` and pipes
+    in the raw observation summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# 20-metric schema from Standard #24 §3.
+SCHEMA_VERSION: str = "ncp-1-v1"
+METRIC_KEYS: tuple = (
+    "request_count",
+    "retry_count",
+    "429_count",
+    "5xx_count",
+    "latency_ms",
+    "time_to_first_token_ms",
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_tokens",
+    "cache_read_tokens",
+    "companion_added_chars",
+    "companion_added_tokens_est",
+    "vault_injection_chars",
+    "capsule_injection_chars",
+    "intent_guidance_chars",
+    "hook_triggered_calls",
+    "extra_background_calls",
+    "retry_after_seconds",
+    "ratelimit_tokens_remaining",
+    "ratelimit_requests_remaining",
+)
+
+# What's available in the current telemetry vs what is unavailable
+# (and why). This map is the single source of truth for the
+# capture-or-mark-unavailable rule from the directive.
+UNAVAILABLE_REASONS: Dict[str, str] = {
+    "time_to_first_token_ms": (
+        "not yet instrumented (proxy stream layer does not record TTFT). "
+        "NCP-1 captures p50/p95 latency_ms only; TTFT lands in NCP-1+ "
+        "instrumentation phase."
+    ),
+    "companion_added_chars": (
+        "companion pre-send hook does not log additionalContext length. "
+        "Capture out-of-band via TOKENPAK_COMPANION_TRACE_DIR=<path> in "
+        "the operator environment, or settle H3 via §5.3 of the "
+        "diagnostic plan."
+    ),
+    "companion_added_tokens_est": (
+        "derived from companion_added_chars / 4; unavailable while "
+        "companion_added_chars is unavailable."
+    ),
+    "vault_injection_chars": (
+        "vault retrieval does not currently log result-set length. "
+        "Capture out-of-band via TOKENPAK_VAULT_DEBUG=1."
+    ),
+    "capsule_injection_chars": (
+        "capsule loader does not currently log loaded-bytes. Capture "
+        "out-of-band via TOKENPAK_COMPANION_TRACE_DIR."
+    ),
+    "hook_triggered_calls": (
+        "companion hook dispatcher does not yet emit a count. Per H8 "
+        "(NCP-0 diagnostic), the companion makes zero upstream model "
+        "calls — this metric is logically zero for NCP-1 settling."
+    ),
+    "extra_background_calls": (
+        "per H8 (NCP-0 diagnostic, ruled out), the companion makes "
+        "zero non-user-initiated upstream calls. Reported as 0 with "
+        "a confidence flag."
+    ),
+    "retry_after_seconds": (
+        "proxy does not currently parse the upstream Retry-After "
+        "header (per H4, NCP-0 diagnostic §1.1). Capture out-of-band "
+        "via mitmproxy until NCP-5 lands."
+    ),
+    "ratelimit_tokens_remaining": (
+        "proxy does not currently capture anthropic-ratelimit-tokens-"
+        "remaining. Capture out-of-band via mitmproxy or Anthropic "
+        "console rate-limit dashboard."
+    ),
+    "ratelimit_requests_remaining": (
+        "proxy does not currently capture anthropic-ratelimit-requests-"
+        "remaining. Capture out-of-band via mitmproxy."
+    ),
+}
+
+
+def _telemetry_db_path() -> Path:
+    home = os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak"))
+    return Path(home) / "telemetry.db"
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _percentiles(values: List[float], pct: List[int]) -> Dict[int, Optional[float]]:
+    if not values:
+        return {p: None for p in pct}
+    s = sorted(values)
+    out: Dict[int, Optional[float]] = {}
+    for p in pct:
+        if p < 0 or p > 100:
+            out[p] = None
+            continue
+        idx = max(0, min(len(s) - 1, int(round((p / 100.0) * (len(s) - 1)))))
+        out[p] = s[idx]
+    return out
+
+
+def _fetch_events(
+    conn: sqlite3.Connection, since_iso: str
+) -> List[sqlite3.Row]:
+    """Pull tp_events rows in the window. Empty list if table missing."""
+    if not _table_exists(conn, "tp_events"):
+        return []
+    conn.row_factory = sqlite3.Row
+    return conn.execute(
+        "SELECT request_id, trace_id, ts, provider, model, agent_id, "
+        "api, stop_reason, session_id, duration_ms, status, error_class, "
+        "route FROM tp_events WHERE ts >= ? ORDER BY ts",
+        (since_iso,),
+    ).fetchall()
+
+
+def _fetch_usage_for_traces(
+    conn: sqlite3.Connection, trace_ids: List[str]
+) -> Dict[str, sqlite3.Row]:
+    if not _table_exists(conn, "tp_usage") or not trace_ids:
+        return {}
+    conn.row_factory = sqlite3.Row
+    out: Dict[str, sqlite3.Row] = {}
+    # SQLite parameter limit: chunk in 500s.
+    for i in range(0, len(trace_ids), 500):
+        batch = trace_ids[i : i + 500]
+        placeholders = ",".join("?" for _ in batch)
+        rows = conn.execute(
+            f"SELECT trace_id, input_billed, output_billed, input_est, "
+            f"output_est, cache_read, cache_write, total_tokens "
+            f"FROM tp_usage WHERE trace_id IN ({placeholders})",
+            batch,
+        ).fetchall()
+        for r in rows:
+            out[r["trace_id"]] = r
+    return out
+
+
+def _fetch_intent_patch_chars(
+    conn: sqlite3.Connection, since_iso: str
+) -> Dict[str, int]:
+    """Map contract_id → patch_text length for applied PI-3 patches."""
+    if not _table_exists(conn, "intent_patches"):
+        return {}
+    rows = conn.execute(
+        "SELECT contract_id, patch_text, applied, applied_at "
+        "FROM intent_patches WHERE created_at >= ?",
+        (since_iso,),
+    ).fetchall()
+    out: Dict[str, int] = {}
+    for r in rows:
+        cid = r[0]
+        text = r[1] or ""
+        if cid:
+            out[cid] = max(out.get(cid, 0), len(text))
+    return out
+
+
+def _claude_code_filter(events: List[sqlite3.Row]) -> List[sqlite3.Row]:
+    """Filter events to Claude Code traffic only.
+
+    Detects via provider slug substring or route metadata. Falls
+    back to all events if no Claude-Code-shaped row is detectable
+    (so the snapshot still has data points).
+    """
+    cc = []
+    other = []
+    for e in events:
+        provider = (e["provider"] or "").lower()
+        route = (e["route"] or "").lower()
+        if (
+            "claude-code" in provider
+            or "claude_code" in provider
+            or "claude-code" in route
+            or "claude_code" in route
+        ):
+            cc.append(e)
+        else:
+            other.append(e)
+    if cc:
+        return cc
+    return events  # fall back to all rows
+
+
+def _bucket(value: Any, default: Any = None) -> Any:
+    """Coerce DB row value to JSON-serializable. None stays None."""
+    if value is None:
+        return default
+    return value
+
+
+def _build_metric_block(
+    *,
+    label: str,
+    window_days: float,
+    since_iso: str,
+    until_iso: str,
+    events: List[sqlite3.Row],
+    usage: Dict[str, sqlite3.Row],
+) -> Dict[str, Any]:
+    """Project the 20 metrics + percentile blocks from telemetry rows."""
+    request_count = len(events)
+
+    status_counter: Counter = Counter()
+    latencies: List[float] = []
+    session_ids: List[str] = []
+    retry_count = 0
+    for e in events:
+        status = e["status"]
+        if status is not None:
+            try:
+                code = int(status)
+                status_counter[code] += 1
+            except (TypeError, ValueError):
+                status_counter[str(status)] += 1
+        if e["duration_ms"] is not None:
+            try:
+                latencies.append(float(e["duration_ms"]))
+            except (TypeError, ValueError):
+                pass
+        if e["session_id"]:
+            session_ids.append(e["session_id"])
+        # The current schema doesn't have a dedicated retry column;
+        # we approximate by counting events flagged with the
+        # ``retry`` event_type — but tp_events.event_type isn't
+        # universally populated for retries, so this is a lower
+        # bound.
+        if (e["error_class"] or "").lower() == "retry":
+            retry_count += 1
+
+    count_429 = status_counter.get(429, 0)
+    count_5xx = sum(v for k, v in status_counter.items() if isinstance(k, int) and 500 <= k < 600)
+
+    input_tokens = 0
+    output_tokens = 0
+    cache_creation_tokens = 0
+    cache_read_tokens = 0
+    for e in events:
+        u = usage.get(e["trace_id"])
+        if u is None:
+            continue
+        input_tokens += int(u["input_billed"] or u["input_est"] or 0)
+        output_tokens += int(u["output_billed"] or u["output_est"] or 0)
+        cache_creation_tokens += int(u["cache_write"] or 0)
+        cache_read_tokens += int(u["cache_read"] or 0)
+
+    # Cache hit ratio is the H1 settling metric; surface it
+    # explicitly so the diff script can read it without re-deriving.
+    cache_total = cache_read_tokens + cache_creation_tokens
+    cache_hit_ratio = (
+        round(cache_read_tokens / cache_total, 4) if cache_total > 0 else None
+    )
+
+    distinct_sessions = sorted(set(session_ids))
+    rotations_per_hour = (
+        round(len(distinct_sessions) / max(0.001, window_days * 24.0), 4)
+        if distinct_sessions
+        else 0.0
+    )
+
+    pct = _percentiles(latencies, [50, 95, 99])
+
+    out: Dict[str, Any] = {
+        "label": label,
+        "window_days": window_days,
+        "window_start": since_iso,
+        "window_end": until_iso,
+        "metrics": {
+            "request_count": request_count,
+            "retry_count": retry_count,
+            "429_count": count_429,
+            "5xx_count": count_5xx,
+            "latency_ms": {
+                "p50": pct[50],
+                "p95": pct[95],
+                "p99": pct[99],
+            },
+            "time_to_first_token_ms": None,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_tokens": cache_creation_tokens,
+            "cache_read_tokens": cache_read_tokens,
+            "cache_hit_ratio": cache_hit_ratio,
+            "companion_added_chars": None,
+            "companion_added_tokens_est": None,
+            "vault_injection_chars": None,
+            "capsule_injection_chars": None,
+            "intent_guidance_chars": None,  # filled below if patches exist
+            "hook_triggered_calls": None,
+            "extra_background_calls": 0,  # H8 ruled out — companion makes no extra calls
+            "retry_after_seconds": None,
+            "ratelimit_tokens_remaining": None,
+            "ratelimit_requests_remaining": None,
+        },
+        "session": {
+            "distinct_session_id_count": len(distinct_sessions),
+            "session_id_rotations_per_hour": rotations_per_hour,
+            "first_session_id": distinct_sessions[0] if distinct_sessions else None,
+            "session_ids_truncated": (
+                # Don't dump unbounded session-id lists into the
+                # baseline; first 10 is enough for H2 settling.
+                distinct_sessions[:10]
+            ),
+        },
+        "_unavailable": {
+            k: v
+            for k, v in UNAVAILABLE_REASONS.items()
+            if out_get(k) is None
+        }
+        if False
+        else dict(UNAVAILABLE_REASONS),  # always include for transparency
+    }
+    return out
+
+
+def out_get(_: str) -> None:
+    """Stub — UNAVAILABLE_REASONS is always emitted for transparency."""
+    return None
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Capture an NCP-1 parity baseline from "
+        "TokenPak telemetry.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--label",
+        required=True,
+        choices=("native", "tokenpak"),
+        help="Variant label: native (no proxy) or tokenpak (through proxy).",
+    )
+    p.add_argument(
+        "--window-days",
+        type=float,
+        default=1.0,
+        help="Lookback window in days. 0 = all rows. Default 1.0.",
+    )
+    p.add_argument(
+        "--db-path",
+        default=None,
+        help="Override telemetry.db path. Default: $TOKENPAK_HOME/telemetry.db.",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Write the JSON baseline to this file.",
+    )
+    p.add_argument(
+        "--note",
+        default="",
+        help="Free-form note to attach to the baseline (e.g. 'native, "
+        "captured via mitmproxy 2026-04-26').",
+    )
+    args = p.parse_args(argv)
+
+    db_path = Path(args.db_path) if args.db_path else _telemetry_db_path()
+    now = _dt.datetime.now(_dt.timezone.utc)
+    if args.window_days <= 0:
+        since = _dt.datetime(1970, 1, 1, tzinfo=_dt.timezone.utc)
+    else:
+        since = now - _dt.timedelta(days=args.window_days)
+    since_iso = since.isoformat()
+    until_iso = now.isoformat()
+
+    if args.label == "native":
+        # Native-side baselines cannot be captured from TokenPak's
+        # telemetry (TokenPak isn't in the path). Operator should
+        # hand-edit the output JSON, or pipe in observations from
+        # a mitmproxy capture.
+        baseline = {
+            "schema_version": SCHEMA_VERSION,
+            "captured_at": until_iso,
+            "label": "native",
+            "window_days": args.window_days,
+            "window_start": since_iso,
+            "window_end": until_iso,
+            "metrics": {k: None for k in METRIC_KEYS},
+            "session": {
+                "distinct_session_id_count": None,
+                "session_id_rotations_per_hour": None,
+                "first_session_id": None,
+                "session_ids_truncated": [],
+            },
+            "_unavailable": {
+                k: "native baseline must be captured out-of-band per "
+                "the NCP-1 A/B test protocol; this template is empty"
+                for k in METRIC_KEYS
+            },
+            "note": args.note
+            or (
+                "Empty native template — operator must fill in via "
+                "mitmproxy / Anthropic-CLI debug logs / Anthropic "
+                "console. See docs/internal/specs/ncp-1-ab-test-"
+                "protocol-2026-04-26.md."
+            ),
+        }
+    else:
+        if not db_path.is_file():
+            print(
+                f"error: telemetry.db not found at {db_path}. "
+                f"Run TokenPak in normal use for the window first.",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            with sqlite3.connect(str(db_path)) as conn:
+                events = _fetch_events(conn, since_iso)
+                events_cc = _claude_code_filter(events)
+                trace_ids = [e["trace_id"] for e in events_cc if e["trace_id"]]
+                usage = _fetch_usage_for_traces(conn, trace_ids)
+
+                metric_block = _build_metric_block(
+                    label=args.label,
+                    window_days=args.window_days,
+                    since_iso=since_iso,
+                    until_iso=until_iso,
+                    events=events_cc,
+                    usage=usage,
+                )
+
+                # PI-3 intent patches — project as
+                # intent_guidance_chars (max patch_text length per
+                # contract).
+                patches = _fetch_intent_patch_chars(conn, since_iso)
+                if patches:
+                    metric_block["metrics"]["intent_guidance_chars"] = max(
+                        patches.values()
+                    )
+        except sqlite3.DatabaseError as exc:
+            print(
+                f"error: telemetry.db unreadable: {exc!r}", file=sys.stderr
+            )
+            return 2
+
+        baseline = {
+            "schema_version": SCHEMA_VERSION,
+            "captured_at": until_iso,
+            "label": args.label,
+            **metric_block,
+            "note": args.note,
+        }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(baseline, indent=2, sort_keys=True))
+    print(f"wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diff_parity_baselines.py
+++ b/scripts/diff_parity_baselines.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-1 — diff two parity baselines and settle H1 / H2.
+
+Reads ``native`` and ``tokenpak`` JSON baselines (as produced by
+``capture_parity_baseline.py``) and emits a results report. The
+report follows the directive's results template:
+
+  - H1 supported / not supported
+  - H2 supported / not supported
+  - dominant cause
+  - confidence level
+  - recommended NCP-2 fix direction
+
+This script makes **no runtime behavior changes**. It is purely a
+read-only analytical tool over already-captured baselines.
+
+Usage:
+
+    scripts/diff_parity_baselines.py \\
+        --native tests/baselines/ncp-1-parity/native-2026-04-26.json \\
+        --tokenpak tests/baselines/ncp-1-parity/tokenpak-2026-04-26.json \\
+        [--json] [--output FILE]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Thresholds for H1 / H2 verdict — calibrated against Standard #24
+# §4 fail-safe contract. Documented here so a future NCP-1 run can
+# tighten or relax them with a one-line edit.
+H1_CACHE_HIT_DELTA_THRESHOLD: float = 0.30
+"""If TokenPak's cache_hit_ratio is ``H1_CACHE_HIT_DELTA_THRESHOLD``
+(absolute) below the native ratio, H1 is "supported"."""
+
+H2_SESSION_ROTATION_RATIO_THRESHOLD: float = 3.0
+"""If native's session_id_rotations_per_hour is at least
+``H2_SESSION_ROTATION_RATIO_THRESHOLD`` × the TokenPak rotation rate,
+H2 is "supported"."""
+
+H2_SESSION_COUNT_RATIO_THRESHOLD: float = 3.0
+"""Same idea applied to distinct_session_id_count when the rotation
+rate is unavailable."""
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _load(path: Path) -> Dict[str, Any]:
+    if not path.is_file():
+        raise SystemExit(f"error: baseline not found: {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"error: baseline is not valid JSON ({path}): {exc}")
+
+
+def _pct(num: Optional[float], denom: Optional[float]) -> Optional[float]:
+    if num is None or denom is None or denom == 0:
+        return None
+    return round(num / denom, 4)
+
+
+def _safe_get(d: Dict[str, Any], *keys: str) -> Any:
+    cur: Any = d
+    for k in keys:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(k)
+    return cur
+
+
+# ── H1 — cache prefix disruption ───────────────────────────────────────
+
+
+def _evaluate_h1(
+    native: Dict[str, Any], tokenpak: Dict[str, Any]
+) -> Dict[str, Any]:
+    nat_ratio = _safe_get(native, "metrics", "cache_hit_ratio")
+    tok_ratio = _safe_get(tokenpak, "metrics", "cache_hit_ratio")
+
+    nat_creation = _safe_get(native, "metrics", "cache_creation_tokens")
+    nat_read = _safe_get(native, "metrics", "cache_read_tokens")
+    tok_creation = _safe_get(tokenpak, "metrics", "cache_creation_tokens")
+    tok_read = _safe_get(tokenpak, "metrics", "cache_read_tokens")
+
+    if nat_ratio is None or tok_ratio is None:
+        return {
+            "verdict": "inconclusive",
+            "reason": "cache_hit_ratio unavailable on at least one side; "
+            "see _unavailable section of the missing baseline. Fill in "
+            "and rerun.",
+            "native_cache_hit_ratio": nat_ratio,
+            "tokenpak_cache_hit_ratio": tok_ratio,
+            "native_cache_creation_tokens": nat_creation,
+            "native_cache_read_tokens": nat_read,
+            "tokenpak_cache_creation_tokens": tok_creation,
+            "tokenpak_cache_read_tokens": tok_read,
+        }
+
+    delta = nat_ratio - tok_ratio
+    supported = delta >= H1_CACHE_HIT_DELTA_THRESHOLD
+    return {
+        "verdict": "supported" if supported else "not_supported",
+        "reason": (
+            f"native cache_hit_ratio={nat_ratio:.4f}, tokenpak={tok_ratio:.4f}, "
+            f"delta={delta:.4f} "
+            f"({'≥' if supported else '<'} {H1_CACHE_HIT_DELTA_THRESHOLD} threshold)"
+        ),
+        "native_cache_hit_ratio": nat_ratio,
+        "tokenpak_cache_hit_ratio": tok_ratio,
+        "delta": round(delta, 4),
+        "threshold": H1_CACHE_HIT_DELTA_THRESHOLD,
+        "native_cache_creation_tokens": nat_creation,
+        "native_cache_read_tokens": nat_read,
+        "tokenpak_cache_creation_tokens": tok_creation,
+        "tokenpak_cache_read_tokens": tok_read,
+    }
+
+
+# ── H2 — session-id collapse ───────────────────────────────────────────
+
+
+def _evaluate_h2(
+    native: Dict[str, Any], tokenpak: Dict[str, Any]
+) -> Dict[str, Any]:
+    nat_rot = _safe_get(native, "session", "session_id_rotations_per_hour")
+    tok_rot = _safe_get(tokenpak, "session", "session_id_rotations_per_hour")
+    nat_distinct = _safe_get(native, "session", "distinct_session_id_count")
+    tok_distinct = _safe_get(tokenpak, "session", "distinct_session_id_count")
+
+    base = {
+        "native_rotations_per_hour": nat_rot,
+        "tokenpak_rotations_per_hour": tok_rot,
+        "native_distinct_session_count": nat_distinct,
+        "tokenpak_distinct_session_count": tok_distinct,
+        "rotation_threshold": H2_SESSION_ROTATION_RATIO_THRESHOLD,
+        "count_threshold": H2_SESSION_COUNT_RATIO_THRESHOLD,
+    }
+
+    if nat_rot is not None and tok_rot is not None and tok_rot > 0:
+        ratio = nat_rot / tok_rot
+        supported = ratio >= H2_SESSION_ROTATION_RATIO_THRESHOLD
+        base["ratio"] = round(ratio, 4)
+        base["verdict"] = "supported" if supported else "not_supported"
+        base["reason"] = (
+            f"native rotations/h={nat_rot:.4f}, tokenpak={tok_rot:.4f}, "
+            f"ratio={ratio:.2f}× "
+            f"({'≥' if supported else '<'} {H2_SESSION_ROTATION_RATIO_THRESHOLD}× threshold)"
+        )
+        return base
+
+    if nat_rot is not None and tok_rot == 0 and nat_rot > 0:
+        # TokenPak collapsed to zero rotation in the window — strongest
+        # form of H2 evidence.
+        base["ratio"] = float("inf")
+        base["verdict"] = "supported"
+        base["reason"] = (
+            f"tokenpak rotations/h=0 over the window while native rotated "
+            f"{nat_rot:.4f}/h — session-id is fully collapsed"
+        )
+        return base
+
+    if nat_distinct is not None and tok_distinct is not None and tok_distinct > 0:
+        ratio = nat_distinct / tok_distinct
+        supported = ratio >= H2_SESSION_COUNT_RATIO_THRESHOLD
+        base["count_ratio"] = round(ratio, 4)
+        base["verdict"] = "supported" if supported else "not_supported"
+        base["reason"] = (
+            f"native distinct sessions={nat_distinct}, tokenpak={tok_distinct}, "
+            f"ratio={ratio:.2f}× "
+            f"({'≥' if supported else '<'} {H2_SESSION_COUNT_RATIO_THRESHOLD}× threshold)"
+        )
+        return base
+
+    base["verdict"] = "inconclusive"
+    base["reason"] = (
+        "session-id rotation data unavailable on at least one side; "
+        "fill in the native baseline's session block per the protocol "
+        "doc and rerun."
+    )
+    return base
+
+
+# ── Synthesis ──────────────────────────────────────────────────────────
+
+
+def _dominant_cause(
+    h1: Dict[str, Any], h2: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Pick the dominant hypothesis from the two verdicts.
+
+    Conservative rule: the synthesis only claims a dominant cause
+    when **both** hypotheses have a definite verdict (supported or
+    not_supported). Any inconclusive verdict falls through to
+    ``inconclusive`` regardless of the other side.
+    """
+    h1_v = h1.get("verdict")
+    h2_v = h2.get("verdict")
+
+    DEFINITE = {"supported", "not_supported"}
+    if h1_v not in DEFINITE or h2_v not in DEFINITE:
+        return {
+            "dominant_cause": "inconclusive",
+            "confidence": "low",
+            "rationale": (
+                "At least one hypothesis verdict is inconclusive — see the "
+                "H1 and H2 blocks for the missing data. Fill in the gap and "
+                "rerun."
+            ),
+        }
+
+    if h1_v == "supported" and h2_v == "supported":
+        return {
+            "dominant_cause": "H1+H2 both supported",
+            "confidence": "high",
+            "rationale": (
+                "Cache prefix disruption AND session-id collapse both fire. "
+                "Both contribute; NCP-2 should fix cache prefix preservation "
+                "and NCP-3 should fix session-id rotation. Run §5.1 and "
+                "§5.2 a second time after each fix to confirm independent "
+                "contribution."
+            ),
+        }
+    if h1_v == "supported":
+        return {
+            "dominant_cause": "H1 — cache prefix disruption",
+            "confidence": "high",
+            "rationale": (
+                "Companion-prepended dynamic content invalidates the "
+                "Anthropic prompt-prefix cache. Native variant gets cache "
+                "hits on the stable system block; TokenPak variant misses "
+                "every request. NCP-2 fix direction: move companion "
+                "context BEHIND the cache boundary, or wrap it in a "
+                "stable cache-key boundary that the provider honours."
+            ),
+        }
+    if h2_v == "supported":
+        return {
+            "dominant_cause": "H2 — session-id collapse",
+            "confidence": "high",
+            "rationale": (
+                "Proxy collapses many CLI invocations onto a single "
+                "X-Claude-Code-Session-Id. Anthropic attributes rate-limit "
+                "consumption to that single id, so the bucket fills "
+                "faster than under native CLI rotation. NCP-3 fix "
+                "direction: rotate session-id per CLI invocation, or per "
+                "K requests / T seconds when invocation boundary cannot "
+                "be detected."
+            ),
+        }
+    # Both not_supported.
+    return {
+        "dominant_cause": "neither H1 nor H2",
+        "confidence": "medium",
+        "rationale": (
+            "Cache hit ratio and session-id rotation are within "
+            "thresholds. The observed rate-limit difference is likely "
+            "driven by H3 (token amplification), H4 (Retry-After "
+            "ignored), or a hypothesis not enumerated in NCP-0. "
+            "Capture H3 / H4 evidence per the diagnostic plan §5.3 / "
+            "§5.4 and re-run NCP-1."
+        ),
+    }
+
+
+def _recommend_fix(
+    h1: Dict[str, Any], h2: Dict[str, Any]
+) -> List[str]:
+    out: List[str] = []
+    if h1.get("verdict") == "supported":
+        out.append(
+            "NCP-2 — Cache prefix preservation. Move companion-added "
+            "context behind the cache boundary on byte-preserved "
+            "adapters (AnthropicAdapter), or wrap it in a cache-key-"
+            "stable boundary. Verify with a second §5.1 A/B run."
+        )
+    if h2.get("verdict") == "supported":
+        out.append(
+            "NCP-3 — Session-id rotation. Rotate "
+            "X-Claude-Code-Session-Id per Claude Code CLI invocation, "
+            "or per K requests / T seconds when the invocation "
+            "boundary cannot be detected. Preserve a per-process "
+            "stable id only for callers that explicitly opt in (e.g. "
+            "OpenClaw billing)."
+        )
+    if not out:
+        out.append(
+            "No fix recommended yet — H1/H2 not supported. Capture H3 "
+            "(token amplification) and H4 (Retry-After) evidence per "
+            "the diagnostic plan and re-run."
+        )
+    return out
+
+
+def _render_markdown(report: Dict[str, Any]) -> str:
+    h1 = report["h1"]
+    h2 = report["h2"]
+    syn = report["synthesis"]
+    lines: List[str] = []
+    lines.append("# NCP-1 parity A/B results")
+    lines.append("")
+    lines.append(f"**Generated**: {report['generated_at']}")
+    lines.append(f"**Native baseline**: `{report['native_path']}`")
+    lines.append(f"**TokenPak baseline**: `{report['tokenpak_path']}`")
+    lines.append("")
+    lines.append("## Verdicts")
+    lines.append("")
+    lines.append(f"- **H1 (cache prefix disruption)**: `{h1.get('verdict')}` — {h1.get('reason', '')}")
+    lines.append(f"- **H2 (session-id collapse)**: `{h2.get('verdict')}` — {h2.get('reason', '')}")
+    lines.append("")
+    lines.append("## Synthesis")
+    lines.append("")
+    lines.append(f"- **Dominant cause**: {syn['dominant_cause']}")
+    lines.append(f"- **Confidence**: {syn['confidence']}")
+    lines.append(f"- **Rationale**: {syn['rationale']}")
+    lines.append("")
+    lines.append("## Recommended next step")
+    lines.append("")
+    for rec in report["recommendation"]:
+        lines.append(f"- {rec}")
+    lines.append("")
+    lines.append("## Raw H1 block")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(h1, indent=2, sort_keys=True))
+    lines.append("```")
+    lines.append("")
+    lines.append("## Raw H2 block")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(h2, indent=2, sort_keys=True))
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ── Entry point ────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Diff two NCP-1 parity baselines.",
+    )
+    p.add_argument("--native", type=Path, required=True)
+    p.add_argument("--tokenpak", type=Path, required=True)
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of markdown.",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the report to this file (default: stdout).",
+    )
+    args = p.parse_args(argv)
+
+    native = _load(args.native)
+    tokenpak = _load(args.tokenpak)
+
+    h1 = _evaluate_h1(native, tokenpak)
+    h2 = _evaluate_h2(native, tokenpak)
+    syn = _dominant_cause(h1, h2)
+    rec = _recommend_fix(h1, h2)
+
+    report = {
+        "schema_version": "ncp-1-diff-v1",
+        "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "native_path": str(args.native),
+        "tokenpak_path": str(args.tokenpak),
+        "h1": h1,
+        "h2": h2,
+        "synthesis": syn,
+        "recommendation": rec,
+    }
+
+    rendered = (
+        json.dumps(report, indent=2, sort_keys=True)
+        if args.json
+        else _render_markdown(report)
+    )
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+        print(f"wrote {args.output}", file=sys.stderr)
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ncp1_parity_baseline.py
+++ b/tests/test_ncp1_parity_baseline.py
@@ -1,0 +1,526 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-1 — capture + diff parity baseline scripts.
+
+Coverage:
+
+  1. capture script — writes a tokenpak baseline from a fixture telemetry.db
+  2. capture script — writes an empty native template
+  3. diff script — H1 supported (cache hit ratio gap)
+  4. diff script — H1 not supported (parity)
+  5. diff script — H2 supported (rotation collapse)
+  6. diff script — H2 not supported (parity)
+  7. diff script — both H1 + H2 supported
+  8. diff script — inconclusive on missing data
+  9. JSON + markdown render parity
+  10. CLI entry point smokes
+  11. capture script: missing telemetry.db handled cleanly
+  12. structural test — no runtime behavior changes (scripts have
+      no imports from proxy / companion business logic that could
+      mutate state)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+# Load the scripts as modules so we can call their main() directly.
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_script(name: str):
+    path = SCRIPT_DIR / name
+    spec = importlib.util.spec_from_file_location(
+        f"_ncp1_test_{path.stem}", path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+capture = _load_script("capture_parity_baseline.py")
+diff = _load_script("diff_parity_baselines.py")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _seed_telemetry(
+    db: Path,
+    *,
+    n_requests: int = 10,
+    cache_read_per_req: int = 100,
+    cache_write_per_req: int = 50,
+    distinct_sessions: int = 1,
+    status_codes: tuple = (200,),
+    provider: str = "tokenpak-claude-code",
+    timestamp_iso: str = "2026-04-26T12:00:00",
+) -> None:
+    """Seed a tp_events + tp_usage pair under ``db``."""
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS tp_events (
+            request_id TEXT, trace_id TEXT, ts TEXT, provider TEXT,
+            model TEXT, agent_id TEXT, api TEXT, stop_reason TEXT,
+            session_id TEXT, duration_ms INTEGER, status TEXT,
+            error_class TEXT, payload TEXT, span_id TEXT,
+            node_id TEXT, route TEXT
+        );
+        CREATE TABLE IF NOT EXISTS tp_usage (
+            trace_id TEXT, usage_source TEXT, confidence REAL,
+            input_billed INTEGER, output_billed INTEGER,
+            input_est INTEGER, output_est INTEGER,
+            cache_read INTEGER, cache_write INTEGER,
+            total_tokens INTEGER, total_tokens_billed INTEGER,
+            total_tokens_est INTEGER, provider_usage_raw TEXT
+        );
+        """
+    )
+    for i in range(n_requests):
+        trace_id = f"trace-{i}"
+        session_id = f"session-{i % max(1, distinct_sessions)}"
+        status = str(status_codes[i % len(status_codes)])
+        conn.execute(
+            "INSERT INTO tp_events (request_id, trace_id, ts, provider, "
+            "model, agent_id, api, stop_reason, session_id, duration_ms, "
+            "status, error_class, route) VALUES "
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                f"req-{i}",
+                trace_id,
+                timestamp_iso,
+                provider,
+                "claude-3-5-sonnet",
+                "agent-x",
+                "messages",
+                "end_turn",
+                session_id,
+                500,
+                status,
+                None,
+                "claude-code",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO tp_usage (trace_id, usage_source, confidence, "
+            "input_billed, output_billed, input_est, output_est, "
+            "cache_read, cache_write, total_tokens, total_tokens_billed, "
+            "total_tokens_est, provider_usage_raw) VALUES "
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                trace_id,
+                "billed",
+                1.0,
+                1000,
+                500,
+                1000,
+                500,
+                cache_read_per_req,
+                cache_write_per_req,
+                1500,
+                1500,
+                1500,
+                "{}",
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ── 1. capture script — tokenpak baseline ─────────────────────────────
+
+
+class TestCaptureTokenpakBaseline:
+
+    def test_writes_baseline_with_metrics(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed_telemetry(db, n_requests=10, distinct_sessions=2)
+        out = tmp_path / "tokenpak.json"
+        rc = capture.main([
+            "--label", "tokenpak",
+            "--db-path", str(db),
+            "--window-days", "0",  # all rows
+            "--output", str(out),
+        ])
+        assert rc == 0
+        d = json.loads(out.read_text())
+        assert d["schema_version"] == capture.SCHEMA_VERSION
+        assert d["label"] == "tokenpak"
+        assert d["metrics"]["request_count"] == 10
+        assert d["metrics"]["cache_read_tokens"] == 1000
+        assert d["metrics"]["cache_creation_tokens"] == 500
+        # 1000 / (1000 + 500) == 0.6667
+        assert abs(d["metrics"]["cache_hit_ratio"] - 0.6667) < 0.001
+        assert d["session"]["distinct_session_id_count"] == 2
+
+    def test_unavailable_metrics_have_reasons(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed_telemetry(db)
+        out = tmp_path / "tokenpak.json"
+        capture.main([
+            "--label", "tokenpak",
+            "--db-path", str(db),
+            "--window-days", "0",
+            "--output", str(out),
+        ])
+        d = json.loads(out.read_text())
+        # Every unavailable metric must have a reason string.
+        for k in capture.UNAVAILABLE_REASONS:
+            assert k in d["_unavailable"]
+            assert d["_unavailable"][k], (
+                f"unavailable metric {k!r} must have a non-empty reason"
+            )
+
+
+# ── 2. capture script — native template ───────────────────────────────
+
+
+class TestCaptureNativeTemplate:
+
+    def test_native_emits_empty_template(self, tmp_path):
+        out = tmp_path / "native.json"
+        rc = capture.main([
+            "--label", "native",
+            "--window-days", "1",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        d = json.loads(out.read_text())
+        assert d["label"] == "native"
+        for k in capture.METRIC_KEYS:
+            assert d["metrics"][k] is None
+        # The note + _unavailable both flag the operator should
+        # fill it in.
+        assert "operator" in d["note"].lower() or "fill" in d["note"].lower()
+
+    def test_native_does_not_read_db(self, tmp_path):
+        # Native template should work even when telemetry.db is
+        # absent (since native traffic doesn't go through TokenPak).
+        out = tmp_path / "native.json"
+        rc = capture.main([
+            "--label", "native",
+            "--db-path", str(tmp_path / "missing.db"),
+            "--output", str(out),
+        ])
+        assert rc == 0
+
+
+# ── 3. diff script — H1 supported ─────────────────────────────────────
+
+
+class TestDiffH1Supported:
+
+    def _build(self, *, native_hr: float, tokenpak_hr: float) -> tuple:
+        native = {
+            "schema_version": capture.SCHEMA_VERSION,
+            "label": "native",
+            "metrics": {
+                "cache_hit_ratio": native_hr,
+                "cache_read_tokens": 9000,
+                "cache_creation_tokens": 1000,
+            },
+            "session": {
+                "session_id_rotations_per_hour": 2.0,
+                "distinct_session_id_count": 5,
+            },
+        }
+        tokenpak = {
+            "schema_version": capture.SCHEMA_VERSION,
+            "label": "tokenpak",
+            "metrics": {
+                "cache_hit_ratio": tokenpak_hr,
+                "cache_read_tokens": 100,
+                "cache_creation_tokens": 9900,
+            },
+            "session": {
+                "session_id_rotations_per_hour": 2.0,
+                "distinct_session_id_count": 5,
+            },
+        }
+        return native, tokenpak
+
+    def test_supported_when_delta_above_threshold(self):
+        native, tokenpak = self._build(native_hr=0.9, tokenpak_hr=0.05)
+        h1 = diff._evaluate_h1(native, tokenpak)
+        assert h1["verdict"] == "supported"
+        assert h1["delta"] >= diff.H1_CACHE_HIT_DELTA_THRESHOLD
+
+    def test_not_supported_when_delta_below_threshold(self):
+        native, tokenpak = self._build(native_hr=0.9, tokenpak_hr=0.85)
+        h1 = diff._evaluate_h1(native, tokenpak)
+        assert h1["verdict"] == "not_supported"
+
+    def test_inconclusive_when_native_missing(self):
+        native, tokenpak = self._build(native_hr=0.0, tokenpak_hr=0.05)
+        native["metrics"]["cache_hit_ratio"] = None
+        h1 = diff._evaluate_h1(native, tokenpak)
+        assert h1["verdict"] == "inconclusive"
+
+
+# ── 4. diff script — H2 verdicts ──────────────────────────────────────
+
+
+class TestDiffH2:
+
+    def _build(self, *, nat_rot, tok_rot, nat_count=10, tok_count=1):
+        return (
+            {
+                "metrics": {},
+                "session": {
+                    "session_id_rotations_per_hour": nat_rot,
+                    "distinct_session_id_count": nat_count,
+                },
+            },
+            {
+                "metrics": {},
+                "session": {
+                    "session_id_rotations_per_hour": tok_rot,
+                    "distinct_session_id_count": tok_count,
+                },
+            },
+        )
+
+    def test_supported_when_native_rotates_much_faster(self):
+        native, tokenpak = self._build(nat_rot=10.0, tok_rot=1.0)
+        h2 = diff._evaluate_h2(native, tokenpak)
+        assert h2["verdict"] == "supported"
+
+    def test_supported_when_tokenpak_rotation_zero(self):
+        native, tokenpak = self._build(nat_rot=2.0, tok_rot=0.0)
+        h2 = diff._evaluate_h2(native, tokenpak)
+        assert h2["verdict"] == "supported"
+        assert h2["ratio"] == float("inf")
+
+    def test_not_supported_when_rotation_parity(self):
+        native, tokenpak = self._build(nat_rot=2.0, tok_rot=1.5)
+        h2 = diff._evaluate_h2(native, tokenpak)
+        assert h2["verdict"] == "not_supported"
+
+    def test_falls_back_to_distinct_count(self):
+        native, tokenpak = self._build(
+            nat_rot=None, tok_rot=None, nat_count=20, tok_count=1
+        )
+        h2 = diff._evaluate_h2(native, tokenpak)
+        assert h2["verdict"] == "supported"
+        assert h2["count_ratio"] == 20.0
+
+    def test_inconclusive_when_data_missing(self):
+        native, tokenpak = self._build(
+            nat_rot=None, tok_rot=None, nat_count=None, tok_count=None
+        )
+        h2 = diff._evaluate_h2(native, tokenpak)
+        assert h2["verdict"] == "inconclusive"
+
+
+# ── 5. dominant cause synthesis ───────────────────────────────────────
+
+
+class TestDominantCauseSynthesis:
+
+    def test_both_supported(self):
+        h1 = {"verdict": "supported"}
+        h2 = {"verdict": "supported"}
+        syn = diff._dominant_cause(h1, h2)
+        assert "H1+H2" in syn["dominant_cause"]
+        assert syn["confidence"] == "high"
+
+    def test_only_h1_supported(self):
+        h1 = {"verdict": "supported"}
+        h2 = {"verdict": "not_supported"}
+        syn = diff._dominant_cause(h1, h2)
+        assert "H1" in syn["dominant_cause"]
+        assert "cache" in syn["rationale"].lower()
+
+    def test_only_h2_supported(self):
+        h1 = {"verdict": "not_supported"}
+        h2 = {"verdict": "supported"}
+        syn = diff._dominant_cause(h1, h2)
+        assert "H2" in syn["dominant_cause"]
+        assert "session" in syn["rationale"].lower()
+
+    def test_neither_supported(self):
+        h1 = {"verdict": "not_supported"}
+        h2 = {"verdict": "not_supported"}
+        syn = diff._dominant_cause(h1, h2)
+        assert "neither" in syn["dominant_cause"].lower()
+        assert "h3" in syn["rationale"].lower()
+
+    def test_inconclusive(self):
+        h1 = {"verdict": "inconclusive"}
+        h2 = {"verdict": "supported"}
+        syn = diff._dominant_cause(h1, h2)
+        assert syn["dominant_cause"] == "inconclusive"
+
+
+# ── 6. fix recommendations ────────────────────────────────────────────
+
+
+class TestFixRecommendations:
+
+    def test_recommends_ncp2_when_h1(self):
+        recs = diff._recommend_fix(
+            {"verdict": "supported"}, {"verdict": "not_supported"}
+        )
+        assert any("NCP-2" in r for r in recs)
+        assert any("cache" in r.lower() for r in recs)
+
+    def test_recommends_ncp3_when_h2(self):
+        recs = diff._recommend_fix(
+            {"verdict": "not_supported"}, {"verdict": "supported"}
+        )
+        assert any("NCP-3" in r for r in recs)
+        assert any("session" in r.lower() for r in recs)
+
+    def test_no_fix_when_neither(self):
+        recs = diff._recommend_fix(
+            {"verdict": "not_supported"}, {"verdict": "not_supported"}
+        )
+        assert any("H3" in r or "H4" in r for r in recs)
+
+
+# ── 7. JSON + markdown render parity ──────────────────────────────────
+
+
+class TestRenderParity:
+
+    def test_diff_main_json_emits_valid_json(self, tmp_path):
+        nat = tmp_path / "native.json"
+        tok = tmp_path / "tokenpak.json"
+        nat.write_text(json.dumps({
+            "metrics": {"cache_hit_ratio": 0.9, "cache_read_tokens": 9, "cache_creation_tokens": 1},
+            "session": {"session_id_rotations_per_hour": 5.0, "distinct_session_id_count": 5},
+        }))
+        tok.write_text(json.dumps({
+            "metrics": {"cache_hit_ratio": 0.05, "cache_read_tokens": 1, "cache_creation_tokens": 19},
+            "session": {"session_id_rotations_per_hour": 0.0, "distinct_session_id_count": 1},
+        }))
+        out = tmp_path / "report.json"
+        rc = diff.main([
+            "--native", str(nat),
+            "--tokenpak", str(tok),
+            "--json",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        d = json.loads(out.read_text())
+        assert d["h1"]["verdict"] == "supported"
+        assert d["h2"]["verdict"] == "supported"
+        assert "dominant_cause" in d["synthesis"]
+
+    def test_diff_main_markdown_default(self, tmp_path):
+        nat = tmp_path / "native.json"
+        tok = tmp_path / "tokenpak.json"
+        nat.write_text(json.dumps({
+            "metrics": {"cache_hit_ratio": 0.9, "cache_read_tokens": 9, "cache_creation_tokens": 1},
+            "session": {"session_id_rotations_per_hour": 5.0, "distinct_session_id_count": 5},
+        }))
+        tok.write_text(json.dumps({
+            "metrics": {"cache_hit_ratio": 0.05, "cache_read_tokens": 1, "cache_creation_tokens": 19},
+            "session": {"session_id_rotations_per_hour": 0.0, "distinct_session_id_count": 1},
+        }))
+        out = tmp_path / "report.md"
+        rc = diff.main([
+            "--native", str(nat),
+            "--tokenpak", str(tok),
+            "--output", str(out),
+        ])
+        assert rc == 0
+        md = out.read_text()
+        assert "# NCP-1 parity A/B results" in md
+        assert "**H1" in md
+        assert "**H2" in md
+        assert "Dominant cause" in md
+
+
+# ── 8. CLI entrypoints (subprocess smokes) ────────────────────────────
+
+
+class TestCliSmoke:
+
+    def test_capture_help(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "capture_parity_baseline.py"), "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--label" in result.stdout
+
+    def test_diff_help(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "diff_parity_baselines.py"), "--help"],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0
+        assert "--native" in result.stdout
+        assert "--tokenpak" in result.stdout
+
+
+# ── 9. capture: missing telemetry.db handled cleanly ──────────────────
+
+
+class TestCaptureMissingDB:
+
+    def test_missing_db_returns_2(self, tmp_path, capsys):
+        out = tmp_path / "tokenpak.json"
+        rc = capture.main([
+            "--label", "tokenpak",
+            "--db-path", str(tmp_path / "missing.db"),
+            "--output", str(out),
+        ])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "telemetry.db not found" in captured.err
+
+
+# ── 10. structural — no runtime mutation imports ──────────────────────
+
+
+class TestNoRuntimeBehaviorChanges:
+
+    def test_capture_does_not_import_proxy_dispatch(self):
+        text = (SCRIPT_DIR / "capture_parity_baseline.py").read_text()
+        for forbidden in (
+            "from tokenpak.proxy.client import",
+            "from tokenpak.proxy.server import",
+            "from tokenpak.proxy.connection_pool import",
+            "forward_headers",
+            "pool.request",
+            "pool.stream",
+            "credential_injector",
+        ):
+            assert forbidden not in text, (
+                f"NCP-1 capture script must not import dispatch primitive: {forbidden}"
+            )
+
+    def test_diff_does_not_import_proxy_dispatch(self):
+        text = (SCRIPT_DIR / "diff_parity_baselines.py").read_text()
+        for forbidden in (
+            "from tokenpak.proxy.client import",
+            "from tokenpak.proxy.server import",
+            "from tokenpak.companion",
+            "forward_headers",
+            "credential_injector",
+        ):
+            assert forbidden not in text, (
+                f"NCP-1 diff script must not import dispatch primitive: {forbidden}"
+            )
+
+    def test_capture_does_not_write_to_telemetry_tables(self):
+        # SQL-keyword scan: capture must read, never write.
+        text = (SCRIPT_DIR / "capture_parity_baseline.py").read_text()
+        for forbidden in (
+            "INSERT INTO tp_",
+            "UPDATE tp_",
+            "DELETE FROM tp_",
+            "DROP TABLE",
+            "ALTER TABLE",
+        ):
+            assert forbidden not in text, (
+                f"NCP-1 capture script must not modify telemetry: {forbidden}"
+            )


### PR DESCRIPTION
## Summary

NCP-1 measurement-only deliverables for the Native Client Concurrency Parity workstream. Settles **H1 (cache prefix disruption)** and **H2 (session-id collapse)** by enabling a side-by-side native vs TokenPak-fronted run on the same Anthropic OAuth account.

**No runtime behavior changes.** Capture script is read-only; diff script is purely analytical; protocol doc is operator-facing.

## What this PR adds

### 1. Capture script (\`scripts/capture_parity_baseline.py\`)

Read-only over \`~/.tokenpak/telemetry.db\`. Joins \`tp_events\` + \`tp_usage\` + \`intent_patches\` and projects the 20-metric measurement contract from Standard #24 §3.

- **12 of 20 metrics** auto-fill from existing telemetry (request_count, latency, input/output/cache tokens, session-id distribution, intent_guidance_chars, etc.)
- **8 of 20 metrics** marked \`null\` with documented \`_unavailable\` reasons:
  - \`time_to_first_token_ms\` — proxy stream layer doesn't record TTFT
  - \`companion_added_chars\` — pre-send hook doesn't log additionalContext length
  - \`companion_added_tokens_est\` — derived; unavailable while #11 is
  - \`vault_injection_chars\` — vault retrieval doesn't log result-set length
  - \`capsule_injection_chars\` — capsule loader doesn't log loaded-bytes
  - \`hook_triggered_calls\` — dispatcher doesn't emit count
  - \`retry_after_seconds\` — proxy doesn't parse \`Retry-After\` (H4 — NCP-5 fix)
  - \`ratelimit_tokens_remaining\` / \`requests_remaining\` — proxy doesn't capture rate-limit headers
- **Native baseline**: emits empty template; operator hand-fills from mitmproxy / Anthropic CLI debug logs (§2.3 of protocol).

### 2. Diff script (\`scripts/diff_parity_baselines.py\`)

Reads two baselines and emits a results report.

- **H1 verdict**: \`cache_hit_ratio\` delta vs 0.30 threshold
- **H2 verdict**: \`session_id_rotations_per_hour\` ratio vs 3× threshold (falls back to \`distinct_session_id_count\` ratio when rotation rate is unavailable)
- **Conservative synthesis**: any inconclusive verdict falls through to \`dominant_cause = inconclusive\` (no premature claim of cause)
- Maps (H1, H2) verdict pairs to NCP-2 / NCP-3 fix recommendations
- Renders markdown (default) or JSON (\`--json\`)

### 3. A/B test protocol (\`docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md\`)

11-section operator-facing protocol:

- §1 Prerequisites + setup
- §2 Variant A (native) capture — mitmproxy or \`ANTHROPIC_LOG=debug\`
- §3 Variant B (TokenPak-fronted) capture — telemetry.db read
- §4 The 20-metric capture map (per metric, per variant: source + fallback)
- §5 Run order: §5.1 quick (cache hit ratio for H1), §5.2 saturated (429 onset for H2)
- §6 Generating the diff report
- §7 **Results template** for operator handoff
- §8 Failure modes + reproducibility checklist
- §9 Out of scope (NCP-2 / NCP-3 / NCP-4 fixes explicitly disclaimed)

### 4. Standard #24 status update

\`docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md\` — moved from \"awaiting Kevin ratification\" to **\"ratified in principle (2026-04-26)\"**. Promotion to \`~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/\` gated on NCP-1 data confirming or adjusting the H1 / H2 thresholds.

### 5. Tests (28 across 12 categories)

\`tests/test_ncp1_parity_baseline.py\` — covers capture + diff scripts including:

- Telemetry seeding fixture exercising the real \`tp_events\` + \`tp_usage\` schema
- Capture: tokenpak baseline auto-fill, native template empty, missing-DB clean exit
- Diff: H1 / H2 verdicts (supported / not_supported / inconclusive)
- Synthesis: 5 dominant-cause paths
- Fix recommendation routing
- JSON + markdown render parity
- CLI subprocess smokes
- Structural: scripts import zero dispatch primitives + write zero rows to telemetry tables (no behavior change)

## Held throughout NCP-1

- ❌ No proxy / companion / credential / failover behavior changes
- ❌ No new env-vars
- ❌ No prompt mutation, cache placement, session-id behavior changes
- ❌ No new SQLite tables
- ❌ No new CLI subcommands inside \`tokenpak\` (scripts live under \`scripts/\` per the existing \`capture_*\` convention)

## Test plan

- [x] \`pytest tests/test_ncp1_parity_baseline.py\` — 28/28 green
- [x] PI-1 + PI-2 + PI-3 regression check — 96/96 green
- [x] \`ruff check tokenpak/ tests/\` clean (CI scope)
- [x] Capture script smoke: writes baseline JSON; idempotent
- [x] Diff script smoke: emits markdown + JSON without crash
- [x] Structural test: no dispatch-primitive imports, no telemetry-table writes
- [ ] CI green

## After this PR

The operator runs §5.1 (cache hit ratio) and §5.2 (session-id collapse) on a real Anthropic account, fills in the §7 results template, and submits back. **NCP-2 / NCP-3 implementation does not begin until those results are in.** This PR explicitly does NOT authorize any of NCP-2 through NCP-6.

## Cross-references

- \`docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md\` — standard proposal §3 measurement contract
- \`docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md\` — NCP-0 hypothesis matrix this protocol settles
- PR #62 (NCP-0 closeout) — direct predecessor