### PR TITLE
feat(proxy,scripts,tests,docs): NCP-3I-v3 — pre-dispatch lifecycle hooks + stream_abort

### DIFF
--- a/docs/internal/specs/ncp-1a-iteration-5-2026-04-27.md
+++ b/docs/internal/specs/ncp-1a-iteration-5-2026-04-27.md
@@ -1,7 +1,7 @@
 # NCP-1A iteration 5 — H10 streaming integrity + NCP-3I activation gap
 
 **Date**: 2026-04-27
-**Status**: 🟢 **NCP-3I-v2 landed** (this PR) — measurement-only; activation verification + streaming-integrity dimensions
+**Status**: 🟡 **superseded by iteration-6** — see banner below
 **Workstream**: NCP (Native Client Concurrency Parity)
 **Operator**: Kevin
 **Companion docs**:
@@ -10,6 +10,9 @@
   - Iteration 3 (2 TP retry + 1 native healthy): `docs/internal/specs/ncp-1a-iteration-3-2026-04-27.md`
   - Iteration 4 (post-tool-result + interp B): `docs/internal/specs/ncp-1a-iteration-4-2026-04-27.md`
   - NCP-3I v1 spec: `docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md`
+  - **Iteration 6 (NCP-3I-v3 pre-dispatch lifecycle)**: `docs/internal/specs/ncp-1a-iteration-6-2026-04-27.md`
+
+> ⚠️ **Iter-6 update (2026-04-27)**: disambiguation confirmed real-workload `tokenpak claude` requests die between handler_entry and upstream_attempt_start. NCP-3I-v3 added 6 new lifecycle hooks in that gap (auth_gate_pass / route_resolved / body_read_complete / adapter_detected / before_dispatch / stream_abort) so the operator can localize exactly where requests stop.
 
 > **Headline:** during the 3-concurrent `tokenpak claude` repro, one TokenPak session displayed `API Error: JSON Parse error: Unterminated string`. This is a **streaming integrity** symptom — TokenPak may be forwarding a malformed / truncated / corrupted SSE response to Claude Code under concurrent load. Adds **H10**. Also: the previous NCP-3I run produced no `tp_parity_trace` table — the instrumentation isn't observing the actual `tokenpak claude` path. NCP-3I-v2 ships an **activation verification script** + **stream-integrity dimensions** + **schema migration** to address both findings.
 

--- a/docs/internal/specs/ncp-1a-iteration-6-2026-04-27.md
+++ b/docs/internal/specs/ncp-1a-iteration-6-2026-04-27.md
@@ -1,0 +1,138 @@
+# NCP-1A iteration 6 — pre-dispatch lifecycle hooks (NCP-3I-v3)
+
+**Date**: 2026-04-27
+**Status**: 🟢 **NCP-3I-v3 landed** (this PR) — measurement-only; pre-dispatch lifecycle hooks
+**Workstream**: NCP (Native Client Concurrency Parity)
+**Operator**: Kevin
+**Companion docs**:
+  - Iteration 5 (H10 + activation gap): `docs/internal/specs/ncp-1a-iteration-5-2026-04-27.md`
+  - NCP-3I v1 spec: `docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md`
+
+> **Headline:** the disambiguation step (4-row trace inspection) confirmed that real-workload `tokenpak claude` requests **reach `_proxy_to_inner` but die before `pool.stream`**. The 1 row from the prior trace is the liveness curl; 3 of 4 rows in the latest disambiguation are real repro requests showing handler_entry without upstream_attempt_start. NCP-3I-v3 wires 6 new lifecycle hooks in the gap so the operator can localize exactly which stage requests stop at.
+
+---
+
+## 1. Disambiguation evidence (operator-supplied)
+
+5 rows in `tp_parity_trace`:
+
+| ts (UTC) | trace | events |
+|---|---|---|
+| 08:57:23 | liveness curl | handler_entry |
+| 08:57:26 | liveness curl | upstream_attempt_start |
+| 09:07:44 | repro req 1 | handler_entry only |
+| 09:37:43 | repro req 2 | handler_entry only |
+| 10:07:44 | repro req 3 | handler_entry only |
+
+**Key finding:** the **liveness curl** flowed all the way through (handler_entry → upstream_attempt_start), proving the proxy's hooks fire end-to-end on a synthetic request. But the **3 actual `tokenpak claude` repro requests** all stop at handler_entry. They reach `_proxy_to_inner`, fire the entry hook, then never fire `upstream_attempt_start`.
+
+The 900-line gap between server.py:772 (handler_entry hook) and server.py:1707/1847 (upstream_attempt_start hook) is where requests die. The liveness curl traverses this gap successfully because it's a simple synthetic POST; the `tokenpak claude` repro fails somewhere in the middle.
+
+---
+
+## 2. NCP-3I-v3 deliverables
+
+### 2.1 Six new lifecycle event types
+
+Per the directive's "minimum acceptable" set:
+
+| Event | Position in `_proxy_to_inner` | Captures |
+|---|---|---|
+| `EVENT_AUTH_GATE_PASS` | top, after `handler_entry` | tautological-but-confirmed (do_POST gates pre-call) |
+| `EVENT_ROUTE_RESOLVED` | top, after auth_gate_pass | confirms do_POST chose this route |
+| `EVENT_BODY_READ_COMPLETE` | line ~813 (after `self.rfile.read`) | request body successfully read |
+| `EVENT_ADAPTER_DETECTED` | line ~840 (after `detect_platform`) | platform adapter resolved |
+| `EVENT_BEFORE_DISPATCH` | adjacent to existing `upstream_attempt_start` | last marker before `pool.stream` / `pool.request` |
+| `EVENT_STREAM_ABORT` | (a) BrokenPipe except + (b) outer except at line 2237+ | downstream client disconnect OR upstream-side exception |
+
+The directive's "optional" set (`EVENT_BODY_READ_START`, `EVENT_COMPRESSION_START/COMPLETE`, `EVENT_ENRICHMENT_START/COMPLETE`, `EVENT_CACHE_LOOKUP_START/COMPLETE`) is **deferred**. The minimum set is sufficient to localize where requests die; finer-grained hooks land if v3 evidence shows the death is between two of the existing checkpoints.
+
+### 2.2 `LIFECYCLE_ORDER` constant
+
+`tokenpak/proxy/parity_trace.py` exports a tuple of all events in canonical order:
+
+```
+handler_entry → auth_gate_pass → route_resolved → body_read_complete →
+request_classified → adapter_detected → before_dispatch →
+upstream_attempt_start → stream_start → stream_complete → stream_abort →
+upstream_attempt_failure → retry_boundary → request_completion
+```
+
+Used by `inspect_session_lanes.py` to render per-trace progression.
+
+### 2.3 Two stream_abort hooks
+
+- **(a) Downstream BrokenPipe** — emitted in the existing `except (BrokenPipeError, ConnectionResetError)` inside the iter_bytes loop. Carries `bytes_from_upstream`, `bytes_to_client`, `connection_closed_early=1`, `retry_owner="claude_code_client"`. This is the **H10b** capture path.
+- **(b) Upstream-side exception** — emitted at the top of the existing outer `except Exception as exc:` at server.py:~2237. Carries `stream_exception_class`, `stream_exception_message_hash`, `retry_owner="upstream_provider"`. This is the **H10c/d** capture path.
+
+Both are pure additions to existing except blocks; no behavior change.
+
+### 2.4 Harness extension — per-trace lifecycle progression
+
+`scripts/inspect_session_lanes.py` dim 9 now reports two new fields:
+
+- **`last_stage_distribution`**: counts of how many traces' last-observed event was each stage. Tells the operator at a glance "N traces died at handler_entry, M at body_read_complete, etc."
+- **`pre_upstream_death_count`**: count of traces whose last-observed event was BEFORE `upstream_attempt_start` — the iter-6 §1 condition.
+- **`pre_upstream_death_stage_distribution`**: same breakdown, filtered to only pre-dispatch deaths.
+
+A new **Q9** synthesis line summarizes: "N traces died BEFORE upstream_attempt_start. Top stages (stage_at_death=count): X=N1, Y=N2, Z=N3."
+
+---
+
+## 3. Death-localization decision tree (post-v3)
+
+After running the workload with v3 hooks live, the harness Q9 line directly identifies the death point. Routing logic:
+
+| Q9 finding | What it means | Next phase |
+|---|---|---|
+| Most deaths at `handler_entry` | Request enters `_proxy_to_inner` then immediately dies — likely an early-return or exception in the first ~50 lines | **NCP-3A-handler-init** — debug the early-return paths |
+| Most deaths at `auth_gate_pass` | Tautological row alone means body read or URL parse died — but `auth_gate_pass` should ALWAYS be paired with `route_resolved` since they emit consecutively. If only one fires, the emit() itself raised | **NCP-3I-v3-fix** |
+| Most deaths at `body_read_complete` | Body read completed but classification / adapter detection died | **NCP-3A-classification** — instrument the classification path |
+| Most deaths at `adapter_detected` | Adapter detection completed but compression / vault / cache lookup died | **NCP-3A-enrichment** — instrument compression / vault / cache |
+| Most deaths at `before_dispatch` | About to call `pool.stream` / `pool.request` and died — classic connection-pool issue, OAuth refresh thundering herd (H9b), or pool lock contention (H9a) | **NCP-9b** OAuth refresh fix OR **NCP-3A-pool** pool fix |
+| `upstream_attempt_start` fires + `stream_abort` with bytes_to_client < bytes_from_upstream | Stream completed upstream-side but client disconnected mid-write | **NCP-3A-streaming** drain-remainder fix |
+| All clean — every trace reaches `request_completion` | The repro didn't reproduce the failure mode in this run | **NCP-1C** more operator data |
+
+---
+
+## 4. Held throughout NCP-3I-v3
+
+- ❌ No routing changes
+- ❌ No retry behavior changes
+- ❌ No cache behavior changes
+- ❌ No auth behavior changes
+- ❌ No prompt mutation changes
+- ❌ No provider/model changes
+- ❌ No raw prompts / secrets stored (8 hooks, all with structured fields only)
+- ❌ No new SQLite tables or columns (uses existing v2 schema)
+- ❌ Module + harness + tests + docs ONLY
+
+The 6 new event types extend `LIFECYCLE_ORDER` but don't change the schema. The `notes` field is the only free-form sink, populated only with target_url-truncated strings (URL is non-secret) or platform_name (already public).
+
+---
+
+## 5. Tests
+
+- `tests/test_parity_trace_phase_ncp_3i.py::TestPreDispatchLifecycleV3` — **5 new tests**:
+  - All 5 minimum-set v3 events present in `ALL_EVENTS`
+  - `LIFECYCLE_ORDER` ordering: handler_entry < auth_gate_pass < body_read_complete < before_dispatch < upstream_attempt_start
+  - Pre-dispatch chain persists when emitted in sequence (death-mid-pipeline simulation)
+  - Full chain persists when emitted to completion
+  - V3 events respect the env-var disable
+- `tests/test_ncp3_inspect_session_lanes.py::TestParityTraceCoverage` — **2 new tests**:
+  - V3 pre-dispatch death localization: 3 traces with different death stages → distribution surfaces correctly
+  - V3 synthesis renders Q9 line when pre-dispatch deaths exist
+
+Total: **40 module + 27 harness = 67 tests** (35 + 5 + 25 + 2).
+
+---
+
+## 6. Cross-references
+
+- `docs/internal/specs/ncp-1a-iteration-5-2026-04-27.md` — H10 + activation gap (predecessor)
+- `docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md` — NCP-3I v1 spec
+- `tokenpak/proxy/parity_trace.py` — module with v3 events + `LIFECYCLE_ORDER`
+- `tokenpak/proxy/server.py::_proxy_to_inner` — 6 new hook insertions
+- `scripts/inspect_session_lanes.py` — dim 9 v3 fields + Q9 synthesis
+- `tests/test_parity_trace_phase_ncp_3i.py::TestPreDispatchLifecycleV3` — module tests
+- `tests/test_ncp3_inspect_session_lanes.py::TestParityTraceCoverage` — harness tests

--- a/scripts/inspect_session_lanes.py
+++ b/scripts/inspect_session_lanes.py
@@ -307,6 +307,24 @@ def _dim_token_usage(
 # ── Dimension 9: parity-trace coverage (NCP-3I) ──────────────────────
 
 
+_NCP_3I_V3_LIFECYCLE: tuple = (
+    "handler_entry",
+    "auth_gate_pass",
+    "route_resolved",
+    "body_read_complete",
+    "request_classified",
+    "adapter_detected",
+    "before_dispatch",
+    "upstream_attempt_start",
+    "stream_start",
+    "stream_complete",
+    "stream_abort",
+    "upstream_attempt_failure",
+    "retry_boundary",
+    "request_completion",
+)
+
+
 def _dim_parity_trace_coverage(
     conn: sqlite3.Connection, since_iso: str, since_ts: float
 ) -> Dict[str, Any]:
@@ -401,6 +419,39 @@ def _dim_parity_trace_coverage(
     else:
         verdict = "interp_a_or_clean"
 
+    # NCP-3I-v3: per-trace lifecycle progression. For each trace,
+    # report the LAST observed event in the canonical lifecycle
+    # order, plus aggregate over all traces.
+    last_event_by_trace: Dict[str, str] = {}
+    last_stage_index_by_trace: Dict[str, int] = {}
+    for tid, d in by_trace.items():
+        # Walk lifecycle in reverse and pick the latest stage that
+        # this trace recorded.
+        last_idx = -1
+        last_evt = None
+        for i, evt in enumerate(_NCP_3I_V3_LIFECYCLE):
+            if evt in d["phases"]:
+                last_idx = i
+                last_evt = evt
+        last_event_by_trace[tid] = last_evt or "(unknown)"
+        last_stage_index_by_trace[tid] = last_idx
+
+    # Distribution of "where traces died" — which lifecycle stage
+    # each trace reached as its last observation.
+    last_stage_distribution: Counter = Counter(
+        last_event_by_trace.values()
+    )
+
+    # Death-localization summary: traces that died BEFORE
+    # upstream_attempt_start are the iter-6 §1 condition. Group
+    # them by the last stage they reached.
+    pre_upstream_idx = _NCP_3I_V3_LIFECYCLE.index("upstream_attempt_start")
+    pre_upstream_traces = {
+        tid: last_event_by_trace[tid]
+        for tid, idx in last_stage_index_by_trace.items()
+        if 0 <= idx < pre_upstream_idx
+    }
+
     return {
         "available": True,
         "row_count": len(rows),
@@ -412,10 +463,21 @@ def _dim_parity_trace_coverage(
         "traces_with_completion_in_tp_events": n_with_completion,
         "interp_b_count": interp_b_count,
         "verdict": verdict,
+        # NCP-3I-v3 — per-trace lifecycle progression
+        "last_stage_distribution": dict(last_stage_distribution),
+        "pre_upstream_death_count": len(pre_upstream_traces),
+        "pre_upstream_death_stage_distribution": dict(
+            Counter(pre_upstream_traces.values())
+        ),
         "note": (
             "interp_b_count = traces that emitted handler_entry but "
             "never completed in tp_events. iter-4 §11 interp B is "
-            "supported when interp_b_count > 0."
+            "supported when interp_b_count > 0. NCP-3I-v3 added "
+            "last_stage_distribution: which lifecycle stage each "
+            "trace's LAST observed event was. Traces with last_stage "
+            "before 'upstream_attempt_start' died in the pre-dispatch "
+            "path — pre_upstream_death_stage_distribution localizes "
+            "exactly which stage."
         ),
     }
 
@@ -642,6 +704,26 @@ def _verdict_lines(report: Dict[str, Any]) -> List[str]:
                 f"**Q8 — NCP-3I parity trace:** indeterminate "
                 f"(traces={d9.get('distinct_traces')}, "
                 f"completion={nc})."
+            )
+        # NCP-3I-v3 — pre-dispatch death localization (Q9).
+        pre_count = d9.get("pre_upstream_death_count", 0)
+        if pre_count > 0:
+            stage_dist = d9.get("pre_upstream_death_stage_distribution") or {}
+            top = sorted(stage_dist.items(), key=lambda x: -x[1])[:3]
+            top_str = ", ".join(f"{k}={v}" for k, v in top)
+            out.append(
+                f"**Q9 — NCP-3I-v3 pre-dispatch death:** {pre_count} "
+                f"traces died BEFORE upstream_attempt_start. Top stages "
+                f"(stage_at_death=count): {top_str}. The most common "
+                "last-observed stage is the death point — instrument "
+                "deeper there if needed."
+            )
+        else:
+            out.append(
+                "**Q9 — NCP-3I-v3 pre-dispatch death:** 0 traces died "
+                "before upstream_attempt_start in window. If a workload "
+                "ran, all requests reached dispatch — H10 is now a "
+                "stream-side hypothesis (check dim 8 / stream events)."
             )
     return out
 

--- a/tests/test_ncp3_inspect_session_lanes.py
+++ b/tests/test_ncp3_inspect_session_lanes.py
@@ -539,6 +539,68 @@ class TestParityTraceCoverage:
         md = out.read_text()
         assert "Q8 — NCP-3I parity trace" in md
 
+    def test_dim9_v3_pre_dispatch_death_localization(self, tmp_path):
+        """V3 — when traces die at different stages, the harness reports
+        a per-stage breakdown that pinpoints where requests stop."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        # Three traces:
+        #   trace-1: died at handler_entry only
+        #   trace-2: died at body_read_complete (got past auth + route)
+        #   trace-3: reached upstream_attempt_start (no death pre-dispatch)
+        rows = []
+        rows.append({"trace_id": "trace-1", "event_type": "handler_entry",
+                     "ts": ts + 0})
+        for evt in ("handler_entry", "auth_gate_pass", "route_resolved",
+                    "body_read_complete"):
+            rows.append({"trace_id": "trace-2", "event_type": evt,
+                         "ts": ts + 10})
+        for evt in ("handler_entry", "auth_gate_pass", "route_resolved",
+                    "body_read_complete", "adapter_detected",
+                    "before_dispatch", "upstream_attempt_start"):
+            rows.append({"trace_id": "trace-3", "event_type": evt,
+                         "ts": ts + 20})
+        self._seed_parity_trace(db, rows=rows)
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+
+        # last_stage_distribution should show trace-1 died at
+        # handler_entry, trace-2 at body_read_complete, trace-3 at
+        # upstream_attempt_start.
+        last = d9["last_stage_distribution"]
+        assert last.get("handler_entry") == 1
+        assert last.get("body_read_complete") == 1
+        assert last.get("upstream_attempt_start") == 1
+
+        # Of the 3, exactly 2 died before upstream_attempt_start
+        # (trace-1 at handler_entry, trace-2 at body_read_complete).
+        assert d9["pre_upstream_death_count"] == 2
+        pre = d9["pre_upstream_death_stage_distribution"]
+        assert pre.get("handler_entry") == 1
+        assert pre.get("body_read_complete") == 1
+
+    def test_dim9_v3_synthesis_renders_q9(self, tmp_path):
+        """When pre-dispatch deaths exist, Q9 summary line appears."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": f"trace-{i}", "event_type": "handler_entry",
+             "ts": ts + i}
+            for i in range(3)
+        ])
+        out = tmp_path / "report.md"
+        rc = inspect.main([
+            "--db-path", str(db),
+            "--window-minutes", "0",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        md = out.read_text()
+        assert "Q9 — NCP-3I-v3 pre-dispatch death" in md
+        assert "handler_entry=3" in md
+
 
 # ── 12. structural — no dispatch / behavior imports ───────────────────
 

--- a/tests/test_parity_trace_phase_ncp_3i.py
+++ b/tests/test_parity_trace_phase_ncp_3i.py
@@ -676,3 +676,117 @@ class TestStreamIntegrityV2:
         finally:
             conn.close()
         assert "idx_parity_lane" in indexes
+
+
+# ── 14. NCP-3I-v3 pre-dispatch lifecycle events ───────────────────────
+
+
+class TestPreDispatchLifecycleV3:
+    """Cover the new lifecycle events that localize where a request
+    dies between handler_entry and upstream_attempt_start."""
+
+    def test_v3_event_constants_exist(self):
+        from tokenpak.proxy.parity_trace import (
+            ALL_EVENTS,
+            EVENT_ADAPTER_DETECTED,
+            EVENT_AUTH_GATE_PASS,
+            EVENT_BEFORE_DISPATCH,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_ROUTE_RESOLVED,
+        )
+        for evt in (
+            EVENT_AUTH_GATE_PASS,
+            EVENT_ROUTE_RESOLVED,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_ADAPTER_DETECTED,
+            EVENT_BEFORE_DISPATCH,
+        ):
+            assert evt in ALL_EVENTS, f"{evt!r} missing from ALL_EVENTS"
+
+    def test_lifecycle_order_includes_v3_events(self):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_AUTH_GATE_PASS,
+            EVENT_BEFORE_DISPATCH,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_HANDLER_ENTRY,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            LIFECYCLE_ORDER,
+        )
+        # Order: handler_entry FIRST, upstream_attempt_start AFTER
+        # the pre-dispatch events.
+        assert LIFECYCLE_ORDER[0] == EVENT_HANDLER_ENTRY
+        idx_handler = LIFECYCLE_ORDER.index(EVENT_HANDLER_ENTRY)
+        idx_auth = LIFECYCLE_ORDER.index(EVENT_AUTH_GATE_PASS)
+        idx_body = LIFECYCLE_ORDER.index(EVENT_BODY_READ_COMPLETE)
+        idx_dispatch = LIFECYCLE_ORDER.index(EVENT_BEFORE_DISPATCH)
+        idx_upstream = LIFECYCLE_ORDER.index(EVENT_UPSTREAM_ATTEMPT_START)
+        assert idx_handler < idx_auth < idx_body < idx_dispatch < idx_upstream
+
+    def test_pre_dispatch_chain_persists(self, store, env_enabled):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_ADAPTER_DETECTED,
+            EVENT_AUTH_GATE_PASS,
+            EVENT_BEFORE_DISPATCH,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_HANDLER_ENTRY,
+            EVENT_ROUTE_RESOLVED,
+        )
+        # Simulate a request reaching adapter_detected then dying.
+        for evt in (
+            EVENT_HANDLER_ENTRY,
+            EVENT_AUTH_GATE_PASS,
+            EVENT_ROUTE_RESOLVED,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_ADAPTER_DETECTED,
+        ):
+            emit(evt, trace_id="t-died-mid-pipeline")
+            time.sleep(0.0005)
+        # before_dispatch + upstream_attempt_start NOT emitted.
+        rows = store.fetch_for_trace("t-died-mid-pipeline")
+        types = [r["event_type"] for r in rows]
+        assert EVENT_HANDLER_ENTRY in types
+        assert EVENT_ADAPTER_DETECTED in types
+        assert EVENT_BEFORE_DISPATCH not in types
+
+    def test_full_chain_persists(self, store, env_enabled):
+        """A successful request hits every pre-dispatch hook + the
+        upstream_attempt_start hook."""
+        from tokenpak.proxy.parity_trace import (
+            EVENT_ADAPTER_DETECTED,
+            EVENT_AUTH_GATE_PASS,
+            EVENT_BEFORE_DISPATCH,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_HANDLER_ENTRY,
+            EVENT_ROUTE_RESOLVED,
+            EVENT_STREAM_COMPLETE,
+            EVENT_STREAM_START,
+            EVENT_UPSTREAM_ATTEMPT_START,
+        )
+        chain = (
+            EVENT_HANDLER_ENTRY,
+            EVENT_AUTH_GATE_PASS,
+            EVENT_ROUTE_RESOLVED,
+            EVENT_BODY_READ_COMPLETE,
+            EVENT_ADAPTER_DETECTED,
+            EVENT_BEFORE_DISPATCH,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            EVENT_STREAM_START,
+            EVENT_STREAM_COMPLETE,
+        )
+        for evt in chain:
+            emit(evt, trace_id="t-full-chain")
+            time.sleep(0.0005)
+        rows = store.fetch_for_trace("t-full-chain")
+        types = [r["event_type"] for r in rows]
+        for evt in chain:
+            assert evt in types, f"{evt!r} missing from full chain"
+        assert len(rows) == len(chain)
+
+    def test_v3_events_with_disabled_env_no_op(self, store, env_disabled):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_AUTH_GATE_PASS,
+            EVENT_BEFORE_DISPATCH,
+        )
+        emit(EVENT_AUTH_GATE_PASS, trace_id="t-disabled-v3")
+        emit(EVENT_BEFORE_DISPATCH, trace_id="t-disabled-v3")
+        assert store.fetch_for_trace("t-disabled-v3") == []

--- a/tokenpak/proxy/parity_trace.py
+++ b/tokenpak/proxy/parity_trace.py
@@ -87,6 +87,16 @@ EVENT_STREAM_START: str = "stream_start"
 EVENT_STREAM_COMPLETE: str = "stream_complete"
 EVENT_STREAM_ABORT: str = "stream_abort"
 
+# NCP-3I-v3 pre-dispatch lifecycle events. Localize where a request
+# dies between handler_entry and upstream_attempt_start (per
+# iter-6 §1 finding: 4 of 4 traces had handler_entry without
+# upstream_attempt_start).
+EVENT_AUTH_GATE_PASS: str = "auth_gate_pass"
+EVENT_ROUTE_RESOLVED: str = "route_resolved"
+EVENT_BODY_READ_COMPLETE: str = "body_read_complete"
+EVENT_ADAPTER_DETECTED: str = "adapter_detected"
+EVENT_BEFORE_DISPATCH: str = "before_dispatch"
+
 ALL_EVENTS: frozenset = frozenset({
     EVENT_HANDLER_ENTRY,
     EVENT_REQUEST_CLASSIFIED,
@@ -97,7 +107,33 @@ ALL_EVENTS: frozenset = frozenset({
     EVENT_STREAM_START,
     EVENT_STREAM_COMPLETE,
     EVENT_STREAM_ABORT,
+    EVENT_AUTH_GATE_PASS,
+    EVENT_ROUTE_RESOLVED,
+    EVENT_BODY_READ_COMPLETE,
+    EVENT_ADAPTER_DETECTED,
+    EVENT_BEFORE_DISPATCH,
 })
+
+# NCP-3I-v3 — canonical pre-dispatch lifecycle order. Used by
+# inspect_session_lanes.py to render per-trace progression and
+# identify the LAST observed event (= the stage where the
+# request died).
+LIFECYCLE_ORDER: tuple = (
+    EVENT_HANDLER_ENTRY,
+    EVENT_AUTH_GATE_PASS,
+    EVENT_ROUTE_RESOLVED,
+    EVENT_BODY_READ_COMPLETE,
+    EVENT_REQUEST_CLASSIFIED,
+    EVENT_ADAPTER_DETECTED,
+    EVENT_BEFORE_DISPATCH,
+    EVENT_UPSTREAM_ATTEMPT_START,
+    EVENT_STREAM_START,
+    EVENT_STREAM_COMPLETE,
+    EVENT_STREAM_ABORT,
+    EVENT_UPSTREAM_ATTEMPT_FAILURE,
+    EVENT_RETRY_BOUNDARY,
+    EVENT_REQUEST_COMPLETION,
+)
 
 
 # Documented value sets for the "free-form-ish" TEXT columns.
@@ -524,15 +560,21 @@ def emit(
 
 __all__ = [
     "ALL_EVENTS",
+    "EVENT_ADAPTER_DETECTED",
+    "EVENT_AUTH_GATE_PASS",
+    "EVENT_BEFORE_DISPATCH",
+    "EVENT_BODY_READ_COMPLETE",
     "EVENT_HANDLER_ENTRY",
     "EVENT_REQUEST_CLASSIFIED",
     "EVENT_REQUEST_COMPLETION",
     "EVENT_RETRY_BOUNDARY",
+    "EVENT_ROUTE_RESOLVED",
     "EVENT_STREAM_ABORT",
     "EVENT_STREAM_COMPLETE",
     "EVENT_STREAM_START",
     "EVENT_UPSTREAM_ATTEMPT_FAILURE",
     "EVENT_UPSTREAM_ATTEMPT_START",
+    "LIFECYCLE_ORDER",
     "PARITY_TRACE_ENV",
     "ParityTraceRow",
     "ParityTraceStore",

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -779,6 +779,23 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 request_id=_req_id,
                 notes=method,
             )
+            # NCP-3I-v3: auth_gate already passed (do_POST gates pre-call);
+            # emit a tautological-but-confirmed marker so the pre-dispatch
+            # lifecycle has its first checkpoint.
+            _pt.emit(
+                _pt.EVENT_AUTH_GATE_PASS,
+                trace_id=_req_id,
+                request_id=_req_id,
+            )
+            # NCP-3I-v3: route_resolved — by the time we're in
+            # _proxy_to_inner, do_POST has already chosen the route
+            # via ps.router.route(). Emit a confirmation marker.
+            _pt.emit(
+                _pt.EVENT_ROUTE_RESOLVED,
+                trace_id=_req_id,
+                request_id=_req_id,
+                notes=target_url[:200] if target_url else None,
+            )
         except Exception:  # noqa: BLE001
             pass
         ps = self.server.proxy_server  # type: ignore[attr-defined]
@@ -794,6 +811,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
 
         content_length = int(self.headers.get("Content-Length", 0))
         body: Optional[bytes] = self.rfile.read(content_length) if content_length > 0 else None
+        # NCP-3I-v3: body_read_complete checkpoint. If the request dies
+        # between handler_entry and this point, the body read failed
+        # (or the rfile was closed by the client mid-handshake).
+        try:
+            from tokenpak.proxy import parity_trace as _pt
+            _pt.emit(
+                _pt.EVENT_BODY_READ_COMPLETE,
+                trace_id=_req_id,
+                body_bytes=(len(body) if body else 0),
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         model = "unknown"
         input_tokens = 0
@@ -826,6 +855,16 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 _adapter.platform_name,
                 target_url[:60],
             )
+            # NCP-3I-v3: adapter_detected checkpoint.
+            try:
+                from tokenpak.proxy import parity_trace as _pt
+                _pt.emit(
+                    _pt.EVENT_ADAPTER_DETECTED,
+                    trace_id=_req_id,
+                    notes=str(_adapter.platform_name)[:200],
+                )
+            except Exception:  # noqa: BLE001
+                pass
             # v1.3.14 live-debug hook: when TOKENPAK_DUMP_HEADERS=1, emit
             # a one-line summary of inbound header names so we can see
             # exactly what OpenClaw / Codex / Claude CLI actually send.
@@ -1704,9 +1743,21 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     )
                 except Exception:
                     pass
-                # NCP-3I: upstream-attempt-start (streaming path).
+                # NCP-3I-v3: before_dispatch + upstream-attempt-start
+                # (streaming path). before_dispatch fires immediately
+                # before pool.stream is invoked — the last
+                # observable lifecycle event a request hits before the
+                # actual outbound HTTP call. If a trace shows
+                # before_dispatch but no upstream_attempt_start,
+                # something between them (rare — they're adjacent) is
+                # the death point.
                 try:
                     from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_BEFORE_DISPATCH,
+                        trace_id=_req_id,
+                        notes="stream",
+                    )
                     _pt.emit(
                         _pt.EVENT_UPSTREAM_ATTEMPT_START,
                         trace_id=_req_id,
@@ -1849,7 +1900,28 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             self.wfile.write(chunk)
                             self.wfile.flush()
                             _ncp3iv2_bytes_down += len(chunk)
-                        except (BrokenPipeError, ConnectionResetError):
+                        except (BrokenPipeError, ConnectionResetError) as _ncp_pipe_exc:
+                            # NCP-3I-v3 stream_abort hook (downstream
+                            # client closed mid-stream — H10b suspect).
+                            # Emit telemetry, then preserve original
+                            # behavior with `break`.
+                            try:
+                                from tokenpak.proxy import parity_trace as _pt
+                                _pt.emit(
+                                    _pt.EVENT_STREAM_ABORT,
+                                    trace_id=_req_id,
+                                    stream_aborted=1,
+                                    bytes_from_upstream=_ncp3iv2_bytes_up,
+                                    bytes_to_client=_ncp3iv2_bytes_down,
+                                    connection_closed_early=1,
+                                    stream_exception_class=type(_ncp_pipe_exc).__name__,
+                                    stream_exception_message_hash=_pt.hash_exception_message(_ncp_pipe_exc),
+                                    retry_signal="connection_reset",
+                                    retry_owner="claude_code_client",
+                                    lane_id=_ncp3iv2_lane,
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
                             break
                         if should_log and is_messages:
                             sse_buffer += chunk
@@ -1918,9 +1990,15 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     )
                 except Exception:
                     pass
-                # NCP-3I: upstream-attempt-start (non-streaming path).
+                # NCP-3I-v3: before_dispatch + upstream-attempt-start
+                # (non-streaming path).
                 try:
                     from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_BEFORE_DISPATCH,
+                        trace_id=_req_id,
+                        notes="request",
+                    )
                     _pt.emit(
                         _pt.EVENT_UPSTREAM_ATTEMPT_START,
                         trace_id=_req_id,
@@ -2235,6 +2313,25 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 # failure is recorded in except block
 
         except Exception as exc:
+            # NCP-3I-v3 stream_abort hook for upstream-side exceptions
+            # (httpx errors, RemoteProtocolError, ReadTimeout etc.) that
+            # propagate past the with-block. This is the OTHER half of
+            # the H10 capture surface — the BrokenPipe path catches
+            # downstream client disconnects; this catches upstream
+            # provider failures.
+            try:
+                from tokenpak.proxy import parity_trace as _pt
+                _pt.emit(
+                    _pt.EVENT_STREAM_ABORT,
+                    trace_id=_req_id,
+                    stream_aborted=1,
+                    stream_exception_class=type(exc).__name__,
+                    stream_exception_message_hash=_pt.hash_exception_message(exc),
+                    retry_signal="unknown",
+                    retry_owner="upstream_provider",
+                )
+            except Exception:  # noqa: BLE001
+                pass
             # ── Circuit breaker: record failure ───────────────────────────
             if _cb_registry is not None and _cb_provider is not None:
                 _cb_registry.record_failure(_cb_provider)


### PR DESCRIPTION
## Summary

Disambiguation evidence (iter-6) confirmed real-workload \`tokenpak claude\` requests **reach \`_proxy_to_inner\` but die before \`pool.stream\`**. The 1 row from the iter-5 trace was the liveness curl (it traversed the full chain); 3 of 4 rows in the latest trace are real repro requests showing handler_entry without upstream_attempt_start.

The 900-line gap between server.py:772 (handler_entry hook) and server.py:1707/1847 (upstream_attempt_start hook) is where requests die. NCP-3I-v3 wires 6 new lifecycle hooks across that gap so the operator can localize exactly which stage requests stop at.

**Measurement-only.** Zero behavior change when \`TOKENPAK_PARITY_TRACE_ENABLED=false\` (default).

## Held throughout (per directive)

- ❌ No routing changes
- ❌ No retry behavior changes
- ❌ No cache behavior changes
- ❌ No auth behavior changes
- ❌ No prompt mutation changes
- ❌ No provider/model changes
- ❌ No raw prompts / secrets stored
- ❌ No new SQLite tables or columns (uses existing v2 schema)

## What landed

### 6 new lifecycle event types (directive's "minimum acceptable")

| Event | Position in \`_proxy_to_inner\` | Captures |
|---|---|---|
| \`EVENT_AUTH_GATE_PASS\` | top, after handler_entry | tautological-but-confirmed checkpoint |
| \`EVENT_ROUTE_RESOLVED\` | top, after auth_gate_pass | confirms do_POST chose this route |
| \`EVENT_BODY_READ_COMPLETE\` | server.py:~813 | request body successfully read |
| \`EVENT_ADAPTER_DETECTED\` | server.py:~840 | platform adapter resolved |
| \`EVENT_BEFORE_DISPATCH\` | adjacent to upstream_attempt_start | last marker before \`pool.stream\` / \`pool.request\` |
| \`EVENT_STREAM_ABORT\` | (a) BrokenPipe except (b) outer except at server.py:~2237 | downstream client disconnect OR upstream-side exception |

The directive's \"optional\" set (\`BODY_READ_START\`, \`COMPRESSION_*\`, \`ENRICHMENT_*\`, \`CACHE_LOOKUP_*\`) is **deferred** — the minimum set is sufficient to localize the death stage.

### \`LIFECYCLE_ORDER\` constant

Canonical ordering exported from \`parity_trace.py\` for the harness to walk.

### Two stream_abort hooks

- (a) Downstream BrokenPipe (H10b — claude_code_client closed mid-stream)
- (b) Upstream-side exception (H10c/d — provider failure during with-block)

### Harness extension

\`scripts/inspect_session_lanes.py\` dim 9 now reports:
- \`last_stage_distribution\` — count of traces by their last-observed event
- \`pre_upstream_death_count\` — how many died BEFORE upstream_attempt_start
- \`pre_upstream_death_stage_distribution\` — per-stage breakdown

New **Q9** synthesis line summarizes: *\"N traces died BEFORE upstream_attempt_start. Top stages: X=N1, Y=N2, Z=N3.\"*

### Death-localization decision tree (post-v3)

| Q9 finding | Next phase |
|---|---|
| Most deaths at \`handler_entry\` | NCP-3A-handler-init |
| Most deaths at \`body_read_complete\` | NCP-3A-classification |
| Most deaths at \`adapter_detected\` | NCP-3A-enrichment |
| Most deaths at \`before_dispatch\` | NCP-9b OAuth refresh / NCP-3A-pool |
| upstream_attempt_start + stream_abort with bytes_to_client < bytes_from_upstream | NCP-3A-streaming |
| All clean | NCP-1C |

### Tests — 7 new

- \`TestPreDispatchLifecycleV3\` (5): event constants, LIFECYCLE_ORDER ordering, pre-dispatch chain persistence, full-chain persistence, env-var disable
- \`TestParityTraceCoverage\` v3 (2): per-trace death localization across 3 simulated traces, Q9 synthesis rendering

**Total: 67 in-scope tests** (40 module + 27 harness).

## Test plan

- [x] 67/67 in-scope tests pass
- [x] \`ruff check tokenpak/ tests/\` clean
- [x] server.py syntax validated (ast.parse)
- [x] Repo hygiene scan clean
- [x] Zero behavior change when env-var disabled (verified by structural test)
- [ ] CI green

## After this PR

\`\`\`bash
scripts/verify_parity_trace_activation.py
tokenpak stop && export TOKENPAK_PARITY_TRACE_ENABLED=true && tokenpak start
# Run 3-concurrent-tokenpak-claude workload
scripts/inspect_session_lanes.py --window-minutes 30 --output trace.md
\`\`\`

Q9 synthesis will pinpoint the death stage. Routing per iter-6 §3 picks the next NCP phase from there.

## Files

- \`tokenpak/proxy/parity_trace.py\` (+6 events, LIFECYCLE_ORDER constant)
- \`tokenpak/proxy/server.py\` (8 new hook insertions, all wrapped in try/except)
- \`scripts/inspect_session_lanes.py\` (dim 9 v3 fields + Q9 synthesis)
- \`tests/test_parity_trace_phase_ncp_3i.py\` (+5 v3 tests)
- \`tests/test_ncp3_inspect_session_lanes.py\` (+2 v3 dim-9 tests)
- \`docs/internal/specs/ncp-1a-iteration-6-2026-04-27.md\` (new — iter-6 + v3 spec)
- \`docs/internal/specs/ncp-1a-iteration-5-2026-04-27.md\` (banner addendum)