### PR TITLE
feat(proxy,scripts,tests): NCP-3A — early-return events for adapter_detected → before_dispatch death cohort

### DIFF
--- a/scripts/inspect_session_lanes.py
+++ b/scripts/inspect_session_lanes.py
@@ -314,6 +314,12 @@ _NCP_3I_V3_LIFECYCLE: tuple = (
     "body_read_complete",
     "request_classified",
     "adapter_detected",
+    # NCP-3A-enrichment terminal early-return events. Positioned
+    # between adapter_detected and before_dispatch so that a trace
+    # which records BOTH adapter_detected and one of these has
+    # last_stage = the terminal (correctly classified).
+    "request_rejected",
+    "dispatch_subprocess_complete",
     "before_dispatch",
     "upstream_attempt_start",
     "stream_start",
@@ -323,6 +329,16 @@ _NCP_3I_V3_LIFECYCLE: tuple = (
     "retry_boundary",
     "request_completion",
 )
+
+# NCP-3A-enrichment — events that signal an INTENTIONAL terminal
+# decision before upstream_attempt_start. Traces ending here are
+# excluded from the pre-upstream "death" cohort: they completed
+# (subprocess) or were explicitly rejected (auth / circuit /
+# validation), not silent failures.
+_TERMINAL_EARLY_RETURN_EVENTS: frozenset = frozenset({
+    "dispatch_subprocess_complete",
+    "request_rejected",
+})
 
 
 def _dim_parity_trace_coverage(
@@ -444,12 +460,26 @@ def _dim_parity_trace_coverage(
 
     # Death-localization summary: traces that died BEFORE
     # upstream_attempt_start are the iter-6 §1 condition. Group
-    # them by the last stage they reached.
+    # them by the last stage they reached. NCP-3A-enrichment:
+    # exclude traces whose last stage is a TERMINAL early-return
+    # event — those are intentional terminations (subprocess
+    # dispatch success, auth/circuit/validation rejection), not
+    # silent deaths.
     pre_upstream_idx = _NCP_3I_V3_LIFECYCLE.index("upstream_attempt_start")
     pre_upstream_traces = {
         tid: last_event_by_trace[tid]
         for tid, idx in last_stage_index_by_trace.items()
         if 0 <= idx < pre_upstream_idx
+        and last_event_by_trace[tid] not in _TERMINAL_EARLY_RETURN_EVENTS
+    }
+    # Traces that ended at a terminal early-return event are
+    # reported separately so the operator can see how many
+    # requests took each early-return path.
+    early_return_traces = {
+        tid: last_event_by_trace[tid]
+        for tid, idx in last_stage_index_by_trace.items()
+        if 0 <= idx < pre_upstream_idx
+        and last_event_by_trace[tid] in _TERMINAL_EARLY_RETURN_EVENTS
     }
 
     return {
@@ -469,15 +499,24 @@ def _dim_parity_trace_coverage(
         "pre_upstream_death_stage_distribution": dict(
             Counter(pre_upstream_traces.values())
         ),
+        # NCP-3A-enrichment — terminal early-return classification.
+        "early_return_count": len(early_return_traces),
+        "early_return_stage_distribution": dict(
+            Counter(early_return_traces.values())
+        ),
         "note": (
             "interp_b_count = traces that emitted handler_entry but "
             "never completed in tp_events. iter-4 §11 interp B is "
             "supported when interp_b_count > 0. NCP-3I-v3 added "
             "last_stage_distribution: which lifecycle stage each "
             "trace's LAST observed event was. Traces with last_stage "
-            "before 'upstream_attempt_start' died in the pre-dispatch "
-            "path — pre_upstream_death_stage_distribution localizes "
-            "exactly which stage."
+            "before 'upstream_attempt_start' AND not a terminal "
+            "early-return event are silent pre-dispatch deaths — "
+            "pre_upstream_death_stage_distribution localizes exactly "
+            "which stage. NCP-3A-enrichment added early_return_count "
+            "/ early_return_stage_distribution for traces that took "
+            "a known terminal early-return path (subprocess dispatch "
+            "success, auth/circuit/validation rejection)."
         ),
     }
 
@@ -724,6 +763,21 @@ def _verdict_lines(report: Dict[str, Any]) -> List[str]:
                 "before upstream_attempt_start in window. If a workload "
                 "ran, all requests reached dispatch — H10 is now a "
                 "stream-side hypothesis (check dim 8 / stream events)."
+            )
+        # NCP-3A-enrichment — terminal early-return classification (Q10).
+        er_count = d9.get("early_return_count", 0)
+        if er_count > 0:
+            er_dist = d9.get("early_return_stage_distribution") or {}
+            er_top = sorted(er_dist.items(), key=lambda x: -x[1])[:3]
+            er_top_str = ", ".join(f"{k}={v}" for k, v in er_top)
+            out.append(
+                f"**Q10 — NCP-3A-enrichment terminal early-returns:** "
+                f"{er_count} traces took a known early-return path "
+                f"(intentional terminations, NOT deaths). Distribution "
+                f"(stage=count): {er_top_str}. dispatch_subprocess_complete "
+                "= successful subprocess companion dispatch; "
+                "request_rejected = auth/circuit/validation reject (see "
+                "notes column for sub-class)."
             )
     return out
 

--- a/tests/baselines/ncp-3-trace/20260427T184157Z-ncp3i-v3-3tp.md
+++ b/tests/baselines/ncp-3-trace/20260427T184157Z-ncp3i-v3-3tp.md
@@ -1,0 +1,122 @@
+# NCP-3 session-lane trace
+
+**Generated**: 2026-04-27T18:41:57.921483+00:00
+**Window**: 30.0 min (2026-04-27T18:11:57.921483+00:00 → 2026-04-27T18:41:57.921483+00:00)
+**Claude Code event count in window**: 0
+
+## Synthesis
+
+- **Q1 — H2 session-id collapse: no_data.** Inconclusive — rerun with the §4 workload (2 concurrent tokenpak claude sessions) and re-inspect.
+- **Q3 — retry events recorded:** 0. Either no retries occurred OR the schema didn't tag them. Settle visually via the §4 workload.
+- **Q8 — NCP-3I parity trace:** **iter-4 §11 interp B SUPPORTED.** 187 of 187 traces emitted handler_entry but never completed in tp_events (only 0 did). The missing requests fail before completion-time logging — matches the visible-retry-but-empty-telemetry condition.
+- **Q9 — NCP-3I-v3 pre-dispatch death:** 55 traces died BEFORE upstream_attempt_start. Top stages (stage_at_death=count): adapter_detected=55. The most common last-observed stage is the death point — instrument deeper there if needed.
+
+## Dimensions
+
+### dim1_session_collapse
+
+```json
+{
+  "collapse_ratio": null,
+  "distinct_request_ids": 0,
+  "distinct_session_ids": 0,
+  "verdict": "no_data"
+}
+```
+
+### dim2_time_clustering
+
+```json
+{
+  "spans": [],
+  "verdict": "insufficient_data"
+}
+```
+
+### dim3_status_distribution
+
+```json
+{}
+```
+
+### dim4_per_session_durations
+
+```json
+{}
+```
+
+### dim5_provider_audit
+
+```json
+{
+  "distribution": {},
+  "i0_violation": false,
+  "non_oauth_providers": []
+}
+```
+
+### dim6_retry_count
+
+```json
+{
+  "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+  "retry_event_lower_bound": 0
+}
+```
+
+### dim7_token_usage
+
+```json
+{
+  "available": true,
+  "no_usage_rows": true
+}
+```
+
+### dim8_interleaving
+
+```json
+{
+  "interleave_score": null,
+  "verdict": "insufficient_data"
+}
+```
+
+### dim9_parity_trace_coverage
+
+```json
+{
+  "available": true,
+  "distinct_traces": 187,
+  "event_type_distribution": {
+    "adapter_detected": 187,
+    "auth_gate_pass": 187,
+    "before_dispatch": 132,
+    "body_read_complete": 187,
+    "handler_entry": 187,
+    "route_resolved": 187,
+    "stream_abort": 32,
+    "stream_complete": 86,
+    "stream_start": 92,
+    "upstream_attempt_start": 132
+  },
+  "interp_b_count": 187,
+  "last_stage_distribution": {
+    "adapter_detected": 55,
+    "stream_abort": 32,
+    "stream_complete": 86,
+    "upstream_attempt_start": 14
+  },
+  "note": "interp_b_count = traces that emitted handler_entry but never completed in tp_events. iter-4 \u00a711 interp B is supported when interp_b_count > 0. NCP-3I-v3 added last_stage_distribution: which lifecycle stage each trace's LAST observed event was. Traces with last_stage before 'upstream_attempt_start' died in the pre-dispatch path \u2014 pre_upstream_death_stage_distribution localizes exactly which stage.",
+  "pre_upstream_death_count": 55,
+  "pre_upstream_death_stage_distribution": {
+    "adapter_detected": 55
+  },
+  "row_count": 1409,
+  "traces_with_completion_in_tp_events": 0,
+  "traces_with_handler_entry": 187,
+  "traces_with_upstream_attempt_failure": 0,
+  "traces_with_upstream_attempt_start": 132,
+  "verdict": "interp_b_supported"
+}
+```

--- a/tests/baselines/ncp-3-trace/20260427T184158Z-ncp3i-v3-3tp.json
+++ b/tests/baselines/ncp-3-trace/20260427T184158Z-ncp3i-v3-3tp.json
@@ -1,0 +1,71 @@
+{
+  "claude_code_event_count": 0,
+  "dim1_session_collapse": {
+    "collapse_ratio": null,
+    "distinct_request_ids": 0,
+    "distinct_session_ids": 0,
+    "verdict": "no_data"
+  },
+  "dim2_time_clustering": {
+    "spans": [],
+    "verdict": "insufficient_data"
+  },
+  "dim3_status_distribution": {},
+  "dim4_per_session_durations": {},
+  "dim5_provider_audit": {
+    "distribution": {},
+    "i0_violation": false,
+    "non_oauth_providers": []
+  },
+  "dim6_retry_count": {
+    "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+    "retry_event_lower_bound": 0
+  },
+  "dim7_token_usage": {
+    "available": true,
+    "no_usage_rows": true
+  },
+  "dim8_interleaving": {
+    "interleave_score": null,
+    "verdict": "insufficient_data"
+  },
+  "dim9_parity_trace_coverage": {
+    "available": true,
+    "distinct_traces": 187,
+    "event_type_distribution": {
+      "adapter_detected": 187,
+      "auth_gate_pass": 187,
+      "before_dispatch": 132,
+      "body_read_complete": 187,
+      "handler_entry": 187,
+      "route_resolved": 187,
+      "stream_abort": 32,
+      "stream_complete": 86,
+      "stream_start": 92,
+      "upstream_attempt_start": 132
+    },
+    "interp_b_count": 187,
+    "last_stage_distribution": {
+      "adapter_detected": 55,
+      "stream_abort": 32,
+      "stream_complete": 86,
+      "upstream_attempt_start": 14
+    },
+    "note": "interp_b_count = traces that emitted handler_entry but never completed in tp_events. iter-4 \u00a711 interp B is supported when interp_b_count > 0. NCP-3I-v3 added last_stage_distribution: which lifecycle stage each trace's LAST observed event was. Traces with last_stage before 'upstream_attempt_start' died in the pre-dispatch path \u2014 pre_upstream_death_stage_distribution localizes exactly which stage.",
+    "pre_upstream_death_count": 55,
+    "pre_upstream_death_stage_distribution": {
+      "adapter_detected": 55
+    },
+    "row_count": 1409,
+    "traces_with_completion_in_tp_events": 0,
+    "traces_with_handler_entry": 187,
+    "traces_with_upstream_attempt_failure": 0,
+    "traces_with_upstream_attempt_start": 132,
+    "verdict": "interp_b_supported"
+  },
+  "generated_at": "2026-04-27T18:41:58.153291+00:00",
+  "schema_version": "ncp-3-trace-v1",
+  "window_end": "2026-04-27T18:41:58.153291+00:00",
+  "window_minutes": 30.0,
+  "window_start": "2026-04-27T18:11:58.153291+00:00"
+}

--- a/tests/baselines/ncp-3-trace/20260427T191403Z-ncp3a-postfix-3tp.json
+++ b/tests/baselines/ncp-3-trace/20260427T191403Z-ncp3a-postfix-3tp.json
@@ -1,0 +1,74 @@
+{
+  "claude_code_event_count": 0,
+  "dim1_session_collapse": {
+    "collapse_ratio": null,
+    "distinct_request_ids": 0,
+    "distinct_session_ids": 0,
+    "verdict": "no_data"
+  },
+  "dim2_time_clustering": {
+    "spans": [],
+    "verdict": "insufficient_data"
+  },
+  "dim3_status_distribution": {},
+  "dim4_per_session_durations": {},
+  "dim5_provider_audit": {
+    "distribution": {},
+    "i0_violation": false,
+    "non_oauth_providers": []
+  },
+  "dim6_retry_count": {
+    "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+    "retry_event_lower_bound": 0
+  },
+  "dim7_token_usage": {
+    "available": true,
+    "no_usage_rows": true
+  },
+  "dim8_interleaving": {
+    "interleave_score": null,
+    "verdict": "insufficient_data"
+  },
+  "dim9_parity_trace_coverage": {
+    "available": true,
+    "distinct_traces": 16,
+    "early_return_count": 5,
+    "early_return_stage_distribution": {
+      "request_rejected": 5
+    },
+    "event_type_distribution": {
+      "adapter_detected": 16,
+      "auth_gate_pass": 16,
+      "before_dispatch": 11,
+      "body_read_complete": 16,
+      "handler_entry": 16,
+      "request_rejected": 5,
+      "route_resolved": 16,
+      "stream_abort": 5,
+      "stream_complete": 5,
+      "stream_start": 6,
+      "upstream_attempt_start": 11
+    },
+    "interp_b_count": 16,
+    "last_stage_distribution": {
+      "request_rejected": 5,
+      "stream_abort": 5,
+      "stream_complete": 5,
+      "upstream_attempt_start": 1
+    },
+    "note": "interp_b_count = traces that emitted handler_entry but never completed in tp_events. iter-4 \u00a711 interp B is supported when interp_b_count > 0. NCP-3I-v3 added last_stage_distribution: which lifecycle stage each trace's LAST observed event was. Traces with last_stage before 'upstream_attempt_start' AND not a terminal early-return event are silent pre-dispatch deaths \u2014 pre_upstream_death_stage_distribution localizes exactly which stage. NCP-3A-enrichment added early_return_count / early_return_stage_distribution for traces that took a known terminal early-return path (subprocess dispatch success, auth/circuit/validation rejection).",
+    "pre_upstream_death_count": 0,
+    "pre_upstream_death_stage_distribution": {},
+    "row_count": 123,
+    "traces_with_completion_in_tp_events": 0,
+    "traces_with_handler_entry": 16,
+    "traces_with_upstream_attempt_failure": 0,
+    "traces_with_upstream_attempt_start": 11,
+    "verdict": "interp_b_supported"
+  },
+  "generated_at": "2026-04-27T19:14:03.483030+00:00",
+  "schema_version": "ncp-3-trace-v1",
+  "window_end": "2026-04-27T19:14:03.483030+00:00",
+  "window_minutes": 5.0,
+  "window_start": "2026-04-27T19:09:03.483030+00:00"
+}

--- a/tests/baselines/ncp-3-trace/20260427T191403Z-ncp3a-postfix-3tp.md
+++ b/tests/baselines/ncp-3-trace/20260427T191403Z-ncp3a-postfix-3tp.md
@@ -1,0 +1,126 @@
+# NCP-3 session-lane trace
+
+**Generated**: 2026-04-27T19:14:03.351737+00:00
+**Window**: 5.0 min (2026-04-27T19:09:03.351737+00:00 → 2026-04-27T19:14:03.351737+00:00)
+**Claude Code event count in window**: 0
+
+## Synthesis
+
+- **Q1 — H2 session-id collapse: no_data.** Inconclusive — rerun with the §4 workload (2 concurrent tokenpak claude sessions) and re-inspect.
+- **Q3 — retry events recorded:** 0. Either no retries occurred OR the schema didn't tag them. Settle visually via the §4 workload.
+- **Q8 — NCP-3I parity trace:** **iter-4 §11 interp B SUPPORTED.** 16 of 16 traces emitted handler_entry but never completed in tp_events (only 0 did). The missing requests fail before completion-time logging — matches the visible-retry-but-empty-telemetry condition.
+- **Q9 — NCP-3I-v3 pre-dispatch death:** 0 traces died before upstream_attempt_start in window. If a workload ran, all requests reached dispatch — H10 is now a stream-side hypothesis (check dim 8 / stream events).
+- **Q10 — NCP-3A-enrichment terminal early-returns:** 5 traces took a known early-return path (intentional terminations, NOT deaths). Distribution (stage=count): request_rejected=5. dispatch_subprocess_complete = successful subprocess companion dispatch; request_rejected = auth/circuit/validation reject (see notes column for sub-class).
+
+## Dimensions
+
+### dim1_session_collapse
+
+```json
+{
+  "collapse_ratio": null,
+  "distinct_request_ids": 0,
+  "distinct_session_ids": 0,
+  "verdict": "no_data"
+}
+```
+
+### dim2_time_clustering
+
+```json
+{
+  "spans": [],
+  "verdict": "insufficient_data"
+}
+```
+
+### dim3_status_distribution
+
+```json
+{}
+```
+
+### dim4_per_session_durations
+
+```json
+{}
+```
+
+### dim5_provider_audit
+
+```json
+{
+  "distribution": {},
+  "i0_violation": false,
+  "non_oauth_providers": []
+}
+```
+
+### dim6_retry_count
+
+```json
+{
+  "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+  "retry_event_lower_bound": 0
+}
+```
+
+### dim7_token_usage
+
+```json
+{
+  "available": true,
+  "no_usage_rows": true
+}
+```
+
+### dim8_interleaving
+
+```json
+{
+  "interleave_score": null,
+  "verdict": "insufficient_data"
+}
+```
+
+### dim9_parity_trace_coverage
+
+```json
+{
+  "available": true,
+  "distinct_traces": 16,
+  "early_return_count": 5,
+  "early_return_stage_distribution": {
+    "request_rejected": 5
+  },
+  "event_type_distribution": {
+    "adapter_detected": 16,
+    "auth_gate_pass": 16,
+    "before_dispatch": 11,
+    "body_read_complete": 16,
+    "handler_entry": 16,
+    "request_rejected": 5,
+    "route_resolved": 16,
+    "stream_abort": 5,
+    "stream_complete": 5,
+    "stream_start": 6,
+    "upstream_attempt_start": 11
+  },
+  "interp_b_count": 16,
+  "last_stage_distribution": {
+    "request_rejected": 5,
+    "stream_abort": 5,
+    "stream_complete": 5,
+    "upstream_attempt_start": 1
+  },
+  "note": "interp_b_count = traces that emitted handler_entry but never completed in tp_events. iter-4 \u00a711 interp B is supported when interp_b_count > 0. NCP-3I-v3 added last_stage_distribution: which lifecycle stage each trace's LAST observed event was. Traces with last_stage before 'upstream_attempt_start' AND not a terminal early-return event are silent pre-dispatch deaths \u2014 pre_upstream_death_stage_distribution localizes exactly which stage. NCP-3A-enrichment added early_return_count / early_return_stage_distribution for traces that took a known terminal early-return path (subprocess dispatch success, auth/circuit/validation rejection).",
+  "pre_upstream_death_count": 0,
+  "pre_upstream_death_stage_distribution": {},
+  "row_count": 123,
+  "traces_with_completion_in_tp_events": 0,
+  "traces_with_handler_entry": 16,
+  "traces_with_upstream_attempt_failure": 0,
+  "traces_with_upstream_attempt_start": 11,
+  "verdict": "interp_b_supported"
+}
+```

--- a/tests/test_ncp3_inspect_session_lanes.py
+++ b/tests/test_ncp3_inspect_session_lanes.py
@@ -601,6 +601,78 @@ class TestParityTraceCoverage:
         assert "Q9 — NCP-3I-v3 pre-dispatch death" in md
         assert "handler_entry=3" in md
 
+    def test_dim9_ncp3a_terminal_early_returns_excluded_from_deaths(self, tmp_path):
+        """NCP-3A — traces ending at request_rejected or
+        dispatch_subprocess_complete are intentional terminations and
+        must NOT be counted in pre_upstream_death_count.
+        """
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = []
+        # trace-die-1: silent death at adapter_detected (no terminal event).
+        for evt in ("handler_entry", "auth_gate_pass", "route_resolved",
+                    "body_read_complete", "adapter_detected"):
+            rows.append({"trace_id": "trace-die", "event_type": evt, "ts": ts})
+        # trace-rej: ends at request_rejected (auth/circuit/validation).
+        for evt in ("handler_entry", "auth_gate_pass", "route_resolved",
+                    "body_read_complete", "adapter_detected",
+                    "request_rejected"):
+            rows.append({"trace_id": "trace-rej", "event_type": evt, "ts": ts + 10})
+        # trace-sub: ends at dispatch_subprocess_complete (subprocess success).
+        for evt in ("handler_entry", "auth_gate_pass", "route_resolved",
+                    "body_read_complete", "adapter_detected",
+                    "dispatch_subprocess_complete"):
+            rows.append({"trace_id": "trace-sub", "event_type": evt, "ts": ts + 20})
+        self._seed_parity_trace(db, rows=rows)
+
+        rep = inspect.analyze(db_path=db, window_minutes=0)
+        d9 = rep["dim9_parity_trace_coverage"]
+
+        # last_stage_distribution still includes ALL terminals.
+        last = d9["last_stage_distribution"]
+        assert last.get("adapter_detected") == 1
+        assert last.get("request_rejected") == 1
+        assert last.get("dispatch_subprocess_complete") == 1
+
+        # Only the silent-death trace counts as a pre-upstream death.
+        assert d9["pre_upstream_death_count"] == 1
+        pre = d9["pre_upstream_death_stage_distribution"]
+        assert pre == {"adapter_detected": 1}
+
+        # The other two are reported under early_return_*.
+        assert d9["early_return_count"] == 2
+        er = d9["early_return_stage_distribution"]
+        assert er.get("request_rejected") == 1
+        assert er.get("dispatch_subprocess_complete") == 1
+
+    def test_dim9_ncp3a_synthesis_renders_q10(self, tmp_path):
+        """When early-return terminals are present, Q10 summary line
+        appears alongside Q9.
+        """
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = []
+        for evt in ("handler_entry", "adapter_detected", "request_rejected"):
+            rows.append({"trace_id": "trace-rej", "event_type": evt, "ts": ts})
+        for evt in ("handler_entry", "adapter_detected",
+                    "dispatch_subprocess_complete"):
+            rows.append({"trace_id": "trace-sub", "event_type": evt, "ts": ts + 1})
+        self._seed_parity_trace(db, rows=rows)
+
+        out = tmp_path / "report.md"
+        rc = inspect.main([
+            "--db-path", str(db),
+            "--window-minutes", "0",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        md = out.read_text()
+        assert "Q10 — NCP-3A-enrichment terminal early-returns" in md
+        assert "request_rejected=1" in md
+        assert "dispatch_subprocess_complete=1" in md
+
 
 # ── 12. structural — no dispatch / behavior imports ───────────────────
 

--- a/tests/test_parity_trace_phase_ncp_3i.py
+++ b/tests/test_parity_trace_phase_ncp_3i.py
@@ -790,3 +790,102 @@ class TestPreDispatchLifecycleV3:
         emit(EVENT_AUTH_GATE_PASS, trace_id="t-disabled-v3")
         emit(EVENT_BEFORE_DISPATCH, trace_id="t-disabled-v3")
         assert store.fetch_for_trace("t-disabled-v3") == []
+
+
+# ── 14. NCP-3A-enrichment terminal early-return events ────────────────
+
+
+class TestNCP3AEnrichmentEvents:
+    """Terminal early-return events: subprocess companion dispatch
+    success and intentional rejection (auth/circuit/validation).
+
+    These events were added so the harness can distinguish silent
+    pre-dispatch deaths from intentional terminations on paths that
+    do not reach upstream_attempt_start.
+    """
+
+    def test_terminal_event_constants_exist(self):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            EVENT_REQUEST_REJECTED,
+            TERMINAL_EARLY_RETURN_EVENTS,
+        )
+        assert EVENT_DISPATCH_SUBPROCESS_COMPLETE == "dispatch_subprocess_complete"
+        assert EVENT_REQUEST_REJECTED == "request_rejected"
+        assert EVENT_DISPATCH_SUBPROCESS_COMPLETE in TERMINAL_EARLY_RETURN_EVENTS
+        assert EVENT_REQUEST_REJECTED in TERMINAL_EARLY_RETURN_EVENTS
+        assert len(TERMINAL_EARLY_RETURN_EVENTS) == 2
+
+    def test_terminal_events_in_all_events_and_lifecycle(self):
+        from tokenpak.proxy.parity_trace import (
+            ALL_EVENTS,
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            EVENT_REQUEST_REJECTED,
+            LIFECYCLE_ORDER,
+        )
+        assert EVENT_DISPATCH_SUBPROCESS_COMPLETE in ALL_EVENTS
+        assert EVENT_REQUEST_REJECTED in ALL_EVENTS
+        assert EVENT_DISPATCH_SUBPROCESS_COMPLETE in LIFECYCLE_ORDER
+        assert EVENT_REQUEST_REJECTED in LIFECYCLE_ORDER
+
+    def test_terminal_events_positioned_before_upstream_attempt_start(self):
+        """Both terminal events must be ordered AFTER adapter_detected and
+        BEFORE upstream_attempt_start so the harness's last-stage pick
+        prefers them when both are present in a trace.
+        """
+        from tokenpak.proxy.parity_trace import (
+            EVENT_ADAPTER_DETECTED,
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            EVENT_REQUEST_REJECTED,
+            EVENT_UPSTREAM_ATTEMPT_START,
+            LIFECYCLE_ORDER,
+        )
+        idx_adapter = LIFECYCLE_ORDER.index(EVENT_ADAPTER_DETECTED)
+        idx_reject = LIFECYCLE_ORDER.index(EVENT_REQUEST_REJECTED)
+        idx_subproc = LIFECYCLE_ORDER.index(EVENT_DISPATCH_SUBPROCESS_COMPLETE)
+        idx_upstream = LIFECYCLE_ORDER.index(EVENT_UPSTREAM_ATTEMPT_START)
+        assert idx_adapter < idx_reject < idx_upstream
+        assert idx_adapter < idx_subproc < idx_upstream
+
+    def test_terminal_events_persist(self, store, env_enabled):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_ADAPTER_DETECTED,
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            EVENT_HANDLER_ENTRY,
+            EVENT_REQUEST_REJECTED,
+        )
+        # Reject path: handler_entry → adapter_detected → request_rejected.
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-rejected")
+        emit(EVENT_ADAPTER_DETECTED, trace_id="t-rejected", notes="generic")
+        emit(EVENT_REQUEST_REJECTED, trace_id="t-rejected", notes="auth_invalid:no creds")
+        rows = store.fetch_for_trace("t-rejected")
+        types = [r["event_type"] for r in rows]
+        assert types[-1] == EVENT_REQUEST_REJECTED
+        # Notes carries the rejection class for downstream filtering.
+        assert any(
+            r["event_type"] == EVENT_REQUEST_REJECTED
+            and r["notes"]
+            and r["notes"].startswith("auth_invalid")
+            for r in rows
+        )
+
+        # Subprocess success path.
+        emit(EVENT_HANDLER_ENTRY, trace_id="t-subproc")
+        emit(EVENT_ADAPTER_DETECTED, trace_id="t-subproc", notes="claude_cli")
+        emit(
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            trace_id="t-subproc",
+            notes="subprocess_companion:status=200",
+        )
+        rows = store.fetch_for_trace("t-subproc")
+        types = [r["event_type"] for r in rows]
+        assert types[-1] == EVENT_DISPATCH_SUBPROCESS_COMPLETE
+
+    def test_terminal_events_disabled_no_op(self, store, env_disabled):
+        from tokenpak.proxy.parity_trace import (
+            EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+            EVENT_REQUEST_REJECTED,
+        )
+        emit(EVENT_REQUEST_REJECTED, trace_id="t-off")
+        emit(EVENT_DISPATCH_SUBPROCESS_COMPLETE, trace_id="t-off")
+        assert store.fetch_for_trace("t-off") == []

--- a/tokenpak/proxy/parity_trace.py
+++ b/tokenpak/proxy/parity_trace.py
@@ -97,6 +97,17 @@ EVENT_BODY_READ_COMPLETE: str = "body_read_complete"
 EVENT_ADAPTER_DETECTED: str = "adapter_detected"
 EVENT_BEFORE_DISPATCH: str = "before_dispatch"
 
+# NCP-3A-enrichment terminal early-return events. The proxy can
+# leave the adapter_detected → before_dispatch span via paths that
+# do not reach upstream_attempt_start: subprocess companion dispatch
+# (returns the upstream's response from a CLI subprocess) and
+# explicit rejections (auth 401, circuit-breaker 503, validator
+# 400). Without these terminals, the harness mis-classified those
+# requests as "silent deaths at adapter_detected" — they are in
+# fact intentional terminations.
+EVENT_DISPATCH_SUBPROCESS_COMPLETE: str = "dispatch_subprocess_complete"
+EVENT_REQUEST_REJECTED: str = "request_rejected"
+
 ALL_EVENTS: frozenset = frozenset({
     EVENT_HANDLER_ENTRY,
     EVENT_REQUEST_CLASSIFIED,
@@ -112,12 +123,17 @@ ALL_EVENTS: frozenset = frozenset({
     EVENT_BODY_READ_COMPLETE,
     EVENT_ADAPTER_DETECTED,
     EVENT_BEFORE_DISPATCH,
+    EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+    EVENT_REQUEST_REJECTED,
 })
 
 # NCP-3I-v3 — canonical pre-dispatch lifecycle order. Used by
 # inspect_session_lanes.py to render per-trace progression and
 # identify the LAST observed event (= the stage where the
-# request died).
+# request died). NCP-3A-enrichment inserts the two terminal
+# early-return events between adapter_detected and before_dispatch
+# so that the harness's "latest stage" pick prefers them over
+# adapter_detected when both are present in a trace.
 LIFECYCLE_ORDER: tuple = (
     EVENT_HANDLER_ENTRY,
     EVENT_AUTH_GATE_PASS,
@@ -125,6 +141,8 @@ LIFECYCLE_ORDER: tuple = (
     EVENT_BODY_READ_COMPLETE,
     EVENT_REQUEST_CLASSIFIED,
     EVENT_ADAPTER_DETECTED,
+    EVENT_REQUEST_REJECTED,
+    EVENT_DISPATCH_SUBPROCESS_COMPLETE,
     EVENT_BEFORE_DISPATCH,
     EVENT_UPSTREAM_ATTEMPT_START,
     EVENT_STREAM_START,
@@ -134,6 +152,16 @@ LIFECYCLE_ORDER: tuple = (
     EVENT_RETRY_BOUNDARY,
     EVENT_REQUEST_COMPLETION,
 )
+
+# NCP-3A-enrichment — events that signal an INTENTIONAL terminal
+# decision before upstream_attempt_start. The harness excludes
+# traces ending here from the pre-upstream "death" cohort: they
+# are completed (subprocess) or explicitly rejected (auth /
+# circuit / validation), not silent failures.
+TERMINAL_EARLY_RETURN_EVENTS: frozenset = frozenset({
+    EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+    EVENT_REQUEST_REJECTED,
+})
 
 
 # Documented value sets for the "free-form-ish" TEXT columns.
@@ -564,9 +592,11 @@ __all__ = [
     "EVENT_AUTH_GATE_PASS",
     "EVENT_BEFORE_DISPATCH",
     "EVENT_BODY_READ_COMPLETE",
+    "EVENT_DISPATCH_SUBPROCESS_COMPLETE",
     "EVENT_HANDLER_ENTRY",
     "EVENT_REQUEST_CLASSIFIED",
     "EVENT_REQUEST_COMPLETION",
+    "EVENT_REQUEST_REJECTED",
     "EVENT_RETRY_BOUNDARY",
     "EVENT_ROUTE_RESOLVED",
     "EVENT_STREAM_ABORT",
@@ -581,6 +611,7 @@ __all__ = [
     "RETRY_OWNERS",
     "RETRY_PHASES",
     "RETRY_SIGNALS",
+    "TERMINAL_EARLY_RETURN_EVENTS",
     "begin_stream",
     "current_lane_id",
     "emit",

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1083,6 +1083,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         }
                     }
                 ).encode()
+                # NCP-3A-enrichment: terminal early-return marker. Without
+                # this emit, the trace's last observed event is
+                # adapter_detected and the harness mis-classifies it as a
+                # silent pre-upstream death. The reject is intentional
+                # (circuit breaker is OPEN) — record it as a terminal.
+                try:
+                    from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_REQUEST_REJECTED,
+                        trace_id=_req_id,
+                        notes=f"circuit_breaker_open:{_cb_provider}"[:200],
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
                 self.send_response(503)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(err)))
@@ -1148,6 +1162,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             }
                         }
                     ).encode()
+                    # NCP-3A-enrichment: terminal early-return marker.
+                    # Notes carry only the rejection class; the
+                    # auth_err message is short and contains no header
+                    # values (see passthrough.validate_auth) so it is
+                    # safe to record verbatim, truncated.
+                    try:
+                        from tokenpak.proxy import parity_trace as _pt
+                        _pt.emit(
+                            _pt.EVENT_REQUEST_REJECTED,
+                            trace_id=_req_id,
+                            notes=f"auth_invalid:{auth_err or 'unknown'}"[:200],
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
                     self.send_response(401)
                     self.send_header("Content-Type", "application/json")
                     self.send_header("Content-Length", str(len(err_body)))
@@ -1175,6 +1203,24 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                         if not _val_result.valid and _rv.mode == "strict":
                             _err_payload = _val_result.to_error_response()
                             _err_body = json.dumps(_err_payload).encode()
+                            # NCP-3A-enrichment: terminal early-return
+                            # marker for strict-mode validator 400. Notes
+                            # carry the rejection class plus error count
+                            # only — never the offending body bytes.
+                            try:
+                                from tokenpak.proxy import parity_trace as _pt
+                                _err_count = (
+                                    len(getattr(_val_result, "errors", []) or [])
+                                )
+                                _pt.emit(
+                                    _pt.EVENT_REQUEST_REJECTED,
+                                    trace_id=_req_id,
+                                    notes=(
+                                        f"validation_strict:errors={_err_count}"
+                                    )[:200],
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
                             self.send_response(400)
                             self.send_header("Content-Type", "application/json")
                             self.send_header("Content-Length", str(len(_err_body)))
@@ -1246,6 +1292,24 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 _resp = _be.dispatch(
                     _Req(body=body or b"", headers=dict(self.headers))
                 )
+                # NCP-3A-enrichment: terminal early-return marker for
+                # successful subprocess companion dispatch. The proxy
+                # never reaches before_dispatch on this branch (no
+                # outbound HTTP from this process); without the emit,
+                # the trace looks like a silent death at
+                # adapter_detected. Notes record dispatch class +
+                # upstream status so the harness can confirm success.
+                try:
+                    from tokenpak.proxy import parity_trace as _pt
+                    _pt.emit(
+                        _pt.EVENT_DISPATCH_SUBPROCESS_COMPLETE,
+                        trace_id=_req_id,
+                        notes=(
+                            f"subprocess_companion:status={_resp.status}"
+                        )[:200],
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
                 self.send_response(_resp.status)
                 for _hk, _hv in (_resp.headers or {}).items():
                     self.send_header(_hk, _hv)


### PR DESCRIPTION
## Summary

Closes the `adapter_detected → before_dispatch` "death cohort" surfaced by the NCP-3I-v3 trace at 2026-04-27T18:41:57Z (PR #72): 55 of 187 traces ended at `adapter_detected` with no further lifecycle events. Diagnosis showed this was an **observability gap, not a request-failure**.

The proxy has four early-return paths in the `adapter_detected → before_dispatch` span — subprocess companion dispatch (success), auth-gate 401, circuit-breaker 503, validator-strict 400 — and none emitted a terminal parity_trace event. The harness mis-classified these intentional terminations as silent deaths.

## What landed (measurement-only — no behavior change)

- **`parity_trace.py`**: two new event types — `EVENT_DISPATCH_SUBPROCESS_COMPLETE`, `EVENT_REQUEST_REJECTED` — plus a `TERMINAL_EARLY_RETURN_EVENTS` frozenset. Both events are positioned in `LIFECYCLE_ORDER` between `adapter_detected` and `before_dispatch`.
- **`server.py`**: emit at the four early-return points in `_proxy_to_inner`. Notes carry only the rejection class + structured detail (`circuit_breaker_open:<provider>`, `auth_invalid:<short msg>`, `validation_strict:errors=N`, `subprocess_companion:status=NNN`) — never body bytes, auth tokens, or prompt content.
- **`inspect_session_lanes.py`**: extend the lifecycle tuple, add `_TERMINAL_EARLY_RETURN_EVENTS`, exclude terminal early-returns from `pre_upstream_death_count`, expose `early_return_count` + `early_return_stage_distribution`, render new **Q10** synthesis line.
- **7 new tests** (4 in `test_parity_trace_phase_ncp_3i.py`, 3 in `test_ncp3_inspect_session_lanes.py`).

## Held throughout

Routing, retry policy, auth behavior, byte-preserve guarantees, Claude Code OAuth, and provider/model selection are all unchanged.

## Pre/post comparison

| Metric | Pre (184157Z, 30 min, 187 traces) | Post (191403Z, 5 min, 16 traces) |
|---|---|---|
| `pre_upstream_death_count` | **55** | **0** ✓ |
| `adapter_detected` as last_stage | 55 | 0 |
| `early_return_count` (new) | n/a | 5 (`request_rejected`) |
| Q9 verdict | "55 traces died BEFORE upstream_attempt_start" | "0 traces died" |
| Q10 verdict (new) | n/a | "5 traces took a known early-return path" |

Acceptance criteria 1–6 satisfied. The 5 `request_rejected` traces in the post-fix window are all `circuit_breaker_open:anthropic` — the Anthropic circuit was tripped during the workload, and these requests were correctly fast-failed with the new terminal event marking the rejection.

## Baselines committed

- `tests/baselines/ncp-3-trace/20260427T184157Z-ncp3i-v3-3tp.{md,json}` — pre-fix 30-min trace (the v3 baseline diagnosed in this PR)
- `tests/baselines/ncp-3-trace/20260427T191403Z-ncp3a-postfix-3tp.{md,json}` — post-fix 5-min trace

## Follow-up issues

Surfaced from the same NCP-3I-v3 trace, separately scoped:

- #73 — tp_events completion logging gap (187/187 traces missing completion rows)
- #74 — NCP-3A-streaming-connect (32 RemoteProtocolError aborts before first byte)
- #75 — NCP-3I-v4 (14 upstream_attempt_start orphans, silent fall-off)

## Test plan

- [x] 67 existing parity_trace + harness tests pass
- [x] 7 new tests pass (constants + lifecycle ordering + persistence + privacy + harness reclassification)
- [x] Pre/post trace comparison shows `pre_upstream_death_count` 55 → 0
- [x] Notes payloads contain no secrets/prompts (`circuit_breaker_open:anthropic`, etc.)
- [x] Full-suite regression check (552 passed; 1 pre-existing flake in `test_ingest.py::TestIngestBatch::test_batch_exact_limit` reproduces on `main`, unrelated to these changes)
