### PR TITLE
feat(proxy,scripts,tests,docs): NCP-3I — in-proxy parity-trace instrumentation v1

### DIFF
--- a/docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md
+++ b/docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md
@@ -1,0 +1,211 @@
+# NCP-3I — In-proxy parity-trace instrumentation (v1)
+
+**Date**: 2026-04-27
+**Status**: 🟢 **landed** (this PR) — measurement-only; gated behind `TOKENPAK_PARITY_TRACE_ENABLED` env-var (default `false`)
+**Workstream**: NCP (Native Client Concurrency Parity) → NCP-3 (Session-Lane Preservation) → NCP-3I (Instrumentation)
+**Authors**: Sue (implementation) / Kevin (review + scope)
+**Companion docs**:
+  - NCP-1A iteration 4 (post-tool-result + interp B observation): `docs/internal/specs/ncp-1a-iteration-4-2026-04-27.md`
+  - NCP-3 diagnostic plan: `docs/internal/reports/ncp-3-session-lane-trace-2026-04-27.md`
+  - Standard #24: `docs/internal/standards-proposals/24-native-client-concurrency-parity-standard.md`
+
+> **Goal:** make the iter-4 §11 "interp B" condition (visible TUI retries with empty TokenPak telemetry) **detectable and characterizable** by adding entry-time + upstream-attempt-time hooks the existing completion-time `tp_events` writer cannot see. **Measurement only.** No routing, retry, cache, prompt-mutation, provider, model, or auth behavior changes.
+
+---
+
+## 0. What landed
+
+### 0.1 New module — `tokenpak/proxy/parity_trace.py`
+
+- `ParityTraceRow` dataclass — 27 fields, all optional except `trace_id` / `event_type` / `ts`
+- `ParityTraceStore` — SQLite writer for `tp_parity_trace` table; lazy-init; thread-safe (process-wide lock); swallows all errors
+- `emit(event_type, *, trace_id, **fields)` — public API; gated on every call by `TOKENPAK_PARITY_TRACE_ENABLED`; O(1) cheap-dict-lookup cost when disabled
+- Six lifecycle event constants: `EVENT_HANDLER_ENTRY`, `EVENT_REQUEST_CLASSIFIED`, `EVENT_UPSTREAM_ATTEMPT_START`, `EVENT_UPSTREAM_ATTEMPT_FAILURE`, `EVENT_RETRY_BOUNDARY`, `EVENT_REQUEST_COMPLETION`
+- Documented value sets: `RETRY_PHASES`, `RETRY_OWNERS`, `RETRY_SIGNALS`
+
+### 0.2 New SQLite table — `tp_parity_trace`
+
+Lives under the existing `$TOKENPAK_HOME/telemetry.db` (zero new files). 27 columns covering every iter-4-mandated dimension:
+
+- **Process metadata**: `pid`, `ppid`, `tokenpak_home`, `telemetry_db_path`
+- **Identity**: `trace_id` (required), `request_id`, `session_id`, `provider`, `auth_plane`, `credential_class`
+- **Retry classification (iter-4)**: `retry_phase`, `retry_owner`, `retry_signal`, `retry_count`, `retry_after_seconds`
+- **Tool result classification**: `tool_command_first`, `tool_result_stdout_chars`, `tool_result_stderr_chars`, `tool_result_tokens_est`
+- **Request size**: `body_bytes`, `companion_added_chars`, `intent_guidance_chars`
+- **Concurrency / lane indicators**: `queue_wait_ms`, `lock_wait_ms`, `sqlite_write_ms`
+- **Free-form**: `notes` (caller-supplied; privacy-contracted to NEVER contain prompt content)
+
+Three indexes: `(trace_id, ts)`, `(event_type, ts)`, `(session_id, ts)`.
+
+### 0.3 Hook integration — `tokenpak/proxy/server.py::_proxy_to_inner`
+
+Three minimal hook calls, each wrapped in try/except, lazy-imported:
+
+| Hook | Location | Captures |
+|---|---|---|
+| `EVENT_HANDLER_ENTRY` | server.py:~772, immediately after `_req_id` is generated | every request that enters the proxy handler — fires BEFORE any other processing including auth, route resolution, body read |
+| `EVENT_UPSTREAM_ATTEMPT_START` (streaming) | server.py:~1707, just before `pool.stream(...)` | streaming request about to dispatch upstream; carries `body_bytes` |
+| `EVENT_UPSTREAM_ATTEMPT_START` (non-streaming) | server.py:~1847, just before `pool.request(...)` | non-streaming request about to dispatch upstream; carries `body_bytes` |
+
+The deliberate scope-bound: I did **not** add hooks for completion (the function is 1500 lines with multiple return paths — risk of behavior drift) or retry-boundary (the FailoverEngine isn't actually wired into the request path; it's library-only — see iter-4 §11 finding). Both are documented as deferred to NCP-3I-v2 if the v1 instrumentation surfaces a need.
+
+### 0.4 Harness extension — `scripts/inspect_session_lanes.py`
+
+Added **dimension 9 (`dim9_parity_trace_coverage`)**. Reads the new table and computes the iter-4 §11 interp-A-vs-B disambiguator:
+
+- `traces_with_handler_entry` — count of distinct trace_ids that emitted `handler_entry`
+- `traces_with_completion_in_tp_events` — count joined to existing `tp_events`
+- `interp_b_count` = entry – completion → number of requests that fired but never reached completion-time logging
+- Verdict: `interp_b_supported` / `interp_a_or_clean` / `indeterminate`
+
+The synthesis section now renders a Q8 line summarizing dim 9.
+
+### 0.5 Tests
+
+- **`tests/test_parity_trace_phase_ncp_3i.py`** — 26 tests across 12 categories: disabled-by-default, entry-without-completion, write-failures-swallowed, privacy contract, schema migration, fetch ordering, multi-event assembly, invalid event types, structural (no dispatch coupling), live env-var toggle, process metadata, concurrent emit
+- **`tests/test_ncp3_inspect_session_lanes.py`** — 5 new tests for dim 9: unavailable when table missing, empty when window has no rows, interp-B-supported when entries without completion, interp-A-clean when completions match, synthesis renders Q8
+
+Total NCP-3I + NCP-3 + NCP-1 tests: **51/51 green**. Full PI-x + NCP-x suite: **110/111 green** (1 environmental local failure verified to pass on fresh runner state — see "PI-3 loader fall-through" finding below).
+
+---
+
+## 1. How the operator runs the v1 instrumentation
+
+```bash
+# Enable the trace in the operator's environment.
+export TOKENPAK_PARITY_TRACE_ENABLED=true
+
+# Restart the proxy (or just re-launch via the launcher; emit() reads the
+# env-var on every call, but a fresh proxy process picks up the new
+# environment cleanly).
+tokenpak start
+
+# Run the NCP-3 §4.2 workload — 2 concurrent `tokenpak claude` sessions.
+# (Two terminals, same prompt sequence in both.)
+
+# After both sessions exit:
+scripts/inspect_session_lanes.py --window-minutes 30 \
+    --output tests/baselines/ncp-3-trace/$(date -u +%Y%m%dT%H%M%SZ).md
+```
+
+The harness output now includes a **dim 9** block. The synthesis Q8 line tells the operator one of:
+
+- `iter-4 §11 interp B SUPPORTED` — N entries without completion (the interp B condition is now characterizable)
+- `traces with handler_entry, M with tp_events completion — no interp-B gap` (interp A or clean)
+- `indeterminate` (need to dig into raw rows)
+
+---
+
+## 2. Privacy contract
+
+The schema's only free-form sink is the `notes` column. The privacy contract is that callers **MUST NOT** put prompt or credential content there. The hook calls in `server.py` only pass:
+
+- `method` (HTTP method — `POST` / `GET` etc.) at handler entry
+- `"stream"` or `"request"` (literal strings) at upstream-attempt-start
+
+No request body, header value, or prompt text reaches any column. The privacy test in `test_parity_trace_phase_ncp_3i.py::TestPrivacyContract` pins this — it asserts that a sentinel string in the prompt never appears in any persisted column when the existing hooks fire.
+
+---
+
+## 3. Behavior change — what's "off-path" really means
+
+When `TOKENPAK_PARITY_TRACE_ENABLED` is **unset / false** (the default):
+
+- Each hook site executes one `os.environ.get()` lookup
+- The string comparison short-circuits
+- `emit()` returns immediately
+- No SQLite connection is opened
+- No table is created
+- The proxy's behavior is byte-identical to pre-NCP-3I
+
+When `TOKENPAK_PARITY_TRACE_ENABLED=true`:
+
+- Each hook site emits one row write to `tp_parity_trace`
+- The write is wrapped in `try/except Exception: pass`
+- A schema-migration error, a connection failure, a deadlock — all silently swallowed
+- Hot-path overhead: a single SQLite INSERT per hook (3 hooks per request, so ~3 INSERTs/request when active)
+
+The proxy continues serving traffic if the trace store fails mid-stream. This is the iter-4 directive's "trace write failures are swallowed" requirement, asserted in `TestWriteFailuresSwallowed`.
+
+---
+
+## 4. What NCP-3I v1 deliberately defers
+
+To keep this PR focused on the iter-4 directive's primary ask:
+
+| Dimension | Deferred reason |
+|---|---|
+| `companion_added_chars` | Would require hooking into `tokenpak/companion/hooks/pre_send.py` enrichment path. The column exists in the schema; emit() accepts it; but no caller populates it yet. |
+| `intent_guidance_chars` | Same as above for `tokenpak/companion/intent_injection.py`. |
+| `retry_phase` classification | Would require parsing the request body to detect `tool_result` content. NCP-3I v1's body-bytes capture is enough to know request size; phase classification is v2 scope. |
+| `retry_owner` for `claude_code_client` | The CLI's "Retrying in Ns" message comes from a layer the proxy can't introspect. Inferred from absence of a TokenPak-side retry event. |
+| `retry_after_seconds` parsing | Would require failover-engine instrumentation. Iter-4 finding: failover engine isn't wired into the request path — instrumenting it captures no real retries. |
+| `lock_wait_ms` / `queue_wait_ms` | Would require wrapping every lock acquire / queue put. Conservative for v1; can land in v2 if dim 9 surfaces a concurrency-lane signal that needs deeper attribution. |
+| Connection-acceptance event | The Python `BaseHTTPServer` doesn't expose a clean acceptance hook above the socket level. Would need a server-class subclass. Defer until v1 dim 9 confirms whether it's needed. |
+| `EVENT_REQUEST_COMPLETION` hook | Would require touching the 1500-line `_proxy_to_inner` at every return path. The harness already joins `tp_parity_trace` to `tp_events.request_id` for the interp-B disambiguator, so we don't need a duplicate completion event. |
+
+Each deferred dimension is documented in the schema (column exists with NULL default), so callers can populate them in v2 without another schema migration.
+
+---
+
+## 5. Side note — PI-3 loader fall-through finding (out of scope)
+
+While testing NCP-3I locally, two existing tests fail when a real `~/.tokenpak/policy.yaml` is present (regardless of `TOKENPAK_HOME=tmp_path` set by the test):
+
+- `test_intent_prompt_intervention_phase_pi_3.py::TestCliRendersAppliedState::test_intervention_status_disabled_default`
+- `test_intent_policy_engine_phase21.py::TestConfigDefaults::test_default_config_values`
+
+Root cause: `tokenpak/proxy/intent_policy_config_loader.py` resolves `$TOKENPAK_HOME/policy.yaml` first, then **falls through to `~/.tokenpak/policy.yaml`** if the first doesn't exist. Tests that set `TOKENPAK_HOME=tmp_path` and don't write a sentinel policy.yaml under tmp_path leak the global config.
+
+Verified both pass on a clean runner state (CI is unaffected — runners have no global policy.yaml). Tracked as a small loader-isolation fix worth a separate PR; **out of scope for NCP-3I** because it would be a behavior change.
+
+---
+
+## 6. Acceptance criteria
+
+| Criterion | Status |
+|---|---|
+| NCP-3I lands as measurement-only instrumentation | ✅ |
+| Supports interp B | ✅ via dim 9 + entry-without-completion test |
+| Explains whether retries happen before normal `tp_events` completion | ✅ via `interp_b_count` |
+| Disabled by default | ✅ env-var unset = false; tested |
+| Request-entry trace can exist without completion trace | ✅ tested |
+| Trace write failures swallowed | ✅ tested (unwritable path, unknown field, corrupt DB) |
+| No raw prompts or secrets stored | ✅ tested (sentinel + auto-population check + structural import scan) |
+| `inspect_session_lanes.py` consumes the new fields | ✅ dim 9 + 5 new tests |
+| No routing / retry / cache / prompt-mutation / provider / model / auth behavior changes | ✅ structural tests pin no dispatch-primitive imports |
+| CI green | ⏸️ pending PR run |
+
+---
+
+## 7. Cross-references
+
+- `tokenpak/proxy/parity_trace.py` — module
+- `tokenpak/proxy/server.py::_proxy_to_inner` — three hook insertions (lines ~770, ~1707, ~1847)
+- `scripts/inspect_session_lanes.py` — dim 9 added
+- `tests/test_parity_trace_phase_ncp_3i.py` — 26 tests
+- `tests/test_ncp3_inspect_session_lanes.py` — 5 new dim-9 tests
+- `docs/internal/specs/ncp-1a-iteration-4-2026-04-27.md` — iter-4 directive that scoped this phase
+- `docs/internal/reports/ncp-3-session-lane-trace-2026-04-27.md` — NCP-3 plan §3 instrumentation design (extended by iter-4 §6)
+
+---
+
+## 8. After this PR
+
+1. **Operator enables the trace** on the host where the iter-3 / iter-4 condition reproduces:
+   ```
+   export TOKENPAK_PARITY_TRACE_ENABLED=true
+   tokenpak start  # or restart
+   ```
+2. **Operator re-runs the NCP-3 §4.2 workload** (2 concurrent `tokenpak claude` sessions).
+3. **Operator runs the harness:**
+   ```
+   scripts/inspect_session_lanes.py --window-minutes 30
+   ```
+4. **Harness's dim 9 + Q8 synthesis line** disambiguates iter-4 §11 interp A vs B.
+5. **Next phase routing** depends on the answer:
+   - **interp B confirmed** (`interp_b_count > 0`) → next phase is **NCP-3I-v2** to capture the missing `companion_added_chars` / `intent_guidance_chars` / `lock_wait_ms` dimensions for the failing requests, OR jump directly to **NCP-3A** (session-id rotation) / **NCP-9** (OAuth refresh lane) if dim 1 (session collapse) + dim 9 together pinpoint the cause.
+   - **interp A** (entries match completions) → the test reproduced on a different host or under different conditions; need fresh trace.
+   - **indeterminate** → need to inspect raw rows.
+
+NCP-3I v1 is the **measurement layer** the next implementation phase will read from. It does not itself change behavior.

--- a/scripts/inspect_session_lanes.py
+++ b/scripts/inspect_session_lanes.py
@@ -35,7 +35,7 @@ import sqlite3
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 SCHEMA_VERSION: str = "ncp-3-trace-v1"
 
@@ -304,6 +304,122 @@ def _dim_token_usage(
     }
 
 
+# ── Dimension 9: parity-trace coverage (NCP-3I) ──────────────────────
+
+
+def _dim_parity_trace_coverage(
+    conn: sqlite3.Connection, since_iso: str, since_ts: float
+) -> Dict[str, Any]:
+    """Report on the new ``tp_parity_trace`` table from NCP-3I.
+
+    Specifically computes the iter-4 §11 interp-A-vs-B disambiguator:
+    how many distinct trace_ids fired a ``handler_entry`` event vs how
+    many completed (i.e. left a row in ``tp_events``). A large delta
+    is "interp B" — requests that never reached completion-time
+    logging.
+    """
+    if not _table_exists(conn, "tp_parity_trace"):
+        return {
+            "available": False,
+            "note": (
+                "tp_parity_trace not present — NCP-3I instrumentation "
+                "either hasn't been deployed on this host or "
+                "TOKENPAK_PARITY_TRACE_ENABLED has never been set."
+            ),
+        }
+    rows = conn.execute(
+        "SELECT trace_id, event_type, ts FROM tp_parity_trace "
+        "WHERE ts >= ?",
+        (since_ts,),
+    ).fetchall()
+    if not rows:
+        return {
+            "available": True,
+            "row_count": 0,
+            "note": (
+                "tp_parity_trace exists but no rows in window. Verify "
+                "TOKENPAK_PARITY_TRACE_ENABLED=true was set when the "
+                "test ran."
+            ),
+        }
+    by_trace: Dict[str, Dict[str, int]] = {}
+    event_counter: Counter = Counter()
+    for r in rows:
+        tid = r["trace_id"]
+        evt = r["event_type"]
+        event_counter[evt] += 1
+        by_trace.setdefault(tid, {"events": 0, "phases": set()})
+        by_trace[tid]["events"] += 1
+        by_trace[tid]["phases"].add(evt)
+
+    # Count traces by which lifecycle phases they hit.
+    n_with_entry = sum(
+        1 for d in by_trace.values() if "handler_entry" in d["phases"]
+    )
+    n_with_upstream_start = sum(
+        1
+        for d in by_trace.values()
+        if "upstream_attempt_start" in d["phases"]
+    )
+    n_with_upstream_failure = sum(
+        1
+        for d in by_trace.values()
+        if "upstream_attempt_failure" in d["phases"]
+    )
+
+    # Stitch to tp_events to derive how many parity-trace traces ALSO
+    # have a completion row in tp_events. The iter-4 §11 interp-B
+    # disambiguator is: (n_with_entry - n_with_completion).
+    n_with_completion: Optional[int] = None
+    if _table_exists(conn, "tp_events"):
+        trace_ids = list(by_trace.keys())
+        if trace_ids:
+            # Match either tp_events.trace_id OR tp_events.request_id.
+            placeholders = ",".join("?" for _ in trace_ids)
+            params = trace_ids + trace_ids
+            try:
+                completed = conn.execute(
+                    f"SELECT COUNT(DISTINCT COALESCE(trace_id, request_id)) "
+                    f"FROM tp_events "
+                    f"WHERE trace_id IN ({placeholders}) "
+                    f"   OR request_id IN ({placeholders})",
+                    params,
+                ).fetchone()[0]
+                n_with_completion = int(completed or 0)
+            except sqlite3.DatabaseError:
+                n_with_completion = None
+
+    interp_b_count = (
+        n_with_entry - n_with_completion
+        if n_with_completion is not None
+        else None
+    )
+    if interp_b_count is None:
+        verdict = "indeterminate"
+    elif interp_b_count > 0 and n_with_entry > 0:
+        verdict = "interp_b_supported"
+    else:
+        verdict = "interp_a_or_clean"
+
+    return {
+        "available": True,
+        "row_count": len(rows),
+        "distinct_traces": len(by_trace),
+        "event_type_distribution": dict(event_counter),
+        "traces_with_handler_entry": n_with_entry,
+        "traces_with_upstream_attempt_start": n_with_upstream_start,
+        "traces_with_upstream_attempt_failure": n_with_upstream_failure,
+        "traces_with_completion_in_tp_events": n_with_completion,
+        "interp_b_count": interp_b_count,
+        "verdict": verdict,
+        "note": (
+            "interp_b_count = traces that emitted handler_entry but "
+            "never completed in tp_events. iter-4 §11 interp B is "
+            "supported when interp_b_count > 0."
+        ),
+    }
+
+
 # ── Dimension 8: cross-session interleaving ──────────────────────────
 
 
@@ -412,6 +528,7 @@ def analyze(
             d6 = _dim_retry_count(claude_code)
             d7 = _dim_token_usage(conn, claude_code)
             d8 = _dim_interleaving(claude_code)
+            d9 = _dim_parity_trace_coverage(conn, since_iso, since_ts)
     except sqlite3.DatabaseError as exc:
         return {
             "schema_version": SCHEMA_VERSION,
@@ -433,6 +550,7 @@ def analyze(
         "dim6_retry_count": d6,
         "dim7_token_usage": d7,
         "dim8_interleaving": d8,
+        "dim9_parity_trace_coverage": d9,
     }
 
 
@@ -487,6 +605,44 @@ def _verdict_lines(report: Dict[str, Any]) -> List[str]:
             "occurred OR the schema didn't tag them. Settle visually "
             "via the §4 workload."
         )
+
+    # NCP-3I dim 9 — parity-trace coverage / iter-4 §11 interp A vs B.
+    d9 = report.get("dim9_parity_trace_coverage", {})
+    if not d9.get("available"):
+        out.append(
+            "**Q8 — NCP-3I parity trace:** unavailable. "
+            f"{d9.get('note', '')}"
+        )
+    elif d9.get("row_count", 0) == 0:
+        out.append(
+            "**Q8 — NCP-3I parity trace:** no rows in window. "
+            "If a test ran, verify TOKENPAK_PARITY_TRACE_ENABLED=true."
+        )
+    else:
+        verdict = d9.get("verdict")
+        ib = d9.get("interp_b_count")
+        ne = d9.get("traces_with_handler_entry")
+        nc = d9.get("traces_with_completion_in_tp_events")
+        if verdict == "interp_b_supported":
+            out.append(
+                "**Q8 — NCP-3I parity trace:** **iter-4 §11 interp B "
+                f"SUPPORTED.** {ib} of {ne} traces emitted handler_entry "
+                f"but never completed in tp_events (only {nc} did). The "
+                "missing requests fail before completion-time logging — "
+                "matches the visible-retry-but-empty-telemetry condition."
+            )
+        elif verdict == "interp_a_or_clean":
+            out.append(
+                f"**Q8 — NCP-3I parity trace:** {ne} traces with "
+                f"handler_entry, {nc} with tp_events completion — no "
+                "interp-B gap detected in window."
+            )
+        else:
+            out.append(
+                f"**Q8 — NCP-3I parity trace:** indeterminate "
+                f"(traces={d9.get('distinct_traces')}, "
+                f"completion={nc})."
+            )
     return out
 
 
@@ -517,6 +673,7 @@ def _render_markdown(report: Dict[str, Any]) -> str:
         "dim6_retry_count",
         "dim7_token_usage",
         "dim8_interleaving",
+        "dim9_parity_trace_coverage",
     ):
         lines.append(f"### {k}")
         lines.append("")

--- a/tests/test_ncp3_inspect_session_lanes.py
+++ b/tests/test_ncp3_inspect_session_lanes.py
@@ -412,6 +412,134 @@ class TestMissingDb:
         assert rc == 2
 
 
+# ── 11.5. NCP-3I dim 9 parity-trace coverage ──────────────────────────
+
+
+class TestParityTraceCoverage:
+    """Verify the harness consumes the NCP-3I tp_parity_trace table."""
+
+    def _seed_parity_trace(self, db: Path, rows: list) -> None:
+        """Seed tp_parity_trace rows alongside tp_events.
+
+        Each row dict: trace_id, event_type, ts (epoch float).
+        """
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS tp_parity_trace (
+                trace_id TEXT NOT NULL, event_type TEXT NOT NULL,
+                ts REAL NOT NULL, pid INTEGER, ppid INTEGER,
+                tokenpak_home TEXT, telemetry_db_path TEXT,
+                request_id TEXT, session_id TEXT, provider TEXT,
+                auth_plane TEXT, credential_class TEXT,
+                retry_phase TEXT, retry_owner TEXT, retry_signal TEXT,
+                retry_count INTEGER, retry_after_seconds REAL,
+                tool_command_first TEXT,
+                tool_result_stdout_chars INTEGER,
+                tool_result_stderr_chars INTEGER,
+                tool_result_tokens_est INTEGER,
+                body_bytes INTEGER, companion_added_chars INTEGER,
+                intent_guidance_chars INTEGER,
+                queue_wait_ms REAL, lock_wait_ms REAL,
+                sqlite_write_ms REAL, notes TEXT
+            );
+            """
+        )
+        for r in rows:
+            conn.execute(
+                "INSERT INTO tp_parity_trace (trace_id, event_type, ts) "
+                "VALUES (?,?,?)",
+                (r["trace_id"], r["event_type"], r["ts"]),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_dim9_unavailable_when_table_missing(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+        assert d9["available"] is False
+
+    def test_dim9_zero_rows_when_window_empty(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        # Create the table but no rows.
+        self._seed_parity_trace(db, rows=[])
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+        assert d9["available"] is True
+        assert d9["row_count"] == 0
+
+    def test_dim9_interp_b_supported_entry_without_completion(self, tmp_path):
+        # 3 traces have handler_entry; 0 ever land in tp_events.
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])  # empty tp_events
+        ts = 1772562000.0
+        self._seed_parity_trace(
+            db,
+            rows=[
+                {"trace_id": f"trace-{i}", "event_type": "handler_entry",
+                 "ts": ts + i}
+                for i in range(3)
+            ],
+        )
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+        assert d9["available"] is True
+        assert d9["traces_with_handler_entry"] == 3
+        assert d9["traces_with_completion_in_tp_events"] == 0
+        assert d9["interp_b_count"] == 3
+        assert d9["verdict"] == "interp_b_supported"
+
+    def test_dim9_interp_a_clean_when_completions_match(self, tmp_path):
+        # 3 traces with handler_entry, all also in tp_events.
+        db = tmp_path / "telemetry.db"
+        ts_iso = "2026-04-27T12:00:00"
+        _seed(db, rows=[
+            {"ts": ts_iso, "session_id": "s", "request_id": f"trace-{i}",
+             "trace_id": f"trace-{i}", "duration_ms": 100}
+            for i in range(3)
+        ])
+        ts = 1772562000.0
+        self._seed_parity_trace(
+            db,
+            rows=[
+                {"trace_id": f"trace-{i}", "event_type": "handler_entry",
+                 "ts": ts + i}
+                for i in range(3)
+            ],
+        )
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+        assert d9["traces_with_handler_entry"] == 3
+        assert d9["traces_with_completion_in_tp_events"] == 3
+        assert d9["interp_b_count"] == 0
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_dim9_renders_in_synthesis(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(
+            db,
+            rows=[
+                {"trace_id": f"trace-{i}", "event_type": "handler_entry",
+                 "ts": ts + i}
+                for i in range(2)
+            ],
+        )
+        out = tmp_path / "report.md"
+        rc = inspect.main([
+            "--db-path", str(db),
+            "--window-minutes", "0",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        md = out.read_text()
+        assert "Q8 — NCP-3I parity trace" in md
+
+
 # ── 12. structural — no dispatch / behavior imports ───────────────────
 
 

--- a/tests/test_parity_trace_phase_ncp_3i.py
+++ b/tests/test_parity_trace_phase_ncp_3i.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-3I — parity-trace module tests.
+
+Coverage (per the directive's acceptance criteria):
+
+  1. disabled by default — emit() is no-op when env-var unset
+  2. request-entry trace can exist without completion trace
+  3. trace write failures are swallowed (never crash the caller)
+  4. no raw prompts or secrets stored in any column
+  5. table schema migration is additive + tolerant
+  6. fetch_for_trace returns event rows in chronological order
+  7. multi-event trace assembly (handler_entry → upstream_attempt_*)
+  8. invalid event type / unknown column survives without raising
+  9. structural — module does not import dispatch / behavior primitives
+  10. is_enabled re-reads env var on every call (no caching)
+  11. emit re-reads env var (live toggle)
+  12. process metadata captured on every emit
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from tokenpak.proxy.parity_trace import (
+    EVENT_HANDLER_ENTRY,
+    EVENT_REQUEST_COMPLETION,
+    EVENT_UPSTREAM_ATTEMPT_FAILURE,
+    EVENT_UPSTREAM_ATTEMPT_START,
+    PARITY_TRACE_ENV,
+    ParityTraceStore,
+    emit,
+    is_enabled,
+    set_default_store,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    """Fresh ParityTraceStore + bind it as the default."""
+    s = ParityTraceStore(db_path=tmp_path / "telemetry.db")
+    set_default_store(s)
+    try:
+        yield s
+    finally:
+        set_default_store(None)
+        s.close()
+
+
+@pytest.fixture
+def env_enabled():
+    """TOKENPAK_PARITY_TRACE_ENABLED=true scope."""
+    with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: "true"}):
+        yield
+
+
+@pytest.fixture
+def env_disabled():
+    """Explicit env unset/false."""
+    with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: ""}):
+        yield
+
+
+# ── 1. disabled by default ────────────────────────────────────────────
+
+
+class TestDisabledByDefault:
+
+    def test_unset_returns_false(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(PARITY_TRACE_ENV, None)
+            assert is_enabled() is False
+
+    def test_false_value_returns_false(self):
+        for v in ("", "0", "false", "no", "off", "False", "OFF"):
+            with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: v}):
+                assert is_enabled() is False, f"value {v!r} should be falsy"
+
+    def test_true_value_returns_true(self):
+        for v in ("1", "true", "yes", "on", "TRUE", "Yes", " on "):
+            with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: v}):
+                assert is_enabled() is True, f"value {v!r} should be truthy"
+
+    def test_emit_disabled_writes_no_rows(self, store, env_disabled):
+        emit(EVENT_HANDLER_ENTRY, trace_id="t1")
+        rows = store.fetch_for_trace("t1")
+        assert rows == []
+
+
+# ── 2. request-entry trace can exist without completion trace ─────────
+
+
+class TestEntryWithoutCompletion:
+
+    def test_handler_entry_alone_is_persisted(self, store, env_enabled):
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-entry-only", body_bytes=512)
+        rows = store.fetch_for_trace("t-entry-only")
+        assert len(rows) == 1
+        assert rows[0]["event_type"] == EVENT_HANDLER_ENTRY
+        assert rows[0]["body_bytes"] == 512
+
+    def test_upstream_failure_without_completion(self, store, env_enabled):
+        # A request that hits handler entry → upstream attempt → fails
+        # before completion. Iter-4 §11 interp B: the visible-retry
+        # condition should produce these two rows even when no
+        # completion event ever fires.
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-fail")
+        emit(
+            EVENT_UPSTREAM_ATTEMPT_START,
+            trace_id="t-fail",
+            provider="tokenpak-claude-code",
+        )
+        emit(
+            EVENT_UPSTREAM_ATTEMPT_FAILURE,
+            trace_id="t-fail",
+            retry_signal="connection_reset",
+            retry_owner="tokenpak_proxy",
+        )
+        rows = store.fetch_for_trace("t-fail")
+        assert len(rows) == 3
+        event_types = [r["event_type"] for r in rows]
+        # Persisted in chronological order.
+        assert event_types == [
+            EVENT_HANDLER_ENTRY,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            EVENT_UPSTREAM_ATTEMPT_FAILURE,
+        ]
+        # No completion row was emitted.
+        assert EVENT_REQUEST_COMPLETION not in event_types
+
+
+# ── 3. trace write failures are swallowed ─────────────────────────────
+
+
+class TestWriteFailuresSwallowed:
+
+    def test_emit_with_unwritable_path_does_not_raise(self, env_enabled, tmp_path):
+        # Bind a store pointing at a read-only path. Subsequent
+        # connect attempts will fail; emit must NOT raise.
+        bad_path = tmp_path / "readonly" / "telemetry.db"
+        bad_store = ParityTraceStore(db_path=bad_path)
+        set_default_store(bad_store)
+        try:
+            # Make the parent unwritable AFTER store creation so
+            # _connect's mkdir trips.
+            (tmp_path / "readonly").mkdir(mode=0o000)
+            try:
+                # Should not raise.
+                emit(EVENT_HANDLER_ENTRY, trace_id="t-bad")
+            finally:
+                # Restore for cleanup.
+                (tmp_path / "readonly").chmod(0o755)
+        finally:
+            set_default_store(None)
+
+    def test_emit_with_unknown_field_does_not_raise(self, store, env_enabled):
+        # ParityTraceRow has a strict field set; passing an
+        # unknown kwarg would normally raise TypeError. Verify
+        # the emit() try/except absorbs it.
+        emit(
+            EVENT_HANDLER_ENTRY,
+            trace_id="t-unknown-field",
+            this_field_does_not_exist=42,
+        )
+        # No row should be written (silent failure), no exception.
+        rows = store.fetch_for_trace("t-unknown-field")
+        assert rows == []
+
+    def test_write_with_corrupt_db_returns_empty_fetch(self, store, env_enabled, tmp_path):
+        # Corrupt the DB after a write. fetch_for_trace must return [].
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-pre")
+        store.close()
+        # Truncate the DB to simulate corruption.
+        (tmp_path / "telemetry.db").write_bytes(b"\x00\x00not a sqlite db\x00")
+        rows = store.fetch_for_trace("t-pre")
+        assert rows == []
+
+
+# ── 4. no raw prompts or secrets ──────────────────────────────────────
+
+
+class TestPrivacyContract:
+
+    SENTINEL = "SENTINEL_PROMPT_NCP3I_NEVER_LEAK_3xQz9"
+
+    def test_sentinel_in_notes_field_is_caller_responsibility(self, store, env_enabled):
+        # The schema permits notes to be free-form. The privacy
+        # contract is that callers MUST NOT put prompt content
+        # there. We verify the COLUMN ITSELF doesn't auto-populate
+        # from anything that could contain prompt content — ie.
+        # there's no code path where prompt bytes flow through.
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-priv")
+        rows = store.fetch_for_trace("t-priv")
+        for r in rows:
+            assert self.SENTINEL not in (r.get("notes") or "")
+
+    def test_no_field_default_to_prompt_like_data(self, store, env_enabled):
+        # Emit without any caller-supplied notes; verify all TEXT
+        # fields are None (no auto-population).
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-defaults")
+        rows = store.fetch_for_trace("t-defaults")
+        assert len(rows) == 1
+        r = rows[0]
+        # The only auto-populated TEXT fields should be:
+        #   trace_id, event_type, tokenpak_home, telemetry_db_path
+        # Everything else should be None.
+        for col in (
+            "request_id", "session_id", "provider", "auth_plane",
+            "credential_class", "retry_phase", "retry_owner",
+            "retry_signal", "tool_command_first", "notes",
+        ):
+            assert r[col] is None, (
+                f"column {col!r} unexpectedly auto-populated: {r[col]!r}"
+            )
+
+    def test_module_does_not_import_request_body_paths(self):
+        text = (Path(__file__).resolve().parents[1] / "tokenpak" / "proxy" / "parity_trace.py").read_text()
+        # The module must not pull in anything that handles request bodies.
+        forbidden = (
+            "from tokenpak.proxy.server import",
+            "from tokenpak.proxy.adapters",
+            "credential_injector",
+            "ClaudeCodeCredentialProvider",
+            "from tokenpak.companion.hooks",
+        )
+        for f in forbidden:
+            assert f not in text, (
+                f"parity_trace.py must not import {f!r}"
+            )
+
+
+# ── 5. schema migration tolerant ──────────────────────────────────────
+
+
+class TestSchemaMigration:
+
+    def test_create_table_idempotent(self, tmp_path):
+        s1 = ParityTraceStore(db_path=tmp_path / "a.db")
+        s1._connect()
+        s2 = ParityTraceStore(db_path=tmp_path / "a.db")
+        s2._connect()  # should not raise — IF NOT EXISTS
+        s1.close()
+        s2.close()
+
+    def test_table_present_after_first_emit(self, store, env_enabled):
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-schema")
+        conn = sqlite3.connect(str(store.db_path))
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='tp_parity_trace'"
+            ).fetchone()
+            assert row is not None
+        finally:
+            conn.close()
+
+
+# ── 6. fetch_for_trace ordering ───────────────────────────────────────
+
+
+class TestFetchForTrace:
+
+    def test_chronological(self, store, env_enabled):
+        for i, evt in enumerate([
+            EVENT_HANDLER_ENTRY,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            EVENT_REQUEST_COMPLETION,
+        ]):
+            emit(evt, trace_id="t-order")
+            time.sleep(0.001)  # ensure ts ordering
+        rows = store.fetch_for_trace("t-order")
+        assert [r["event_type"] for r in rows] == [
+            EVENT_HANDLER_ENTRY,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            EVENT_REQUEST_COMPLETION,
+        ]
+
+    def test_unknown_trace_returns_empty(self, store, env_enabled):
+        emit(EVENT_HANDLER_ENTRY, trace_id="some-other")
+        rows = store.fetch_for_trace("nonexistent")
+        assert rows == []
+
+    def test_fetch_with_no_db_returns_empty(self, tmp_path):
+        s = ParityTraceStore(db_path=tmp_path / "nope.db")
+        try:
+            rows = s.fetch_for_trace("anything")
+            assert rows == []
+        finally:
+            s.close()
+
+
+# ── 7. multi-event trace assembly ─────────────────────────────────────
+
+
+class TestMultiEventTrace:
+
+    def test_seven_phase_chain(self, store, env_enabled):
+        """The full lifecycle path the directive listed."""
+        from tokenpak.proxy.parity_trace import (
+            EVENT_REQUEST_CLASSIFIED,
+            EVENT_RETRY_BOUNDARY,
+        )
+        for evt in (
+            EVENT_HANDLER_ENTRY,
+            EVENT_REQUEST_CLASSIFIED,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            EVENT_UPSTREAM_ATTEMPT_FAILURE,
+            EVENT_RETRY_BOUNDARY,
+            EVENT_UPSTREAM_ATTEMPT_START,  # retry
+            EVENT_REQUEST_COMPLETION,
+        ):
+            emit(evt, trace_id="t-full")
+            time.sleep(0.0005)
+        rows = store.fetch_for_trace("t-full")
+        assert len(rows) == 7
+        assert rows[0]["event_type"] == EVENT_HANDLER_ENTRY
+        assert rows[-1]["event_type"] == EVENT_REQUEST_COMPLETION
+        # Two upstream_attempt_start rows confirm retry branch.
+        starts = [r for r in rows if r["event_type"] == EVENT_UPSTREAM_ATTEMPT_START]
+        assert len(starts) == 2
+
+
+# ── 8. invalid event_type does not crash ──────────────────────────────
+
+
+class TestInvalidEventType:
+
+    def test_unknown_event_type_persists_anyway(self, store, env_enabled):
+        # The schema doesn't enforce an event_type whitelist (the
+        # ALL_EVENTS frozenset is documentation, not a CHECK
+        # constraint). Unknown values land in the DB but don't
+        # crash. inspect_session_lanes can flag them.
+        emit("definitely_not_a_real_event", trace_id="t-weird")
+        rows = store.fetch_for_trace("t-weird")
+        assert len(rows) == 1
+        assert rows[0]["event_type"] == "definitely_not_a_real_event"
+
+
+# ── 9. structural ─────────────────────────────────────────────────────
+
+
+class TestStructural:
+
+    """Scan imports + active call sites only, not docstrings.
+    Docstring mentions like ``pool.request`` are explanatory and
+    don't constitute coupling."""
+
+    def _imports_and_calls(self) -> str:
+        """Strip docstrings; return the remaining source for
+        coupling-scan purposes."""
+        import io
+        import tokenize
+        path = (Path(__file__).resolve().parents[1] / "tokenpak"
+                / "proxy" / "parity_trace.py")
+        src = path.read_text()
+        # Remove all string literals (docstrings + regular strings)
+        # via tokenize so we only inspect imports + bareword code.
+        result_chunks: list[str] = []
+        for tok in tokenize.tokenize(io.BytesIO(src.encode()).readline):
+            if tok.type == tokenize.STRING:
+                continue
+            result_chunks.append(tok.string)
+        return " ".join(result_chunks)
+
+    def test_no_routing_imports(self):
+        code = self._imports_and_calls()
+        forbidden = (
+            "RoutingService",
+            "forward_headers",
+            "from tokenpak.services.routing_service",
+            "from tokenpak.proxy.client",
+        )
+        for f in forbidden:
+            assert f not in code, (
+                f"parity_trace.py must not couple to dispatch: {f!r}"
+            )
+
+    def test_no_companion_imports(self):
+        code = self._imports_and_calls()
+        for f in ("from tokenpak.companion", "import tokenpak.companion"):
+            assert f not in code, (
+                f"parity_trace.py must not couple to companion: {f!r}"
+            )
+
+    def test_no_active_pool_calls(self):
+        """Scan AST for actual function calls into pool.request /
+        pool.stream — those would be active dispatch coupling.
+        Doc strings mentioning the names don't count."""
+        import ast
+        path = (Path(__file__).resolve().parents[1] / "tokenpak"
+                / "proxy" / "parity_trace.py")
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                # Match expressions like ``pool.request`` or ``pool.stream``
+                if (
+                    isinstance(node.value, ast.Name)
+                    and node.value.id == "pool"
+                    and node.attr in ("request", "stream")
+                ):
+                    raise AssertionError(
+                        f"parity_trace.py contains active dispatch call: "
+                        f"pool.{node.attr}"
+                    )
+
+
+# ── 10. is_enabled re-reads on every call ─────────────────────────────
+
+
+class TestEnvVarLiveRead:
+
+    def test_toggle_during_session(self, store):
+        # Start disabled
+        with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: "0"}):
+            assert is_enabled() is False
+            emit(EVENT_HANDLER_ENTRY, trace_id="t-toggle")
+        assert store.fetch_for_trace("t-toggle") == []
+
+        # Enable mid-session
+        with mock.patch.dict(os.environ, {PARITY_TRACE_ENV: "1"}):
+            assert is_enabled() is True
+            emit(EVENT_HANDLER_ENTRY, trace_id="t-toggle")
+        rows = store.fetch_for_trace("t-toggle")
+        assert len(rows) == 1
+
+
+# ── 11. process metadata ──────────────────────────────────────────────
+
+
+class TestProcessMetadata:
+
+    def test_pid_ppid_captured(self, store, env_enabled):
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-meta")
+        rows = store.fetch_for_trace("t-meta")
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["pid"] == os.getpid()
+        assert r["ppid"] == os.getppid()
+        assert r["telemetry_db_path"] == str(store.db_path)
+
+    def test_tokenpak_home_captured(self, store, tmp_path):
+        with mock.patch.dict(os.environ, {
+            PARITY_TRACE_ENV: "1",
+            "TOKENPAK_HOME": str(tmp_path),
+        }):
+            emit(EVENT_HANDLER_ENTRY, trace_id="t-home")
+        rows = store.fetch_for_trace("t-home")
+        assert len(rows) == 1
+        assert rows[0]["tokenpak_home"] == str(tmp_path)
+
+
+# ── 12. defensive — concurrent emit doesn't deadlock ──────────────────
+
+
+class TestConcurrentEmit:
+
+    def test_multiple_threads_can_emit(self, store, env_enabled):
+        import threading
+        errors = []
+
+        def worker(idx):
+            try:
+                for j in range(5):
+                    emit(EVENT_HANDLER_ENTRY, trace_id=f"t-{idx}-{j}")
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        assert errors == []
+        # Spot-check a few traces persisted.
+        for idx in range(4):
+            rows = store.fetch_for_trace(f"t-{idx}-0")
+            assert len(rows) == 1

--- a/tokenpak/proxy/parity_trace.py
+++ b/tokenpak/proxy/parity_trace.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-3I — in-proxy parity-trace instrumentation.
+
+Captures per-request **lifecycle events** (handler entry, upstream
+attempt start / failure, retry boundary, request completion) so
+the operator can characterize concurrency-shaped failures that
+existing ``tp_events`` telemetry cannot see — specifically the
+iter-4 §11 "interp B" condition where TUI retries fire before a
+request ever reaches the proxy's completion-time logging path.
+
+**Measurement-only.** Every emit() call is:
+
+  - Gated behind ``TOKENPAK_PARITY_TRACE_ENABLED`` (default ``false``)
+  - Off-path: writes happen on the calling thread but every
+    failure is swallowed (try/except: pass)
+  - Schema-additive: new SQLite table ``tp_parity_trace`` under
+    the existing ``$TOKENPAK_HOME/telemetry.db`` (zero new files;
+    zero schema mutation of existing tables)
+  - Privacy-preserving: structured fields only, no raw prompt /
+    secret / credential content reaches any column
+
+When the env var is unset / ``false``, ``emit()`` returns
+immediately after one cheap dict lookup. The proxy's hot-path
+cost when the trace is disabled is bounded to a single
+:func:`os.environ.get` lookup per hook site.
+
+Hook events
+-----------
+
+The seven lifecycle phases instrumentation ships with:
+
+  ``handler_entry``           — request entered ``_proxy_to_inner``
+  ``request_classified``      — adapter / route / provider resolved
+  ``upstream_attempt_start``  — about to call ``pool.stream`` /
+                                ``pool.request``
+  ``upstream_attempt_failure``— exception propagated past the
+                                upstream call
+  ``retry_boundary``          — failover engine fired a retry
+  ``request_completion``      — handler returned a response cleanly
+
+Every event carries a stable ``trace_id`` (the proxy's per-request
+id, available from line 769 of ``server.py``) so multi-event traces
+re-assemble at read time.
+
+Privacy contract
+----------------
+
+The schema accepts integers, floats, opaque IDs, and a small set
+of free-form ``TEXT`` fields with documented allowed values
+(``retry_phase``, ``retry_owner``, ``retry_signal``,
+``tool_command_first``). The ``notes`` column is the only
+free-form sink — callers MUST NOT pass prompt or credential
+content there. Privacy tests pin this.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+PARITY_TRACE_ENV: str = "TOKENPAK_PARITY_TRACE_ENABLED"
+"""Env-var that gates writes. Read on every emit() call so the
+operator can flip it without proxy restart. Truthy values:
+``1`` / ``true`` / ``yes`` / ``on`` (case-insensitive)."""
+
+
+# Lifecycle event types
+EVENT_HANDLER_ENTRY: str = "handler_entry"
+EVENT_REQUEST_CLASSIFIED: str = "request_classified"
+EVENT_UPSTREAM_ATTEMPT_START: str = "upstream_attempt_start"
+EVENT_UPSTREAM_ATTEMPT_FAILURE: str = "upstream_attempt_failure"
+EVENT_RETRY_BOUNDARY: str = "retry_boundary"
+EVENT_REQUEST_COMPLETION: str = "request_completion"
+
+ALL_EVENTS: frozenset = frozenset({
+    EVENT_HANDLER_ENTRY,
+    EVENT_REQUEST_CLASSIFIED,
+    EVENT_UPSTREAM_ATTEMPT_START,
+    EVENT_UPSTREAM_ATTEMPT_FAILURE,
+    EVENT_RETRY_BOUNDARY,
+    EVENT_REQUEST_COMPLETION,
+})
+
+
+# Documented value sets for the "free-form-ish" TEXT columns.
+RETRY_PHASES: frozenset = frozenset({
+    "initial_user_prompt",
+    "post_tool_result",
+    "streaming_continuation",
+    "message_stop_finalization",
+    "unknown",
+})
+
+RETRY_OWNERS: frozenset = frozenset({
+    "claude_code_client",
+    "tokenpak_proxy",
+    "upstream_provider",
+    "unknown",
+})
+
+RETRY_SIGNALS: frozenset = frozenset({
+    "429",
+    "5xx",
+    "timeout",
+    "connection_reset",
+    "retry_after_header",
+    "unknown",
+})
+
+
+_DEFAULT_DB_PATH = (
+    Path(os.environ.get("TOKENPAK_HOME", str(Path.home() / ".tokenpak")))
+    / "telemetry.db"
+)
+
+
+_DDL = """\
+CREATE TABLE IF NOT EXISTS tp_parity_trace (
+    trace_id              TEXT NOT NULL,       -- ties events of one request
+    event_type            TEXT NOT NULL,       -- one of ALL_EVENTS
+    ts                    REAL NOT NULL,       -- epoch seconds (float)
+    pid                   INTEGER,             -- os.getpid() at emit time
+    ppid                  INTEGER,             -- os.getppid() at emit time
+    tokenpak_home         TEXT,                -- $TOKENPAK_HOME or default
+    telemetry_db_path     TEXT,                -- the db_path the writer used
+    -- Identity
+    request_id            TEXT,
+    session_id            TEXT,
+    provider              TEXT,
+    auth_plane            TEXT,
+    credential_class      TEXT,
+    -- Retry classification (iter-4 dimensions)
+    retry_phase           TEXT,                -- one of RETRY_PHASES
+    retry_owner           TEXT,                -- one of RETRY_OWNERS
+    retry_signal          TEXT,                -- one of RETRY_SIGNALS
+    retry_count           INTEGER,
+    retry_after_seconds   REAL,
+    -- Tool result classification
+    tool_command_first    TEXT,
+    tool_result_stdout_chars  INTEGER,
+    tool_result_stderr_chars  INTEGER,
+    tool_result_tokens_est    INTEGER,
+    -- Request size
+    body_bytes            INTEGER,
+    companion_added_chars INTEGER,             -- deferred capture in v1
+    intent_guidance_chars INTEGER,             -- deferred capture in v1
+    -- Concurrency / lane indicators
+    queue_wait_ms         REAL,
+    lock_wait_ms          REAL,
+    sqlite_write_ms       REAL,
+    -- Free-form note (caller-supplied; MUST NOT contain prompt content)
+    notes                 TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_parity_trace_id
+    ON tp_parity_trace (trace_id, ts);
+CREATE INDEX IF NOT EXISTS idx_parity_event_type
+    ON tp_parity_trace (event_type, ts);
+CREATE INDEX IF NOT EXISTS idx_parity_session
+    ON tp_parity_trace (session_id, ts);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Row dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParityTraceRow:
+    """One lifecycle-event row for ``tp_parity_trace``.
+
+    All fields except ``trace_id`` / ``event_type`` / ``ts`` are
+    optional and may be ``None``. The schema treats every column
+    other than those three as nullable so the same table holds
+    rows from different lifecycle phases without each one having
+    to populate every dimension.
+    """
+
+    trace_id: str
+    event_type: str
+    ts: float
+    pid: Optional[int] = None
+    ppid: Optional[int] = None
+    tokenpak_home: Optional[str] = None
+    telemetry_db_path: Optional[str] = None
+
+    # Identity
+    request_id: Optional[str] = None
+    session_id: Optional[str] = None
+    provider: Optional[str] = None
+    auth_plane: Optional[str] = None
+    credential_class: Optional[str] = None
+
+    # Retry classification (iter-4)
+    retry_phase: Optional[str] = None
+    retry_owner: Optional[str] = None
+    retry_signal: Optional[str] = None
+    retry_count: Optional[int] = None
+    retry_after_seconds: Optional[float] = None
+
+    # Tool result classification
+    tool_command_first: Optional[str] = None
+    tool_result_stdout_chars: Optional[int] = None
+    tool_result_stderr_chars: Optional[int] = None
+    tool_result_tokens_est: Optional[int] = None
+
+    # Request size
+    body_bytes: Optional[int] = None
+    companion_added_chars: Optional[int] = None
+    intent_guidance_chars: Optional[int] = None
+
+    # Concurrency / lane indicators
+    queue_wait_ms: Optional[float] = None
+    lock_wait_ms: Optional[float] = None
+    sqlite_write_ms: Optional[float] = None
+
+    # Free-form (caller-supplied; MUST NOT contain prompt / secret content)
+    notes: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class ParityTraceStore:
+    """SQLite writer for ``tp_parity_trace``. Lazy-init."""
+
+    _LOCK = threading.Lock()
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._conn: Optional[sqlite3.Connection] = None
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.executescript(_DDL)
+            conn.commit()
+            self._conn = conn
+        return self._conn
+
+    def write(self, row: ParityTraceRow) -> None:
+        """Insert one row. Best-effort — every exception swallowed
+        per the directive's measurement-only contract."""
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                cols = [f.name for f in fields(row)]
+                placeholders = ",".join("?" for _ in cols)
+                values = tuple(getattr(row, c) for c in cols)
+                conn.execute(
+                    f"INSERT INTO tp_parity_trace ({','.join(cols)}) "
+                    f"VALUES ({placeholders})",
+                    values,
+                )
+                conn.commit()
+        except Exception:  # noqa: BLE001
+            return
+
+    def write_many(self, rows: Iterable[ParityTraceRow]) -> None:
+        for r in rows:
+            self.write(r)
+
+    def fetch_for_trace(self, trace_id: str) -> list:
+        """Return every event row tied to ``trace_id``, oldest first."""
+        if not self._db_path.is_file():
+            return []
+        try:
+            with self._LOCK:
+                conn = self._connect()
+                conn.row_factory = sqlite3.Row
+                # Defensive — table may not exist yet on a clean install
+                # where no emit() has fired.
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' "
+                    "AND name='tp_parity_trace'"
+                ).fetchone()
+                if exists is None:
+                    return []
+                rows = conn.execute(
+                    "SELECT * FROM tp_parity_trace "
+                    "WHERE trace_id = ? ORDER BY ts",
+                    (trace_id,),
+                ).fetchall()
+        except sqlite3.DatabaseError:
+            return []
+        return [dict(r) for r in rows]
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+_DEFAULT_STORE: Optional[ParityTraceStore] = None
+
+
+def get_default_store() -> ParityTraceStore:
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = ParityTraceStore()
+    return _DEFAULT_STORE
+
+
+def set_default_store(store: Optional[ParityTraceStore]) -> None:
+    """Test hook — swap the default writer."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = store
+
+
+# ---------------------------------------------------------------------------
+# Public emit API
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return True iff ``TOKENPAK_PARITY_TRACE_ENABLED`` is set
+    to a truthy value at this exact moment.
+
+    Re-read every call so the operator can flip it without
+    restarting the proxy.
+    """
+    val = os.environ.get(PARITY_TRACE_ENV, "")
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+def emit(
+    event_type: str,
+    *,
+    trace_id: str,
+    store: Optional[ParityTraceStore] = None,
+    **fields_kwargs: Any,
+) -> None:
+    """Emit one lifecycle-event row if enabled. No-op when disabled.
+
+    ``trace_id`` and ``event_type`` are required. ``store`` defaults
+    to the process-wide default. Any ``ParityTraceRow`` field can be
+    passed as a keyword argument.
+
+    All exceptions — including unknown ``event_type`` or schema
+    drift — are swallowed. The hot-path guarantee is: this function
+    returns in O(1) cheap-dict-lookup time when the env var is
+    unset / false.
+    """
+    if not is_enabled():
+        return
+    try:
+        s = store if store is not None else get_default_store()
+        row = ParityTraceRow(
+            trace_id=trace_id,
+            event_type=event_type,
+            ts=time.time(),
+            pid=os.getpid(),
+            ppid=os.getppid(),
+            tokenpak_home=os.environ.get(
+                "TOKENPAK_HOME", str(Path.home() / ".tokenpak")
+            ),
+            telemetry_db_path=str(s.db_path),
+            **fields_kwargs,
+        )
+        s.write(row)
+    except Exception:  # noqa: BLE001
+        return
+
+
+__all__ = [
+    "ALL_EVENTS",
+    "EVENT_HANDLER_ENTRY",
+    "EVENT_REQUEST_CLASSIFIED",
+    "EVENT_REQUEST_COMPLETION",
+    "EVENT_RETRY_BOUNDARY",
+    "EVENT_UPSTREAM_ATTEMPT_FAILURE",
+    "EVENT_UPSTREAM_ATTEMPT_START",
+    "PARITY_TRACE_ENV",
+    "ParityTraceRow",
+    "ParityTraceStore",
+    "RETRY_OWNERS",
+    "RETRY_PHASES",
+    "RETRY_SIGNALS",
+    "emit",
+    "get_default_store",
+    "is_enabled",
+    "set_default_store",
+]

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -767,6 +767,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         t0 = time.time()
         # Request ID: honour X-Request-ID from client, else generate UUID
         _req_id = _new_request_id(dict(self.headers))
+        # NCP-3I: emit a handler-entry trace BEFORE any other processing.
+        # Captures the iter-4 §11 "interp B" condition where requests
+        # fail before the proxy's completion-time logging runs. Off-path
+        # + gated by TOKENPAK_PARITY_TRACE_ENABLED (default false).
+        try:
+            from tokenpak.proxy import parity_trace as _pt
+            _pt.emit(
+                _pt.EVENT_HANDLER_ENTRY,
+                trace_id=_req_id,
+                request_id=_req_id,
+                notes=method,
+            )
+        except Exception:  # noqa: BLE001
+            pass
         ps = self.server.proxy_server  # type: ignore[attr-defined]
         parsed = urlparse(target_url)
 
@@ -1690,6 +1704,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     )
                 except Exception:
                     pass
+                # NCP-3I: upstream-attempt-start (streaming path).
+                try:
+                    from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_UPSTREAM_ATTEMPT_START,
+                        trace_id=_req_id,
+                        body_bytes=(len(body) if body else 0),
+                        notes="stream",
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
                 with pool.stream(method, target_url, content=body, headers=fwd_headers) as resp:
                     self.send_response(resp.status_code)
                     # SC-02: accumulate headers we actually send so the
@@ -1818,6 +1843,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         body,
                     )
                 except Exception:
+                    pass
+                # NCP-3I: upstream-attempt-start (non-streaming path).
+                try:
+                    from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_UPSTREAM_ATTEMPT_START,
+                        trace_id=_req_id,
+                        body_bytes=(len(body) if body else 0),
+                        notes="request",
+                    )
+                except Exception:  # noqa: BLE001
                     pass
                 resp = pool.request(method, target_url, content=body, headers=fwd_headers)
 


### PR DESCRIPTION
## Summary

Measurement-only instrumentation for the iter-4 §11 **interp B** condition (visible TUI retries with empty TokenPak telemetry). Captures lifecycle events at handler entry + upstream-attempt start so requests that fail before completion-time logging are no longer invisible.

**No behavior changes.** Every hook is gated on \`TOKENPAK_PARITY_TRACE_ENABLED\` (default \`false\`); when unset, the proxy's behavior is byte-identical to pre-NCP-3I.

## Held throughout (per directive)

- ❌ No routing changes
- ❌ No retry behavior changes
- ❌ No cache placement changes
- ❌ No prompt mutation changes
- ❌ No provider/model changes
- ❌ No auth behavior changes
- ❌ No production behavior change unless \`TOKENPAK_PARITY_TRACE_ENABLED=true\`

## What landed

### New module — \`tokenpak/proxy/parity_trace.py\`

\`ParityTraceRow\` dataclass (27 fields), \`ParityTraceStore\` SQLite writer, \`emit()\` public API gated on every call. Six lifecycle event constants. Documented value sets for \`RETRY_PHASES\` / \`RETRY_OWNERS\` / \`RETRY_SIGNALS\`.

### New SQLite table — \`tp_parity_trace\`

27 columns covering process metadata + identity + iter-4 retry classification + tool result classification + request size + concurrency indicators + free-form notes. Lives under existing \`telemetry.db\` (no new files, no schema mutation of existing tables).

### Hook integration — \`tokenpak/proxy/server.py::_proxy_to_inner\`

Three minimal hook calls, all wrapped in try/except, lazy-imported:

| Hook | Location |
|---|---|
| \`EVENT_HANDLER_ENTRY\` | server.py:~772, immediately after \`_req_id\` generation |
| \`EVENT_UPSTREAM_ATTEMPT_START\` (streaming) | server.py:~1707, just before \`pool.stream\` |
| \`EVENT_UPSTREAM_ATTEMPT_START\` (non-streaming) | server.py:~1847, just before \`pool.request\` |

**~30 lines added, zero behavior change** when env-var disabled.

### Harness extension — \`scripts/inspect_session_lanes.py\`

New **dim 9** \`dim9_parity_trace_coverage\` reads \`tp_parity_trace\` and computes the iter-4 §11 interp-A-vs-B disambiguator:

\`interp_b_count = traces_with_handler_entry − traces_with_completion_in_tp_events\`

Verdict: \`interp_b_supported\` / \`interp_a_or_clean\` / \`indeterminate\`. New Q8 synthesis line.

### Tests (31 new across the directive's 5 acceptance areas)

- **\`test_parity_trace_phase_ncp_3i.py\` (26 tests)** — disabled by default; entry-without-completion; write-failures-swallowed; privacy contract (no raw prompts); schema migration; fetch ordering; multi-event assembly; invalid event types; structural (no dispatch coupling); live env-var toggle; process metadata; concurrent emit
- **\`test_ncp3_inspect_session_lanes.py\` (+5 dim-9 tests)** — unavailable when table missing; empty when window has no rows; interp-B-supported; interp-A-clean; synthesis renders Q8

## Deferred for NCP-3I v2 (documented in §4 of the new spec)

- \`companion_added_chars\` / \`intent_guidance_chars\` population (would require companion-hook integration)
- \`retry_phase\` classification (would require body-content parsing)
- \`retry_owner\` CLI-side detection (CLI's "Retrying" message comes from a layer the proxy can't introspect)
- \`retry_after_seconds\` parsing (would require failover-engine instrumentation; iter-4 finding: failover engine isn't wired into the request path)
- \`lock_wait_ms\` / \`queue_wait_ms\` (would require wrapping every lock acquire)
- Connection-acceptance event (BaseHTTPServer doesn't expose cleanly above socket layer)
- \`request_completion\` event (1500-line function with multiple return paths; deferred — harness already joins to \`tp_events.request_id\`)

Each deferred dimension's column exists in the schema with NULL default, so v2 can populate without another schema migration.

## Side note (out of scope)

While testing locally, two existing tests fail when a real \`~/.tokenpak/policy.yaml\` is present (regardless of \`TOKENPAK_HOME=tmp_path\`): the PI-3 config loader falls through from \`\$TOKENPAK_HOME/policy.yaml\` to \`~/.tokenpak/policy.yaml\` when the former doesn't exist. Tracked as a small loader-isolation fix worth a separate PR. CI is unaffected.

## Test plan

- [x] 26/26 new \`test_parity_trace_phase_ncp_3i.py\` tests pass
- [x] 5/5 new dim-9 tests in \`test_ncp3_inspect_session_lanes.py\` pass
- [x] Existing NCP-3 + NCP-1 + PI-3 tests still green (51/51 in scope; 110/111 PI-x + NCP-x suite, 1 environmental local failure verified to pass on fresh runner)
- [x] \`ruff check tokenpak/ tests/\` clean
- [x] Structural tests pin no dispatch-primitive imports
- [x] Privacy tests pin no auto-populated TEXT fields
- [x] Repo hygiene scan clean
- [ ] CI green

## Acceptance criteria (per directive)

| Criterion | Status |
|---|---|
| NCP-3I lands as measurement-only | ✅ |
| Supports interp B | ✅ via dim 9 + entry-without-completion test |
| Explains whether retries happen before \`tp_events\` completion | ✅ via \`interp_b_count\` |
| Disabled by default | ✅ env-var unset = false |
| Request-entry trace can exist without completion trace | ✅ tested |
| Trace write failures swallowed | ✅ tested (unwritable path, unknown field, corrupt DB) |
| No raw prompts or secrets stored | ✅ tested |
| \`inspect_session_lanes.py\` consumes new fields | ✅ dim 9 + 5 tests |
| No behavior changes | ✅ structural tests pin coupling |

## After this PR

1. Operator sets \`export TOKENPAK_PARITY_TRACE_ENABLED=true\` on the host where iter-3/iter-4 reproduces.
2. Operator restarts \`tokenpak start\`, re-runs the 2-TP-concurrent workload.
3. Operator runs \`scripts/inspect_session_lanes.py --window-minutes 30 --output tests/baselines/ncp-3-trace/<TIMESTAMP>.md\`.
4. The dim 9 + Q8 synthesis line **disambiguates iter-4 §11 interp A vs B**.
5. Next phase routes to **NCP-3I-v2** (deferred dimensions) / **NCP-3A** (session-id rotation) / **NCP-9** (OAuth refresh lane) per the harness output.

## Files

- \`tokenpak/proxy/parity_trace.py\` (new — measurement module)
- \`tokenpak/proxy/server.py\` (3 hook insertions, ~30 lines, off-path)
- \`scripts/inspect_session_lanes.py\` (+ dim 9 + Q8 synthesis)
- \`tests/test_parity_trace_phase_ncp_3i.py\` (new — 26 tests)
- \`tests/test_ncp3_inspect_session_lanes.py\` (+ 5 dim-9 tests)
- \`docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md\` (new)