### PR TITLE
docs(ncp-1r): OAuth/subscription parity redesign — auth-plane scoping correction

### DIFF
--- a/docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md
+++ b/docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md
@@ -1,10 +1,17 @@
 # Native Client Concurrency Parity — diagnostic plan (NCP-0)
 
-**Date**: 2026-04-26
+**Date**: 2026-04-26 (NCP-1R-amended — see banner below)
 **Status**: 🟡 **diagnostic only** — no runtime behavior changes proposed
 **Workstream**: NCP (Native Client Concurrency Parity)
-**Authors**: Sue (diagnostic) / Kevin (review)
-**Companion standard proposal**: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
+**Authors**: Sue (diagnostic) / Kevin (review + auth-plane scoping correction)
+**Companion docs**:
+  - Standard proposal: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
+  - **Primary** (NCP-1R) protocol: `docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md`
+  - **Secondary** (harness validation) protocol: `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md`
+
+> ⚠️ **NCP-1R amendment (2026-04-26)**: the original §5 A/B test methodology was scoped against generic Anthropic API-key traffic. Kevin's scoping correction reframed the test target as **Claude Code OAuth/subscription** parity. The hypothesis matrix (§2) remains valid, but the measurement methodology is now governed by the NCP-1R OAuth-parity protocol. The §5 sections in this document below remain useful as harness validation, but the *primary* test methodology is in the NCP-1R protocol.
+
+> **Auth-plane scope (added NCP-1R)**: this diagnostic targets the **Claude Code OAuth/subscription** auth plane (Standard #24 §1.5). Hypothesis evidence collected on a different auth plane (API key, cloud provider, proxy passthrough) is not transferable. H2 (session-id collapse) in particular is an **auth-plane parity** issue — it only matters when both variants are on the OAuth/subscription bucket.
 
 > **Premise (from the directive):** TokenPak Companion Claude Code appears to hit upstream rate-limit / retry behavior with **fewer concurrent sessions** than native Claude Code TUI direct, on the same account. NCP-0 is the **measurement-and-evidence** phase. No knobs are flipped. No code is changed. The goal is to **find the cause** before proposing a fix.
 

--- a/docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md
+++ b/docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md
@@ -1,14 +1,17 @@
 # NCP-1 — Claude Code parity A/B test protocol
 
 **Date**: 2026-04-26
-**Status**: 🟡 **measurement-only** — no behavior changes proposed
+**Status**: 🟡 **SECONDARY — harness validation only** (NCP-1R 2026-04-26 supersedes for the OAuth/subscription parity question)
 **Workstream**: NCP (Native Client Concurrency Parity)
 **Authors**: Sue (protocol) / Kevin (review)
 **Companion docs**:
   - Standard proposal: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
   - Diagnostic plan: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
+  - **Primary** (NCP-1R) protocol: `docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md`
 
-> **Goal:** settle hypotheses **H1 (cache prefix disruption)** and **H2 (session-id collapse)** from NCP-0 by running a side-by-side A/B test against the same Anthropic OAuth account, identical prompts, identical concurrency. Capture the 20-metric measurement contract from Standard #24 §3 (or mark unavailable with a documented reason). Produce a results report. **No code path is modified during the test run.**
+> ⚠️ **Demoted to secondary on 2026-04-26 (NCP-1R revision).** This protocol uses mitmproxy to capture upstream traffic — that works for **Anthropic API-key** comparisons but **cannot settle the OAuth/subscription parity question** which is the actual product issue. Reasons: (a) mitmproxy MAY break the Claude Code OAuth flow (TLS intercept), (b) API-key buckets and OAuth/subscription seats are different rate-limit attribution dimensions (Standard #24 §1.5 + I-0). Use this protocol ONLY to validate that the capture / diff harness is wired correctly. Use `ncp-1r-oauth-parity-protocol-2026-04-26.md` for the real product test.
+
+> **Goal (secondary use):** validate the `capture_parity_baseline.py` + `diff_parity_baselines.py` harness end-to-end with API-key telemetry, where mitmproxy can faithfully record upstream `usage` blocks + `Retry-After` headers + `anthropic-ratelimit-*` headers. **No code path is modified during the test run.**
 
 ---
 

--- a/docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md
+++ b/docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md
@@ -1,0 +1,446 @@
+# NCP-1R — Claude Code OAuth/Subscription parity test protocol (PRIMARY)
+
+**Date**: 2026-04-26 (NCP-1R revision)
+**Status**: 🟡 **measurement-only** — no behavior changes proposed
+**Workstream**: NCP (Native Client Concurrency Parity)
+**Authors**: Sue (protocol) / Kevin (review + auth-plane scoping correction)
+**Companion docs**:
+  - Standard proposal: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
+  - Diagnostic plan: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
+  - **Secondary** protocol (harness validation only): `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md`
+
+> **Goal:** settle hypotheses **H1 (cache prefix disruption)** and **H2 (session-id collapse)** plus the new NCP-1R parity invariants **I-0 (auth-plane)**, **I-3 (session)**, and **I-6 (retry)** by running a side-by-side native-vs-TokenPak A/B test on the **same Claude Code OAuth/subscription account**, with identical workload. **No code path is modified during the test run.**
+
+> **What changed from NCP-1**: the original protocol's mitmproxy-based capture was scoped against generic Anthropic API-key traffic. That cannot answer the OAuth/subscription parity question — different auth plane, different bucket, different rate-limit attribution. NCP-1R replaces the runbook with an OAuth/subscription-only protocol that observes CLI-side behavior + TokenPak telemetry.
+
+---
+
+## 0. Reading guide
+
+| § | Question |
+|---|---|
+| 1 | What's the auth plane being tested, and how do we verify it? |
+| 2 | Pre-test invariant checks (I-0 / I-3 / I-6) |
+| 3 | Variant A — native Claude Code TUI (OAuth/subscription) |
+| 4 | Variant B — TokenPak Companion (OAuth/subscription) |
+| 5 | Run order + workload (§5.1 quick / §5.2 saturated / §5.3 concurrency ceiling) |
+| 6 | Observable-behavior capture (no API-key telemetry) |
+| 7 | Generating the diff report |
+| 8 | Results template (operator handoff) |
+| 9 | Failure modes + reproducibility |
+| 10 | Out of scope |
+| 11 | Why mitmproxy is forbidden in this protocol |
+
+---
+
+## 1. Auth plane under test
+
+This protocol tests **Claude Code OAuth/subscription** parity only. Both variants MUST:
+
+- Authenticate with the **same** `~/.claude/.credentials.json` OAuth token.
+- Send the `claude-code-20250219` beta header (and `oauth-2025-04-20` companion beta).
+- Hit the user's **same subscription seat** (Claude Pro / Max / Team).
+- Use the **same model** (e.g. `claude-sonnet-4-6` or whichever the operator's Claude Code TUI defaults to today).
+- Use the **same** `User-Agent: claude-cli/<version>` fingerprint.
+
+If any of these differs, the test is invalid for the I-0 master invariant. The pre-test check in §2 enforces this.
+
+The four other auth planes from Standard #24 §1.5 are **out of scope for this protocol**:
+
+- ❌ Anthropic API key (`x-api-key: sk-ant-…`) — different bucket, different attribution. Use the *secondary* protocol if API-key parity is the question.
+- ❌ Cloud-provider (Bedrock / Vertex) — different attribution model entirely.
+- ❌ TokenPak proxy API-compatible passthrough — caller credential matters; out of NCP-1R scope.
+- ❌ Mixed plane (e.g. native uses OAuth, TokenPak uses API key) — invalid by I-0.
+
+---
+
+## 2. Pre-test invariant checks
+
+Before running either variant, verify all six gates pass. If any gate fails, abort the test — running with a known I-0 / I-3 / I-6 violation produces an invalid result.
+
+### 2.1 I-0 (auth plane is OAuth/subscription on both sides)
+
+```bash
+# 1. The OAuth credentials file exists and is recent.
+test -f ~/.claude/.credentials.json && \
+    echo "✓ OAuth credentials present" || \
+    echo "✗ MISSING OAuth credentials — run 'claude auth login'"
+
+# 2. The credentials carry the OAuth path (not just an API key).
+python3 -c "
+import json
+d = json.load(open('${HOME}/.claude/.credentials.json'))
+oauth = d.get('claudeAiOauth')
+assert oauth and oauth.get('accessToken'), 'no claudeAiOauth.accessToken in credentials'
+print('✓ OAuth access token present, account_uuid=', oauth.get('account_uuid', '(unset)'))
+"
+
+# 3. TokenPak's claude-code provider is the active route.
+tokenpak creds list 2>/dev/null | grep -qi 'tokenpak-claude-code' && \
+    echo "✓ TokenPak claude-code provider available" || \
+    echo "✗ TokenPak claude-code provider not configured"
+
+# 4. TokenPak is NOT pointed at an API-key bucket for the test.
+# (Inspect ~/.tokenpak/config.json or whichever config is active.)
+echo "→ Manually verify TokenPak's effective claude-code route uses tokenpak-claude-code, NOT anthropic API-key path."
+```
+
+### 2.2 I-3 (session model is independent across CLI invocations)
+
+The native `claude` CLI rotates `X-Claude-Code-Session-Id` per invocation. TokenPak's `ClaudeCodeCredentialProvider` (current implementation) collapses to one UUID per proxy process. **Observe and record both behaviors during the test** — that's the primary H2 evidence.
+
+For the test, **start a fresh TokenPak proxy process** before variant B so any observed session-id is from this run:
+
+```bash
+# Kill any existing TokenPak proxy.
+pkill -f 'tokenpak serve' || true
+sleep 2
+```
+
+### 2.3 I-6 (retry layer behavior — observe but don't change)
+
+NCP-1R is measurement-only. Do NOT disable TokenPak's failover engine. Just record what happens — if the proxy retries on 429s while the CLI is also retrying, that's H4 evidence and a candidate for NCP-5.
+
+### 2.4 Workload identity check
+
+The two variants MUST run the **same prompt sequence** against the **same model** in the **same repo**:
+
+- Same `claude` CLI version: capture `claude --version` for both runs and pin them in the results.
+- Same model selection: if the operator changes models in mid-run, both variants must change at the same point.
+- Same repo: if the operator references files (`/path/to/file.py`), both variants must reference the same paths.
+- Same prompt sequence: the operator runs from a script or saved transcript so the prompts are byte-identical.
+
+---
+
+## 3. Variant A — native Claude Code TUI (OAuth/subscription)
+
+### 3.1 Setup
+
+```bash
+# Belt-and-suspenders: ensure no proxy redirect leaks into this run.
+unset ANTHROPIC_BASE_URL
+unset CLAUDE_BASE_URL
+unset HTTPS_PROXY
+unset HTTP_PROXY
+
+# Verify the CLI fingerprint.
+claude --version > ~/ncp1r-claude-version-A.txt
+```
+
+### 3.2 What the operator records
+
+For variant A, **TokenPak is not in the path** — there is no telemetry to read. The operator captures **observable client behavior**:
+
+- **Latency** — wall-clock from prompt enter to first response chunk; from prompt enter to completion. Use `time(1)` or screen-record the TUI.
+- **Retry messages** — anything the TUI prints about transient failures, backoff, "rate limit hit, waiting Ns". Copy these verbatim.
+- **API error messages** — anything the TUI surfaces as a hard failure. Capture the exact text.
+- **Success / failure rate** — fraction of prompts that produced a usable response.
+- **Session boundary count** — for §5.3 concurrency runs: how many distinct CLI invocations the operator opened. Native CLI opens one per `claude` start; record `N_invocations`.
+- **Concurrency ceiling** — the smallest N at which the TUI starts surfacing rate-limit / retry / error messages.
+
+The operator does **not** capture API-key-style telemetry (no mitmproxy, no `ANTHROPIC_LOG=debug` headers). That would change the auth plane (mitmproxy intercepts TLS; some `claude` CLI versions refuse to OAuth through a TLS-intercepting proxy). The test must observe *what the user observes* — TUI text, response times, success rate.
+
+### 3.3 Optional: `claude` CLI built-in observability
+
+If the CLI exposes a non-mitmproxy diagnostic (e.g. `claude --debug` writing to a log), the operator MAY record that — but only if it doesn't alter the OAuth flow. Verify the credential class hasn't changed by re-running the §2.1 check after `--debug` is enabled.
+
+---
+
+## 4. Variant B — TokenPak Claude Code Companion (OAuth/subscription)
+
+### 4.1 Setup
+
+```bash
+# Start TokenPak (or verify it's already running with claude-code OAuth route).
+tokenpak serve &
+sleep 2
+curl -s http://127.0.0.1:8765/healthz   # sanity check
+
+# Verify TokenPak's effective Claude Code route.
+tokenpak creds list 2>&1 | grep -i claude-code
+# Expected: tokenpak-claude-code (OAuth + claude-code-20250219 beta).
+# NOT expected: 'anthropic' (API-key path).
+
+# Point Claude Code at TokenPak.
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8765
+unset HTTPS_PROXY HTTP_PROXY        # don't double-proxy
+
+claude --version > ~/ncp1r-claude-version-B.txt
+diff ~/ncp1r-claude-version-A.txt ~/ncp1r-claude-version-B.txt && \
+    echo "✓ same CLI version on both sides" || \
+    echo "✗ ABORT — CLI version differs"
+```
+
+### 4.2 What the operator records
+
+For variant B, TokenPak telemetry captures most of what we need. The same observable-behavior categories from §3.2 also apply (TUI messages still come from the CLI even when TokenPak is in the path), but additionally:
+
+- The capture script (`scripts/capture_parity_baseline.py`) reads `tp_events` + `tp_usage` + `intent_patches` and emits the standard JSON.
+- The `provider` field on every `tp_events` row MUST be `tokenpak-claude-code`. Any row with `provider='anthropic'` indicates an I-0 violation and the run is invalid.
+
+### 4.3 Capture
+
+After the run completes:
+
+```bash
+scripts/capture_parity_baseline.py \
+    --label tokenpak \
+    --window-days 1 \
+    --output tests/baselines/ncp-1r-parity/tokenpak-$(date -u +%Y%m%dT%H%M%SZ).json
+
+# Verify auth plane in the JSON before submitting.
+python3 -c "
+import json, sys
+d = json.load(open('${OUTPUT_PATH}'))
+# All Claude-Code-shaped events should have provider=tokenpak-claude-code.
+# (The capture script's _claude_code_filter handles this; we re-verify here
+# for I-0 enforcement.)
+print('verify provider field in source telemetry: tp_events.provider should be tokenpak-claude-code on every row')
+"
+```
+
+---
+
+## 5. Run order + workload
+
+### 5.1 Quick run — H1 (cache prefix disruption)
+
+**Goal:** measure cache hit ratio with identical prompt sequences on the same OAuth account.
+
+**Workload:** 10 sequential prompts, single CLI invocation per variant. Total: ~3 minutes.
+
+1. **Variant A first.** Run `claude` direct (no TokenPak). Issue 10 sequential identical prompts. Note start + end time.
+2. Wait **15 minutes** for any cache-prefix state to settle (Anthropic cache windows are short).
+3. **Variant B.** Start fresh TokenPak proxy, point CLI at it, issue the same 10 prompts.
+4. Capture variant B telemetry; hand-fill variant A's observable behavior into the native template (see §6).
+5. Run the diff.
+
+The H1 evidence here is mostly observable on the variant B side — `cache_hit_ratio` from `tp_usage.cache_read / (cache_read + cache_write)`. Variant A's contribution is the workload identity (same prompts) plus the observed latency / success rate. If TokenPak's `cache_hit_ratio` is materially lower than what Anthropic typically returns for a stable system block, H1 is supported.
+
+### 5.2 Saturated run — H2 (session-id collapse)
+
+**Goal:** observe whether N concurrent CLIs through TokenPak hit rate-limit / retry behavior earlier than N concurrent native CLIs.
+
+**Workload:**
+- Variant A: spawn N parallel `claude` CLI processes, each with its own session-id. Each loops one prompt every 5 seconds for 10 minutes.
+- Variant B: spawn N parallel `claude` CLI processes all pointed at the same TokenPak proxy. The proxy collapses to one shared session-id (current behavior).
+
+Recommended N: start with 5; if no disruption fires, double to 10.
+
+For each variant, record:
+- `N_invocations` — number of parallel CLIs.
+- Wall-clock minute at which the first retry message / API error / rate-limit notice appears in any TUI.
+- Fraction of CLIs that completed the full 10-minute loop without disruption.
+
+The H2 evidence is the **disparity in time-to-first-disruption** between the two variants under identical N. If TokenPak's first disruption fires at request count `≈ R/N` where R is variant A's per-CLI disruption point, H2 is supported.
+
+### 5.3 Concurrency ceiling — §4.5 target
+
+**Goal:** establish the §4.5 concurrency parity target value.
+
+For each variant, find the **largest N** that completes the §5.2 workload without disruption. Record:
+- Variant A ceiling: `N_native_max`.
+- Variant B ceiling: `N_tokenpak_max`.
+
+The §4.5 target is `N_tokenpak_max ≥ 0.8 × N_native_max`. Anything below requires an attribution note (vault overhead? capsule overhead? intent-guidance overhead? retry layer? session-id collapse?).
+
+---
+
+## 6. Observable-behavior capture (variant A)
+
+For variant A, the operator hand-fills the empty native template:
+
+```bash
+scripts/capture_parity_baseline.py \
+    --label native \
+    --window-days 1 \
+    --note "OAuth/subscription, claude-cli/$(grep -oP 'claude-cli/\S+' ~/ncp1r-claude-version-A.txt), Claude Pro account, no proxy in path" \
+    --output tests/baselines/ncp-1r-parity/native-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+Then edit the JSON. For NCP-1R OAuth/subscription scope, fill in **only the metrics you actually observed**:
+
+- `metrics.request_count` — count of prompts you issued.
+- `metrics.429_count` — number of times the TUI surfaced a rate-limit message.
+- `metrics.5xx_count` — number of upstream failures the TUI reported (may be 0 — CLI usually surfaces these as "request failed").
+- `metrics.latency_ms.p50` / `.p95` — from your stopwatch / recording.
+- `metrics.input_tokens` / `output_tokens` — leave `null` (you can't observe these without API-key telemetry, and capturing those requires a different auth plane). Document in the note: "input/output tokens not observable on OAuth/subscription path".
+- `metrics.cache_creation_tokens` / `cache_read_tokens` / `cache_hit_ratio` — leave `null`. **The native variant's cache fields are NOT directly observable on the OAuth/subscription path** without API-key telemetry. This is the NCP-1R limitation: H1 must be settled by inference (does TokenPak's variant-B cache_hit_ratio look reasonable on its own merits?) rather than direct A/B comparison.
+- `session.distinct_session_id_count` — the operator records how many `claude` invocations they opened. Each invocation rotates the session-id, so this is the count of independent session-ids the upstream observed.
+- `session.session_id_rotations_per_hour` — `distinct_session_id_count / wall_clock_hours`.
+
+For metrics that genuinely cannot be observed on the OAuth/subscription path, leave them `null` and note the reason. The diff script's `inconclusive` verdict path will surface the gap.
+
+---
+
+## 7. Generating the diff report
+
+```bash
+scripts/diff_parity_baselines.py \
+    --native tests/baselines/ncp-1r-parity/native-<TIMESTAMP>.json \
+    --tokenpak tests/baselines/ncp-1r-parity/tokenpak-<TIMESTAMP>.json \
+    --output tests/baselines/ncp-1r-parity/results-<TIMESTAMP>.md
+```
+
+Expected outcomes for an OAuth/subscription run:
+
+- **H1 cache verdict** is most likely `inconclusive` for NCP-1R, because variant A can't surface cache fields without API-key telemetry. The variant B cache_hit_ratio is still informative as a standalone signal: if it's near zero, H1 is *suggestive* even though the diff verdict is inconclusive.
+- **H2 session verdict** is the strongest NCP-1R signal: the diff compares variant A's `distinct_session_id_count` (operator-recorded; one per CLI invocation) vs variant B's (read from `tp_events`; usually one per proxy process). If TokenPak collapses to 1 session over N variant-A invocations, H2 supported with high confidence.
+
+---
+
+## 8. Results template
+
+Send this back to the workstream for NCP-2 / NCP-3 ratification.
+
+```markdown
+# NCP-1R results — <YYYY-MM-DD>
+
+**Operator**: <name>
+**Auth plane**: Claude Code OAuth/subscription (Claude Pro / Max / Team — specify)
+**Account / seat ID**: <account_uuid> (from credentials.json — first 8 chars OK)
+**Claude CLI version (both variants identical)**: <claude-cli/...>
+**TokenPak version**: <tokenpak --version>
+**Workload**: <§5.1 quick / §5.2 saturated / §5.3 ceiling — list which sections ran>
+**Wall-clock window**: <ISO-8601 start> → <ISO-8601 end>
+
+## Pre-test invariant checks
+
+- I-0 (auth plane parity): <pass | fail>
+  - Variant A credential class: oauth_subscription
+  - Variant B credential class: <oauth_subscription | api_key | OTHER>
+  - If FAIL: abort, fix routing, rerun.
+- I-3 (session-id model): observed
+  - Variant A distinct session-ids: <N>
+  - Variant B distinct session-ids: <N>
+- I-6 (retry layer): observed
+  - Variant A retry messages observed: <count>
+  - Variant B retry messages observed: <count>
+  - TokenPak proxy retry events recorded: <count from tp_events.error_class='retry'>
+
+## Verdicts
+
+- **H1 (cache prefix disruption)**: <supported | not_supported | inconclusive>
+  - Reason: <e.g. variant A cache fields unobservable on OAuth path; variant B cache_hit_ratio = X.XX taken as standalone signal>
+- **H2 (session-id collapse)**: <supported | not_supported | inconclusive>
+  - Variant A distinct sessions: <N>
+  - Variant B distinct sessions: <N>
+  - Ratio: <N>×
+
+## Concurrency ceiling (§4.5 target)
+
+- Native: N_native_max = <number>
+- TokenPak: N_tokenpak_max = <number>
+- Ratio: <N_tokenpak_max / N_native_max>×
+- §4.5 target met (≥ 0.8×): <yes | no>
+- If no, attribution: <which feature accounts for the gap?>
+
+## Dominant cause
+
+<copy-paste from the diff script's "Synthesis" block, OR write your own
+when the diff is inconclusive due to OAuth/subscription unobservability>
+
+## Confidence
+
+<high | medium | low>
+
+## Recommended next phase
+
+- <NCP-2 if H1 supported and well-attributed>
+- <NCP-3 if H2 supported>
+- <Combined NCP-2 + NCP-3 if both>
+- <Instrumentation expansion (NCP-1+ instrumentation phase) if H1 inconclusive
+   on OAuth path AND we need direct cache evidence>
+- <No fix if both unsupported and concurrency ceiling parity is met>
+
+## Out-of-band observations
+
+<free-form: anomalies the operator noticed during the run>
+
+## Attached files
+
+- `tests/baselines/ncp-1r-parity/native-<TIMESTAMP>.json`
+- `tests/baselines/ncp-1r-parity/tokenpak-<TIMESTAMP>.json`
+- `tests/baselines/ncp-1r-parity/results-<TIMESTAMP>.md`
+- `~/ncp1r-claude-version-A.txt` and `-B.txt` (CLI version captures)
+```
+
+---
+
+## 9. Failure modes + reproducibility
+
+### 9.1 Common gotchas (NCP-1R-specific)
+
+- **Variant B routes through TokenPak's `anthropic` provider (API key) instead of `tokenpak-claude-code` (OAuth).** Symptom: `tp_events.provider='anthropic'` rows. Fix: re-check `tokenpak creds list`, ensure the claude-code-OAuth route is selected. Re-run the test — the previous data is invalid for I-0.
+- **Variant A and variant B Claude CLI versions differ.** Pinning matters because `User-Agent` matters for billing-pool routing. Re-run with the same version.
+- **TokenPak proxy was started under a different OS user / `TOKENPAK_HOME`.** TokenPak may pick up a different `~/.claude/.credentials.json`. Verify the OAuth account UUID matches between variants.
+- **Variant A used a proxy (`HTTPS_PROXY` was set).** The CLI may refuse OAuth through a TLS-intercepting proxy, OR the test inadvertently became an API-key test. Re-run with `unset HTTPS_PROXY`.
+- **Anthropic rolled out a model change between runs.** Pin the model explicitly (e.g. via the CLI's `--model` flag) so both variants hit the same model.
+
+### 9.2 Reproducibility
+
+The protocol is reproducible when:
+
+- The two `*.json` baselines + the diff `*.md` are checked into `tests/baselines/ncp-1r-parity/`.
+- The operator's CLI version captures (`*-A.txt`, `*-B.txt`) are attached.
+- The pre-test invariant check output is captured (e.g. via `tee`).
+- The workload (prompt sequence) is captured in the results.
+
+A second operator running the same workload with the same TokenPak / Claude versions on a similar Claude Pro / Max / Team seat should reach the same verdicts (within threshold noise).
+
+---
+
+## 10. Out of scope for NCP-1R
+
+- ❌ Implementing measurement instrumentation (NCP-1+ instrumentation phase).
+- ❌ Implementing fail-safe (NCP-4).
+- ❌ Changing companion behavior.
+- ❌ Changing proxy behavior (failover, connection pool, retry, credential injection unchanged).
+- ❌ Changing session-id behavior (NCP-3 fix).
+- ❌ Changing cache placement (NCP-2 fix).
+- ❌ Comparing across auth planes (would invalidate I-0).
+- ❌ mitmproxy / TLS-intercept-based capture on the OAuth/subscription path. (See §11.)
+- ❌ Other interactive clients (Codex, Cursor) — the standard generalizes; this protocol is Claude Code only.
+
+NCP-1R is **strictly observational + operator-run on the same OAuth/subscription account.**
+
+---
+
+## 11. Why mitmproxy is forbidden in this protocol
+
+mitmproxy works by intercepting TLS — installing a CA cert that signs upstream certs on the fly. For an Anthropic API-key call, that's fine: the CLI just sends `x-api-key`, the intercept terminates TLS, decrypts the body, re-encrypts, forwards. The auth plane is unchanged.
+
+For Claude Code OAuth/subscription, **mitmproxy MAY break the OAuth flow** depending on `claude` CLI version: the CLI may detect a TLS intercept and refuse the OAuth handshake, OR it may complete but with subtly different headers (e.g. dropping the `claude-code-20250219` beta because it can't verify the server cert chain). Either way: the variant under test is no longer the same as the user's normal Claude Code behavior.
+
+For the **secondary** API-key protocol (`ncp-1-ab-test-protocol-2026-04-26.md`), mitmproxy is fine — the auth plane is API-key on both sides. Use that protocol if you specifically want to settle API-key parity questions.
+
+For NCP-1R, capture observable client behavior (TUI text, latency, success rate, retry messages, concurrency ceiling) instead. The data is less granular but it answers the right question.
+
+---
+
+## 12. Cross-references
+
+- `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md` — the standard (NCP-1R revision); §1.5 auth-plane definitions; I-0 master invariant; §4.5 concurrency parity target
+- `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md` — the diagnostic plan + hypothesis matrix
+- `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md` — the secondary (harness validation) protocol
+- `scripts/capture_parity_baseline.py` — capture script (works for both protocols; auth-plane-aware filtering for NCP-1R is a future NCP-1+ instrumentation deliverable)
+- `scripts/diff_parity_baselines.py` — diff script
+- `tokenpak/services/routing_service/credential_injector.py::ClaudeCodeCredentialProvider` — the I-0 / I-3 surface (auth-plane preservation + session-id rotation)
+- `tokenpak/proxy/failover_engine.py` — the I-6 surface (retry layer)
+
+---
+
+## 13. Acceptance criteria
+
+NCP-1R is **complete** when:
+
+- [x] The auth-plane scoping correction is reflected in the standard (§1.5 + I-0 + I-3 + I-6 + §4.5).
+- [x] This primary protocol exists.
+- [x] The 2026-04-26 NCP-1 protocol is marked secondary with a forwarding banner.
+- [x] The pre-test invariant checks (§2) are concrete and runnable.
+- [x] The observable-behavior capture (§3.2 + §6) is documented.
+- [x] The results template (§8) handles the OAuth/subscription unobservability cleanly.
+- [x] No runtime / classifier / routing / retry / cache / session-id behavior changes.
+- [ ] CI green on the closeout PR.
+
+After NCP-1R lands, the next step is the operator (NCP-1A) running §5.1 + §5.2 + §5.3 on a real Claude Code OAuth/subscription account and submitting the §8 results.

--- a/docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md
+++ b/docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md
@@ -1,25 +1,26 @@
 # Standard #24 (proposal) — Native Client Concurrency Parity
 
-**Status**: 🟡 **ratified in principle (2026-04-26)** — promotion to vault gated on NCP-1 data
-**Date**: 2026-04-26
-**Workstream**: NCP (Native Client Concurrency Parity) diagnostic
-**Authors**: Sue (draft) / Kevin (review)
+**Status**: 🟡 **NCP-1R revision (2026-04-26)** — supersedes the 2026-04-26 draft after auth-plane scoping correction; promotion to vault gated on NCP-1R-validated test data
+**Date**: 2026-04-26 (NCP-1R revision)
+**Workstream**: NCP (Native Client Concurrency Parity)
+**Authors**: Sue (draft) / Kevin (review + auth-plane scoping correction)
 **Canonical home (when promoted)**: `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/24-native-client-concurrency-parity-standard.md`
 **Companion docs**:
   - Diagnostic plan: `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`
-  - A/B test protocol: `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md`
+  - **Primary** (NCP-1R) test protocol: `docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md`
+  - **Secondary** (harness validation only) test protocol: `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md`
 
-> Kevin **ratified the five invariants and the fail-safe contract in principle on 2026-04-26**. Promotion to the canonical vault location is gated on NCP-1 data either confirming or adjusting the measurement thresholds (specifically the H1 cache-hit-delta threshold and H2 session-id rotation-ratio threshold). Until promoted, no code path is required to honour the standard, but the invariants ARE the design contract for any NCP-x implementation work.
+> Kevin **ratified the invariants in principle on 2026-04-26**, then issued a scoping correction the same day: the test target is **Claude Code OAuth/subscription** parity, not generic Anthropic API-key traffic. The 2026-04-26 NCP-1 protocol was redesigned to enforce this scope (NCP-1R). Promotion to the canonical vault location is gated on NCP-1R data. Until promoted, the invariants ARE the design contract for any NCP-x implementation work.
 
 ---
 
 ## 0. Premise
 
-When TokenPak fronts an interactive client (Claude Code Companion through TokenPak; future: Codex, Cursor, etc.), users observe upstream rate-limit behavior **earlier** than they would when running the same client natively. This standard codifies the invariants that prevent TokenPak from becoming the **rate-limit amplifier** in any user's stack.
+When TokenPak fronts an interactive client (Claude Code Companion through TokenPak; future: Codex, Cursor, etc.), users observe upstream rate-limit / retry behavior **earlier** than they would when running the same client natively. This standard codifies the invariants that prevent TokenPak from becoming the **rate-limit amplifier** in any user's stack.
 
-The principle: *a TokenPak-fronted client must reach upstream rate limits at the same wall-clock rate as the same client running natively against the same account, under the same workload.* When parity cannot be achieved, the deviation must be **documented**, **opt-in**, and **measurable**.
+The principle: *a TokenPak-fronted client must reach upstream rate limits at the same wall-clock rate as the same client running natively against the same account, under the same workload, **on the same authentication plane**.* When parity cannot be achieved, the deviation must be **documented**, **opt-in**, and **measurable**.
 
-This standard does NOT prescribe specific implementations. It pins the **invariants**, the **measurement surfaces**, and the **fail-safe contract** that any TokenPak surface fronting a native interactive client must satisfy.
+This standard pins the **invariants**, the **measurement surfaces**, and the **fail-safe contract** that any TokenPak surface fronting a native interactive client must satisfy.
 
 ---
 
@@ -33,11 +34,37 @@ This standard does NOT prescribe specific implementations. It pins the **invaria
 - **Session bucket**: the rate-limit attribution dimension keyed by the provider's session-id-equivalent header (e.g. `X-Claude-Code-Session-Id`).
 - **Concurrency parity**: the property that N concurrent native sessions and N concurrent TokenPak-fronted sessions, doing the same work, hit upstream rate limits at the same time.
 
+### 1.5 Authentication planes (NCP-1R)
+
+The product issue is **auth-plane-specific**. A test that compares two variants on different auth planes is invalid for parity questions even when every other variable is controlled. The four auth planes TokenPak observes:
+
+| Auth plane | Native CLI signal | TokenPak provider slug | Bucket attribution |
+|---|---|---|---|
+| **Claude Code OAuth/subscription** | `~/.claude/.credentials.json` OAuth token + `claude-code-20250219` beta + `X-Claude-Code-Session-Id` | `tokenpak-claude-code` | User's Claude Pro / Max / Team subscription seat |
+| **Anthropic API key** | `x-api-key: sk-ant-…` header | `anthropic` | API key's organization quota |
+| **Cloud-provider** (Bedrock / Vertex) | SigV4 / Vertex OAuth | `aws-bedrock` / `gcp-vertex` (future) | Cloud account quota |
+| **TokenPak proxy API-compatible** | Caller credential passed through TokenPak | varies | Same as the caller's underlying credential class |
+
+Cross-plane comparison is **invalid by default** (see Invariant I-0). When TokenPak fronts an OAuth user, the proxy MUST keep the OAuth attribution — never silently convert to an API-key path, never collapse the user's seat into a different bucket.
+
 ---
 
 ## 2. Invariants
 
-The five invariants every TokenPak surface fronting a native client MUST honour. Numbered for citation in PRs and bug reports.
+The five original invariants from the 2026-04-26 draft are kept; **two new invariants (I-0, I-6)** were added in the NCP-1R revision and **I-3 was strengthened** to reflect the OAuth/subscription scoping correction.
+
+### Invariant I-0 — Auth-plane parity (master invariant — added NCP-1R)
+
+A native-client parity comparison is **only valid** when both variants use the same auth plane (per §1.5). TokenPak surfaces fronting a native OAuth/subscription client MUST:
+
+- Keep the same credential class on the wire — pass through the OAuth token, do NOT swap to API-key authentication.
+- Attribute traffic to the same subscription bucket — never reroute through a different organization or account.
+- Preserve the model-selection behavior the native client would observe (e.g. `claude-code-20250219` beta-gated model lists).
+- Not introduce a TokenPak-side bucket (e.g. a TokenPak-managed API key) that supersedes the user's auth.
+
+If a TokenPak surface ever needs to convert auth (e.g. to share a TokenPak-managed key for billing isolation), that conversion MUST be deliberate, configured, and disclosed to the user — never the default for a native-client-fronted surface.
+
+**Test validity rule**: any NCP-1R-style A/B comparison that spans two different auth planes is automatically inconclusive. The diff tool MUST detect cross-plane comparisons and refuse to render a verdict.
 
 ### Invariant I-1 — Token amplification is bounded and disclosed
 
@@ -55,11 +82,12 @@ For every adapter that declares `tip.byte-preserved-passthrough`:
 - Companion-side context injection that runs **pre-bytes** (before the proxy) is exempt from the proxy's byte-preservation guarantee but is **still subject to I-1**.
 - The cache hit ratio for TokenPak-fronted requests MUST be measurable per surface.
 
-### Invariant I-3 — Session bucket parity
+### Invariant I-3 — Session parity (strengthened NCP-1R)
 
 When fronting a client whose upstream provider attributes rate limits per session-id (or equivalent dimension):
 
-- TokenPak surfaces MUST NOT collapse multiple native invocations onto a **single** session-id by default. The session-id MUST either: (a) be passed through from the native client unchanged, or (b) be rotated on a per-invocation / per-time-window basis.
+- TokenPak surfaces MUST NOT collapse multiple native invocations onto a **single** session-id by default. Specifically: **TokenPak must not collapse multiple Claude Code sessions into a single process/session identity if native Claude Code would treat them independently.**
+- The session-id MUST either: (a) be passed through from the native client unchanged, or (b) be rotated on a per-invocation / per-time-window basis matching the native client's natural rotation cadence.
 - A long-lived proxy process that synthesizes one session-id and reuses it for hours / days **violates** this invariant.
 - Where session-id pass-through is impossible (the native client doesn't emit one), the surface MUST rotate at a frequency that approximates the native client's natural rotation cadence.
 
@@ -80,6 +108,15 @@ When upstream rate-limit headroom is **low** (heuristic: ≥ N 429s in the last 
 - The degradation MUST be observable in `tokenpak doctor --parity` and in the request trace.
 - The degradation MUST NOT alter the request's user-visible content (the user prompt MUST still go through unchanged); only TokenPak-added enrichment is dropped.
 - After H seconds of clear traffic, the surface MAY re-enable features (hysteresis).
+
+### Invariant I-6 — Retry parity (added NCP-1R)
+
+TokenPak surfaces MUST NOT add an additional retry layer on top of the native client's own retry behavior by default. Specifically for Claude Code:
+
+- The `claude` CLI handles its own backoff + retry against `api.anthropic.com`. A TokenPak proxy that ALSO retries on the same 429 multiplies upstream pressure and burns the user's quota faster than the native CLI would.
+- The proxy's failover-engine retry path MUST be **off by default** for native-client-fronted traffic — the client retries, the proxy passes the response through unchanged.
+- A proxy-side retry MAY be enabled when the user explicitly opts in (e.g. for non-interactive callers like OpenClaw that have no native retry layer), but MUST NOT be the default for OAuth/subscription Claude Code traffic.
+- The first error response from the upstream MUST reach the client unchanged, including 429s with `Retry-After` headers — the client decides whether to retry.
 
 ---
 
@@ -111,6 +148,8 @@ Every TokenPak surface fronting a native client MUST report the following metric
 | `ratelimit_requests_remaining` | gauge per req | upstream response header |
 | `session_id` | label | injected session-id at the wire |
 | `session_id_rotations_per_hour` | gauge | session-id-rotation logic |
+| **`auth_plane`** *(NCP-1R)* | **label** | **provider slug at the wire — used to enforce I-0** |
+| **`credential_class`** *(NCP-1R)* | **label** | **`oauth_subscription` / `api_key` / `cloud_provider` / `passthrough` — used to enforce I-0** |
 
 The metrics MUST be available as both:
 
@@ -138,6 +177,16 @@ The fail-safe behavior MUST be:
 
 The exact thresholds (3 / 60 / 120 / 10%) are defaults; the surface MAY expose them as host-configurable knobs in `~/.tokenpak/policy.yaml` under a new `parity_fail_safe` block.
 
+### 4.5 Concurrency parity target (added NCP-1R)
+
+This is a **soft target**, not a hard invariant — but it's the load-bearing user-facing property:
+
+> If native Claude Code can sustain N concurrent TUI sessions before disruptive rate-limit / retry behavior, TokenPak Companion should sustain materially similar concurrency unless a measured, documented TokenPak feature overhead explains the difference.
+
+"Materially similar" is operationalized as: **TokenPak Companion sustains ≥ 0.8 × N before equivalent disruption**, where N is the native baseline at the same workload + same auth plane.
+
+Anything below 0.8 × N requires a documented attribution: which feature (vault, capsule, intent guidance, retry layer, etc.) accounts for the gap. A gap with no measured attribution is a parity bug.
+
 ---
 
 ## 5. What this standard does NOT mandate
@@ -145,10 +194,11 @@ The exact thresholds (3 / 60 / 120 / 10%) are defaults; the surface MAY expose t
 To avoid scope creep:
 
 - ❌ **Specific implementation** of session-id rotation. Rotate per-invocation, per-time-window, or per-N-requests — the standard pins the **outcome** (no quota debt accumulation on a single id), not the mechanism.
-- ❌ **Hard ceiling on companion features**. Vault, capsules, intent guidance can ALL stay enabled at full tilt as long as I-1 (amplification bounded), I-2 (cache prefix preserved), and I-5 (fail-safe wired) hold.
+- ❌ **Hard ceiling on companion features**. Vault, capsules, intent guidance can ALL stay enabled at full tilt as long as I-0 (auth-plane parity), I-1 (amplification bounded), I-2 (cache prefix preserved), and I-5 (fail-safe wired) hold.
 - ❌ **Breaking changes to existing config**. Today's `TOKENPAK_COMPANION_ENRICH = 0` env-var path stays valid. The standard adds a new parity-aware fail-safe; it does not deprecate the existing knobs.
 - ❌ **Proxy-side mutation of byte-preserved adapters** to satisfy I-2. The companion runs pre-bytes; that's where I-2 is enforced. The proxy's byte-preservation guarantee is preserved by construction.
 - ❌ **Rate-limit prediction** (e.g. "decline this request because we expect a 429"). The standard pins **reactive** fail-safe; predictive admission control is a future ratification.
+- ❌ **Auth-plane conversion**. Even when an operator has both an OAuth subscription AND an API key, the standard does NOT permit silent conversion between them — it's I-0's whole point.
 
 ---
 
@@ -157,10 +207,11 @@ To avoid scope creep:
 A TokenPak surface (companion / proxy / future Codex companion / future Cursor companion) is "Native Client Parity conformant" when:
 
 1. It declares conformance via a manifest entry (e.g. `tip.parity.native-client-v1` capability).
-2. Every metric in §3 is emitted on every request (or a documented subset for surfaces that don't see every dimension).
+2. Every metric in §3 is emitted on every request (or a documented subset for surfaces that don't see every dimension), **including the new `auth_plane` and `credential_class` labels (NCP-1R)**.
 3. The fail-safe contract in §4 is wired and tested under load.
-4. The five invariants in §2 are pinned by tests in CI.
-5. The host-facing operator surface (`tokenpak doctor --parity` or equivalent) renders the conformance state.
+4. The seven invariants in §2 (I-0, I-1, I-2, I-3, I-4, I-5, I-6) are pinned by tests in CI.
+5. The host-facing operator surface (`tokenpak doctor --parity` or equivalent) renders the conformance state, including the auth-plane label.
+6. The §4.5 concurrency parity target is measured and reported.
 
 A surface that **cannot** satisfy a specific invariant (e.g. a future BedrockAdapter that has no equivalent of `Retry-After`) MUST document the deviation explicitly in its standard manifest, and the surface declares "partial-parity" instead of "parity".
 
@@ -185,12 +236,13 @@ Once this standard is ratified, the implementation work falls into the NCP serie
 
 | Phase | Scope |
 |---|---|
-| **NCP-1** | Measurement implementation. Wire every metric in §3. `tokenpak doctor --parity`. No behavior change. |
-| **NCP-2** | Cache-prefix-preserving companion injection. Fix the I-2 deviation that the diagnostic identified (vault content varying per request → cache miss every request). |
-| **NCP-3** | Session-id rotation strategy. Fix the I-3 deviation (proxy collapses many invocations onto one id). |
+| **NCP-1R** | Auth-plane-corrected diagnostic standard + test protocol redesign. Documentation only. *(landing now)* |
+| **NCP-1A** | Operator-run A/B test against a real Claude Code OAuth/subscription account. Settles H1 + H2 + the I-0 / I-3 / I-6 invariants under real load. |
+| **NCP-2** | Cache-prefix-preserving companion injection. Fix the I-2 deviation if NCP-1A confirms H1. |
+| **NCP-3** | Session-id rotation strategy. Fix the I-3 deviation if NCP-1A confirms H2. |
 | **NCP-4** | Fail-safe circuit breaker. Wire I-5. |
-| **NCP-5** | `Retry-After` honour layer. Fix the I-4 deviation. |
-| **NCP-6** | `tokenpak parity report` CLI + dashboard panel. |
+| **NCP-5** | `Retry-After` honour layer + I-6 retry-parity enforcement. |
+| **NCP-6** | `tokenpak parity report` CLI + dashboard panel + auth-plane label rendering. |
 
 Each NCP-x requires its own ratification cycle; this standard does not pre-authorize any of them.
 
@@ -200,21 +252,33 @@ Each NCP-x requires its own ratification cycle; this standard does not pre-autho
 
 The standard is ratified when:
 
-- [ ] Kevin signs off on the five invariants (§2) and the fail-safe contract (§4).
+- [ ] Kevin signs off on the seven invariants (§2) and the fail-safe contract (§4) **in their NCP-1R-revised form**.
 - [ ] A copy lands at `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/24-native-client-concurrency-parity-standard.md` (canonical home).
 - [ ] The `09-audit-rubric.md` standard gains a new row referencing this one.
-- [ ] The diagnostic report (`docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`) is referenced from the §1 of this standard.
-- [ ] An NCP-1 directive (or equivalent) opens the implementation work.
+- [ ] The diagnostic report (`docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md`) is referenced from §1 of this standard.
+- [ ] An NCP-1A operator-run test result is in, settling H1 + H2 + the auth-plane invariants.
 
-Until those five gates close, this document remains a **proposal**. No surface is required to honour it.
+Until those gates close, this document remains a **proposal**. No surface is required to honour it.
 
 ---
 
 ## 10. Cross-references
 
 - `docs/internal/specs/native-client-concurrency-parity-diagnostic-2026-04-26.md` — companion diagnostic plan + hypothesis matrix + recommended tests
+- `docs/internal/specs/ncp-1r-oauth-parity-protocol-2026-04-26.md` — **primary** NCP-1R operator protocol (OAuth/subscription scoped)
+- `docs/internal/specs/ncp-1-ab-test-protocol-2026-04-26.md` — **secondary** harness validation protocol (API-key / mitmproxy; cannot settle the OAuth/subscription parity issue)
 - `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/23-provider-adapter-standard.md` — adapter capability standard this builds on
 - `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/09-audit-rubric.md` — audit checklist (will gain a parity row at ratification)
-- `tokenpak/proxy/adapters/anthropic_adapter.py` — current AnthropicAdapter (declares `tip.byte-preserved-passthrough`; would also declare `tip.parity.native-client-v1` once NCP-1 lands)
+- `tokenpak/proxy/adapters/anthropic_adapter.py` — current AnthropicAdapter (declares `tip.byte-preserved-passthrough`; would also declare `tip.parity.native-client-v1` once NCP-1+ instrumentation lands)
 - `tokenpak/companion/hooks/pre_send.py` — companion pre-send enrichment (the primary I-1 / I-2 surface to instrument)
-- `tokenpak/services/routing_service/credential_injector.py::ClaudeCodeCredentialProvider` — the I-3 surface (session-id collapse)
+- `tokenpak/services/routing_service/credential_injector.py::ClaudeCodeCredentialProvider` — the I-0 / I-3 surface (auth-plane preservation + session-id collapse)
+- `tokenpak/proxy/failover_engine.py` — the I-4 / I-6 surface (Retry-After + retry parity)
+
+---
+
+## 11. Revision history
+
+| Date | Revision | Notes |
+|---|---|---|
+| 2026-04-26 | NCP-0 draft | Initial proposal. Five invariants (I-1 through I-5). API-key-flavored test protocol. |
+| 2026-04-26 | **NCP-1R revision** | Auth-plane scoping correction. Added I-0 (auth-plane parity master invariant) and I-6 (retry parity). Strengthened I-3 wording. Added §1.5 (auth-plane definitions). Added §4.5 (concurrency parity target). Added `auth_plane` + `credential_class` to §3 measurement contract. New primary protocol `ncp-1r-oauth-parity-protocol-2026-04-26.md`; old protocol marked secondary (harness validation only). |


### PR DESCRIPTION
## Summary

Kevin's scoping correction (2026-04-26): the NCP test target is **Claude Code OAuth/subscription** parity, not generic Anthropic API-key traffic. The original NCP-0 standard + NCP-1 protocol were scoped against API-key auth, which **cannot answer the actual product issue**.

This is a **docs-only** PR. No code, no tests change. The capture / diff scripts and the 28-test suite from NCP-1 still apply.

## What changed

### Standard #24 — major revision

- **New §1.5 \"Authentication planes\"** defining four auth-plane classes (OAuth/subscription, API key, cloud provider, proxy passthrough)
- **New Invariant I-0 (master)** — auth-plane parity. A cross-plane comparison is automatically inconclusive
- **Strengthened I-3** — TokenPak must not collapse multiple Claude Code sessions into a single process/session identity if native Claude Code would treat them independently
- **New Invariant I-6** — retry parity. TokenPak must not add an additional retry layer on top of Claude Code's own retry behavior by default
- **New §4.5 concurrency parity target** — TokenPak Companion sustains ≥ 0.8 × N before equivalent disruption (soft target with documented-attribution requirement below threshold)
- **New §3 metrics** — \`auth_plane\` + \`credential_class\` labels added to the measurement contract
- **§11 revision history** added

### Primary protocol (new): \`ncp-1r-oauth-parity-protocol-2026-04-26.md\`

- §1 Auth plane under test — OAuth/subscription only; the other four planes explicitly out of scope
- §2 Pre-test invariant checks — I-0 / I-3 / I-6 + workload identity gates
- §3 Variant A — native Claude Code TUI capture (observable behavior only; no mitmproxy)
- §4 Variant B — TokenPak Companion capture (telemetry-driven; must verify \`provider=tokenpak-claude-code\`, NEVER \`anthropic\` API-key path)
- §5 Run order — §5.1 quick / §5.2 saturated / §5.3 concurrency ceiling
- §6 Observable-behavior capture rules — metrics not observable on the OAuth path stay null with documented reason
- §7 Diff report generation
- §8 Results template — OAuth/subscription-aware
- §9 Failure modes — I-0 violation detection, CLI version mismatch, HTTPS_PROXY leakage
- §11 Why mitmproxy is forbidden in this protocol — TLS intercept MAY break the Claude Code OAuth flow

### Secondary protocol (banner update): \`ncp-1-ab-test-protocol-2026-04-26.md\`

- Top banner: \"DEMOTED to secondary on 2026-04-26 (NCP-1R)\"
- The mitmproxy-based capture validates the harness end-to-end on **API-key** traffic, but **cannot settle the OAuth/subscription parity question**
- Use case: harness wiring validation only

### Diagnostic plan (banner addendum)

- NCP-1R amendment notice at the top
- Auth-plane scope clarified: H1/H2 evidence collected on different auth planes is not transferable

## Held throughout NCP-1R

- ❌ No runtime / proxy / companion / credential / failover behavior changes
- ❌ No script changes (capture + diff scripts unchanged; auth-plane label enforcement is a future NCP-1+ deliverable)
- ❌ No new tests (existing 28 still pass)
- ❌ No changes to retry / cache placement / session-id behavior

## Test plan

- [x] No code changes — 28/28 NCP-1 tests still green
- [x] Repo hygiene scan clean
- [x] All four docs cross-reference each other
- [x] Standard's §11 revision history captures the NCP-1R diff
- [ ] CI green

## Cross-references

- Standard #24 §1.5 (new auth-plane definitions)
- I-0 (master invariant added in NCP-1R)
- I-3 (strengthened in NCP-1R)
- I-6 (new in NCP-1R)
- §4.5 concurrency parity target (new in NCP-1R)
- \`tokenpak/services/routing_service/credential_injector.py::ClaudeCodeCredentialProvider\` — the I-0 / I-3 surface
- \`tokenpak/proxy/failover_engine.py\` — the I-6 surface

## After this PR

The next step is the operator (NCP-1A) running §5.1 + §5.2 + §5.3 of the **primary** OAuth/subscription protocol against a real Claude Pro / Max / Team account, then submitting the §8 results template. **NCP-2 / NCP-3 implementation does not begin until those results are in.**