### PR TITLE
feat(proxy,scripts,tests,docs): #74 phase 1 — stream_abort phase classification

### DIFF
--- a/docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md
+++ b/docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md
@@ -1,0 +1,166 @@
+# NCP-3A-streaming-connect — Phase 1 spec (issue #74)
+
+**Date:** 2026-04-27
+**Status:** ✅ **Phase 1 approved + landing in this PR** — Kevin approved 2026-04-27 evening; observability-only; #74 stays open for Phase 2
+**Workstream:** NCP-3 (Session-Lane Preservation) → NCP-3A (Streaming) → NCP-3A-streaming-connect (pre-first-byte aborts)
+**Authors:** Sue (scope) / Kevin (review + go-ahead)
+**Tracker:** [tokenpak/tokenpak#74](https://github.com/tokenpak/tokenpak/issues/74)
+**Companion docs:**
+- NCP-3I-v3 (pre-dispatch lifecycle hooks + stream_abort emit): PR #72 merged 2026-04-27
+- NCP-3A-enrichment (terminal early-return events): PR #77 merged 2026-04-27
+- Issue #73 / PR #78 (`tp_parity_trace` canonicality): merged 2026-04-27
+- Standards §7.1 amendment (canonicality clause): vault commit `8dc2d8f` 2026-04-27
+
+> **Goal:** scope #74 — the 32-trace `stream_abort` / `RemoteProtocolError` cohort surfaced by NCP-3I-v3 and reproduced (3/22 traces) in the post-#78 baseline at `tests/baselines/ncp-3-trace/20260427T210920Z-issue73-postfix-3tp.{md,json}`. Recommend a **two-phase split**: Phase 1 = observability-only (`abort_phase` classification — directly satisfies #74's "Distinguishable telemetry exists for pre-first-byte vs mid-stream vs post-completion abort" acceptance bullet), Phase 2 = behavior change (root-cause / mitigation — separate initiative because it touches retry / pool / upstream-coordination).
+
+---
+
+## 0. Symptom (post-#78 baseline)
+
+The 2026-04-27T21:09:20Z 3-concurrent workload produced 3 `stream_abort` events:
+
+| trace_id | ts (epoch) | exception | hash |
+|---|---|---|---|
+| `12a9b22a-…` | 1777324155.281 | `RemoteProtocolError` | `8e43b815…` |
+| `b970f41e-…` | 1777324155.282 | `RemoteProtocolError` | `8e43b815…` |
+| `aa9b5ebe-…` | 1777324155.302 | `RemoteProtocolError` | `8e43b815…` |
+
+**All three are identical-hash, within ~20 ms.** That is a strong shared-state-failure signature — most likely httpx connection-pool reuse (Anthropic-side keepalive collapse) or a single TCP reset taking down multiple streams that share a pooled connection. The pattern matches hypothesis 1 from the #74 body ("httpx connection-pool reuse: stale keepalive connection collapsing on first use") and is consistent with the original 32-trace cohort's profile (`bytes_from_upstream=0`, mostly `upstream_status=null`).
+
+**At today's emit site** (`tokenpak/proxy/server.py` line 2389, the upstream-exception path of `_proxy_to_inner`), the following fields are **not captured** for `stream_abort`:
+- `bytes_from_upstream` (NULL — not in scope at the exception site)
+- `bytes_to_client` (NULL)
+- `upstream_status` (NULL — except the 6 cases in #74 where headers had arrived before the body abort)
+- `connection_closed_early` (NULL — only set on the in-band BrokenPipe path inside the streaming with-block)
+
+So the harness can see "stream_abort happened" but cannot today distinguish *when* — pre-headers, post-headers/pre-first-byte, mid-stream, or post-completion. This is exactly the gap #74's second acceptance bullet calls out.
+
+---
+
+## 1. Two-phase split
+
+### Phase 1 — observability (recommended for this lane)
+
+**Goal:** make the abort phase distinguishable in `tp_parity_trace` so the 32-trace cohort can be characterized without changing runtime behavior.
+
+**What changes (observability-only):**
+1. **`tokenpak/proxy/server.py`** — at the existing two `EVENT_STREAM_ABORT` emit sites (the in-band BrokenPipe path around line 1968 and the upstream-exception path around line 2389), add an `abort_phase` classifier in the `notes` column as `abort_phase=<value>` (no schema migration). Allowed values per Kevin 2026-04-27:
+   - `before_headers` — exception fired before `resp.status_code` was bound (no response headers seen)
+   - `after_headers_before_first_byte` — headers received (`resp.status_code` bound) but `bytes_from_upstream==0`
+   - `mid_stream` — `bytes_from_upstream>0` (body partially streamed before abort)
+   - `client_disconnect` — downstream client closed mid-stream (the existing BrokenPipe / ConnectionResetError path, line 1968)
+   - `upstream_protocol_error` — exception class is `RemoteProtocolError` or `LocalProtocolError` (the #74 cohort signature; classifier wins over phase axis to keep the protocol-error bucket targetable)
+   - `unknown` — emit-side fallback when none of the above can be determined; also used by the harness for legacy traces emitted before this PR landed
+2. **`tokenpak/proxy/server.py`** — at the upstream-exception emit site, also capture whatever fields ARE in scope: `bytes_from_upstream` and `upstream_status` if the variables exist in the local frame (Python-side `getattr` defensively, no new captures from outside). The downstream BrokenPipe site already captures these.
+3. **`scripts/inspect_session_lanes.py`** — `_dim_parity_trace_coverage` exposes a new sub-distribution `stream_abort_phase_distribution` parsed from the `notes` column for `event_type='stream_abort'` rows. Q-line addition to synthesis.
+4. **`tests/test_ncp3_inspect_session_lanes.py`** — new tests: per-phase classification + synthesis-line presence + invariance to pre-existing aborts without the new notes prefix (legacy traces should be classified as `unknown`).
+
+**Acceptance for Phase 1 (matches #74 acceptance bullet 2):**
+- For each `stream_abort` event going forward, `notes` carries `abort_phase=<value>`
+- The harness reports a distribution by phase
+- The 3-abort signature in the post-#78 baseline is reproduced under the new emit but classified — likely all `pre_first_byte` or `pre_headers`
+
+**What is NOT changed in Phase 1:**
+- No schema migration (everything goes in the existing `notes` TEXT column)
+- No retry logic, no pool config, no upstream-coordination
+- No new HTTP behavior; no new headers; no new connection management
+- `parity_trace.py` event constants, `LIFECYCLE_ORDER`, and `TERMINAL_EARLY_RETURN_EVENTS` are unchanged
+- `tp_events` is not touched (per #79 canonicality)
+
+### Phase 2 — behavior (separate initiative; do NOT bundle)
+
+**Goal:** materially reduce the abort cohort (matches #74 acceptance bullet 1: "The 32-trace stream_abort cohort is materially reduced or root-caused").
+
+**What it would touch (NOT observability-only):**
+- httpx pool sizing / `Keep-Alive` settings under the `services/` dispatch layer
+- Selective retry on `RemoteProtocolError` (limited cases) — provider-policy decision
+- Pool warmup / probe-and-discard on stale keepalive
+- Possibly `services/transport_pool/*` reframe
+
+**Why Phase 2 is a separate initiative:**
+- Retry / pool / upstream-coordination changes are explicitly *behavior* changes
+- Per the #73 / #74-A pattern, the user's standing rule is observability-first; behavior changes get their own scoping cycle
+- Phase 1 produces the data needed to *target* Phase 2 — running Phase 2 before Phase 1 is "fix without diagnosis"
+
+**Out of scope for THIS issue's scope doc.** Phase 2 will be opened as its own initiative once Phase 1 has produced 1+ workload's worth of phased abort data. Filename for that future spec: `docs/internal/specs/ncp-3a-streaming-connect-phase-2-mitigation-<date>.md`.
+
+---
+
+## 2. Out of scope (do not start)
+
+Per Kevin's standing direction:
+- **#75 NCP-3I-v4** (14 upstream_attempt_start orphans) — explicitly held until #74 is scoped (this doc), and likely until Phase 1 ships
+- NCP-4 / NCP-9 — not in this lane
+- streaming-connect Phase 2 (root-cause / mitigation) — separate initiative
+- Any retry / routing / cache / auth / provider / model / prompt / pool change in Phase 1
+- Any new `tp_parity_trace` schema column
+
+---
+
+## 3. Files in Phase 1 (if approved)
+
+| File | Change | Δ LOC |
+|---|---|---|
+| `docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md` | This doc, finalized as the Phase 1 spec | new |
+| `tokenpak/proxy/server.py` | Two `EVENT_STREAM_ABORT` emit sites: add `abort_phase=…` to `notes`; capture in-scope `bytes_from_upstream` / `upstream_status` defensively at the upstream-exception site | ~40 (additive, inside existing try-except guards) |
+| `scripts/inspect_session_lanes.py` | `_dim_parity_trace_coverage`: parse `abort_phase` from `notes` for `event_type='stream_abort'`; new `stream_abort_phase_distribution` field; Q11 synthesis line | ~50 |
+| `tests/test_ncp3_inspect_session_lanes.py` | Phase classification tests + synthesis renders Q11 + legacy-notes-classified-as-unknown | ~120 |
+
+**Files NOT touched in Phase 1:**
+- `tokenpak/proxy/parity_trace.py` — no schema, no event-constant changes
+- `tokenpak/services/**` — no edits
+- `tokenpak/proxy/connection_pool.py` (or wherever httpx pool lives) — no edits in Phase 1
+- All routing / retry / cache / auth / provider / model / prompt code
+
+---
+
+## 4. Test plan (Phase 1)
+
+- **Unit tests** in `tests/test_ncp3_inspect_session_lanes.py`:
+  1. `test_stream_abort_pre_headers_classified` — synthetic `notes='abort_phase=pre_headers'` → distribution `{pre_headers: 1}`, legacy stream_abort row → `{unknown: 1}` mixed
+  2. `test_stream_abort_pre_first_byte_classified` — same for `pre_first_byte`
+  3. `test_stream_abort_mid_stream_classified` — same for `mid_stream`
+  4. `test_stream_abort_post_completion_classified` — same for `post_completion`
+  5. `test_stream_abort_legacy_notes_classified_unknown` — emit without the prefix → `{unknown: 1}`
+  6. `test_q11_synthesis_renders_phase_breakdown` — markdown synthesis includes Q11 line with phase distribution
+- **Regression:** all 36 existing `test_ncp3_inspect_session_lanes.py` cases must still pass; existing `test_parity_trace_phase_ncp_3i.py` cases unchanged
+- **Integration sanity:** rerun the 3-concurrent post-#78 workload; confirm the 3 stream_aborts now carry `abort_phase=pre_first_byte` (or `pre_headers`) in `notes`
+
+---
+
+## 5. CI plan
+
+All required-status checks must remain green: `bandit (blocking)`, `cli-docs-in-sync (blocking)`, `headline-benchmark (blocking)`, `self-conformance (blocking) (3.10/3.11/3.12)`, `Test (Python 3.10–3.13)`, `Lint (Ruff)`, `Import contracts`, `Repo Hygiene Check`. Process-enforced gating per `21 §9.8`.
+
+---
+
+## 6. Acceptance against #74
+
+| #74 acceptance bullet | Phase | Satisfied by |
+|---|---|---|
+| "The 32-trace `stream_abort` cohort is materially reduced or root-caused." | Phase 2 | Out of scope for this PR — separate initiative |
+| "Distinguishable telemetry exists for `pre-first-byte abort` vs `mid-stream abort` vs `post-completion abort`." | **Phase 1 (this PR)** | `abort_phase` in `notes` + `stream_abort_phase_distribution` in harness output + Q11 synthesis |
+
+Phase 1 closes the *observability* half of #74 and provides the data needed to direct Phase 2 work. The issue itself stays open after Phase 1 lands until Phase 2 closes the cohort. Alternatively #74 closes after Phase 1 with a follow-up issue opened for Phase 2 — Kevin's call.
+
+---
+
+## 7. Open questions for Kevin
+
+1. **Phase 1 only, or also propose Phase 2 timing?** Recommendation: Phase 1 only in this lane; Phase 2 scoped after Phase 1 ships and one workload's phased data is in hand.
+2. **Issue-close shape.** Close #74 on Phase 1 merge (and open a Phase 2 issue) — OR — keep #74 open until Phase 2 also lands? Recommendation: close #74 on Phase 1, open `NCP-3A-streaming-connect Phase 2: root-cause / mitigation` as the successor.
+3. **Should `connection_closed_early` be retroactively populated from existing per-trace fields where derivable?** Recommendation: no — keep Phase 1 strictly forward-looking to avoid back-filling that could mask future bugs.
+4. **`abort_phase=unknown` for legacy traces** (those without the new notes prefix). Recommendation: yes — surfaces in the distribution as a known "pre-instrumentation" cohort.
+
+---
+
+## 8. Next steps (gated on Kevin approval)
+
+1. Kevin reviews this scope doc and approves Phase 1
+2. Open feature branch `feat/issue-74-streaming-connect-phase-1`
+3. Land the four files as one PR titled `feat(proxy,scripts,tests,docs): #74 phase 1 — abort_phase classification`
+4. Re-run the 3-concurrent workload; confirm classified abort phases land in `notes` and surface in the harness Q11 line
+5. Merge per `21 §2.1` (squash) once CI green
+6. Close #74 (Phase 1 acceptance bullet only) and open Phase 2 successor issue
+
+**Estimated effort (Phase 1):** ~2 hours (proxy emit-site additions + harness parsing + 6 tests + workload rerun + PR cycle).

--- a/scripts/inspect_session_lanes.py
+++ b/scripts/inspect_session_lanes.py
@@ -353,6 +353,36 @@ _CANONICAL_TERMINAL_EVENTS: frozenset = frozenset({
     "stream_abort",
 })
 
+# Issue #74 phase 1 — allowed abort_phase classifier values, parsed
+# from the `notes` column on stream_abort rows. Legacy traces (no
+# `abort_phase=` prefix) classify as `unknown`. See
+# docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md.
+_ABORT_PHASE_VALUES: frozenset = frozenset({
+    "before_headers",
+    "after_headers_before_first_byte",
+    "mid_stream",
+    "client_disconnect",
+    "upstream_protocol_error",
+    "unknown",
+})
+
+
+def _parse_abort_phase(notes: Optional[str]) -> str:
+    """Extract the abort_phase value from a tp_parity_trace notes
+    field. Returns `unknown` when no `abort_phase=<value>` token is
+    present (legacy stream_abort rows pre-#74 phase 1) or when the
+    value is not in the documented enum."""
+    if not notes:
+        return "unknown"
+    for token in str(notes).split(","):
+        token = token.strip()
+        if token.startswith("abort_phase="):
+            value = token.split("=", 1)[1].strip()
+            if value in _ABORT_PHASE_VALUES:
+                return value
+            return "unknown"
+    return "unknown"
+
 
 def _dim_parity_trace_coverage(
     conn: sqlite3.Connection, since_iso: str, since_ts: float
@@ -375,7 +405,7 @@ def _dim_parity_trace_coverage(
             ),
         }
     rows = conn.execute(
-        "SELECT trace_id, event_type, ts FROM tp_parity_trace "
+        "SELECT trace_id, event_type, ts, notes FROM tp_parity_trace "
         "WHERE ts >= ?",
         (since_ts,),
     ).fetchall()
@@ -391,6 +421,10 @@ def _dim_parity_trace_coverage(
         }
     by_trace: Dict[str, Dict[str, int]] = {}
     event_counter: Counter = Counter()
+    # Issue #74 phase 1 — abort_phase distribution across stream_abort
+    # rows. Parsed per-row from the notes column; legacy rows without
+    # the `abort_phase=` prefix classify as `unknown`.
+    abort_phase_counter: Counter = Counter()
     for r in rows:
         tid = r["trace_id"]
         evt = r["event_type"]
@@ -398,6 +432,8 @@ def _dim_parity_trace_coverage(
         by_trace.setdefault(tid, {"events": 0, "phases": set()})
         by_trace[tid]["events"] += 1
         by_trace[tid]["phases"].add(evt)
+        if evt == "stream_abort":
+            abort_phase_counter[_parse_abort_phase(r["notes"])] += 1
 
     # Count traces by which lifecycle phases they hit.
     n_with_entry = sum(
@@ -552,6 +588,8 @@ def _dim_parity_trace_coverage(
         "early_return_stage_distribution": dict(
             Counter(early_return_traces.values())
         ),
+        # Issue #74 phase 1 — stream_abort phase classification.
+        "stream_abort_phase_distribution": dict(abort_phase_counter),
         "note": (
             "Issue #73: Q8 is now answered against tp_parity_trace "
             "terminal events (stream_complete, "
@@ -568,7 +606,13 @@ def _dim_parity_trace_coverage(
             "true pre-dispatch silent deaths. NCP-3A-enrichment: "
             "early_return_count / early_return_stage_distribution "
             "report traces that took an intentional early-return "
-            "path before upstream_attempt_start."
+            "path before upstream_attempt_start. "
+            "Issue #74 phase 1: stream_abort_phase_distribution "
+            "categorizes stream_abort events by abort_phase parsed "
+            "from the notes column (before_headers, "
+            "after_headers_before_first_byte, mid_stream, "
+            "client_disconnect, upstream_protocol_error); legacy "
+            "rows without an abort_phase= prefix classify as unknown."
         ),
     }
 
@@ -839,6 +883,26 @@ def _verdict_lines(report: Dict[str, Any]) -> List[str]:
                 "= successful subprocess companion dispatch; "
                 "request_rejected = auth/circuit/validation reject (see "
                 "notes column for sub-class)."
+            )
+        # Issue #74 phase 1 — stream_abort phase distribution (Q11).
+        abort_dist = d9.get("stream_abort_phase_distribution") or {}
+        abort_total = sum(abort_dist.values())
+        if abort_total > 0:
+            top = sorted(abort_dist.items(), key=lambda x: -x[1])
+            top_str = ", ".join(f"{k}={v}" for k, v in top)
+            out.append(
+                f"**Q11 — NCP-3A-streaming-connect stream_abort phase "
+                f"(issue #74):** {abort_total} stream_abort events "
+                f"classified by phase. Distribution (phase=count): "
+                f"{top_str}. before_headers = exception before "
+                "response headers; after_headers_before_first_byte = "
+                "headers received but no body bytes; mid_stream = "
+                "body partially streamed; client_disconnect = "
+                "downstream client closed mid-stream; "
+                "upstream_protocol_error = httpx "
+                "RemoteProtocolError / LocalProtocolError "
+                "(the #74 cohort signature). unknown = legacy row "
+                "emitted before the phase-1 classifier landed."
             )
     return out
 

--- a/tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.json
+++ b/tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.json
@@ -1,0 +1,87 @@
+{
+  "claude_code_event_count": 0,
+  "dim1_session_collapse": {
+    "collapse_ratio": null,
+    "distinct_request_ids": 0,
+    "distinct_session_ids": 0,
+    "verdict": "no_data"
+  },
+  "dim2_time_clustering": {
+    "spans": [],
+    "verdict": "insufficient_data"
+  },
+  "dim3_status_distribution": {},
+  "dim4_per_session_durations": {},
+  "dim5_provider_audit": {
+    "distribution": {},
+    "i0_violation": false,
+    "non_oauth_providers": []
+  },
+  "dim6_retry_count": {
+    "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+    "retry_event_lower_bound": 0
+  },
+  "dim7_token_usage": {
+    "available": true,
+    "no_usage_rows": true
+  },
+  "dim8_interleaving": {
+    "interleave_score": null,
+    "verdict": "insufficient_data"
+  },
+  "dim9_parity_trace_coverage": {
+    "available": true,
+    "distinct_traces": 149,
+    "early_return_count": 13,
+    "early_return_stage_distribution": {
+      "dispatch_subprocess_complete": 1,
+      "request_rejected": 12
+    },
+    "event_type_distribution": {
+      "adapter_detected": 149,
+      "auth_gate_pass": 149,
+      "before_dispatch": 136,
+      "body_read_complete": 149,
+      "dispatch_subprocess_complete": 1,
+      "handler_entry": 149,
+      "request_rejected": 12,
+      "route_resolved": 149,
+      "stream_abort": 8,
+      "stream_complete": 86,
+      "stream_start": 88,
+      "upstream_attempt_start": 136
+    },
+    "interp_b_count": 42,
+    "last_stage_distribution": {
+      "dispatch_subprocess_complete": 1,
+      "request_rejected": 12,
+      "stream_abort": 8,
+      "stream_complete": 86,
+      "stream_start": 1,
+      "upstream_attempt_start": 41
+    },
+    "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start. Issue #74 phase 1: stream_abort_phase_distribution categorizes stream_abort events by abort_phase parsed from the notes column (before_headers, after_headers_before_first_byte, mid_stream, client_disconnect, upstream_protocol_error); legacy rows without an abort_phase= prefix classify as unknown.",
+    "pre_upstream_death_count": 0,
+    "pre_upstream_death_stage_distribution": {},
+    "row_count": 1212,
+    "stream_abort_phase_distribution": {
+      "unknown": 3,
+      "upstream_protocol_error": 5
+    },
+    "traces_with_clean_wire_completion": 86,
+    "traces_with_completion_in_tp_events_deprecated": 0,
+    "traces_with_handler_entry": 149,
+    "traces_with_terminal_abort": 8,
+    "traces_with_terminal_fast_fail": 12,
+    "traces_with_upstream_attempt_failure": 0,
+    "traces_with_upstream_attempt_start": 136,
+    "traces_with_wire_completion": 107,
+    "traces_without_terminal_event": 42,
+    "verdict": "interp_b_supported"
+  },
+  "generated_at": "2026-04-27T21:37:04.045293+00:00",
+  "schema_version": "ncp-3-trace-v1",
+  "window_end": "2026-04-27T21:37:04.045293+00:00",
+  "window_minutes": 30.0,
+  "window_start": "2026-04-27T21:07:04.045293+00:00"
+}

--- a/tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.md
+++ b/tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.md
@@ -1,0 +1,140 @@
+# NCP-3 session-lane trace
+
+**Generated**: 2026-04-27T21:37:03.779489+00:00
+**Window**: 30.0 min (2026-04-27T21:07:03.779489+00:00 → 2026-04-27T21:37:03.779489+00:00)
+**Claude Code event count in window**: 0
+
+## Synthesis
+
+- **Q1 — H2 session-id collapse: no_data.** Inconclusive — rerun with the §4 workload (2 concurrent tokenpak claude sessions) and re-inspect.
+- **Q3 — retry events recorded:** 0. Either no retries occurred OR the schema didn't tag them. Settle visually via the §4 workload.
+- **Q8 — wire-side completion (issue #73):** **interp B SUPPORTED.** 42 of 149 handler_entry traces have NO canonical terminal wire-side event (stream_complete / dispatch_subprocess_complete / request_rejected / stream_abort). True silent-death cohort — investigate which stage these traces last reached via pre_upstream_death_stage_distribution.
+- **Q9 — NCP-3I-v3 pre-dispatch death:** 0 traces died before upstream_attempt_start in window. If a workload ran, all requests reached dispatch — H10 is now a stream-side hypothesis (check dim 8 / stream events).
+- **Q10 — NCP-3A-enrichment terminal early-returns:** 13 traces took a known early-return path (intentional terminations, NOT deaths). Distribution (stage=count): request_rejected=12, dispatch_subprocess_complete=1. dispatch_subprocess_complete = successful subprocess companion dispatch; request_rejected = auth/circuit/validation reject (see notes column for sub-class).
+- **Q11 — NCP-3A-streaming-connect stream_abort phase (issue #74):** 8 stream_abort events classified by phase. Distribution (phase=count): upstream_protocol_error=5, unknown=3. before_headers = exception before response headers; after_headers_before_first_byte = headers received but no body bytes; mid_stream = body partially streamed; client_disconnect = downstream client closed mid-stream; upstream_protocol_error = httpx RemoteProtocolError / LocalProtocolError (the #74 cohort signature). unknown = legacy row emitted before the phase-1 classifier landed.
+
+## Dimensions
+
+### dim1_session_collapse
+
+```json
+{
+  "collapse_ratio": null,
+  "distinct_request_ids": 0,
+  "distinct_session_ids": 0,
+  "verdict": "no_data"
+}
+```
+
+### dim2_time_clustering
+
+```json
+{
+  "spans": [],
+  "verdict": "insufficient_data"
+}
+```
+
+### dim3_status_distribution
+
+```json
+{}
+```
+
+### dim4_per_session_durations
+
+```json
+{}
+```
+
+### dim5_provider_audit
+
+```json
+{
+  "distribution": {},
+  "i0_violation": false,
+  "non_oauth_providers": []
+}
+```
+
+### dim6_retry_count
+
+```json
+{
+  "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+  "retry_event_lower_bound": 0
+}
+```
+
+### dim7_token_usage
+
+```json
+{
+  "available": true,
+  "no_usage_rows": true
+}
+```
+
+### dim8_interleaving
+
+```json
+{
+  "interleave_score": null,
+  "verdict": "insufficient_data"
+}
+```
+
+### dim9_parity_trace_coverage
+
+```json
+{
+  "available": true,
+  "distinct_traces": 149,
+  "early_return_count": 13,
+  "early_return_stage_distribution": {
+    "dispatch_subprocess_complete": 1,
+    "request_rejected": 12
+  },
+  "event_type_distribution": {
+    "adapter_detected": 149,
+    "auth_gate_pass": 149,
+    "before_dispatch": 136,
+    "body_read_complete": 149,
+    "dispatch_subprocess_complete": 1,
+    "handler_entry": 149,
+    "request_rejected": 12,
+    "route_resolved": 149,
+    "stream_abort": 8,
+    "stream_complete": 86,
+    "stream_start": 88,
+    "upstream_attempt_start": 136
+  },
+  "interp_b_count": 42,
+  "last_stage_distribution": {
+    "dispatch_subprocess_complete": 1,
+    "request_rejected": 12,
+    "stream_abort": 8,
+    "stream_complete": 86,
+    "stream_start": 1,
+    "upstream_attempt_start": 41
+  },
+  "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start. Issue #74 phase 1: stream_abort_phase_distribution categorizes stream_abort events by abort_phase parsed from the notes column (before_headers, after_headers_before_first_byte, mid_stream, client_disconnect, upstream_protocol_error); legacy rows without an abort_phase= prefix classify as unknown.",
+  "pre_upstream_death_count": 0,
+  "pre_upstream_death_stage_distribution": {},
+  "row_count": 1212,
+  "stream_abort_phase_distribution": {
+    "unknown": 3,
+    "upstream_protocol_error": 5
+  },
+  "traces_with_clean_wire_completion": 86,
+  "traces_with_completion_in_tp_events_deprecated": 0,
+  "traces_with_handler_entry": 149,
+  "traces_with_terminal_abort": 8,
+  "traces_with_terminal_fast_fail": 12,
+  "traces_with_upstream_attempt_failure": 0,
+  "traces_with_upstream_attempt_start": 136,
+  "traces_with_wire_completion": 107,
+  "traces_without_terminal_event": 42,
+  "verdict": "interp_b_supported"
+}
+```

--- a/tests/test_ncp3_inspect_session_lanes.py
+++ b/tests/test_ncp3_inspect_session_lanes.py
@@ -447,9 +447,11 @@ class TestParityTraceCoverage:
         )
         for r in rows:
             conn.execute(
-                "INSERT INTO tp_parity_trace (trace_id, event_type, ts) "
-                "VALUES (?,?,?)",
-                (r["trace_id"], r["event_type"], r["ts"]),
+                "INSERT INTO tp_parity_trace "
+                "(trace_id, event_type, ts, notes) "
+                "VALUES (?,?,?,?)",
+                (r["trace_id"], r["event_type"], r["ts"],
+                 r.get("notes")),
             )
         conn.commit()
         conn.close()
@@ -821,6 +823,167 @@ class TestParityTraceCoverage:
         ), "deprecated field must remain available"
         assert d9["traces_with_clean_wire_completion"] == 1
         assert d9["verdict"] == "interp_a_or_clean"
+
+    # ── Issue #74 phase 1 — stream_abort phase classification ─────────
+
+    def _abort_row(self, trace_id, ts, notes):
+        return {"trace_id": trace_id, "event_type": "stream_abort",
+                "ts": ts, "notes": notes}
+
+    def test_stream_abort_phase_before_headers_classified(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-bh", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-bh", ts + 0.5,
+                            "abort_phase=before_headers"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {"before_headers": 1}
+        assert d9["traces_with_terminal_abort"] == 1
+
+    def test_stream_abort_phase_after_headers_before_first_byte_classified(
+        self, tmp_path
+    ):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-ahbf", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-ahbf", ts + 0.5,
+                            "abort_phase=after_headers_before_first_byte"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {
+            "after_headers_before_first_byte": 1
+        }
+
+    def test_stream_abort_phase_mid_stream_classified(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-ms", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-ms", ts + 0.5, "abort_phase=mid_stream"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {"mid_stream": 1}
+
+    def test_stream_abort_phase_client_disconnect_classified(self, tmp_path):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-cd", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-cd", ts + 0.5,
+                            "abort_phase=client_disconnect"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {
+            "client_disconnect": 1
+        }
+
+    def test_stream_abort_phase_upstream_protocol_error_classified(
+        self, tmp_path
+    ):
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-upe", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-upe", ts + 0.5,
+                            "abort_phase=upstream_protocol_error"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {
+            "upstream_protocol_error": 1
+        }
+
+    def test_stream_abort_legacy_notes_classified_unknown(self, tmp_path):
+        """Legacy stream_abort rows pre-#74 phase 1 (no abort_phase=
+        prefix in notes, or null notes) classify as unknown."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-legacy", "event_type": "handler_entry",
+             "ts": ts},
+            # notes=None (legacy rows have no notes field set)
+            self._abort_row("t-legacy", ts + 0.5, None),
+            {"trace_id": "t-other", "event_type": "handler_entry",
+             "ts": ts + 1},
+            # notes set but no abort_phase= prefix
+            self._abort_row("t-other", ts + 1.5,
+                            "circuit_breaker_open:anthropic"),
+        ])
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {"unknown": 2}
+
+    def test_stream_abort_phase_distribution_aggregates_multiple(
+        self, tmp_path
+    ):
+        """Multi-class distribution sums correctly."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        rows = [
+            {"trace_id": f"t-{i}", "event_type": "handler_entry",
+             "ts": ts + i}
+            for i in range(5)
+        ]
+        rows.append(self._abort_row("t-0", ts + 0.5,
+                                    "abort_phase=upstream_protocol_error"))
+        rows.append(self._abort_row("t-1", ts + 1.5,
+                                    "abort_phase=upstream_protocol_error"))
+        rows.append(self._abort_row("t-2", ts + 2.5,
+                                    "abort_phase=upstream_protocol_error"))
+        rows.append(self._abort_row("t-3", ts + 3.5,
+                                    "abort_phase=client_disconnect"))
+        rows.append(self._abort_row("t-4", ts + 4.5, None))  # legacy
+        self._seed_parity_trace(db, rows=rows)
+        d9 = inspect.analyze(
+            db_path=db, window_minutes=0
+        )["dim9_parity_trace_coverage"]
+        assert d9["stream_abort_phase_distribution"] == {
+            "upstream_protocol_error": 3,
+            "client_disconnect": 1,
+            "unknown": 1,
+        }
+
+    def test_q11_synthesis_renders_phase_breakdown(self, tmp_path):
+        """Markdown synthesis must include the Q11 line with the phase
+        distribution when stream_abort events are present."""
+        db = tmp_path / "telemetry.db"
+        _seed(db, rows=[])
+        ts = 1772562000.0
+        self._seed_parity_trace(db, rows=[
+            {"trace_id": "t-x", "event_type": "handler_entry", "ts": ts},
+            self._abort_row("t-x", ts + 0.5,
+                            "abort_phase=upstream_protocol_error"),
+        ])
+        out = tmp_path / "report.md"
+        rc = inspect.main([
+            "--db-path", str(db),
+            "--window-minutes", "0",
+            "--output", str(out),
+        ])
+        assert rc == 0
+        md = out.read_text()
+        assert "Q11 — NCP-3A-streaming-connect stream_abort phase" in md
+        assert "upstream_protocol_error=1" in md
 
     def test_q8_verdict_unaffected_when_tp_events_empty(self, tmp_path):
         """Issue #73 invariant: handler_entry + stream_complete with

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1983,6 +1983,11 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                                     retry_signal="connection_reset",
                                     retry_owner="claude_code_client",
                                     lane_id=_ncp3iv2_lane,
+                                    # NCP-3A-streaming-connect #74 phase 1:
+                                    # downstream client closed the socket
+                                    # while we were writing — categorical
+                                    # `client_disconnect`.
+                                    notes="abort_phase=client_disconnect",
                                 )
                             except Exception:  # noqa: BLE001
                                 pass
@@ -2385,14 +2390,42 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             # provider failures.
             try:
                 from tokenpak.proxy import parity_trace as _pt
+                # NCP-3A-streaming-connect #74 phase 1 — abort_phase
+                # classification. RemoteProtocolError / LocalProtocolError
+                # are the #74 cohort signature; classify them as
+                # `upstream_protocol_error` regardless of byte phase so
+                # the bucket is targetable. For other exceptions, fall
+                # through to the phase axis based on whether response
+                # headers had been bound and bytes had been streamed.
+                _exc_name = type(exc).__name__
+                _abort_phase: str
+                if _exc_name in ("RemoteProtocolError", "LocalProtocolError"):
+                    _abort_phase = "upstream_protocol_error"
+                else:
+                    _frame = locals()
+                    _bytes_up = int(_frame.get("_ncp3iv2_bytes_up", 0) or 0)
+                    _resp_obj = _frame.get("resp", None)
+                    _headers_seen = (
+                        _resp_obj is not None
+                        and getattr(_resp_obj, "status_code", None) is not None
+                    )
+                    if _bytes_up > 0:
+                        _abort_phase = "mid_stream"
+                    elif _headers_seen:
+                        _abort_phase = "after_headers_before_first_byte"
+                    elif _resp_obj is None:
+                        _abort_phase = "before_headers"
+                    else:
+                        _abort_phase = "unknown"
                 _pt.emit(
                     _pt.EVENT_STREAM_ABORT,
                     trace_id=_req_id,
                     stream_aborted=1,
-                    stream_exception_class=type(exc).__name__,
+                    stream_exception_class=_exc_name,
                     stream_exception_message_hash=_pt.hash_exception_message(exc),
                     retry_signal="unknown",
                     retry_owner="upstream_provider",
+                    notes=f"abort_phase={_abort_phase}",
                 )
             except Exception:  # noqa: BLE001
                 pass


### PR DESCRIPTION
## Summary

Refs #74 — **Phase 1 of two**. Observability-only. Phase 2 (root-cause / mitigation) deferred to a separate initiative once this PR's data confirms the dominant abort phase. **#74 stays open after this PR merges** per Kevin's 2026-04-27 directive; only Phase 1 of #74's acceptance is satisfied here.

The 32-trace `stream_abort` cohort surfaced by NCP-3I-v3 (and reproduced 3/22 in the post-#78 baseline) all carried the **same** `RemoteProtocolError` exception-message hash within ~20 ms windows — a strong shared-state-failure signature, most likely httpx pool collapse. But today's emit sites couldn't distinguish *which* phase the abort happened in. This PR adds the classifier so Phase 2 can target the right thing.

## What landed (observability-only — no behavior change)

- **`tokenpak/proxy/server.py`**: at the existing two `EVENT_STREAM_ABORT` emit sites, add `notes="abort_phase=<value>"`. Allowed values per Kevin:

  | Value | When |
  |---|---|
  | `before_headers` | exception fired before `resp.status_code` was bound |
  | `after_headers_before_first_byte` | headers received but `bytes_from_upstream==0` |
  | `mid_stream` | body partially streamed before abort |
  | `client_disconnect` | downstream BrokenPipe / ConnectionResetError (categorical for that emit site) |
  | `upstream_protocol_error` | `RemoteProtocolError` or `LocalProtocolError` (the #74 cohort signature; classifier wins over phase axis) |
  | `unknown` | emit-side fallback or harness fallback for legacy traces with no `abort_phase=` prefix |

  The upstream-exception path uses defensive `locals().get('resp', None)` + `locals().get('_ncp3iv2_bytes_up', 0)` — no new captures from outside the existing scope, no schema migration.

- **`scripts/inspect_session_lanes.py`**: `_parse_abort_phase` helper + `stream_abort_phase_distribution` field in `dim9_parity_trace_coverage` + new **Q11** synthesis line. The classifier is parsed from the existing `notes` TEXT column.

- **`tests/test_ncp3_inspect_session_lanes.py`**: **+8 new tests** — one per enum value (5 cases including `unknown`), multi-class aggregation, and Q11 synthesis rendering. `_seed_parity_trace` fixture extended to accept an optional `notes` column (backward-compat default `None`).

- **`docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md`**: Phase 1 spec finalized.

- **`tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.{md,json}`**: post-fix 3-concurrent baseline.

## End-to-end verification

| Source | Phase | Count | Note |
|---|---|---|---|
| Verification workload (21:35:01–21:37:03Z) | `upstream_protocol_error` | 5 | new emit, correctly classified — the #74 cohort signature |
| Verification workload | `client_disconnect` | 1 | new emit at the BrokenPipe site (just outside the 30-min harness window by ~2s — verified directly via SQL) |
| Issue-#73 baseline (21:09:20Z) | `unknown` | 3 | legacy traces from before this PR — correctly mapped to `unknown` |

The Q11 synthesis line in the markdown report:
> **Q11 — NCP-3A-streaming-connect stream_abort phase (issue #74):** 8 stream_abort events classified by phase. Distribution (phase=count): `upstream_protocol_error=5, unknown=3`.

## Held throughout

- No schema migration (everything in the existing `notes` TEXT column)
- No retry logic, no httpx pool config, no upstream-coordination changes
- No routing / auth / provider / model / prompt-mutation edits
- No backfill of pre-PR rows (legacy → `unknown` is forward-only by design)
- `parity_trace.py` event constants and `LIFECYCLE_ORDER` unchanged
- `tp_events` untouched (per #79 canonicality)

## Acceptance against Kevin's 2026-04-27 bar

- [x] Observability-only
- [x] No runtime behavior changes
- [x] `stream_abort` traces become phase-distinguishable
- [x] Q11 identifies the abort phase distribution
- [x] Existing traces without phase classify as `unknown`
- [ ] CI green (gating)

Test counts:
- Targeted file (`test_ncp3_inspect_session_lanes.py`): **44 passed** (36 prior + 8 new)
- Parity-trace suite (`test_parity_trace_phase_ncp_3i.py`): **45 passed**
- Lint (Ruff): clean

## Out of scope

- Phase 2 root-cause / mitigation (httpx pool sizing, selective retry on `RemoteProtocolError`, pool warmup) — separate initiative
- #75 NCP-3I-v4 (14 upstream_attempt_start orphans) — Kevin's standing hold
- NCP-4, NCP-9, streaming-connect Phase 2 — not in this lane
- Closing #74 — Kevin's explicit instruction is to keep it open for Phase 2

## Phase 2 hand-off

Phase 1's data confirms the dominant abort class is **`upstream_protocol_error`** (5/8 = 62.5% in this workload; the #74 issue body cited 31/32 = 96.9%). Phase 2 should focus on the httpx connection-pool / keepalive-collapse hypothesis (#74 hypothesis 1) since the protocol-error class is over-represented and consistent with stale-connection reuse. Recommendation for Phase 2 scope doc: `docs/internal/specs/ncp-3a-streaming-connect-phase-2-mitigation-<date>.md`, focused on `services/transport_pool/*` (or wherever httpx pool config lives), pool warmup probes, and selective retry-on-protocol-error.
