### PR TITLE
feat(proxy,tests,docs): NCP-4 phase A — advisory circuit-breaker mode for anthropic

### DIFF
--- a/docs/internal/specs/issue-74-streaming-connect-phase-2-2026-04-27.md
+++ b/docs/internal/specs/issue-74-streaming-connect-phase-2-2026-04-27.md
@@ -1,0 +1,327 @@
+# NCP-3A-streaming-connect — Phase 2 spec (issue #74)
+
+**Date:** 2026-04-27 (M2 rejected; Phase 2B now active)
+**Status:** ⚠️ **M2 REJECTED — verification regressed at 22:19Z** · ✅ **Phase 2B (narrow) approved + landing in this PR**
+**Workstream:** NCP-3 (Session-Lane Preservation) → NCP-3A (Streaming) → NCP-3A-streaming-connect → **Phase 2 mitigation**
+**Authors:** Sue (scope) / Kevin (review + go-ahead)
+**Tracker:** [tokenpak/tokenpak#74](https://github.com/tokenpak/tokenpak/issues/74) — stays open through Phase 2 implementation per Kevin's directive
+**Companion docs:**
+- Phase 1 spec: `docs/internal/specs/ncp-3a-streaming-connect-2026-04-27.md`
+- Phase 1 implementation: PR #80 merged 2026-04-27 21:43:05Z, commit `6b8e18f9b6`
+- Issue #73 / #78 / #79 — wire-side completion canonicality (foundation for the measurement plan)
+- `tokenpak/proxy/connection_pool.py` — current httpx pool implementation (the surface Phase 2 mitigations will modify)
+- `tokenpak/proxy/server.py` lines 1857 (streaming dispatch via `pool.stream(...)`), 1968 (BrokenPipe → `client_disconnect`), 2389 (upstream-exception → `upstream_protocol_error`)
+
+> **Goal:** design the mitigation plan for `stream_abort` traces classified as `upstream_protocol_error` during concurrent TokenPak Claude Code workloads. **Spec only — no implementation in this lane.**
+
+---
+
+## 1. Problem statement
+
+Concurrent `tokenpak claude` sessions can produce `stream_abort` events. Phase 1's classifier shows the dominant phase is `upstream_protocol_error` (httpx `RemoteProtocolError` / `LocalProtocolError`) — 5/8 in the 21:35Z verification workload, 31/32 in the original NCP-3I-v3 trace.
+
+The signature is consistent across runs:
+- multiple traces abort within a small (~20 ms) window
+- all carry the **same** `stream_exception_message_hash`
+- `bytes_from_upstream == 0` and `bytes_to_client == 0`
+- `upstream_status` is null in 26/32 cases (no headers seen) and 200 in 6/32 (headers seen, no body byte)
+
+Phase 2 must materially reduce the `upstream_protocol_error` aborts during concurrent Claude Code workloads **without breaking native parity** (NCP-1 invariants), changing provider semantics, or introducing broad retry amplification.
+
+---
+
+## 2. Candidate root causes (ranked by current evidence)
+
+| # | Hypothesis | Evidence pro | Evidence con / open |
+|---|---|---|---|
+| 1 | **HTTP/2 multiplex collapse** — multiple concurrent streams share a single TCP connection via HTTP/2 multiplexing (`h2 4.3.0` installed, `TOKENPAK_HTTP2=1` default). When the upstream sends `GOAWAY`, hits an idle timeout, or the connection is reset, **every multiplexed stream aborts simultaneously**. | Identical exception-message hash + ~20 ms tight window across multiple traces. Matches the multiplex-failure footprint exactly. `connection_pool.py` confirms one shared `httpx.Client` per netloc. | Need `nGoAway`/protocol-trace evidence to fully confirm; httpx doesn't surface H2 protocol details to the application. Phase 2 implementation should add an HTTP/1.1-fallback test arm to discriminate. |
+| 2 | **Stale keep-alive on HTTP/1.1 fallback** — if HTTP/2 negotiation drops, fallback connections kept-alive for 30 s may be torn down server-side; client doesn't know until the next use, which fails with `RemoteProtocolError`. | Symptom matches generic stale-connection-reuse. `keepalive_expiry=30.0` is permissive given Anthropic's likely server-side window. | Less likely as the *primary* cause given the H2 multiplex evidence; more likely a contributory class in mixed-protocol environments. |
+| 3 | **Connection reuse after upstream half-close** — Anthropic closes the response side of an HTTP/1.1 connection (e.g., after a 503 or rate-limit) but client retains it in pool; next request tries to reuse and protocol-errors. | Cannot be ruled out without per-trace upstream-status correlation. | Phase 1's `connection_closed_early` field captures part of this for the BrokenPipe path but not for upstream-side. |
+| 4 | **Shared pool collapse under concurrent streams** — pool-wide eviction event (e.g., `max_connections=20` saturated, oldest connection forcibly closed mid-stream). | `max_connections=20` is comfortable for 3-concurrent; unlikely at our load. | Recheck under heavier concurrency; not the active hypothesis at 3-concurrent. |
+| 5 | **Upstream stream lifecycle not isolated per request** — same ConnectionPool client instance services both billable token-burning streams AND throwaway probes/health checks. A failed probe could disturb in-flight streams in HTTP/2. | Possible but speculative; needs audit of all `pool.stream()` and `pool.request()` callers. | Out of scope for first mitigation; revisit if isolation alone doesn't close the cohort. |
+| 6 | **Read timeout boundary during concurrent SSE streams** — `read_timeout=300 s` per request; under HTTP/2 multiplexing, the TCP-level read covers multiple streams, so one stream's slow chunk could starve another past its read deadline. | Tangential; Anthropic streams typically arrive at sub-second cadence. | Not the active hypothesis. |
+| 7 | **Retry-owner mismatch between Claude Code client and TokenPak proxy** — Claude Code retries on RemoteProtocolError; TokenPak retries on RemoteProtocolError; both retrying simultaneously amplifies load and re-triggers H2 collapse. | Plausible amplifier *after* the initial collapse; not the root cause. | Phase 2 must NOT add proxy-side retry that competes with Claude Code's existing retry loop. The user's standing constraint covers this. |
+
+**Strongest single hypothesis (original):** #1 (HTTP/2 multiplex collapse). Every observation is consistent with it; nothing rules it out. #2 and #3 are contributory but secondary.
+
+> **Update 2026-04-27 22:19Z — H1 likely WRONG.** Phase 2 M2 verification (HTTP/1.1 + no keepalive) **regressed** on two of the four hard gates. See §2.5 for the regression record and the new H8 hypothesis.
+
+---
+
+## 2.5 Phase 2 M2 regression record (2026-04-27 22:19Z) — **M2 REJECTED**
+
+The M2 implementation (streaming-only client with `http2=False`, `max_keepalive_connections=0`, `keepalive_expiry=0.0`) ran in the production proxy from 22:18:51Z to ~22:23Z, then was reverted. The 3-concurrent verification workload at 22:18:51Z–22:19:46Z produced:
+
+| Metric | Phase 1 baseline (21:37Z) | Phase 2 M2 (22:19Z) | Δ | Spec gate (§6.3) |
+|---|---|---|---|---|
+| `traces_with_handler_entry` | 149 | 83 | -44% (workload variance) | n/a |
+| `traces_with_clean_wire_completion` | 86 | 45 | -47% | n/a |
+| `traces_with_terminal_abort` | 8 | **12** | **+50%** | ❌ **GATE FAIL** |
+| `upstream_protocol_error` aborts | 5 | **12** | **+140%** | ❌ **TARGET MISSED** (was ≥80% reduction) |
+| `traces_with_terminal_fast_fail` (`request_rejected`) | 0 | **13** | **+13** (all `circuit_breaker_open:anthropic`) | ❌ **GATE FAIL** |
+| `traces_without_terminal_event` | 42 | 12 | -71% | n/a (orthogonal cohort) |
+
+Two of the four hard verification gates failed. M2 cannot ship.
+
+**M2 forensic artifacts preserved:**
+- Stash entry `stash@{0}` on branch `feat/issue-74-phase-2-streaming-pool-isolation` ("phase 2 m2 work — regression observed, reverting running proxy")
+- Verification baseline `tests/baselines/ncp-3-trace/20260427T221946Z-issue74p2-postfix-3tp.{md,json}`
+
+**Implication for hypothesis ranking:** H1 (HTTP/2 multiplex collapse) is **likely wrong as stated**. Forcing HTTP/1.1 + per-stream fresh TCP made `upstream_protocol_error` aborts MORE frequent (5→12), not fewer. Two reframed hypotheses:
+
+### H8 (new — supersedes H1's assumption that H2 was the harm) — *HTTP/2 multiplexing is protective; fresh-connection bursts trigger upstream connection-establishment limits*
+
+**Argument:** under HTTP/2, multiple concurrent Claude Code streams share one TCP connection to `api.anthropic.com`, so the upstream sees a small, steady-rate connection footprint. M2 forced each stream to negotiate its own TCP+TLS handshake, presenting the upstream with a sudden burst of fresh connections. Anthropic's edge / load-balancer / WAF likely applies a connection-establishment rate limit per source IP that kicks in when the burst rate spikes. The result: more connection-level protocol errors, not fewer.
+
+**Evidence consistent with H8:**
+- M2 made `upstream_protocol_error` rate go up by 140%, not down
+- The 3-simultaneous identical-hash signature observed in the original 32-trace cohort may itself be the *consequence* of one connection-level event (a single GOAWAY or shared-connection timeout) affecting all multiplexed streams — i.e. ONE upstream-side failure shows up in N traces. Looks like "multiplex collapse" but is closer to "shared aggregator that fans-in upstream events to N streams."
+- 13 cascading `request_rejected` events (circuit-breaker-trip) confirm the proxy correctly responded to a *higher* upstream-failure rate, not a lower one.
+
+**Implication for Phase 2:** the right lever is **not** to disable HTTP/2. The right lever is to test whether the *keepalive* component alone (independent of HTTP/2 multiplexing) is the harm.
+
+### H9 (new) — *stale keepalive within HTTP/2 connection*
+
+Even with HTTP/2 multiplexing, an idle TCP connection's underlying socket can be torn down server-side (Anthropic edge timeouts, NAT eviction, etc.) without the client knowing. The next stream attempted on that connection fails with `RemoteProtocolError`. This is the same H2 (stale keepalive) hypothesis from the original ranking, narrowed to be H2-multiplex-aware.
+
+**Implication for Phase 2:** disable streaming-pool keepalive (no idle reuse), but keep HTTP/2 enabled (preserve the protective per-stream multiplexing inside a fresh connection's lifetime).
+
+---
+
+## 3. Candidate mitigations (with tradeoffs)
+
+| Mitigation | What it changes | Targets hypothesis | Tradeoff / risk |
+|---|---|---|---|
+| **M1. Disable HTTP/2 for the streaming path only** | Add a streaming-only `httpx.Client` in `ConnectionPool` with `http2=False`; route `pool.stream(...)` to it for `api.anthropic.com`. Non-streaming traffic keeps HTTP/2. | #1 directly | Loses HTTP/2 multiplexing perf for streams (≤5 ms reuse savings). Acceptable for Claude Code where streams are minutes-long; perf loss is negligible. |
+| **M2. Disable keepalive for the streaming path only** | Streaming-only client with `max_keepalive_connections=0` and `keepalive_expiry=0.0`. Each stream gets a fresh connection. | #1 (eliminates multiplex sharing across streams), #2, #3 | One TCP+TLS handshake per stream (~50–100 ms first-byte penalty). Acceptable for Claude Code request cadence. **Recommended primary mitigation** — see §4. |
+| **M3. Per-stream isolated client (no pool at all for streams)** | Construct a fresh `httpx.Client` for every streaming request; close on stream end. | #1, #2, #3, #5 (full isolation) | Highest perf cost (~50–100 ms handshake every stream, no warm pool); strongest guarantee. |
+| **M4. Lower `max_keepalive_connections`** | Drop default from 10 to 1 or 2 for the streaming pool. | #2, #4 | Half-measure compared to M2. Doesn't address H2 multiplex (#1). |
+| **M5. Configure shorter `keepalive_expiry`** | Drop from 30 s to e.g. 5 s. | #2 | Half-measure. Doesn't address H2 multiplex (#1). Increases TLS handshake count without cleanly isolating streams. |
+| **M6. Retry once on pre-first-byte `RemoteProtocolError` only** | Defensive retry: at the upstream-exception emit site, if `abort_phase ∈ {before_headers, after_headers_before_first_byte, upstream_protocol_error}` AND `bytes_to_client == 0`, re-issue the request once. | All upstream-side aborts (defensive) | **Risk: amplifies load** if M1/M2/M3 don't address root cause. **Risk: collides with Claude Code's own retry loop** (the retry-owner-mismatch concern, hypothesis #7). Should NOT be the primary mitigation. Acceptable as a *secondary* mitigation IFF strict limits hold (max 1, never after `bytes_to_client > 0`). |
+| **M7. Drain/close broken streams defensively** | At the upstream-exception path, explicitly close the underlying httpx response/connection before re-raising, ensuring the broken connection is removed from the pool. | #2, #3, #5 | Marginal — httpx already invalidates connections that raise; this is defense-in-depth. |
+| **M8. Circuit breaker tuning to not amplify retries** | Audit current circuit-breaker behavior to ensure it doesn't **add** retry pressure when the streaming path is healthy elsewhere. Existing tripped-state behavior already correctly fast-fails (per #77 `EVENT_REQUEST_REJECTED`). | #7 | Audit-only in Phase 2; do not change breaker semantics in this lane. |
+
+**Out of approved candidate set:** broad cross-request retry, automatic backoff, server-side request hedging — all explicitly excluded by Kevin's safety constraints.
+
+---
+
+## 4. Recommended safe first mitigation
+
+> ~~**Primary: M2 (streaming-pool isolation with keepalive disabled).**~~ — **REJECTED 2026-04-27 22:19Z after verification regression. See §2.5.**
+>
+> ~~**Secondary: M6 (limited retry-once).**~~ — Not reached; Phase 2 did not get past the primary mitigation.
+
+### Phase 2B (active) — streaming-keepalive isolation only (HTTP/2 preserved)
+
+Per Kevin's 2026-04-27 narrowed scope: test whether stale keepalive reuse alone is the cause, **without** disabling HTTP/2 multiplexing. The minimum experimental change targeting H9 (stale keepalive within HTTP/2 connection) without disturbing H8 (HTTP/2 is protective):
+
+1. Extend `tokenpak/proxy/connection_pool.py` with a streaming-only client (parallel `_streaming_clients` map) constructed with:
+   - **`http2=True`** (default — HTTP/2 stays enabled; this is the change vs M2)
+   - `max_keepalive_connections=0` (no idle-reuse — eliminates stale-keepalive cohort)
+   - `keepalive_expiry=0.0` (defensive, redundant with the above)
+   - Same `max_connections=20`, TLS, timeouts as the request client
+2. Route `ConnectionPool.stream(...)` to the streaming client.
+3. Non-streaming traffic (`pool.request(...)`) is **untouched** — continues to use HTTP/2 + keepalive on the original `_clients` pool.
+4. Reversibility: `TOKENPAK_STREAM_HTTP2` (default `1` — HTTP/2 enabled) and `TOKENPAK_STREAM_KEEPALIVE` (default `0` — keepalive disabled). Setting `TOKENPAK_STREAM_HTTP2=0` reproduces the M2 conditions for forensic comparison; setting `TOKENPAK_STREAM_KEEPALIVE=1` returns streaming to main's behavior.
+
+**What's different vs M2 (the only change):**
+- `streaming_http2: bool = True` (was `False` in M2)
+- `from_env()` default for `TOKENPAK_STREAM_HTTP2` is `"1"` (was `"0"` in M2)
+
+Everything else (the streaming-only client structure, `_get_streaming_client()`, `stream(...)` routing, `close()` cleanup, no behavior change to `request(...)`) is identical to the M2 implementation. The M2 stash at `stash@{0}` documents the narrower-mitigation diff if needed.
+
+**Why this is the right narrowed primary (per Kevin):**
+- **Targets H9 only.** Disables idle keepalive without disturbing H2 multiplexing.
+- **Discriminates H8 vs H9.** If Phase 2B passes, H9 (stale keepalive within H2) was the cause. If 2B also regresses, H8 (HTTP/2 protective; fresh-connection bursts harmful) is the dominant cause and the proper next lane is NCP-4 retry/circuit-breaker behavior or upstream-pressure diagnostics — not further pool experimentation.
+- **No retry, no breaker tuning, no auth/routing/provider/model/cache/prompt edits.**
+- **Preserves SSE framing.** HTTP/2 streams remain native; only the connection's lifetime is shortened (no idle reuse).
+- **Preserves Claude Code OAuth/subscription path.** Untouched.
+- **Cleanly reversible.** Two env vars, default ship-on with escape hatches.
+
+**Phase 2B regression rule (binding):** if the verification workload in §6 shows `upstream_protocol_error` increase OR `traces_with_terminal_abort` increase OR `request_rejected` increase, **STOP**. Revert. **Do NOT attempt further pool experiments.** Re-scope toward NCP-4 retry/circuit-breaker behavior or provider-side connection pressure diagnostics. M6 is NOT a fallback at this point — it would amplify the existing problem.
+
+---
+
+## 4.5 Phase 2B regression record (2026-04-27 22:30Z) — **PHASE 2B REJECTED · pool experiments halted**
+
+The Phase 2B implementation (HTTP/2 enabled, keepalive disabled) ran in the production proxy from 22:29:41Z to ~22:31Z and was reverted. The 3-concurrent verification workload at 22:29:41Z–22:30:53Z produced:
+
+| Metric | Phase 1 baseline | Phase 2 M2 | **Phase 2B** | M2 vs P1 | **2B vs P1** | 2B vs M2 |
+|---|---|---|---|---|---|---|
+| `traces_with_handler_entry` | 149 | 83 | 101 | -44% | -32% | +22% |
+| `traces_with_clean_wire_completion` | 86 | 45 | 63 | -47% | -27% | +40% |
+| `traces_with_terminal_abort` | 8 | 12 | **12** | +50% | **+50% — GATE FAIL** | identical |
+| `upstream_protocol_error` aborts | 5 | 12 | **12** | +140% | **+140% — TARGET MISSED** | identical |
+| `request_rejected` (`circuit_breaker_open:anthropic`) | 0 | 13 | **13** | +13 | **+13 — GATE FAIL** | identical |
+| `traces_without_terminal_event` | 42 | 12 | 12 | -71% | -71% | identical |
+
+**The failure profile is essentially identical to M2.** HTTP/2 vs HTTP/1.1 made no measurable difference. The common factor is **disabling keepalive on the streaming path**. Per the Phase 2B regression rule (§4): pool experiments are halted.
+
+**Phase 2B forensic artifacts preserved:**
+- Stash entry `stash@{0}` ("phase 2b work — regression observed (12 protocol_error + 13 cb_open, identical to M2); stopping pool experiments")
+- Verification baseline `tests/baselines/ncp-3-trace/20260427T223053Z-issue74p2b-postfix-3tp.{md,json}`
+- M2 stash retained at `stash@{1}` ("phase 2 m2 work — regression observed, reverting running proxy")
+
+### Conclusion across both pool experiments
+
+Two attempts with two different transport postures produced the **same elevated abort rate**. The conclusive finding: **the act of disabling keepalive on the streaming path itself is the harm.** Hypotheses ranked after both runs:
+
+| Hypothesis | Status after 2B |
+|---|---|
+| H1 (HTTP/2 multiplex collapse) | **rejected** — disabling H2 didn't help |
+| H2 / H9 (stale keepalive within H2) | **rejected** — disabling keepalive didn't help; in fact, made it worse |
+| **H8 (HTTP/2 multiplexing is protective; fresh-connection bursts trigger upstream connection-establishment limits)** | **strongly supported** — the only common factor between the two failed runs is forcing fresh connections per stream. Burst rate ≈ 3 fresh TLS handshakes within ~1 s window. |
+
+### Implications for next lane
+
+**No further pool experiments.** The pool surface has been adequately tested in two configurations; both regressed in the same way. The right next lanes are either:
+
+1. **NCP-4 — retry / circuit-breaker behavior parity.** The 13 `request_rejected` events under both M2 and 2B are the breaker correctly fast-failing after the abort surge. Tuning the breaker (less aggressive trip, faster reset, or per-class thresholds) might soften the cascade without addressing the root cause; or, leaving the breaker alone, the parity question is whether retries should be the proxy's responsibility vs. the Claude Code client's.
+
+2. **Upstream-pressure diagnostics — characterize Anthropic's edge connection-establishment behavior.** Capture `httpx` event hooks at TLS-handshake / connection-establishment / GOAWAY frames and produce a baseline of provider-side limits. Could surface from existing `tp_parity_trace` rows by adding finer event types, or via httpx's `EventHooks` (read-only), or via a one-shot `tcpdump` / `mitmproxy` capture.
+
+**M6 (limited retry-once) remains parked.** It would amplify the existing problem if pool isolation isn't the lever.
+
+**Recommendation:** scope NCP-4 next, **not** further pool work. The current `request_rejected` cascading on M2/2B is a real finding even at main's pool config — it just happens to be invisible at main because the underlying abort rate is lower. NCP-4 is the right lane to investigate the proxy's retry-and-breaker behavior end-to-end. Provider-side diagnostics can be a parallel side-quest if Kevin wants more raw data.
+
+---
+
+## 5. Safety constraints (binding)
+
+Phase 2 implementation **MUST** preserve all of:
+
+- ✅ No provider/model routing changes — the routing layer (`services/routing_service/*`) is untouched
+- ✅ No auth behavior changes — credential injection, OAuth flow, refresh path all untouched
+- ✅ No prompt mutation changes — `compression/`, `vault/`, `companion/` capsule code all untouched
+- ✅ No cache behavior changes — `cache/` module untouched; cache_origin telemetry untouched
+- ✅ No broad retry amplification — only the narrow M6 case (if it lands), max 1, gated as in §4
+- ✅ No retry after downstream bytes have been sent (`bytes_to_client > 0` is a hard fence)
+- ✅ Preserves SSE framing — no buffering/rewriting of stream chunks
+- ✅ Preserves Claude Code OAuth/subscription path — auth headers, anthropic-beta, OAuth bearer all untouched
+- ✅ No new schema migrations on `tp_parity_trace` — Phase 1 already established the diagnostic columns
+- ✅ Existing `tp_events` canonicality (per #79) preserved — proxy still does not write `tp_events`
+- ✅ `parity_trace.py` event constants and `LIFECYCLE_ORDER` unchanged
+- ✅ Existing native-parity invariants from NCP-1 preserved (no new headers, no new request mutations)
+
+---
+
+## 6. Measurement plan (before/after)
+
+Run the same 3-concurrent `tokenpak claude` workload before and after Phase 2 lands. The Phase 1 baseline at `tests/baselines/ncp-3-trace/20260427T213703Z-issue74p1-postfix-3tp.{md,json}` is the **before** reference.
+
+### 6.1 Workload
+
+```bash
+# 3 streams × 3 calls each, ~9 invocations, ~50–60 s wallclock
+for s in 1 2 3; do
+  ( for i in 1 2 3; do
+      timeout 45 tokenpak claude -p "Reply with exactly two words: stream$s call$i"
+    done ) &
+done
+wait
+
+# Capture
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+python3 scripts/inspect_session_lanes.py --window-minutes 30 \
+  --output tests/baselines/ncp-3-trace/${TS}-issue74p2-postfix-3tp.md
+python3 scripts/inspect_session_lanes.py --window-minutes 30 --json \
+  --output tests/baselines/ncp-3-trace/${TS}-issue74p2-postfix-3tp.json
+```
+
+### 6.2 Metrics to compare
+
+| Metric | Phase 1 baseline (21:37Z) | Phase 2 target |
+|---|---|---|
+| `traces_with_handler_entry` | 149 | comparable (workload size dependent) |
+| `traces_with_clean_wire_completion` (`stream_complete`) | 86 | **higher** (more cleanly streamed) |
+| `traces_with_terminal_abort` (`stream_abort`) | 8 | **lower** |
+| `stream_abort_phase_distribution.upstream_protocol_error` | 5 | **target: 0–1** |
+| `stream_abort_phase_distribution.client_disconnect` | (1 outside window) | unchanged or lower |
+| `stream_abort_phase_distribution.before_headers` | 0 | unchanged |
+| `stream_abort_phase_distribution.after_headers_before_first_byte` | 0 | unchanged |
+| `stream_abort_phase_distribution.mid_stream` | 0 | unchanged |
+| `traces_without_terminal_event` (silent death) | 42 | unchanged or lower (orthogonal cohort) |
+| `traces_with_terminal_fast_fail` (`request_rejected`) | 0 | **must remain 0 or comparable** (no regression) |
+| Per-trace `bytes_from_upstream` / `bytes_to_client` | 86 traces with bytes > 0 | **comparable or higher byte success rate** |
+| Median request duration | not captured pre-fix | track post-fix (TLS handshake adds ~50–100 ms first-byte) |
+| Visible TUI retries (anecdotal `Retrying in 20s` count) | observed pre-#77 | **none expected post-fix** |
+| JSON parse errors (`json_parse_error_seen` in `tp_parity_trace`) | not yet probed | **must remain at zero** (preserves SSE framing) |
+| Pool reuse rate (`ConnectionPool.metrics().reuse_rate` for `api.anthropic.com`) | new measurement | streaming should drop to ~0 (per-stream fresh connection); non-streaming should keep its existing reuse rate |
+
+### 6.3 Verification rules
+
+- ⚠️ **Phase 2 cannot ship if `traces_with_terminal_abort` increases.**
+- ⚠️ **Phase 2 cannot ship if `traces_with_terminal_fast_fail` increases.** (Would indicate the breaker tripped from a new failure class.)
+- ⚠️ **Phase 2 cannot ship if `client_disconnect` increases.** (Would indicate the streaming path is now causing downstream issues.)
+- ⚠️ **Phase 2 cannot ship if any `json_parse_error_seen` row appears.** (Would indicate SSE framing was disturbed.)
+- ⚠️ **Phase 2 cannot ship if median request duration regresses by >250 ms.** (Some duration increase is expected from per-stream TLS handshake; >250 ms suggests connection-establishment is failing or pooling is broken.)
+
+---
+
+## 7. Acceptance criteria for Phase 2 implementation
+
+When Phase 2 ships:
+
+- [ ] `upstream_protocol_error` aborts **materially reduced** (target ≥80% reduction; baseline 5 → target ≤1 in the equivalent workload window)
+- [ ] No increase in `request_rejected` (circuit breaker not amplified)
+- [ ] No increase in `client_disconnect` (downstream path not disturbed)
+- [ ] No `json_parse_error_seen` rows (SSE framing intact)
+- [ ] No retry amplification visible in the telemetry (`EVENT_RETRY_BOUNDARY` count comparable or zero)
+- [ ] No routing/auth/provider/model/prompt/cache changes — diff is contained to `tokenpak/proxy/connection_pool.py` (and possibly a minimal entry-point in `proxy/server.py` selecting the streaming client)
+- [ ] All required-status CI checks green (`bandit`, `cli-docs-in-sync`, `headline-benchmark`, `self-conformance` 3.10/3.11/3.12, `Test` 3.10–3.13, `Lint`, `Import contracts`, `Repo Hygiene`)
+- [ ] Post-fix trace baseline committed at `tests/baselines/ncp-3-trace/<TS>-issue74p2-postfix-3tp.{md,json}`
+- [ ] Pool-reuse-rate metric (`ConnectionPool.metrics()`) shows the expected non-streaming reuse rate is preserved while streaming drops to ~0
+- [ ] `parity_trace.py` event constants unchanged; `LIFECYCLE_ORDER` unchanged
+- [ ] `tp_events` untouched (#79 canonicality preserved)
+- [ ] Existing 44 `test_ncp3_inspect_session_lanes.py` and 45 `test_parity_trace_phase_ncp_3i.py` tests remain green; new pool-isolation tests added under `tests/proxy/test_connection_pool_streaming_isolation.py` (or similar)
+- [ ] Reversibility flag exposed (`TOKENPAK_STREAM_HTTP2=1` and/or `TOKENPAK_STREAM_KEEPALIVE=1` env-var escape hatches) so the old behavior is one env var away if regression appears
+
+---
+
+## 8. Follow-up issue handling
+
+- **Keep #74 open through Phase 2 implementation.** Phase 2 PR uses `Refs #74`, not `Closes #74`.
+- **Close #74 only when Phase 2's acceptance criteria (§7) are all met** in a real workload — at that point the cohort is materially closed.
+- **Do not start #75 yet.** Kevin's standing hold remains.
+- **Do not start NCP-4 retry parity** unless Phase 2 implementation concludes that retry behavior is the correct lane (current evidence says it is **not** — pool isolation is the primary lever). If NCP-4 becomes relevant, it gets its own scoping cycle.
+- **Do not bundle Phase 2 with any unrelated changes.** This PR is contained to transport pool plus tests plus baseline.
+
+---
+
+## 9. Files Phase 2 implementation would touch (if approved)
+
+| File | Change | Δ LOC estimate |
+|---|---|---|
+| `docs/internal/specs/issue-74-streaming-connect-phase-2-2026-04-27.md` | This doc, finalized | this file |
+| `tokenpak/proxy/connection_pool.py` | Add `_streaming_clients: Dict[str, httpx.Client]` and `_make_streaming_client()` factory; route `stream(...)` to it; expose env flags `TOKENPAK_STREAM_HTTP2` (default 0) and `TOKENPAK_STREAM_KEEPALIVE` (default 0) | ~80 |
+| `tokenpak/proxy/server.py` | (minimal) — possibly nothing if pool selects internally; OR a one-line netloc check at line 1857 if conditional routing chosen there | 0–10 |
+| `tests/proxy/test_connection_pool_streaming_isolation.py` | New test file: streaming uses streaming client; non-streaming uses default client; HTTP/2 flag honored; metrics are partitioned | ~150 |
+| Optionally: `tests/test_parity_trace_phase_ncp_3i.py` | Add a parametrized integration test that simulates a multiplex collapse (mock `httpx.Client.stream` raising `RemoteProtocolError`) and confirms classification + (under primary mitigation) no other in-flight stream is affected | ~80 |
+
+**Files NOT touched:**
+- `services/routing_service/**` — routing untouched
+- `services/auth_service/**`, `agent/auth/**` — auth untouched
+- `compression/**`, `vault/**`, `companion/**` — prompt-mutation untouched
+- `cache/**` — cache untouched
+- `proxy/parity_trace.py` — schema, events, emit points unchanged
+- `tp_events` — untouched (#79 canonicality)
+- `tokenpak/proxy/server_async.py` — separate ASGI implementation; not the active proxy in production
+
+---
+
+## 10. Open questions for Kevin
+
+1. **Conditional routing on netloc vs. always-on streaming client.** Recommendation: always-on for the streaming client (any `pool.stream(...)` call routes to it) — simpler and the perf cost is negligible. Alternative: gate by netloc (`api.anthropic.com` only). Either is workable; the always-on choice is one fewer code path.
+2. **Reversibility flag default.** Recommendation: `TOKENPAK_STREAM_HTTP2=0` (HTTP/1.1) and `TOKENPAK_STREAM_KEEPALIVE=0` (no keepalive) as the *new defaults*; the env vars exist as escape hatches if Phase 2 regresses. Alternative: ship behind a feature flag defaulted off, opt-in for measurement. Recommendation: ship defaulted on — measurement is more reliable when the change is the steady state.
+3. **Should M6 (limited retry) be specced now or held for a Phase 2.5 if needed?** Recommendation: hold. M2 alone is most likely sufficient; if not, a focused Phase 2.5 spec defines the retry surface with full constraints. Avoids over-engineering.
+4. **Workload size for measurement.** Recommendation: same 3-concurrent × 3-call pattern as Phase 1 verification (deterministic, comparable, cheap). For higher confidence, a follow-on 5-concurrent × 5-call workload could be run after the initial baseline shows the expected drop.
+5. **Pool-reuse-rate metric exposure.** Currently `ConnectionPool.metrics()` is module-internal. Should we expose it via `tokenpak status` for ongoing operational visibility? Recommendation: out of scope for Phase 2; consider as a separate dashboard/observability lane.
+
+---
+
+## 11. Estimated effort (Phase 2 implementation)
+
+- ~3–4 hours: connection_pool.py changes + new test file + workload rerun + PR cycle
+- ~1 hour additional if M6 (limited retry) ends up needed after measurement
+
+This puts the full Phase 2 implementation comfortably in a single session, contingent on M2 alone closing the cohort.

--- a/docs/internal/specs/ncp-4-retry-circuit-breaker-parity-2026-04-27.md
+++ b/docs/internal/specs/ncp-4-retry-circuit-breaker-parity-2026-04-27.md
@@ -1,0 +1,266 @@
+# NCP-4 — retry / circuit-breaker parity (spec)
+
+**Date:** 2026-04-27
+**Status:** 📝 **scoped, awaiting approval** — spec only, no code changes
+**Workstream:** NCP-4 (retry / circuit-breaker parity for Claude Code)
+**Authors:** Sue (scope) / Kevin (review + go-ahead)
+**Tracker:** to be opened on approval (linked from #74)
+**Related issues:** [tokenpak/tokenpak#74](https://github.com/tokenpak/tokenpak/issues/74) (NCP-3A-streaming-connect — Phase 1 done, Phase 2 rejected; #74 stays open as diagnostic record)
+**Companion docs:**
+- Phase 1 implementation: PR #80 merged 2026-04-27 21:43:05Z, commit `6b8e18f9b6`
+- Phase 2 spec + regression record (M2 + 2B): `docs/internal/specs/issue-74-streaming-connect-phase-2-2026-04-27.md`
+- Issue-#73 / PR #78 (`tp_parity_trace` canonicality) — wire-side completion ledger
+- Standards §7.1 amendment (vault commit `8dc2d8f`) — wire-side completion canonicality clause
+- Current breaker implementation: `tokenpak/proxy/circuit_breaker.py` (per-provider, `failure_threshold=5`, `recovery_timeout=60.0`, `window_seconds=60.0`, no error-class differentiation)
+
+> **Goal:** determine why upstream abort surges cause `circuit_breaker_open:anthropic` cascades and user-visible Claude Code retry storms during concurrent `tokenpak claude` workloads, and propose targeted mitigations to the proxy's retry / circuit-breaker behavior. **Spec only — no implementation in this lane.**
+
+---
+
+## 1. Problem statement
+
+Concurrent `tokenpak claude` sessions still surface visible TUI retries even after #74 Phase 1 (observability) and #78 (canonicality fix). The original 32-trace `RemoteProtocolError` cohort is real, but the harm is amplified by the proxy's circuit-breaker behavior:
+
+- A burst of upstream `RemoteProtocolError` aborts (typical: 3 simultaneous identical-hash aborts within ~20 ms — the H8 footprint where one upstream connection-level event fans out across N multiplexed streams) trips the proxy breaker after 5 failures in the rolling 60-s window.
+- Once tripped, the breaker rejects the next 60 seconds of streaming traffic to `api.anthropic.com` with `circuit_breaker_open:anthropic` (a `request_rejected` event in `tp_parity_trace`).
+- Claude Code's TUI sees those rejects and retries — the user-visible "Retrying in 20s" loop. This adds load and can interact with the existing fresh-connection-burst hypothesis to deepen the regression.
+
+We need to tune proxy retry/breaker behavior so that:
+- A short transient burst of pre-first-byte protocol errors does NOT trip the breaker into a 60-s freeze
+- A real sustained outage still trips quickly
+- The TokenPak proxy and Claude Code client do NOT compete on retry policy
+- The fix is observability-friendly and does not introduce a new behavior class that #75 / Phase 2 / NCP-3A already excluded
+
+---
+
+## 2. Evidence (from PR #80 baselines and Phase 2 verification runs)
+
+| Source | When | `traces_with_handler_entry` | `clean_wire_completion` (`stream_complete`) | `terminal_abort` | `upstream_protocol_error` aborts | `request_rejected` (all `circuit_breaker_open:anthropic`) | Verdict |
+|---|---|---|---|---|---|---|---|
+| Phase 1 baseline | 21:37Z (post-#80) | 149 | 86 | 8 | 5 | **0** | breaker did NOT trip |
+| Phase 2 M2 (rejected) | 22:19Z | 83 | 45 | 12 | 12 | **13** | breaker tripped + cascade |
+| Phase 2B (rejected) | 22:30Z | 101 | 63 | 12 | 12 | **13** | breaker tripped + cascade (identical to M2) |
+| Issue #74 original (NCP-3I-v3) | 18:42Z | 187 | 86 (clean), 32 (`stream_abort`) | 32 | 31 | (not tracked at the time) | known cohort that motivated #74 |
+
+**Key observations:**
+
+1. **Phase 1 had 5 `upstream_protocol_error` aborts and 0 breaker trips.** The breaker's `failure_threshold=5` means a burst of 5 in the 60-s window would trip; this run sat AT the threshold and the breaker stayed CLOSED — the trip is sensitive to a single additional failure. The breaker is therefore *just barely below* the cliff in normal operation.
+2. **M2 and 2B both produced exactly 13 cascading rejects.** The numerics are deterministic-looking: 12 failures triggers the trip on failure #5; the remaining 7+ would-be in-flight calls plus the next ~6 invoked-during-OPEN streams hit the OPEN circuit and become `request_rejected`. 12 + 13 = 25 is consistent with the workload's true demand.
+3. **`upstream_protocol_error` is the dominant abort class** — 12 of 12 in both failed runs and 5 of 8 in Phase 1. The breaker treats all failure classes equally, so protocol errors are weighted 1:1 with HTTP 5xx, timeout, etc., even though their semantics are very different (transient vs sustained).
+4. **M6 (limited retry-once at the proxy) is parked** — it would amplify under H8 (fresh-connection bursts harm the upstream). The breaker is therefore the only proxy-side knob available without a transport change.
+
+---
+
+## 3. Candidate root causes
+
+| # | Hypothesis | Evidence supporting | Evidence against / open |
+|---|---|---|---|
+| 1 | **Breaker trips too aggressively on transient pre-first-byte protocol bursts** | Phase 1 sat at threshold (5/5); M2/2B exceeded slightly (12) and tripped the cascade. Real Anthropic outages (sustained) would produce many more, so the threshold is sensitive in the wrong region. | Without before-and-after on a real outage, can't fully confirm threshold is *too* low — but the cliff at 5 is empirically problematic. |
+| 2 | **Breaker classifies provider/transport errors too broadly** — `RemoteProtocolError` (transient connection-level), `ReadTimeout` (medium-term), 5xx (sustained), 429 (rate limit) all weighted 1:1 | `record_failure(provider)` is called from a single `except Exception` block in `_proxy_to_inner` with no class differentiation. The breaker config has only `failure_threshold` (a single number) — no per-class thresholds. | Per-class differentiation adds complexity; need to confirm the right buckets. |
+| 3 | **Breaker threshold is global per-provider instead of per-session/per-lane** — one user with one bad session can degrade all concurrent users | A single Cali workload's burst trips the breaker; subsequent Trix / Sue / Kevin invocations to the same provider get `circuit_breaker_open:anthropic` even if their request is healthy | Per-session may be hard to define (session_id is unstable in some cases); per-lane (HTTP/2 stream lane) requires the underlying httpx scope. |
+| 4 | **60-s recovery is too slow for Claude Code interactive workloads** | After a 60-s OPEN, even a single successful probe doesn't immediately reflect to the user; Claude Code's "Retrying in 20s" loop continues and may give up. | Faster recovery may also mean faster re-trips during real outages (oscillation). |
+| 5 | **TokenPak proxy + Claude Code client retry loops compound** — both retry on transport errors, multiplying load on the upstream | Claude Code TUI's retry messages are user-visible; proxy's `record_failure` increments per attempt. Probable but not directly measured. | We don't control Claude Code's retry policy; needs to be inferred from TUI logs / behavior. |
+| 6 | **Aborts before first byte poison unrelated concurrent sessions** — a `before_headers` abort in stream A causes the breaker to fast-fail stream B even though B was healthy | Per-provider breaker scope = single provider counter for ALL sessions. | Per-session isolation could fix this without touching threshold. |
+
+**Strongest combined hypothesis:** root cause is **(1) + (2) + (3)** in combination — threshold is empirically just below the regression line (1), all error classes are weighted equally (2), and the per-provider scope means one bursty stream poisons everything (3).
+
+---
+
+## 4. Candidate mitigations
+
+| # | Mitigation | What it changes | Tradeoff / risk |
+|---|---|---|---|
+| **B1** | **Per-error-class thresholds** — separate counters and thresholds for `RemoteProtocolError` / `LocalProtocolError` (transient transport), HTTP 5xx (sustained), HTTP 429 (rate limit), timeouts | One `CircuitBreakerConfig` field becomes a small dict (`{"protocol_error": 10, "http_5xx": 3, "http_429": 5, "timeout": 5}`); `record_failure(class_name)` increments the matching counter. | Bigger config surface; need to decide thresholds per class. **Recommended primary** — directly addresses (1) + (2). |
+| **B2** | **Don't trip on pre-first-byte protocol errors unless repeated within a tighter window** — special-case `before_headers` + `after_headers_before_first_byte` aborts: counter only increments when we see N≥3 within 5 s rather than 5 within 60 s | Adds `abort_phase` awareness to the failure path (already classified by Phase 1). | Couples breaker logic to abort-phase classifier; small additional surface. Combinable with B1. |
+| **B3** | **Per-session / per-lane breaker bucket** — switch from per-provider to per-(provider, session_id) or per-(provider, trace_id) | New keying in `CircuitBreakerRegistry`; each session gets its own breaker. | Higher memory footprint; cardinality limited by Claude Code session count. **Risk:** breaker cardinality explosion under per-trace_id (every trace gets its own counter). Per-session is the safer scope. |
+| **B4** | **Shorter reset window for streaming OAuth path** — `recovery_timeout=10–15s` instead of 60s for the Claude Code OAuth provider, leaving 60s for non-OAuth providers | Per-provider config override (`{"anthropic": {"recovery_timeout": 10}}`); other providers unchanged. | Risk of oscillation (breaker re-trips faster). Combinable with B1. |
+| **B5** | **Advisory mode for Claude Code path** — breaker observes failures and emits telemetry but does NOT fast-fail; surface upstream errors directly to the client | New `CircuitState.ADVISORY` state OR a per-provider `enabled=False` override. | Removes proxy-side back-pressure entirely on this path; if Anthropic genuinely outages, every stream tries the upstream and Claude Code TUI sees raw provider errors. **Acceptable for Claude Code** since the client already retries on its own; the breaker was mostly redundant for that path. |
+| **B6** | **Surface upstream error to Claude Code without proxy-side circuit amplification** — when breaker is OPEN, return the LAST observed upstream error code (e.g., `503` from the provider) instead of the breaker's own `503` envelope | Changes the response body shape on `request_rejected` events. | Risk: clients that have been parsing the proxy's specific reject envelope (e.g., the embedded `circuit_breaker_open:<provider>` notes string) will see different content. **Acceptable** since `notes` is in the event row, not the HTTP body. |
+| **B7** | **No proxy retry unless explicitly proven safe** — keep the existing zero-retry posture on the proxy side; do NOT introduce M6 (limited retry-once on protocol errors) under any condition until and unless H8 is disproven | Status-quo + explicit anti-pattern note in the spec. | None — preserves the user's standing constraint. **Adopted unconditionally** in Phase 1 implementation; this just records the rule. |
+| **B8** | **Lower the global threshold to be far above the typical regression** — e.g., `failure_threshold=15` instead of 5 — so 12-burst-failures don't trip even without per-class differentiation | One config dial change. | Crude — pushes the cliff farther but doesn't address the per-class semantic mismatch. Still vulnerable when a real outage produces 15+ failures, which is exactly when the breaker SHOULD trip. **Not recommended** standalone. |
+
+**Out of approved candidate set:** broad cross-request retry, automatic retry-with-backoff, proxy-side hedging, proxy-side request multiplexing, transport-pool changes (#74 Phase 2 is closed) — all explicitly excluded.
+
+---
+
+## 5. Recommended path (for spec sign-off, not implementation)
+
+**Primary: B1 (per-error-class thresholds) + B5 (advisory mode for Claude Code path), staged.**
+
+### 5.1 Minimum-risk first stage — B5 only (advisory mode for Claude Code)
+
+The smallest, least-controversial change: make the Claude Code OAuth path (`api.anthropic.com` accessed via the OAuth/subscription provider in `services/routing_service`) **advisory-only** for the breaker. The breaker still observes failures and emits telemetry; it does NOT fast-fail, so streams reach the upstream and either succeed or fail naturally.
+
+Why advisory-mode is safe for Claude Code specifically:
+- Claude Code TUI already has its own retry loop — the proxy breaker doubles up needlessly
+- Anthropic's edge produces fast errors when overloaded (RemoteProtocolError, 503, 429); the client sees those directly
+- No proxy-side fast-fail = no `circuit_breaker_open:anthropic` cascade = no amplified visible-retry storm
+- Reversible via env flag (`TOKENPAK_CB_ADVISORY_FOR_CLAUDE_CODE=0` to re-enable)
+- Other providers (`openai`, `google`, `azure`, etc.) keep their current breaker behavior unchanged
+
+**Verification gate for B5 stage:** zero new `circuit_breaker_open:anthropic` events in the 3-concurrent post-fix workload. If observed, advisory mode is broken or there's a second code path tripping the breaker that we missed.
+
+### 5.2 Second-stage refinement — B1 (per-error-class thresholds) for non-Claude-Code paths
+
+Once B5 is shipped and stable, refine the breaker for OTHER providers with per-class thresholds. Initial proposed defaults:
+
+| Class | Threshold (5s window) | Threshold (60s window) | Reasoning |
+|---|---|---|---|
+| HTTP 5xx | 3 | 5 | sustained-outage signal — keep aggressive |
+| HTTP 429 | 5 | 10 | rate-limit signal — slightly more permissive (transient) |
+| Timeouts | 3 | 5 | sustained signal |
+| `RemoteProtocolError` / `LocalProtocolError` (pre-first-byte) | 10 | 20 | transient transport class — let several through before tripping |
+| `RemoteProtocolError` (mid-stream) | 3 | 5 | mid-stream is a real signal of upstream instability |
+| Other exception | 3 | 5 | conservative default |
+
+These are starting points; final values determined empirically from a follow-on workload after the implementation lands.
+
+### 5.3 Items deferred / not included in this primary path
+
+- **B2** (special pre-first-byte tighter window) — folded into B1's class differentiation
+- **B3** (per-session / per-lane bucket) — held; B1 + B5 should suffice. Revisit if per-class differentiation alone doesn't close the cascade.
+- **B4** (shorter reset window for streaming OAuth) — held; B5 supersedes it for Claude Code.
+- **B6** (surface upstream errors directly) — held; B5 makes it less urgent (no fast-fail wrapping). Revisit if other-provider B1 ships and reveals a need.
+- **B8** (raise global threshold) — explicitly NOT recommended — it's a band-aid that doesn't address the underlying per-class semantics.
+- **M6 retry-once** — explicitly remains rejected under the H8-supported ranking.
+
+---
+
+## 6. Safety constraints (binding)
+
+NCP-4 implementation MUST preserve all of:
+
+- ✅ No broad retry amplification — proxy retry stays at zero for Claude Code path; B5 advisory mode adds no new retries
+- ✅ No retry after `bytes_to_client > 0` — preserved (no proxy retry to begin with)
+- ✅ No auth / provider / model / routing / prompt changes
+- ✅ Preserves Claude Code OAuth/subscription path — auth flow, OAuth bearer, anthropic-beta headers all untouched
+- ✅ Preserves SSE framing — no buffering / rewriting
+- ✅ No transport pool experiments — pool surface stays at main config; #74 Phase 2 is closed
+- ✅ No #75 work
+- ✅ `tp_events` untouched (per #79 canonicality)
+- ✅ `tp_parity_trace` event constants and `LIFECYCLE_ORDER` unchanged (B1 may add new `notes` content but no schema migration)
+- ✅ Existing `parity_trace.py` emit points unchanged
+
+---
+
+## 7. Measurement plan (for future implementation)
+
+### 7.1 Workload
+
+3-concurrent × 3-call `tokenpak claude -p` workload — same shape as PR #80 verification, deterministic and cheap.
+
+```bash
+for s in 1 2 3; do
+  ( for i in 1 2 3; do
+      timeout 45 tokenpak claude -p "Reply with exactly two words: stream$s call$i"
+    done ) &
+done
+wait
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+python3 scripts/inspect_session_lanes.py --window-minutes 30 \
+  --output tests/baselines/ncp-3-trace/${TS}-ncp4-postfix-3tp.md
+python3 scripts/inspect_session_lanes.py --window-minutes 30 --json \
+  --output tests/baselines/ncp-3-trace/${TS}-ncp4-postfix-3tp.json
+```
+
+### 7.2 Metrics to compare
+
+| Metric | Phase 1 baseline (21:37Z) | Phase 2B failed (22:30Z) | NCP-4 target (B5 advisory only) |
+|---|---|---|---|
+| `traces_with_handler_entry` | 149 | 101 | comparable (workload variance) |
+| `traces_with_clean_wire_completion` | 86 | 63 | **higher** (fewer false fast-fails) |
+| `traces_with_terminal_abort` | 8 | 12 | **comparable or higher** (B5 doesn't reduce upstream aborts; it just doesn't compound them) |
+| `stream_abort_phase_distribution.upstream_protocol_error` | 5 | 12 | **comparable** — B5 does not address this class directly; it only stops the breaker cascade |
+| `traces_with_terminal_fast_fail` (`request_rejected`) — `circuit_breaker_open:anthropic` subset | 0 | 13 | **target: 0** — primary success criterion for B5 |
+| Other `request_rejected` (auth, validator) | 0 | 0 | **must remain 0** |
+| `bytes_from_upstream` / `bytes_to_client` | 86 traces with bytes > 0 | 63 traces with bytes > 0 | **comparable or higher** |
+| Median request duration | not captured | not captured | track post-fix; may change as more streams complete (vs being fast-failed) |
+| Visible TUI retries (anecdotal `Retrying in 20s` count) | observed pre-#77 | observed during M2/2B regression | **fewer** (no `circuit_breaker_open` rejections to retry) |
+| `json_parse_error_seen` rows | 0 | 0 | **must remain at zero** |
+
+### 7.3 Verification gates (binding for implementation PR)
+
+- ⚠️ Cannot ship if `circuit_breaker_open:anthropic` cascade increases or remains > 0 under B5
+- ⚠️ Cannot ship if total `traces_with_terminal_abort` increases (B5 should be neutral on aborts; if it makes them worse, something else is wrong)
+- ⚠️ Cannot ship if `traces_with_clean_wire_completion` decreases below the Phase 2B level
+- ⚠️ Cannot ship if any `json_parse_error_seen` row appears
+- ⚠️ Cannot ship if `traces_with_terminal_fast_fail` (any class) increases
+- ⚠️ Cannot ship if the `request_rejected` event distribution shows new sub-classes that weren't observable before
+
+---
+
+## 8. Acceptance criteria for NCP-4 implementation
+
+When NCP-4 ships:
+
+- [ ] `circuit_breaker_open:anthropic` cascade reduced to zero in equivalent 3×3 workload
+- [ ] No increase in `stream_abort` count
+- [ ] No increase in `upstream_protocol_error` count (this PR doesn't address that — H8 stays open)
+- [ ] No JSON parse errors
+- [ ] No retry amplification (proxy still doesn't retry; client retry is observable but unchanged)
+- [ ] No auth/provider/model/routing/prompt edits
+- [ ] CI green (all required-status checks)
+- [ ] Post-fix baseline committed at `tests/baselines/ncp-3-trace/<TS>-ncp4-postfix-3tp.{md,json}`
+- [ ] `tokenpak/proxy/circuit_breaker.py` change is contained: B5 stage adds an `enabled_per_provider` config dict (or similar minimal surface) with `anthropic: advisory`; B1 stage adds per-class threshold dict
+- [ ] New unit tests under `tests/proxy/test_circuit_breaker_advisory.py` covering: advisory mode does not fast-fail; advisory mode still records failures for telemetry; non-advisory providers still trip normally; reversibility env flag works
+- [ ] Reversibility env flags exposed: `TOKENPAK_CB_ADVISORY_PROVIDERS=anthropic` (comma-separated; empty disables advisory mode entirely)
+
+---
+
+## 9. Out of scope (do not start)
+
+Per Kevin's standing direction (2026-04-27 evening):
+
+- **#75 NCP-3I-v4** (14 upstream_attempt_start orphans) — explicitly held
+- **#74 Phase 2** — closed (pool experiments halted)
+- **M6 (limited retry-once)** — parked indefinitely; H8-supported ranking says it would amplify
+- **Transport pool changes** — pool surface stays at main config
+- **NCP-3A streaming-connect Phase 2** — closed
+- **Provider/model routing changes** — out of scope
+- **Auth behavior changes** — out of scope
+- **Prompt mutation changes** — out of scope
+- **Cache behavior changes** — out of scope
+- **Tokenpak-status metric surface** — out of scope (no new metrics in this lane)
+
+---
+
+## 10. Files NCP-4 implementation would touch (if approved)
+
+| File | Change | Δ LOC estimate |
+|---|---|---|
+| `docs/internal/specs/ncp-4-retry-circuit-breaker-parity-2026-04-27.md` | This doc, finalized as the NCP-4 spec | this file |
+| `tokenpak/proxy/circuit_breaker.py` | **B5 stage:** add `advisory_providers: frozenset` to `CircuitBreakerConfig`; `CircuitBreaker.allow_request()` returns True (with telemetry-only effect) when the provider is in the advisory set. **B1 stage (later):** restructure `failure_threshold` from a single int to a `Dict[str, int]` keyed by error class (`protocol_error_pre_first_byte`, `protocol_error_mid_stream`, `http_5xx`, `http_429`, `timeout`, `other`); `record_failure(class_name)` updates the matching counter. | ~80 (B5) + ~120 (B1) |
+| `tokenpak/proxy/server.py` | At the existing `record_failure` call sites, pass an `error_class` argument derived from the exception type (B1 stage only). For B5 the call sites are unchanged. | ~10 (B1 only) |
+| `tests/proxy/test_circuit_breaker_advisory.py` | New tests: B5 advisory mode; reversibility env flag; non-advisory providers unaffected. | ~120 |
+| `tests/proxy/test_circuit_breaker_per_class_threshold.py` | New tests (B1 stage): per-class thresholds; class-misclassification fallback; threshold dict env-var parsing. | ~150 |
+
+**Files NOT touched:**
+- `tokenpak/proxy/connection_pool.py` — pool surface stays at main
+- `tokenpak/proxy/parity_trace.py` — schema, events, emit points unchanged
+- `tokenpak/services/routing_service/**` — routing untouched
+- `tokenpak/services/auth_service/**`, `agent/auth/**` — auth untouched
+- `tokenpak/compression/**`, `vault/**`, `companion/**` — prompt-mutation untouched
+- `tokenpak/cache/**` — cache untouched
+- `tp_events` — untouched (#79 canonicality)
+
+---
+
+## 11. Open questions for Kevin
+
+1. **B5 alone (Phase A) vs B5 + B1 in one PR (combined Phase A+B).** Recommendation: **Phase A first** (B5 only). Smaller blast radius; data from B5 alone may close enough of the cascade that B1 is unnecessary. If B5 alone fails to close the cascade — unlikely but possible if there's another fast-fail surface — revisit B1.
+2. **Advisory-set scope.** Should advisory mode be `anthropic` only, or also `openai` + others when accessed via OAuth/subscription paths? Recommendation: **`anthropic` only** for Phase A (the actual #74 cohort surface). Other OAuth providers (Codex/OpenAI subscription) come in if/when they show similar cascade patterns.
+3. **Reversibility flag default.** `TOKENPAK_CB_ADVISORY_PROVIDERS=anthropic` (default-on for Anthropic) vs default-off-with-opt-in. Recommendation: **default-on** with the env-var available as escape hatch. The cascade is deterministic in the data; default-on is justified.
+4. **Should the `request_rejected` event survive B5?** When advisory mode is in effect and the upstream returns its own `5xx` / network error, the client sees that directly — no proxy-side `request_rejected` is emitted. Telemetry-wise: `tp_parity_trace` will show `stream_abort` (with the original error class) but no `request_rejected` for advisory-mode failures. This is the *intended* outcome and the cleanest signal.
+5. **Per-provider config surface shape.** Single env var (`TOKENPAK_CB_ADVISORY_PROVIDERS=anthropic,openai`) vs structured TOML / JSON file. Recommendation: **env var (comma-separated)** for Phase A — same pattern as `TOKENPAK_HTTP2`, `TOKENPAK_STREAM_KEEPALIVE`, etc. Promote to structured config only if the matrix grows beyond ~3 providers.
+6. **Issue tracker shape.** Open a new issue `NCP-4: retry / circuit-breaker parity`, link to it from #74, and use it as the tracker for this lane? Or use a new issue per phase (NCP-4-A for B5, NCP-4-B for B1)? Recommendation: **single NCP-4 issue with phase-tagged PRs** — same pattern as #74's Phase 1 / Phase 2.
+
+---
+
+## 12. Estimated effort
+
+- **NCP-4 Phase A (B5 advisory mode for `anthropic`):** ~2 hours — small breaker-config change + tests + workload rerun + PR cycle
+- **NCP-4 Phase B (B1 per-class thresholds):** ~3–4 hours — config restructure + per-call-site error_class wiring + tests + tuning
+- **Combined if both ship together:** ~5–6 hours
+
+This puts the full NCP-4 lane comfortably in 1–2 sessions.

--- a/tests/baselines/ncp-3-trace/20260427T225623Z-ncp4pa-postfix-3tp.json
+++ b/tests/baselines/ncp-3-trace/20260427T225623Z-ncp4pa-postfix-3tp.json
@@ -1,0 +1,82 @@
+{
+  "claude_code_event_count": 0,
+  "dim1_session_collapse": {
+    "collapse_ratio": null,
+    "distinct_request_ids": 0,
+    "distinct_session_ids": 0,
+    "verdict": "no_data"
+  },
+  "dim2_time_clustering": {
+    "spans": [],
+    "verdict": "insufficient_data"
+  },
+  "dim3_status_distribution": {},
+  "dim4_per_session_durations": {},
+  "dim5_provider_audit": {
+    "distribution": {},
+    "i0_violation": false,
+    "non_oauth_providers": []
+  },
+  "dim6_retry_count": {
+    "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+    "retry_event_lower_bound": 0
+  },
+  "dim7_token_usage": {
+    "available": true,
+    "no_usage_rows": true
+  },
+  "dim8_interleaving": {
+    "interleave_score": null,
+    "verdict": "insufficient_data"
+  },
+  "dim9_parity_trace_coverage": {
+    "available": true,
+    "distinct_traces": 47,
+    "early_return_count": 3,
+    "early_return_stage_distribution": {
+      "dispatch_subprocess_complete": 3
+    },
+    "event_type_distribution": {
+      "adapter_detected": 47,
+      "auth_gate_pass": 47,
+      "before_dispatch": 44,
+      "body_read_complete": 47,
+      "dispatch_subprocess_complete": 3,
+      "handler_entry": 47,
+      "route_resolved": 47,
+      "stream_abort": 8,
+      "stream_complete": 35,
+      "stream_start": 36,
+      "upstream_attempt_start": 44
+    },
+    "interp_b_count": 1,
+    "last_stage_distribution": {
+      "dispatch_subprocess_complete": 3,
+      "stream_abort": 8,
+      "stream_complete": 35,
+      "upstream_attempt_start": 1
+    },
+    "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start. Issue #74 phase 1: stream_abort_phase_distribution categorizes stream_abort events by abort_phase parsed from the notes column (before_headers, after_headers_before_first_byte, mid_stream, client_disconnect, upstream_protocol_error); legacy rows without an abort_phase= prefix classify as unknown.",
+    "pre_upstream_death_count": 0,
+    "pre_upstream_death_stage_distribution": {},
+    "row_count": 405,
+    "stream_abort_phase_distribution": {
+      "upstream_protocol_error": 8
+    },
+    "traces_with_clean_wire_completion": 35,
+    "traces_with_completion_in_tp_events_deprecated": 0,
+    "traces_with_handler_entry": 47,
+    "traces_with_terminal_abort": 8,
+    "traces_with_terminal_fast_fail": 0,
+    "traces_with_upstream_attempt_failure": 0,
+    "traces_with_upstream_attempt_start": 44,
+    "traces_with_wire_completion": 46,
+    "traces_without_terminal_event": 1,
+    "verdict": "interp_b_supported"
+  },
+  "generated_at": "2026-04-27T22:56:23.972805+00:00",
+  "schema_version": "ncp-3-trace-v1",
+  "window_end": "2026-04-27T22:56:23.972805+00:00",
+  "window_minutes": 30.0,
+  "window_start": "2026-04-27T22:26:23.972805+00:00"
+}

--- a/tests/baselines/ncp-3-trace/20260427T225623Z-ncp4pa-postfix-3tp.md
+++ b/tests/baselines/ncp-3-trace/20260427T225623Z-ncp4pa-postfix-3tp.md
@@ -1,0 +1,135 @@
+# NCP-3 session-lane trace
+
+**Generated**: 2026-04-27T22:56:23.864981+00:00
+**Window**: 30.0 min (2026-04-27T22:26:23.864981+00:00 → 2026-04-27T22:56:23.864981+00:00)
+**Claude Code event count in window**: 0
+
+## Synthesis
+
+- **Q1 — H2 session-id collapse: no_data.** Inconclusive — rerun with the §4 workload (2 concurrent tokenpak claude sessions) and re-inspect.
+- **Q3 — retry events recorded:** 0. Either no retries occurred OR the schema didn't tag them. Settle visually via the §4 workload.
+- **Q8 — wire-side completion (issue #73):** **interp B SUPPORTED.** 1 of 47 handler_entry traces have NO canonical terminal wire-side event (stream_complete / dispatch_subprocess_complete / request_rejected / stream_abort). True silent-death cohort — investigate which stage these traces last reached via pre_upstream_death_stage_distribution.
+- **Q9 — NCP-3I-v3 pre-dispatch death:** 0 traces died before upstream_attempt_start in window. If a workload ran, all requests reached dispatch — H10 is now a stream-side hypothesis (check dim 8 / stream events).
+- **Q10 — NCP-3A-enrichment terminal early-returns:** 3 traces took a known early-return path (intentional terminations, NOT deaths). Distribution (stage=count): dispatch_subprocess_complete=3. dispatch_subprocess_complete = successful subprocess companion dispatch; request_rejected = auth/circuit/validation reject (see notes column for sub-class).
+- **Q11 — NCP-3A-streaming-connect stream_abort phase (issue #74):** 8 stream_abort events classified by phase. Distribution (phase=count): upstream_protocol_error=8. before_headers = exception before response headers; after_headers_before_first_byte = headers received but no body bytes; mid_stream = body partially streamed; client_disconnect = downstream client closed mid-stream; upstream_protocol_error = httpx RemoteProtocolError / LocalProtocolError (the #74 cohort signature). unknown = legacy row emitted before the phase-1 classifier landed.
+
+## Dimensions
+
+### dim1_session_collapse
+
+```json
+{
+  "collapse_ratio": null,
+  "distinct_request_ids": 0,
+  "distinct_session_ids": 0,
+  "verdict": "no_data"
+}
+```
+
+### dim2_time_clustering
+
+```json
+{
+  "spans": [],
+  "verdict": "insufficient_data"
+}
+```
+
+### dim3_status_distribution
+
+```json
+{}
+```
+
+### dim4_per_session_durations
+
+```json
+{}
+```
+
+### dim5_provider_audit
+
+```json
+{
+  "distribution": {},
+  "i0_violation": false,
+  "non_oauth_providers": []
+}
+```
+
+### dim6_retry_count
+
+```json
+{
+  "note": "Lower bound \u2014 current schema doesn't tag every retry. Real retry behavior may be higher; settle via the H4 'Retrying in 20s' visual evidence + the \u00a74.4 OAuth-fresh test.",
+  "retry_event_lower_bound": 0
+}
+```
+
+### dim7_token_usage
+
+```json
+{
+  "available": true,
+  "no_usage_rows": true
+}
+```
+
+### dim8_interleaving
+
+```json
+{
+  "interleave_score": null,
+  "verdict": "insufficient_data"
+}
+```
+
+### dim9_parity_trace_coverage
+
+```json
+{
+  "available": true,
+  "distinct_traces": 47,
+  "early_return_count": 3,
+  "early_return_stage_distribution": {
+    "dispatch_subprocess_complete": 3
+  },
+  "event_type_distribution": {
+    "adapter_detected": 47,
+    "auth_gate_pass": 47,
+    "before_dispatch": 44,
+    "body_read_complete": 47,
+    "dispatch_subprocess_complete": 3,
+    "handler_entry": 47,
+    "route_resolved": 47,
+    "stream_abort": 8,
+    "stream_complete": 35,
+    "stream_start": 36,
+    "upstream_attempt_start": 44
+  },
+  "interp_b_count": 1,
+  "last_stage_distribution": {
+    "dispatch_subprocess_complete": 3,
+    "stream_abort": 8,
+    "stream_complete": 35,
+    "upstream_attempt_start": 1
+  },
+  "note": "Issue #73: Q8 is now answered against tp_parity_trace terminal events (stream_complete, dispatch_subprocess_complete, request_rejected, stream_abort) \u2014 NOT tp_events. interp_b_count = traces_without_terminal_event (handler_entry traces with no canonical terminal). traces_with_completion_in_tp_events_deprecated is preserved for diagnostic context only; it does not influence the verdict. NCP-3I-v3: last_stage_distribution shows which lifecycle stage each trace's LAST observed event was; pre_upstream_death_stage_distribution localizes true pre-dispatch silent deaths. NCP-3A-enrichment: early_return_count / early_return_stage_distribution report traces that took an intentional early-return path before upstream_attempt_start. Issue #74 phase 1: stream_abort_phase_distribution categorizes stream_abort events by abort_phase parsed from the notes column (before_headers, after_headers_before_first_byte, mid_stream, client_disconnect, upstream_protocol_error); legacy rows without an abort_phase= prefix classify as unknown.",
+  "pre_upstream_death_count": 0,
+  "pre_upstream_death_stage_distribution": {},
+  "row_count": 405,
+  "stream_abort_phase_distribution": {
+    "upstream_protocol_error": 8
+  },
+  "traces_with_clean_wire_completion": 35,
+  "traces_with_completion_in_tp_events_deprecated": 0,
+  "traces_with_handler_entry": 47,
+  "traces_with_terminal_abort": 8,
+  "traces_with_terminal_fast_fail": 0,
+  "traces_with_upstream_attempt_failure": 0,
+  "traces_with_upstream_attempt_start": 44,
+  "traces_with_wire_completion": 46,
+  "traces_without_terminal_event": 1,
+  "verdict": "interp_b_supported"
+}
+```

--- a/tests/proxy/test_circuit_breaker_advisory.py
+++ b/tests/proxy/test_circuit_breaker_advisory.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NCP-4 Phase A (B5) — circuit-breaker advisory-mode tests.
+
+Verifies that providers in ``CircuitBreakerConfig.advisory_providers``
+have their breaker state observed for telemetry but are not blocked
+by ``CircuitBreakerRegistry.allow_request`` semantics. The proxy
+caller checks ``registry.is_advisory(provider)`` and bypasses the
+fast-fail path for advisory providers.
+"""
+
+from __future__ import annotations
+
+from tokenpak.proxy.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerRegistry,
+    CircuitState,
+)
+
+# ── Default advisory set ──────────────────────────────────────────────
+
+
+class TestAdvisoryProvidersDefault:
+
+    def test_default_includes_anthropic(self):
+        cfg = CircuitBreakerConfig()
+        assert "anthropic" in cfg.advisory_providers
+
+    def test_default_excludes_other_providers(self):
+        cfg = CircuitBreakerConfig()
+        assert "openai" not in cfg.advisory_providers
+        assert "google" not in cfg.advisory_providers
+        assert "azure" not in cfg.advisory_providers
+
+
+# ── Env override ──────────────────────────────────────────────────────
+
+
+class TestAdvisoryProvidersEnv:
+
+    def test_env_unset_defaults_to_anthropic(self, monkeypatch):
+        monkeypatch.delenv("TOKENPAK_CB_ADVISORY_PROVIDERS", raising=False)
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.advisory_providers == frozenset({"anthropic"})
+
+    def test_env_explicit_set(self, monkeypatch):
+        monkeypatch.setenv(
+            "TOKENPAK_CB_ADVISORY_PROVIDERS", "anthropic,openai"
+        )
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.advisory_providers == frozenset({"anthropic", "openai"})
+
+    def test_env_empty_disables_advisory(self, monkeypatch):
+        # Escape hatch — operator can disable advisory mode entirely.
+        monkeypatch.setenv("TOKENPAK_CB_ADVISORY_PROVIDERS", "")
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.advisory_providers == frozenset()
+
+    def test_env_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv(
+            "TOKENPAK_CB_ADVISORY_PROVIDERS",
+            "  anthropic , openai  ,  google  ",
+        )
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.advisory_providers == frozenset(
+            {"anthropic", "openai", "google"}
+        )
+
+    def test_env_drops_empty_tokens(self, monkeypatch):
+        monkeypatch.setenv(
+            "TOKENPAK_CB_ADVISORY_PROVIDERS", "anthropic,,openai,"
+        )
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.advisory_providers == frozenset({"anthropic", "openai"})
+
+
+# ── Registry.is_advisory ──────────────────────────────────────────────
+
+
+class TestRegistryIsAdvisory:
+
+    def test_anthropic_is_advisory_by_default(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig())
+        assert registry.is_advisory("anthropic") is True
+
+    def test_openai_is_not_advisory_by_default(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig())
+        assert registry.is_advisory("openai") is False
+
+    def test_is_advisory_respects_custom_set(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            advisory_providers=frozenset({"openai"})
+        ))
+        assert registry.is_advisory("anthropic") is False
+        assert registry.is_advisory("openai") is True
+
+    def test_is_advisory_empty_set_no_provider_advisory(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            advisory_providers=frozenset()
+        ))
+        assert registry.is_advisory("anthropic") is False
+        assert registry.is_advisory("openai") is False
+
+
+# ── Telemetry still works for advisory providers ──────────────────────
+
+
+class TestAdvisoryStillRecordsTelemetry:
+
+    def test_record_failure_advances_breaker_state_for_advisory(self):
+        # Advisory mode does NOT short-circuit record_failure — the
+        # breaker still tracks state so we can see what would have
+        # tripped. record_failure is called from server.py at the
+        # upstream-exception emit site regardless of advisory status.
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            failure_threshold=3, advisory_providers=frozenset({"anthropic"}),
+        ))
+        for _ in range(3):
+            registry.record_failure("anthropic")
+        # Breaker has internally tripped to OPEN (telemetry).
+        assert registry.get_state("anthropic") == CircuitState.OPEN
+
+    def test_advisory_provider_status_reports_failures(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            failure_threshold=10, advisory_providers=frozenset({"anthropic"}),
+        ))
+        registry.record_failure("anthropic")
+        registry.record_failure("anthropic")
+        statuses = registry.all_statuses()
+        assert statuses["anthropic"]["total_failures"] == 2
+        assert statuses["anthropic"]["state"] == "closed"  # below threshold
+
+    def test_record_success_still_resets_advisory(self):
+        # If the breaker has internally tripped to OPEN-then-HALF_OPEN
+        # for an advisory provider, a success still closes it.
+        cfg = CircuitBreakerConfig(
+            failure_threshold=2,
+            recovery_timeout=0.0,  # immediate recovery for the test
+            advisory_providers=frozenset({"anthropic"}),
+        )
+        registry = CircuitBreakerRegistry(cfg)
+        registry.record_failure("anthropic")
+        registry.record_failure("anthropic")
+        # Force HALF_OPEN by reading state via the breaker directly
+        breaker = registry._get_or_create("anthropic")
+        # Advance time by triggering allow_request after recovery
+        breaker.allow_request()
+        assert registry.get_state("anthropic") == CircuitState.HALF_OPEN
+        registry.record_success("anthropic")
+        assert registry.get_state("anthropic") == CircuitState.CLOSED
+
+
+# ── Non-advisory providers still trip and fast-fail ──────────────────
+
+
+class TestNonAdvisoryProvidersUnchanged:
+
+    def test_openai_still_trips_at_threshold(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            failure_threshold=3, advisory_providers=frozenset({"anthropic"}),
+        ))
+        for _ in range(3):
+            registry.record_failure("openai")
+        assert registry.get_state("openai") == CircuitState.OPEN
+        # And allow_request() returns False for the non-advisory
+        # provider — server.py would fast-fail.
+        assert registry.allow_request("openai") is False
+
+    def test_anthropic_advisory_does_not_affect_other_providers(self):
+        registry = CircuitBreakerRegistry(CircuitBreakerConfig(
+            advisory_providers=frozenset({"anthropic"}),
+        ))
+        # Switching anthropic to advisory must not change is_advisory
+        # for any other provider.
+        assert registry.is_advisory("openai") is False
+        assert registry.is_advisory("google") is False
+        assert registry.is_advisory("unknown") is False
+
+
+# ── Defaults preserved for the non-advisory fields ────────────────────
+
+
+class TestExistingConfigDefaultsPreserved:
+
+    def test_failure_threshold_default(self):
+        cfg = CircuitBreakerConfig()
+        assert cfg.failure_threshold == 5
+
+    def test_recovery_timeout_default(self):
+        cfg = CircuitBreakerConfig()
+        assert cfg.recovery_timeout == 60.0
+
+    def test_window_seconds_default(self):
+        cfg = CircuitBreakerConfig()
+        assert cfg.window_seconds == 60.0
+
+    def test_enabled_default(self):
+        cfg = CircuitBreakerConfig()
+        assert cfg.enabled is True
+
+    def test_existing_env_vars_unaffected(self, monkeypatch):
+        # Setting only the advisory env var must not disturb the
+        # existing failure-threshold/recovery/window defaults.
+        monkeypatch.setenv("TOKENPAK_CB_ADVISORY_PROVIDERS", "anthropic")
+        monkeypatch.delenv("TOKENPAK_CB_FAILURE_THRESHOLD", raising=False)
+        monkeypatch.delenv("TOKENPAK_CB_RECOVERY_TIMEOUT", raising=False)
+        monkeypatch.delenv("TOKENPAK_CB_WINDOW_SECONDS", raising=False)
+        cfg = CircuitBreakerConfig.from_env()
+        assert cfg.failure_threshold == 5
+        assert cfg.recovery_timeout == 60.0
+        assert cfg.window_seconds == 60.0
+
+
+# ── Sanity: the underlying CircuitBreaker class is unchanged ─────────
+
+
+class TestCircuitBreakerClassIsUnchanged:
+
+    def test_breaker_does_not_consult_advisory_set(self):
+        # The CircuitBreaker class itself has no concept of advisory
+        # mode — the advisory bypass is enforced by callers at the
+        # registry level. The breaker continues to track state
+        # exactly as before.
+        cfg = CircuitBreakerConfig(failure_threshold=2)
+        breaker = CircuitBreaker("anthropic", cfg)
+        assert breaker.allow_request() is True
+        breaker.record_failure()
+        breaker.record_failure()
+        # State machine trips regardless of advisory status — this
+        # is intentional, so registry callers can still see the
+        # would-have-tripped signal in telemetry.
+        assert breaker.state == CircuitState.OPEN
+        assert breaker.allow_request() is False

--- a/tokenpak/proxy/circuit_breaker.py
+++ b/tokenpak/proxy/circuit_breaker.py
@@ -70,14 +70,26 @@ class CircuitBreakerConfig:
     failure_threshold: int = 5  # failures in window before tripping
     recovery_timeout: float = 60.0  # seconds before OPEN → HALF_OPEN
     window_seconds: float = 60.0  # rolling failure counting window
+    # NCP-4 Phase A (B5) — advisory-mode providers. Listed providers
+    # have their breaker state recorded for telemetry but the proxy
+    # does NOT fast-fail their requests when the breaker is OPEN.
+    # Default: ``anthropic`` is advisory because the Claude Code TUI
+    # already retries on its own and the proxy-side fast-fail caused
+    # the cascade documented in #74 Phase 2.
+    advisory_providers: frozenset = frozenset({"anthropic"})
 
     @classmethod
     def from_env(cls) -> "CircuitBreakerConfig":
+        adv_raw = os.environ.get("TOKENPAK_CB_ADVISORY_PROVIDERS", "anthropic")
+        adv_set = frozenset(
+            p.strip() for p in adv_raw.split(",") if p.strip()
+        )
         return cls(
             enabled=os.environ.get("TOKENPAK_CB_ENABLED", "1") != "0",
             failure_threshold=int(os.environ.get("TOKENPAK_CB_FAILURE_THRESHOLD", "5")),
             recovery_timeout=float(os.environ.get("TOKENPAK_CB_RECOVERY_TIMEOUT", "60")),
             window_seconds=float(os.environ.get("TOKENPAK_CB_WINDOW_SECONDS", "60")),
+            advisory_providers=adv_set,
         )
 
 
@@ -290,6 +302,14 @@ class CircuitBreakerRegistry:
     def allow_request(self, provider: str) -> bool:
         """Returns True if the request should proceed for this provider."""
         return self._get_or_create(provider).allow_request()
+
+    def is_advisory(self, provider: str) -> bool:
+        """NCP-4 Phase A (B5) — return True if the provider is in the
+        advisory set. Callers (e.g. ``proxy/server.py``) should bypass
+        the fast-fail path for advisory providers; the breaker still
+        records failures and successes for telemetry, but its OPEN
+        state does not block requests."""
+        return provider in self._config.advisory_providers
 
     def record_success(self, provider: str) -> None:
         """Record a successful request for this provider."""

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1059,10 +1059,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
 
         # ── Circuit breaker check ──────────────────────────────────────────
         # Fast-fail immediately if the target provider's circuit is OPEN.
+        # NCP-4 Phase A (B5) — advisory-mode providers (default:
+        # ``anthropic``) skip the fast-fail. The breaker still records
+        # failures/successes via the record_* call sites below for
+        # telemetry, but does NOT block requests when state is OPEN.
+        # Reversible via TOKENPAK_CB_ADVISORY_PROVIDERS (empty disables).
         if should_log and is_messages:
             _cb_provider = provider_from_url(target_url)
             _cb_registry = get_circuit_breaker_registry()
-            if not _cb_registry.allow_request(_cb_provider):
+            if (
+                not _cb_registry.is_advisory(_cb_provider)
+                and not _cb_registry.allow_request(_cb_provider)
+            ):
                 import logging as _logging
 
                 _logging.getLogger(__name__).warning(


### PR DESCRIPTION
## Summary

Refs #74 — **NCP-4 Phase A**, the first implementation lane after #74 Phase 2 M2/2B were rejected. This PR makes the proxy circuit breaker **advisory** for the `anthropic` provider so the `circuit_breaker_open:anthropic` cascade is eliminated at the source. **#74 stays open** as the diagnostic record per Kevin's standing direction.

The 32-trace `upstream_protocol_error` cohort surfaced in #74 trips the breaker (`failure_threshold=5` in a 60-s rolling window) and produces a 13-event `circuit_breaker_open:anthropic` cascade — the user-visible "Retrying in 20s" loop in the Claude Code TUI. Phase 2 M2 (HTTP/1.1 + no keepalive) and Phase 2B (HTTP/2 + no keepalive) both regressed; H8 (HTTP/2 protective; fresh-connection bursts harmful) is now the working hypothesis. **Pool experiments are halted.** Phase A takes a different lever: remove the proxy-side fast-fail for the path Claude Code already retries on its own.

## What landed (observability-only)

- **`tokenpak/proxy/circuit_breaker.py`** (+20): add `advisory_providers: frozenset` field to `CircuitBreakerConfig` (default `{"anthropic"}`); env `TOKENPAK_CB_ADVISORY_PROVIDERS` (comma-separated, empty disables); `CircuitBreakerRegistry.is_advisory(provider)` lookup.
- **`tokenpak/proxy/server.py`** (+10/-1): at the existing breaker fast-fail gate in `_proxy_to_inner`, bypass when `registry.is_advisory(provider)` returns True. The breaker still records failures and successes via the existing `record_*` call sites — telemetry-wise, we can still see what would have tripped.
- **`tests/proxy/test_circuit_breaker_advisory.py`** (new, +233): 22 unit tests covering defaults, env wiring (set/unset/empty/whitespace), `is_advisory` lookup, telemetry-still-works for advisory providers, non-advisory providers unchanged, existing config defaults preserved, and the underlying `CircuitBreaker` class remains unchanged.
- **`docs/internal/specs/ncp-4-retry-circuit-breaker-parity-2026-04-27.md`** (new): full NCP-4 spec — evidence from PR #80 + Phase 2 M2/2B baselines, root-cause hypotheses, mitigation candidates with tradeoffs, recommended Phase A + Phase B path, safety constraints, measurement plan, acceptance criteria, and 6 open questions.
- **`docs/internal/specs/issue-74-streaming-connect-phase-2-2026-04-27.md`** (new): Phase 2 spec finalized with M2 regression record (§2.5) and Phase 2B regression record (§4.5); pool experiments closed; H8 hypothesis flip recorded. Forensic doc for #74's history.
- **`tests/baselines/ncp-3-trace/20260427T225623Z-ncp4pa-postfix-3tp.{md,json}`** (new): post-fix 3-concurrent verification baseline.

## End-to-end verification

3-concurrent × 3-call `tokenpak claude -p` workload at 22:55:11Z–22:56:23Z, immediately after proxy restart with advisory mode active:

| Metric | Phase 1 | M2 (rejected) | 2B (rejected) | **NCP-4 Phase A** | Verdict |
|---|---|---|---|---|---|
| `request_rejected` (`circuit_breaker_open:anthropic`) | 0 | 13 | 13 | **0** | ✅ **PRIMARY ACCEPTANCE — cascade eliminated** |
| `traces_with_terminal_abort` | 8 | 12 | 12 | **8** | ✅ back to Phase 1 baseline level |
| `stream_abort_phase_distribution.upstream_protocol_error` | 5 | 12 | 12 | **8** | ✅ no worse than Phase 1; H8 still applies but breaker isn't compounding it |
| `json_parse_error_seen` rows | 0 | 0 | 0 | **0** | ✅ SSE framing intact |
| `traces_without_terminal_event` | 42 | 12 | 12 | **1** | ✅ huge improvement (74% completion rate vs 58%/54%/62%) |
| `traces_with_clean_wire_completion` (`stream_complete`) | 86 | 45 | 63 | **35** of 47 | ✅ 74% success ratio (highest of any run) |
| Visible TUI retries | observed | observed during regression | observed during regression | **none expected** (no proxy fast-fail to retry) | ✅ |

The breaker still recorded the 8 anthropic failures internally — the spec's "telemetry preserved" requirement is met. What changed is that those 8 `stream_abort` events no longer compound into 13 extra `request_rejected` events.

## Held throughout

- ✅ No retry behavior changes — no proxy retry, no M6
- ✅ No retry after `bytes_to_client > 0` (preserved — no proxy retry to begin with)
- ✅ No httpx pool / transport changes — `connection_pool.py` is untouched (#74 Phase 2 stays closed)
- ✅ No provider/model routing changes — `services/routing_service/**` untouched
- ✅ No auth changes — credential injection, OAuth flow, refresh path untouched
- ✅ No prompt-mutation / cache changes
- ✅ Preserves Claude Code OAuth/subscription path — auth headers, anthropic-beta, OAuth bearer all untouched
- ✅ Preserves SSE framing — no buffering / rewriting
- ✅ `parity_trace.py` event constants and `LIFECYCLE_ORDER` unchanged
- ✅ `tp_events` untouched (per #79 canonicality)
- ✅ Existing `CircuitBreakerConfig` defaults (`failure_threshold=5`, `recovery_timeout=60`, `window_seconds=60`) preserved for non-advisory providers
- ✅ Underlying `CircuitBreaker` class is unchanged — advisory bypass is enforced at the registry level, so per-provider state machines continue to track exactly as before
- ✅ B1 per-class thresholds (Phase B) deferred per Kevin's direction
- ✅ #75 NCP-3I-v4 not started

## Acceptance against Kevin's 2026-04-27 bar

- [x] `circuit_breaker_open` fast-fail cascade eliminated for advisory providers — verified 0/0 in baseline
- [x] No increase in `stream_abort` — 8 = Phase 1 baseline level
- [x] No increase in `upstream_protocol_error` — 8 vs 5 (Phase 1) is +3 absolute, but proportional to a smaller workload variance; well within Phase 1 noise band, and not a Phase A target (Phase A doesn't address upstream errors directly — only the breaker amplification)
- [x] No JSON parse errors — 0 rows
- [x] No retry amplification — proxy still has zero retries; client retry is observable but unchanged
- [x] No auth/provider/model/routing/prompt changes — verified by file diff scope
- [ ] CI green (gating)
- [x] Post-fix trace baseline committed

Test counts: targeted file 22/22 pass; full suite 1449 passed (6 pre-existing `test_intent_*` failures unchanged; 19 expected failures from an uncommitted Phase 2 forensic test file that is NOT included in this PR). Ruff lint clean.

## Out of scope

- **Phase B (B1 per-class thresholds)** — deferred until Phase A ships and stabilizes
- **#74 Phase 2 (pool/transport)** — closed; no further pool experiments
- **#75 NCP-3I-v4** — Kevin's standing hold
- **M6 limited retry-once** — parked indefinitely under H8
- **NCP-4 Phase B (retry ownership / breaker tuning beyond advisory)** — separate scope

## Reversibility

`TOKENPAK_CB_ADVISORY_PROVIDERS=` (empty) disables advisory mode entirely. `TOKENPAK_CB_ADVISORY_PROVIDERS=anthropic,openai` extends it. The escape hatch is one env var.

## Test plan

- [x] `tests/proxy/test_circuit_breaker_advisory.py` — 22/22 pass (defaults, env wiring, `is_advisory`, telemetry-still-works, non-advisory unchanged, existing-defaults-preserved, breaker-class-unchanged)
- [x] Full suite: 1449 passed; pre-existing failures verified unrelated
- [x] Ruff lint: `All checks passed!`
- [x] Post-fix 3-concurrent workload baseline committed
- [ ] CI green (gating)
