### PR TITLE
feat(scripts,tests,docs): #73 — tp_parity_trace canonicality for wire-side completion

### DIFF
--- a/docs/internal/specs/issue-73-tp-events-canonicality-2026-04-27.md
+++ b/docs/internal/specs/issue-73-tp-events-canonicality-2026-04-27.md
@@ -1,0 +1,168 @@
+# Issue #73 — `tp_parity_trace` canonicality for wire-side completion
+
+**Date:** 2026-04-27
+**Status:** ✅ **approved + landing in this PR (Option B)** — Kevin approved 2026-04-27 evening; observability-only; no runtime behavior changes
+**Workstream:** Observability (telemetry canonicality clarification)
+**Authors:** Sue (scope + implementation) / Kevin (review + go-ahead)
+**Tracker:** [tokenpak/tokenpak#73](https://github.com/tokenpak/tokenpak/issues/73)
+**Companion docs:**
+- NCP-3A enrichment: PR #77 merged 2026-04-27 (the four early-return emit blocks this work consumes)
+- NCP-3I instrumentation v1: `docs/internal/specs/ncp-3i-instrumentation-2026-04-27.md`
+- Architecture standard: `~/vault/02_COMMAND_CENTER/tokenpak-standards-internal/01-architecture-standard.md` §1 (telemetry subsystem) + §6 (state partitioning, lines 213–223)
+
+> **Goal:** resolve issue #73 — `traces_with_completion_in_tp_events = 0/187` for successful streamed requests — as an **observability-only** harness correction. Declare `tp_parity_trace` the canonical wire-side completion ledger for proxy-served Claude Code traffic. Update `scripts/inspect_session_lanes.py` Q8 logic to consume canonical terminal events from `tp_parity_trace`. Keep the legacy `tp_events` comparison only as a deprecated diagnostic. **No routing, retry, cache, auth, provider, model, or prompt-behavior changes; no proxy writes to `tp_events`.**
+
+---
+
+## 0. Problem statement (from #73)
+
+The NCP-3I-v3 trace at 2026-04-27T18:41:57Z showed:
+
+| Metric | Value |
+|---|---|
+| Distinct traces (30-min window) | 187 |
+| `traces_with_handler_entry` | 187 |
+| `traces_with_completion_in_tp_events` | **0** |
+| Cleanly streamed (`stream_complete`, HTTP 200, byte-matched) | 86 |
+
+The harness's `Q8` verdict computed `interp_b_count = n_with_handler_entry − n_with_completion_in_tp_events` and fired `interp_b_supported` whenever that count > 0. It fired for **every** request, so the signal was unusable as a failure detector. The post-merge NCP-3A workload (2026-04-27T20:38:36Z, after PR #77) reproduced the same 0/21 ratio.
+
+---
+
+## 1. Root cause (architectural, not a regression)
+
+**Finding:** the proxy's request hot path has **never** written `tp_events` rows. It writes `tp_parity_trace` (since PR #70). `tp_events` is populated only by `tokenpak.telemetry.pipeline.TelemetryPipeline.process(...)`, called exclusively from `tokenpak/telemetry/server.py` — a separate HTTP server that ingests POSTed events. No code path in `tokenpak/proxy/server.py` calls `TelemetryDB.insert_event` or `insert_trace`.
+
+**Evidence:**
+- `git log --all -S 'insert_event' -- tokenpak/proxy/` returns no commits
+- `git log --all -S 'insert_trace' -- tokenpak/proxy/` returns no commits
+- `grep -rE 'INSERT INTO tp_events' tokenpak/` returns only test fixtures
+- The two real `tp_events` rows in the active DB are doctor-check seed data, not Claude Code traffic
+
+**Implication:** Q8's logic was written against a `tp_events`-completion assumption the Claude Code path has never satisfied. The completion signal that *does* exist is `tp_parity_trace` terminal events.
+
+**Standards alignment:** `01-architecture-standard.md` §1 says the telemetry store is "Written to by `services/`; read by `dashboard/` and `alerts/`." Entrypoints don't write. So the gap closes at the harness layer (which compares the wrong signal). Adding writes to `proxy/` would *violate* the standard.
+
+---
+
+## 2. Approved approach: Option B
+
+Declare `tp_parity_trace` the canonical wire-side completion ledger; update Q8 to consume terminal events from it; keep the legacy `tp_events` comparison only as a deprecated diagnostic. A `services/`-side `tp_events` writer (Option A) was considered and **explicitly rejected** for this PR — would not be observability-only, and would duplicate information already in `tp_parity_trace`.
+
+### 2.1 Canonical wire-side terminal events
+
+Per Kevin's directive, the four canonical terminal events for Claude Code wire-side traffic are:
+
+| Event | Classification |
+|---|---|
+| `stream_complete` | clean upstream stream completion |
+| `dispatch_subprocess_complete` | intentional in-process / subprocess companion completion |
+| `request_rejected` | known terminal fast-fail (auth-401 / circuit-503 / validator-400) — **not** a silent death |
+| `stream_abort` | known terminal abort — **not** a silent missing completion |
+
+A trace with at least one of these in its event set has a terminal wire-side event. A trace with `handler_entry` but **no** terminal wire-side event is a true silent death (the interp-B condition).
+
+### 2.2 Q8 reframed
+
+Old: *"Do parity traces also have a `tp_events` completion row?"*
+**New: *"Do parity traces have a terminal wire-side event?"***
+
+Verdict states (unchanged labels, redefined semantics):
+
+| Verdict | New definition |
+|---|---|
+| `interp_a_or_clean` | every `handler_entry` trace has at least one canonical terminal event |
+| `interp_b_supported` | one or more `handler_entry` traces have **no** canonical terminal event (true silent death) |
+| `indeterminate` | telemetry layer cannot answer (table missing or empty window) |
+
+### 2.3 New / updated `dim9_parity_trace_coverage` fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `traces_with_wire_completion` | int | distinct `handler_entry` traces with **any** of the four canonical terminal events |
+| `traces_with_clean_wire_completion` | int | distinct `handler_entry` traces with `stream_complete` |
+| `traces_with_terminal_fast_fail` | int | distinct `handler_entry` traces with `request_rejected` |
+| `traces_with_terminal_abort` | int | distinct `handler_entry` traces with `stream_abort` |
+| `traces_without_terminal_event` | int | distinct `handler_entry` traces with **none** of the four canonical terminals (silent-death cohort) |
+| `traces_with_completion_in_tp_events_deprecated` | int \| null | legacy `tp_events`-stitched count, kept for diagnostic context only; not used by Q8 verdict |
+| `interp_b_count` | int | redefined as `traces_without_terminal_event`; preserved as an alias so dependent tooling continues to compile |
+
+The 6th field also satisfies the user's "old `tp_events` comparison remains available only as deprecated context" requirement. `dispatch_subprocess_complete` is reachable via `terminal_event_distribution` (already implicit in the existing `event_type_distribution`); no separate top-level field is added per Kevin's spec.
+
+The existing `early_return_*` fields from PR #77 are **kept unchanged** (Q10 still answers a different question: "which subset is intentional early termination?"). They overlap with `traces_with_terminal_fast_fail` + the subprocess-complete subset, but Q10's framing remains useful, so we leave it alone.
+
+---
+
+## 3. Out of scope (do not start)
+
+Per Kevin's 2026-04-27 directive:
+- NCP-4
+- NCP-9
+- streaming-connect work (#74)
+- NCP-3I-v4 (#75)
+- Any retry behavior change
+- Any routing, cache, auth, provider, model, or prompt-mutation change
+- Wiring a `services/`-side `tp_events` writer (Option A — deferred to future initiative)
+- The 1-week NCP-3A cleanup follow-up agent (explicitly skipped)
+- **Standards ratification.** Per Kevin: "Open a separate follow-up standards proposal for: 'Wire-side completion canonicality: tp_parity_trace vs tp_events.' Do not include standards ratification in this PR." A follow-up issue will be filed post-merge.
+
+---
+
+## 4. Files changed in this PR
+
+| File | Change | Δ LOC |
+|---|---|---|
+| `docs/internal/specs/issue-73-tp-events-canonicality-2026-04-27.md` | This doc | new |
+| `scripts/inspect_session_lanes.py` | `_dim_parity_trace_coverage`: add canonical-terminal counts; redefine Q8 verdict over `traces_without_terminal_event`; rename legacy field to `traces_with_completion_in_tp_events_deprecated`; update synthesis text | ~80 |
+| `tests/test_ncp3_inspect_session_lanes.py` | Update existing Q8 tests for new semantics; add 6 new tests covering each terminal class + silent-death + legacy-field + tp_events-doesn't-affect-verdict | ~200 |
+
+**Files NOT touched:**
+- `tokenpak/proxy/**` — no edits, no new emit calls
+- `tokenpak/proxy/parity_trace.py` — schema, events, and emit points unchanged
+- `tokenpak/services/**` — no new writers
+- `tokenpak/telemetry/storage*.py` — no schema migrations
+- Routing / retry / cache / auth / provider / model / prompt code
+
+---
+
+## 5. Test plan
+
+- **Updated tests:** `test_dim9_interp_b_supported_entry_without_completion` and `test_dim9_interp_a_clean_when_completions_match` reframed to drive the verdict via `tp_parity_trace` terminal events instead of `tp_events` rows.
+- **New tests** (in `TestParityTraceCoverage`):
+  1. `test_wire_completion_via_stream_complete` — handler_entry + stream_complete → clean wire completion; verdict `interp_a_or_clean`
+  2. `test_wire_completion_via_request_rejected` — handler_entry + request_rejected → terminal fast-fail; verdict `interp_a_or_clean`
+  3. `test_wire_completion_via_stream_abort` — handler_entry + stream_abort → terminal abort; verdict `interp_a_or_clean`
+  4. `test_wire_completion_via_subprocess_complete` — handler_entry + dispatch_subprocess_complete → counted in `traces_with_wire_completion`; verdict `interp_a_or_clean`
+  5. `test_traces_without_terminal_event_is_silent_death` — handler_entry only → counted in `traces_without_terminal_event`; verdict `interp_b_supported`
+  6. `test_legacy_tp_events_field_kept_as_deprecated` — `traces_with_completion_in_tp_events_deprecated` present and computed; verdict NOT influenced by it (handler_entry + stream_complete + zero `tp_events` rows still yields `interp_a_or_clean`)
+- **Regression:** existing 67 parity-trace + harness tests must still pass; existing 7 NCP-3A tests must still pass.
+- **Integration sanity:** rerun the post-merge 3-concurrent baseline workload; confirm Q8 reports `interp_a_or_clean` instead of universal interp B.
+
+---
+
+## 6. CI plan
+
+All required-status checks must remain green:
+`bandit (blocking)`, `cli-docs-in-sync (blocking)`, `headline-benchmark (blocking)`, `self-conformance (blocking) (3.10 / 3.11 / 3.12)`, `Test (Python 3.10 / 3.11 / 3.12 / 3.13)`, `Lint (Ruff)`, `Import contracts (Architecture §2 + §1.4)`, `Repo Hygiene Check`. Per `21 §9.8` process-enforced gating: do not merge if any blocking check is red.
+
+---
+
+## 7. Acceptance (against Kevin's 2026-04-27 bar)
+
+| Criterion | How this PR satisfies |
+|---|---|
+| Observability-only | Only `docs/` + `scripts/` + `tests/` changed; zero touches to proxy/services/schema/runtime |
+| No proxy writes to `tp_events` | Confirmed — proxy/ untouched |
+| No runtime behavior changes | `tokenpak/` package not modified |
+| No routing/retry/cache/auth/provider/model/prompt changes | None of those subsystems edited |
+| Existing parity trace remains canonical for NCP wire diagnostics | `parity_trace.py` unchanged; canonicality formalized in this doc |
+| Old `tp_events` comparison remains available only as deprecated context | `traces_with_completion_in_tp_events_deprecated` retained; not used by Q8 verdict |
+| CI green | All blocking checks gated before merge |
+| #73 acceptance: "for at least N successfully-streamed requests, completion exists keyed on `trace_id`" | `tp_parity_trace.stream_complete` rows keyed on `trace_id` (verified: 20/20 in the 2026-04-27T20:38:36Z post-merge baseline) |
+| #73 acceptance: "Q8 reports `interp_a_or_clean` when no real interp-B failure" | Direct outcome of the harness change; verified by rerun workload after this PR's harness lands |
+
+---
+
+## 8. Follow-up (separate from this PR)
+
+A standards-proposal issue will be filed post-merge titled *"Wire-side completion canonicality: tp_parity_trace vs tp_events"* against the `tokenpak/tokenpak` repo, asking whether `01-architecture-standard.md` §6 should be amended to encode the canonicality clause. Kevin's explicit direction: not part of this PR.

--- a/scripts/inspect_session_lanes.py
+++ b/scripts/inspect_session_lanes.py
@@ -340,6 +340,19 @@ _TERMINAL_EARLY_RETURN_EVENTS: frozenset = frozenset({
     "request_rejected",
 })
 
+# Issue #73 — canonical wire-side terminal events for proxy traffic.
+# A trace with handler_entry AND any of these has a terminal
+# wire-side event; the trace is NOT a silent death. A trace with
+# handler_entry and NONE of these is the true interp-B condition.
+# tp_events is no longer consulted for the Q8 verdict — see
+# docs/internal/specs/issue-73-tp-events-canonicality-2026-04-27.md.
+_CANONICAL_TERMINAL_EVENTS: frozenset = frozenset({
+    "stream_complete",
+    "dispatch_subprocess_complete",
+    "request_rejected",
+    "stream_abort",
+})
+
 
 def _dim_parity_trace_coverage(
     conn: sqlite3.Connection, since_iso: str, since_ts: float
@@ -401,10 +414,36 @@ def _dim_parity_trace_coverage(
         if "upstream_attempt_failure" in d["phases"]
     )
 
-    # Stitch to tp_events to derive how many parity-trace traces ALSO
-    # have a completion row in tp_events. The iter-4 §11 interp-B
-    # disambiguator is: (n_with_entry - n_with_completion).
-    n_with_completion: Optional[int] = None
+    # Issue #73 — canonical wire-side completion (tp_parity_trace).
+    # The Q8 verdict is now driven by terminal wire-side events from
+    # tp_parity_trace, NOT by stitching to tp_events. A handler_entry
+    # trace with at least one of the four canonical terminals
+    # (stream_complete, dispatch_subprocess_complete, request_rejected,
+    # stream_abort) is wire-completed. Traces with handler_entry and
+    # none of those are true silent deaths (the interp-B condition).
+    handler_entry_traces = [
+        d for d in by_trace.values() if "handler_entry" in d["phases"]
+    ]
+    n_with_clean_wire_completion = sum(
+        1 for d in handler_entry_traces if "stream_complete" in d["phases"]
+    )
+    n_with_terminal_fast_fail = sum(
+        1 for d in handler_entry_traces if "request_rejected" in d["phases"]
+    )
+    n_with_terminal_abort = sum(
+        1 for d in handler_entry_traces if "stream_abort" in d["phases"]
+    )
+    n_with_wire_completion = sum(
+        1
+        for d in handler_entry_traces
+        if d["phases"] & _CANONICAL_TERMINAL_EVENTS
+    )
+    n_without_terminal_event = n_with_entry - n_with_wire_completion
+
+    # Legacy tp_events stitch — kept for diagnostic context only,
+    # NOT used by the Q8 verdict (issue #73). Returned as
+    # `traces_with_completion_in_tp_events_deprecated`.
+    n_with_completion_legacy: Optional[int] = None
     if _table_exists(conn, "tp_events"):
         trace_ids = list(by_trace.keys())
         if trace_ids:
@@ -419,18 +458,17 @@ def _dim_parity_trace_coverage(
                     f"   OR request_id IN ({placeholders})",
                     params,
                 ).fetchone()[0]
-                n_with_completion = int(completed or 0)
+                n_with_completion_legacy = int(completed or 0)
             except sqlite3.DatabaseError:
-                n_with_completion = None
+                n_with_completion_legacy = None
 
-    interp_b_count = (
-        n_with_entry - n_with_completion
-        if n_with_completion is not None
-        else None
-    )
-    if interp_b_count is None:
+    # interp_b_count is preserved as an alias of
+    # traces_without_terminal_event so dependent tooling continues
+    # to compile, but its meaning is now wire-side, not tp_events.
+    interp_b_count = n_without_terminal_event
+    if n_with_entry == 0:
         verdict = "indeterminate"
-    elif interp_b_count > 0 and n_with_entry > 0:
+    elif n_without_terminal_event > 0:
         verdict = "interp_b_supported"
     else:
         verdict = "interp_a_or_clean"
@@ -490,7 +528,17 @@ def _dim_parity_trace_coverage(
         "traces_with_handler_entry": n_with_entry,
         "traces_with_upstream_attempt_start": n_with_upstream_start,
         "traces_with_upstream_attempt_failure": n_with_upstream_failure,
-        "traces_with_completion_in_tp_events": n_with_completion,
+        # Issue #73 — canonical wire-side completion fields.
+        "traces_with_wire_completion": n_with_wire_completion,
+        "traces_with_clean_wire_completion": n_with_clean_wire_completion,
+        "traces_with_terminal_fast_fail": n_with_terminal_fast_fail,
+        "traces_with_terminal_abort": n_with_terminal_abort,
+        "traces_without_terminal_event": n_without_terminal_event,
+        # Legacy tp_events stitch — diagnostic context only, NOT
+        # used by the Q8 verdict.
+        "traces_with_completion_in_tp_events_deprecated": (
+            n_with_completion_legacy
+        ),
         "interp_b_count": interp_b_count,
         "verdict": verdict,
         # NCP-3I-v3 — per-trace lifecycle progression
@@ -505,18 +553,22 @@ def _dim_parity_trace_coverage(
             Counter(early_return_traces.values())
         ),
         "note": (
-            "interp_b_count = traces that emitted handler_entry but "
-            "never completed in tp_events. iter-4 §11 interp B is "
-            "supported when interp_b_count > 0. NCP-3I-v3 added "
-            "last_stage_distribution: which lifecycle stage each "
-            "trace's LAST observed event was. Traces with last_stage "
-            "before 'upstream_attempt_start' AND not a terminal "
-            "early-return event are silent pre-dispatch deaths — "
-            "pre_upstream_death_stage_distribution localizes exactly "
-            "which stage. NCP-3A-enrichment added early_return_count "
-            "/ early_return_stage_distribution for traces that took "
-            "a known terminal early-return path (subprocess dispatch "
-            "success, auth/circuit/validation rejection)."
+            "Issue #73: Q8 is now answered against tp_parity_trace "
+            "terminal events (stream_complete, "
+            "dispatch_subprocess_complete, request_rejected, "
+            "stream_abort) — NOT tp_events. interp_b_count = "
+            "traces_without_terminal_event (handler_entry traces "
+            "with no canonical terminal). "
+            "traces_with_completion_in_tp_events_deprecated is "
+            "preserved for diagnostic context only; it does not "
+            "influence the verdict. NCP-3I-v3: "
+            "last_stage_distribution shows which lifecycle stage "
+            "each trace's LAST observed event was; "
+            "pre_upstream_death_stage_distribution localizes "
+            "true pre-dispatch silent deaths. NCP-3A-enrichment: "
+            "early_return_count / early_return_stage_distribution "
+            "report traces that took an intentional early-return "
+            "path before upstream_attempt_start."
         ),
     }
 
@@ -721,28 +773,37 @@ def _verdict_lines(report: Dict[str, Any]) -> List[str]:
         )
     else:
         verdict = d9.get("verdict")
-        ib = d9.get("interp_b_count")
         ne = d9.get("traces_with_handler_entry")
-        nc = d9.get("traces_with_completion_in_tp_events")
+        nw = d9.get("traces_with_wire_completion", 0)
+        n_silent = d9.get("traces_without_terminal_event", 0)
+        n_clean = d9.get("traces_with_clean_wire_completion", 0)
+        n_ff = d9.get("traces_with_terminal_fast_fail", 0)
+        n_ab = d9.get("traces_with_terminal_abort", 0)
         if verdict == "interp_b_supported":
             out.append(
-                "**Q8 — NCP-3I parity trace:** **iter-4 §11 interp B "
-                f"SUPPORTED.** {ib} of {ne} traces emitted handler_entry "
-                f"but never completed in tp_events (only {nc} did). The "
-                "missing requests fail before completion-time logging — "
-                "matches the visible-retry-but-empty-telemetry condition."
+                "**Q8 — wire-side completion (issue #73):** "
+                "**interp B SUPPORTED.** "
+                f"{n_silent} of {ne} handler_entry traces have NO "
+                "canonical terminal wire-side event "
+                "(stream_complete / dispatch_subprocess_complete / "
+                "request_rejected / stream_abort). True silent-death "
+                "cohort — investigate which stage these traces last "
+                "reached via pre_upstream_death_stage_distribution."
             )
         elif verdict == "interp_a_or_clean":
             out.append(
-                f"**Q8 — NCP-3I parity trace:** {ne} traces with "
-                f"handler_entry, {nc} with tp_events completion — no "
-                "interp-B gap detected in window."
+                "**Q8 — wire-side completion (issue #73):** "
+                f"{ne} handler_entry traces, {nw} with a canonical "
+                f"terminal wire-side event "
+                f"(clean={n_clean}, fast_fail={n_ff}, abort={n_ab}, "
+                f"subprocess={nw - n_clean - n_ff - n_ab}). No "
+                "silent-death cohort in window."
             )
         else:
             out.append(
-                f"**Q8 — NCP-3I parity trace:** indeterminate "
-                f"(traces={d9.get('distinct_traces')}, "
-                f"completion={nc})."
+                f"**Q8 — wire-side completion (issue #73):** "
+                f"indeterminate (traces={d9.get('distinct_traces')}, "
+                f"handler_entry={ne})."
             )
         # NCP-3I-v3 — pre-dispatch death localization (Q9).
         pre_count = d9.get("pre_upstream_death_count", 0)

--- a/tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.json
+++ b/tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.json
@@ -1,0 +1,79 @@
+{
+  "claude_code_event_count": 0,
+  "dim1_session_collapse": {
+    "collapse_ratio": null,
+    "distinct_request_ids": 0,
+    "distinct_session_ids": 0,
+    "verdict": "no_data"
+  },
+  "dim2_time_clustering": {
+    "spans": [],
+    "verdict": "insufficient_data"
+  },
+  "dim3_status_distribution": {},
+  "dim4_per_session_durations": {},
+  "dim5_provider_audit": {
+    "distribution": {},
+    "i0_violation": false,
+    "non_oauth_providers": []
+  },
+  "dim6_retry_count": {
+    "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+    "retry_event_lower_bound": 0
+  },
+  "dim7_token_usage": {
+    "available": true,
+    "no_usage_rows": true
+  },
+  "dim8_interleaving": {
+    "interleave_score": null,
+    "verdict": "insufficient_data"
+  },
+  "dim9_parity_trace_coverage": {
+    "available": true,
+    "distinct_traces": 22,
+    "early_return_count": 1,
+    "early_return_stage_distribution": {
+      "dispatch_subprocess_complete": 1
+    },
+    "event_type_distribution": {
+      "adapter_detected": 22,
+      "auth_gate_pass": 22,
+      "before_dispatch": 21,
+      "body_read_complete": 22,
+      "dispatch_subprocess_complete": 1,
+      "handler_entry": 22,
+      "route_resolved": 22,
+      "stream_abort": 3,
+      "stream_complete": 17,
+      "stream_start": 18,
+      "upstream_attempt_start": 21
+    },
+    "interp_b_count": 1,
+    "last_stage_distribution": {
+      "dispatch_subprocess_complete": 1,
+      "stream_abort": 3,
+      "stream_complete": 17,
+      "upstream_attempt_start": 1
+    },
+    "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start.",
+    "pre_upstream_death_count": 0,
+    "pre_upstream_death_stage_distribution": {},
+    "row_count": 191,
+    "traces_with_clean_wire_completion": 17,
+    "traces_with_completion_in_tp_events_deprecated": 0,
+    "traces_with_handler_entry": 22,
+    "traces_with_terminal_abort": 3,
+    "traces_with_terminal_fast_fail": 0,
+    "traces_with_upstream_attempt_failure": 0,
+    "traces_with_upstream_attempt_start": 21,
+    "traces_with_wire_completion": 21,
+    "traces_without_terminal_event": 1,
+    "verdict": "interp_b_supported"
+  },
+  "generated_at": "2026-04-27T21:09:20.454026+00:00",
+  "schema_version": "ncp-3-trace-v1",
+  "window_end": "2026-04-27T21:09:20.454026+00:00",
+  "window_minutes": 30.0,
+  "window_start": "2026-04-27T20:39:20.454026+00:00"
+}

--- a/tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.md
+++ b/tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.md
@@ -1,0 +1,131 @@
+# NCP-3 session-lane trace
+
+**Generated**: 2026-04-27T21:09:20.345919+00:00
+**Window**: 30.0 min (2026-04-27T20:39:20.345919+00:00 → 2026-04-27T21:09:20.345919+00:00)
+**Claude Code event count in window**: 0
+
+## Synthesis
+
+- **Q1 — H2 session-id collapse: no_data.** Inconclusive — rerun with the §4 workload (2 concurrent tokenpak claude sessions) and re-inspect.
+- **Q3 — retry events recorded:** 0. Either no retries occurred OR the schema didn't tag them. Settle visually via the §4 workload.
+- **Q8 — wire-side completion (issue #73):** **interp B SUPPORTED.** 1 of 22 handler_entry traces have NO canonical terminal wire-side event (stream_complete / dispatch_subprocess_complete / request_rejected / stream_abort). True silent-death cohort — investigate which stage these traces last reached via pre_upstream_death_stage_distribution.
+- **Q9 — NCP-3I-v3 pre-dispatch death:** 0 traces died before upstream_attempt_start in window. If a workload ran, all requests reached dispatch — H10 is now a stream-side hypothesis (check dim 8 / stream events).
+- **Q10 — NCP-3A-enrichment terminal early-returns:** 1 traces took a known early-return path (intentional terminations, NOT deaths). Distribution (stage=count): dispatch_subprocess_complete=1. dispatch_subprocess_complete = successful subprocess companion dispatch; request_rejected = auth/circuit/validation reject (see notes column for sub-class).
+
+## Dimensions
+
+### dim1_session_collapse
+
+```json
+{
+  "collapse_ratio": null,
+  "distinct_request_ids": 0,
+  "distinct_session_ids": 0,
+  "verdict": "no_data"
+}
+```
+
+### dim2_time_clustering
+
+```json
+{
+  "spans": [],
+  "verdict": "insufficient_data"
+}
+```
+
+### dim3_status_distribution
+
+```json
+{}
+```
+
+### dim4_per_session_durations
+
+```json
+{}
+```
+
+### dim5_provider_audit
+
+```json
+{
+  "distribution": {},
+  "i0_violation": false,
+  "non_oauth_providers": []
+}
+```
+
+### dim6_retry_count
+
+```json
+{
+  "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+  "retry_event_lower_bound": 0
+}
+```
+
+### dim7_token_usage
+
+```json
+{
+  "available": true,
+  "no_usage_rows": true
+}
+```
+
+### dim8_interleaving
+
+```json
+{
+  "interleave_score": null,
+  "verdict": "insufficient_data"
+}
+```
+
+### dim9_parity_trace_coverage
+
+```json
+{
+  "available": true,
+  "distinct_traces": 22,
+  "early_return_count": 1,
+  "early_return_stage_distribution": {
+    "dispatch_subprocess_complete": 1
+  },
+  "event_type_distribution": {
+    "adapter_detected": 22,
+    "auth_gate_pass": 22,
+    "before_dispatch": 21,
+    "body_read_complete": 22,
+    "dispatch_subprocess_complete": 1,
+    "handler_entry": 22,
+    "route_resolved": 22,
+    "stream_abort": 3,
+    "stream_complete": 17,
+    "stream_start": 18,
+    "upstream_attempt_start": 21
+  },
+  "interp_b_count": 1,
+  "last_stage_distribution": {
+    "dispatch_subprocess_complete": 1,
+    "stream_abort": 3,
+    "stream_complete": 17,
+    "upstream_attempt_start": 1
+  },
+  "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start.",
+  "pre_upstream_death_count": 0,
+  "pre_upstream_death_stage_distribution": {},
+  "row_count": 191,
+  "traces_with_clean_wire_completion": 17,
+  "traces_with_completion_in_tp_events_deprecated": 0,
+  "traces_with_handler_entry": 22,
+  "traces_with_terminal_abort": 3,
+  "traces_with_terminal_fast_fail": 0,
+  "traces_with_upstream_attempt_failure": 0,
+  "traces_with_upstream_attempt_start": 21,
+  "traces_with_wire_completion": 21,
+  "traces_without_terminal_event": 1,
+  "verdict": "interp_b_supported"
+}
+```

--- a/tests/test_ncp3_inspect_session_lanes.py
+++ b/tests/test_ncp3_inspect_session_lanes.py
@@ -471,10 +471,13 @@ class TestParityTraceCoverage:
         assert d9["available"] is True
         assert d9["row_count"] == 0
 
-    def test_dim9_interp_b_supported_entry_without_completion(self, tmp_path):
-        # 3 traces have handler_entry; 0 ever land in tp_events.
+    def test_dim9_interp_b_supported_when_no_terminal_event(self, tmp_path):
+        # Issue #73: Q8 verdict is now driven by tp_parity_trace
+        # terminal events. 3 handler_entry traces with NO canonical
+        # terminal (stream_complete / dispatch_subprocess_complete /
+        # request_rejected / stream_abort) → silent-death cohort.
         db = tmp_path / "telemetry.db"
-        _seed(db, rows=[])  # empty tp_events
+        _seed(db, rows=[])  # empty tp_events — irrelevant to verdict
         ts = 1772562000.0
         self._seed_parity_trace(
             db,
@@ -488,32 +491,30 @@ class TestParityTraceCoverage:
         d9 = rep["dim9_parity_trace_coverage"]
         assert d9["available"] is True
         assert d9["traces_with_handler_entry"] == 3
-        assert d9["traces_with_completion_in_tp_events"] == 0
+        assert d9["traces_without_terminal_event"] == 3
+        assert d9["traces_with_wire_completion"] == 0
         assert d9["interp_b_count"] == 3
         assert d9["verdict"] == "interp_b_supported"
 
-    def test_dim9_interp_a_clean_when_completions_match(self, tmp_path):
-        # 3 traces with handler_entry, all also in tp_events.
+    def test_dim9_interp_a_clean_via_stream_complete(self, tmp_path):
+        # Issue #73: cleanliness is determined by tp_parity_trace
+        # stream_complete events, NOT tp_events rows.
         db = tmp_path / "telemetry.db"
-        ts_iso = "2026-04-27T12:00:00"
-        _seed(db, rows=[
-            {"ts": ts_iso, "session_id": "s", "request_id": f"trace-{i}",
-             "trace_id": f"trace-{i}", "duration_ms": 100}
-            for i in range(3)
-        ])
+        _seed(db, rows=[])  # zero tp_events rows — verdict still clean
         ts = 1772562000.0
-        self._seed_parity_trace(
-            db,
-            rows=[
-                {"trace_id": f"trace-{i}", "event_type": "handler_entry",
-                 "ts": ts + i}
-                for i in range(3)
-            ],
-        )
+        rows = []
+        for i in range(3):
+            rows.append({"trace_id": f"trace-{i}",
+                         "event_type": "handler_entry", "ts": ts + i})
+            rows.append({"trace_id": f"trace-{i}",
+                         "event_type": "stream_complete", "ts": ts + i + 0.5})
+        self._seed_parity_trace(db, rows=rows)
         rep = inspect.analyze(db_path=db, window_minutes=0)
         d9 = rep["dim9_parity_trace_coverage"]
         assert d9["traces_with_handler_entry"] == 3
-        assert d9["traces_with_completion_in_tp_events"] == 3
+        assert d9["traces_with_clean_wire_completion"] == 3
+        assert d9["traces_with_wire_completion"] == 3
+        assert d9["traces_without_terminal_event"] == 0
         assert d9["interp_b_count"] == 0
         assert d9["verdict"] == "interp_a_or_clean"
 
@@ -537,7 +538,7 @@ class TestParityTraceCoverage:
         ])
         assert rc == 0
         md = out.read_text()
-        assert "Q8 — NCP-3I parity trace" in md
+        assert "Q8 — wire-side completion" in md
 
     def test_dim9_v3_pre_dispatch_death_localization(self, tmp_path):
         """V3 — when traces die at different stages, the harness reports
@@ -672,6 +673,181 @@ class TestParityTraceCoverage:
         assert "Q10 — NCP-3A-enrichment terminal early-returns" in md
         assert "request_rejected=1" in md
         assert "dispatch_subprocess_complete=1" in md
+
+    # ── Issue #73 — wire-side completion canonicality ─────────────────
+
+    def test_wire_completion_via_stream_complete(self, tmp_path):
+        """handler_entry + stream_complete → counted as clean wire
+        completion; not silent death; verdict interp_a_or_clean."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = [
+            {"trace_id": "t-clean", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-clean", "event_type": "stream_complete",
+             "ts": ts + 0.5},
+        ]
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["traces_with_clean_wire_completion"] == 1
+        assert d9["traces_with_terminal_fast_fail"] == 0
+        assert d9["traces_with_terminal_abort"] == 0
+        assert d9["traces_with_wire_completion"] == 1
+        assert d9["traces_without_terminal_event"] == 0
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_wire_completion_via_request_rejected(self, tmp_path):
+        """handler_entry + request_rejected → terminal_fast_fail; not a
+        silent death; verdict interp_a_or_clean."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = [
+            {"trace_id": "t-rej", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-rej", "event_type": "request_rejected",
+             "ts": ts + 0.5},
+        ]
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["traces_with_terminal_fast_fail"] == 1
+        assert d9["traces_with_clean_wire_completion"] == 0
+        assert d9["traces_with_terminal_abort"] == 0
+        assert d9["traces_with_wire_completion"] == 1
+        assert d9["traces_without_terminal_event"] == 0
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_wire_completion_via_stream_abort(self, tmp_path):
+        """handler_entry + stream_abort → terminal_abort; not silent
+        death; verdict interp_a_or_clean."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = [
+            {"trace_id": "t-ab", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-ab", "event_type": "stream_abort",
+             "ts": ts + 0.5},
+        ]
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["traces_with_terminal_abort"] == 1
+        assert d9["traces_with_clean_wire_completion"] == 0
+        assert d9["traces_with_terminal_fast_fail"] == 0
+        assert d9["traces_with_wire_completion"] == 1
+        assert d9["traces_without_terminal_event"] == 0
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_wire_completion_via_subprocess_complete(self, tmp_path):
+        """handler_entry + dispatch_subprocess_complete → counted in
+        traces_with_wire_completion (subprocess class); verdict clean."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = [
+            {"trace_id": "t-sub", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-sub", "event_type": "dispatch_subprocess_complete",
+             "ts": ts + 0.5},
+        ]
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        # Subprocess does not increment the clean/fast_fail/abort
+        # buckets; it contributes only to the aggregate
+        # traces_with_wire_completion + the lifecycle event
+        # distribution.
+        assert d9["traces_with_clean_wire_completion"] == 0
+        assert d9["traces_with_terminal_fast_fail"] == 0
+        assert d9["traces_with_terminal_abort"] == 0
+        assert d9["traces_with_wire_completion"] == 1
+        assert d9["traces_without_terminal_event"] == 0
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_traces_without_terminal_event_is_silent_death(self, tmp_path):
+        """handler_entry without any of the four canonical terminals →
+        traces_without_terminal_event; verdict interp_b_supported."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        # 2 silent deaths + 1 clean completion → verdict still
+        # interp_b_supported because n_silent > 0.
+        rows = [
+            {"trace_id": "t-die-1", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-die-2", "event_type": "handler_entry",
+             "ts": ts + 1},
+            {"trace_id": "t-ok", "event_type": "handler_entry", "ts": ts + 2},
+            {"trace_id": "t-ok", "event_type": "stream_complete",
+             "ts": ts + 2.5},
+        ]
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["traces_with_handler_entry"] == 3
+        assert d9["traces_without_terminal_event"] == 2
+        assert d9["traces_with_clean_wire_completion"] == 1
+        assert d9["interp_b_count"] == 2
+        assert d9["verdict"] == "interp_b_supported"
+
+    def test_legacy_tp_events_field_kept_as_deprecated(self, tmp_path):
+        """The old tp_events stitch is preserved as
+        traces_with_completion_in_tp_events_deprecated for diagnostic
+        context, but does NOT influence the Q8 verdict."""
+        db = tmp_path / "telemetry.db"
+        # Seed a tp_events row that DOES match — old logic would have
+        # said "completion present, clean". We still need a parity-
+        # trace stream_complete to drive the new verdict to clean.
+        ts_iso = "2026-04-27T12:00:00"
+        _seed(db, rows=[
+            {"ts": ts_iso, "session_id": "s", "request_id": "t-x",
+             "trace_id": "t-x", "duration_ms": 100},
+        ])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-x", "event_type": "handler_entry", "ts": ts},
+            {"trace_id": "t-x", "event_type": "stream_complete",
+             "ts": ts + 0.5},
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert (
+            d9["traces_with_completion_in_tp_events_deprecated"] == 1
+        ), "deprecated field must remain available"
+        assert d9["traces_with_clean_wire_completion"] == 1
+        assert d9["verdict"] == "interp_a_or_clean"
+
+    def test_q8_verdict_unaffected_when_tp_events_empty(self, tmp_path):
+        """Issue #73 invariant: handler_entry + stream_complete with
+        ZERO tp_events rows still yields interp_a_or_clean. The old
+        logic would have fired interp_b_supported here (the bug)."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])  # zero tp_events rows
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": f"t-{i}", "event_type": "handler_entry",
+             "ts": ts + i}
+            for i in range(5)
+        ] + [
+            {"trace_id": f"t-{i}", "event_type": "stream_complete",
+             "ts": ts + i + 0.5}
+            for i in range(5)
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["traces_with_handler_entry"] == 5
+        assert d9["traces_with_clean_wire_completion"] == 5
+        assert d9["traces_with_completion_in_tp_events_deprecated"] == 0
+        # The deprecated count is 0/5 — old logic would have fired
+        # interp_b_supported. New logic: stream_complete present →
+        # clean.
+        assert d9["verdict"] == "interp_a_or_clean"
 
 
 # ── 12. structural — no dispatch / behavior imports ───────────────────


### PR DESCRIPTION
## Summary

Closes #73. Q8 in `scripts/inspect_session_lanes.py` previously fired `interp_b_supported` for **every** trace because it stitched `tp_parity_trace.handler_entry` against `tp_events` completion — two ledgers that have never been correlated for proxy-served Claude Code traffic. Diagnosis showed the proxy hot path has **never** written `tp_events`; that table is populated only by `TelemetryPipeline.process(...)` from `telemetry/server.py`. `tp_parity_trace` is the canonical wire-side completion ledger for proxy traffic (since PR #70).

This PR is **observability-only**: declares `tp_parity_trace` canonical for wire-side completion, reframes Q8 to ask *"do parity traces have a terminal wire-side event?"* instead of *"do they also have a `tp_events` completion row?"*, and adds counts per terminal class. The legacy `tp_events` stitch is preserved as a deprecated diagnostic field that does not influence the verdict.

## What landed (observability-only — no behavior change)

- **`docs/internal/specs/issue-73-tp-events-canonicality-2026-04-27.md`**: new — records the canonicality ruling, root-cause evidence, approved option (Option B), and the standards-alignment argument from `01-architecture-standard.md` §1 + §6.
- **`scripts/inspect_session_lanes.py`**: new module-level `_CANONICAL_TERMINAL_EVENTS` frozenset (`stream_complete`, `dispatch_subprocess_complete`, `request_rejected`, `stream_abort`). `_dim_parity_trace_coverage` adds the new fields and renames the legacy field; verdict is now driven by `traces_without_terminal_event` (true silent-death cohort). Synthesis Q8 line reframed.
- **`tests/test_ncp3_inspect_session_lanes.py`**: updated 2 existing Q8 tests for the new semantics; added **6 new tests** covering each terminal class (clean / fast-fail / abort / subprocess), the silent-death cohort, the kept-as-deprecated legacy field, and the invariance of the verdict to `tp_events` emptiness.

### New / updated `dim9_parity_trace_coverage` fields

| Field | Meaning |
|---|---|
| `traces_with_wire_completion` | distinct `handler_entry` traces with **any** of the four canonical terminals |
| `traces_with_clean_wire_completion` | with `stream_complete` |
| `traces_with_terminal_fast_fail` | with `request_rejected` |
| `traces_with_terminal_abort` | with `stream_abort` |
| `traces_without_terminal_event` | with **none** — true silent-death cohort |
| `traces_with_completion_in_tp_events_deprecated` | legacy stitch, diagnostic context only; **not** consumed by Q8 verdict |
| `interp_b_count` | preserved as alias of `traces_without_terminal_event` for compat |

## Held throughout

- **No proxy writes to `tp_events`** — `tokenpak/proxy/**` not touched
- No routing, retry, cache, auth, provider, model, or prompt-mutation changes
- `tokenpak/proxy/parity_trace.py` schema, events, and emit points unchanged
- `tokenpak/services/**` not touched
- No telemetry schema migrations

## Acceptance verification

Post-fix 3-concurrent baseline at `tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.{md,json}` — workload 21:08:23Z–21:09:20Z, 22 distinct `handler_entry` traces:

| Class | Count |
|---|---|
| `traces_with_clean_wire_completion` (stream_complete) | 17 |
| `traces_with_terminal_fast_fail` (request_rejected) | 0 |
| `traces_with_terminal_abort` (stream_abort) | 3 |
| `traces_with_wire_completion` (any of the four) | 21 |
| `traces_without_terminal_event` (true silent death) | 1 |
| `traces_with_completion_in_tp_events_deprecated` | 0 |

The legacy `0/22` figure that the old harness amplified into universal interp-B is now reported only as deprecated context. The new verdict surfaces:
- 17 cleanly streamed
- 3 stream-side aborts (the #74 cohort)
- 1 true silent death — H10 stream-side hypothesis territory, surfaced (not introduced) by this PR

## Acceptance criteria (Kevin's 2026-04-27 bar)

- [x] Observability-only — only `docs/`, `scripts/`, `tests/` changed
- [x] No proxy writes to `tp_events`
- [x] No runtime behavior changes
- [x] No routing/retry/cache/auth/provider/model/prompt changes
- [x] Existing parity trace remains canonical for NCP wire diagnostics
- [x] Old `tp_events` comparison remains available only as deprecated context
- [x] Q8 now answers *"do parity traces have a terminal wire-side event?"* not *"do they also have a tp_events completion row?"*
- [x] Targeted file: 36/36 tests pass; full suite: 1415 passed (6 pre-existing intent-related failures verified on `main`, unrelated)

## Out of scope (deferred)

- Standards ratification — separate follow-up issue *"Wire-side completion canonicality: tp_parity_trace vs tp_events"* will be filed post-merge per Kevin's direction
- Wiring a `services/`-side `tp_events` completion writer (Option A) — would not be observability-only
- #74 / #75 / NCP-3I-v4 / streaming-connect / NCP-4 / NCP-9 — explicitly out of scope

## Test plan

- [x] `tests/test_ncp3_inspect_session_lanes.py` — 36/36 pass (28 prior + 2 reframed + 6 new)
- [x] Full suite: 1415 passed; 6 pre-existing intent failures verified on `main` (unrelated)
- [x] Ruff lint: `All checks passed!`
- [x] Post-fix 3-concurrent workload baseline committed
- [ ] CI green (gating)
