### PR TITLE
feat(integrations/openclaw): governor failover provisioning batch (5 commits)

### DIFF
--- a/integrations/openclaw/tokenpak-inject.sh
+++ b/integrations/openclaw/tokenpak-inject.sh
@@ -45,6 +45,11 @@ set -euo pipefail
 
 PROXY_URL="${TOKENPAK_URL:-http://localhost:8766}"
 
+# Locate this script's own directory so the embedded Python can find the
+# openclaw-adapter bundle that ships next to it under ./hooks/.
+TOKENPAK_INJECT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export TOKENPAK_INJECT_SCRIPT_DIR
+
 # ── Mode flag ────────────────────────────────────────────────────────
 # Default = additive. Pass --exclusive (or set
 # TOKENPAK_INJECT_EXCLUSIVE=1) to also rewrite primary models +
@@ -528,6 +533,149 @@ def sync_codex_jwt():
             log(f"Warning: {af}: {e}")
     return changed > 0
 
+# ── 6. openclaw-adapter hook (Path C session-binding, OAS-05) ──────────
+#
+# The openclaw-adapter hook (initiative
+# 2026-04-28-openclaw-adapter-session-binding) writes
+# ``~/.openclaw/sessions/active.json`` on every ``message:received`` /
+# ``message:sent`` event so the tokenpak proxy can bind the session UUID
+# as ``journal.db.session_id``. Installing it on a fleet host:
+#   1. Copy bundle (``handler.js`` + ``HOOK.md`` + ``tests/test-active-json.js``)
+#      to ``~/.openclaw/hooks/openclaw-adapter/``.
+#   2. Add (or upgrade) ``hooks.internal.entries.openclaw-adapter`` in
+#      ``~/.openclaw/openclaw.json``.
+#   3. Idempotent — re-running is a clean no-op when nothing has changed,
+#      a clean upgrade when the bundle drifted.
+# Additive only (``feedback_tokenpak_additive_only``) — never removes the
+# user's existing hooks; never touches ``tokenpak-telemetry``.
+
+ADAPTER_BUNDLE_REL = "hooks/openclaw-adapter"
+
+
+def _resolve_adapter_bundle(script_dir):
+    """Find the openclaw-adapter source bundle.
+
+    The hook bundle lives under ``tokenpak/integrations/openclaw/hooks/``
+    (sibling of the Python package); the install script lives one level
+    up at ``integrations/openclaw/tokenpak-inject.sh``. Tolerate both
+    layouts so the script works whether invoked from the package or the
+    repo root.
+    """
+    candidates = [
+        script_dir / ADAPTER_BUNDLE_REL,
+        # Repo-root fallback: <repo>/tokenpak/integrations/openclaw/hooks/openclaw-adapter
+        script_dir.parent.parent
+            / "tokenpak" / "integrations" / "openclaw" / ADAPTER_BUNDLE_REL,
+    ]
+    for c in candidates:
+        if (c / "handler.js").is_file():
+            return c
+    return candidates[0]  # for the FAIL-message path
+
+
+def _read_hook_version(hook_md):
+    """Pull the ``version:`` field from a HOOK.md YAML frontmatter."""
+    try:
+        text = Path(hook_md).read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    in_front = False
+    for line in text.splitlines():
+        if line.strip() == "---":
+            if in_front:
+                break
+            in_front = True
+            continue
+        if not in_front:
+            continue
+        if line.startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def _files_equal(a, b):
+    try:
+        return Path(a).read_bytes() == Path(b).read_bytes()
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def install_openclaw_adapter():
+    """Install / upgrade the ``openclaw-adapter`` hook bundle (OAS-05).
+
+    Returns True when the openclaw.json file was mutated (so the caller
+    knows a save is needed); False when nothing changed.
+    """
+    script_dir = Path(os.environ.get("TOKENPAK_INJECT_SCRIPT_DIR") or ".").resolve()
+    src_dir = _resolve_adapter_bundle(script_dir)
+    src_handler = src_dir / "handler.js"
+    src_hook_md = src_dir / "HOOK.md"
+    src_test = src_dir / "tests" / "test-active-json.js"
+
+    if not src_handler.is_file() or not src_hook_md.is_file():
+        log(f"[openclaw-adapter] FAIL: missing bundle in {src_dir}")
+        return False
+
+    target_dir = OPENCLAW_DIR / "hooks" / "openclaw-adapter"
+    tgt_handler = target_dir / "handler.js"
+    tgt_hook_md = target_dir / "HOOK.md"
+    tgt_test = target_dir / "tests" / "test-active-json.js"
+
+    src_version = _read_hook_version(src_hook_md) or "?"
+    tgt_version = _read_hook_version(tgt_hook_md)
+
+    bundle_uptodate = (
+        tgt_version == src_version
+        and _files_equal(src_handler, tgt_handler)
+        and _files_equal(src_hook_md, tgt_hook_md)
+        and (not src_test.is_file() or _files_equal(src_test, tgt_test))
+    )
+
+    if bundle_uptodate:
+        log(f"[openclaw-adapter] up-to-date (v{src_version})")
+    else:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "tests").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_handler, tgt_handler)
+        shutil.copy2(src_hook_md, tgt_hook_md)
+        if src_test.is_file():
+            shutil.copy2(src_test, tgt_test)
+        if tgt_version:
+            log(f"[openclaw-adapter] upgraded {tgt_version} -> {src_version}")
+        else:
+            log(f"[openclaw-adapter] installed v{src_version}")
+
+    # Patch openclaw.json (additive). When MAIN_CONFIG doesn't exist, the
+    # host hasn't been bootstrapped yet — surface that and bail without
+    # crashing the rest of the inject pipeline.
+    if not MAIN_CONFIG.exists():
+        log(f"[openclaw-adapter] WARN: {MAIN_CONFIG} missing — skipping config patch")
+        return False
+    config = load_json(MAIN_CONFIG)
+    hooks = config.setdefault("hooks", {})
+    internal = hooks.setdefault("internal", {})
+    entries = internal.setdefault("entries", {})
+
+    desired = {
+        "enabled": True,
+        "path": str(Path("~/.openclaw/hooks/openclaw-adapter")),
+    }
+    current = entries.get("openclaw-adapter") or {}
+    needs_patch = (
+        current.get("enabled") is not True
+        or current.get("path") != desired["path"]
+    )
+    if needs_patch:
+        merged = dict(current)
+        merged.update(desired)
+        entries["openclaw-adapter"] = merged
+        save_json(MAIN_CONFIG, config)
+        log(f"[openclaw-adapter] openclaw.json entry added/updated")
+        return True
+    log(f"[openclaw-adapter] openclaw.json entry already enabled")
+    return False
+
+
 def main():
     log(f"Proxy: {PROXY_URL}")
     total = False; all_pm = {}
@@ -553,6 +701,13 @@ def main():
         total = True
     if sync_codex_jwt():
         total = True
+
+    # OAS-05: openclaw-adapter (Path C session-binding hook).
+    try:
+        if install_openclaw_adapter():
+            total = True
+    except Exception as e:
+        log(f"[openclaw-adapter] WARN: install raised: {e}")
 
     log(f"Done — mirrored {len(all_pm)} providers" if total else "No changes needed")
 

--- a/integrations/openclaw/tokenpak-inject.sh
+++ b/integrations/openclaw/tokenpak-inject.sh
@@ -496,6 +496,117 @@ def refresh_native_codex_profile():
     return changed > 0
 
 
+def _load_claude_oauth():
+    """Return (access_token, refresh_token, expires_ms) from ~/.claude/.credentials.json.
+
+    The Claude CLI stores its OAuth bundle under ``claudeAiOauth`` —
+    ``accessToken`` / ``refreshToken`` / ``expiresAt`` (ms-precision unix
+    epoch). Returns (None, None, None) on missing/corrupt file. Never
+    raises into the inject pipeline.
+    """
+    cred_path = Path.home() / ".claude" / ".credentials.json"
+    if not cred_path.is_file():
+        return (None, None, None)
+    try:
+        d = json.loads(cred_path.read_text())
+        oauth = d.get("claudeAiOauth", d)
+        access = oauth.get("accessToken") or oauth.get("access_token") or ""
+        refresh = oauth.get("refreshToken") or oauth.get("refresh_token") or ""
+        expires = oauth.get("expiresAt") or oauth.get("expires_at") or 0
+        if not access:
+            return (None, None, None)
+        return (access, refresh, int(expires) if expires else 0)
+    except Exception:
+        return (None, None, None)
+
+
+def refresh_native_claude_oauth():
+    """Sync ~/.claude/.credentials.json → tokenpak-claude-code:manual profile.
+
+    Path A from proposal `2026-04-29-suki-codex-rate-limit-failover-provisioning`.
+    OpenClaw's built-in model-failover (per ~/.openclaw-governor/openclaw.json
+    `agents.list[main].model.fallbacks`) selects
+    ``tokenpak-claude-code/claude-opus-4-7`` as the next candidate when
+    the Codex primary returns ``rate_limit``. The failover currently
+    throws ``FailoverError`` because the per-agent
+    ``tokenpak-claude-code:manual`` profile has no live OAuth. This
+    function provisions it from the host's existing Claude CLI
+    credentials so the failover actually completes.
+
+    Sync targets: BOTH the top-level openclaw.json
+    ``auth.profiles["tokenpak-claude-code:manual"]`` AND the per-agent
+    ``agents/*/agent/auth-profiles.json`` (OpenClaw reads the per-agent
+    one first; the top-level is the discovery seed).
+
+    Kill-switch: ``TOKENPAK_GOVERNOR_FAILOVER_DISABLED=1`` skips the
+    sync entirely (lets us revert behavior in one cron tick if a
+    refresh-token-reused incident reproduces — see
+    ``feedback_never_mirror_claude_creds``).
+
+    Same-host single-machine use only. Do NOT mirror to other hosts.
+    """
+    if os.environ.get("TOKENPAK_GOVERNOR_FAILOVER_DISABLED", "0").strip() in {"1", "true", "yes"}:
+        log("Skipping Claude OAuth sync — TOKENPAK_GOVERNOR_FAILOVER_DISABLED=1")
+        return False
+
+    access, refresh, expires_ms = _load_claude_oauth()
+    if not access:
+        return False
+
+    changed = 0
+    profile_key = "tokenpak-claude-code:manual"
+
+    # Top-level governor profile.
+    if MAIN_CONFIG.exists():
+        try:
+            cfg = load_json(MAIN_CONFIG)
+            profiles = cfg.setdefault("auth", {}).setdefault("profiles", {})
+            existing = profiles.get(profile_key, {})
+            if existing.get("access") != access:
+                profiles[profile_key] = {
+                    "provider": "tokenpak-claude-code",
+                    "type": "oauth",
+                    "access": access,
+                    "refresh": refresh or existing.get("refresh", ""),
+                    "expires": expires_ms or existing.get("expires", 0),
+                }
+                save_json(MAIN_CONFIG, cfg)
+                log(f"Refreshed Claude OAuth in top-level {profile_key}")
+                changed += 1
+        except Exception as e:
+            log(f"Warning: top-level claude oauth sync: {e}")
+
+    # Per-agent auth-profiles.json (the file OpenClaw actually reads at
+    # request-time; the failover throws FailoverError when this is the
+    # gap).
+    for af in glob(str(OPENCLAW_DIR / "agents/*/agent/auth-profiles.json")):
+        try:
+            path = Path(af)
+            auth = load_json(path)
+            profiles = auth.setdefault("profiles", {})
+            existing = profiles.get(profile_key, {})
+            if existing.get("access") == access:
+                continue  # already fresh
+            profiles[profile_key] = {
+                "provider": "tokenpak-claude-code",
+                "type": "oauth",
+                "access": access,
+                "refresh": refresh or existing.get("refresh", ""),
+                "expires": expires_ms or existing.get("expires", 0),
+            }
+            # Also ensure auth.order routes the failover provider through
+            # this profile.
+            order = auth.setdefault("order", {})
+            order.setdefault("tokenpak-claude-code", [profile_key])
+            save_json(path, auth)
+            log(f"Refreshed Claude OAuth in per-agent {path}")
+            changed += 1
+        except Exception as e:
+            log(f"Warning: per-agent claude oauth sync ({af}): {e}")
+
+    return changed > 0
+
+
 def sync_codex_jwt():
     """Mirror fresh JWT from openai-codex:default → tokenpak-openai-codex:default.
 
@@ -700,6 +811,15 @@ def main():
     if refresh_native_codex_profile():
         total = True
     if sync_codex_jwt():
+        total = True
+
+    # Claude OAuth sync — Path A from proposal
+    # 2026-04-29-suki-codex-rate-limit-failover-provisioning. Provisions the
+    # `tokenpak-claude-code:manual` auth profile so OpenClaw's built-in
+    # model-failover from gpt-5.5 → claude-opus-4-7 actually has credentials
+    # to use. Same-host single-machine only. Kill-switch:
+    # TOKENPAK_GOVERNOR_FAILOVER_DISABLED=1.
+    if refresh_native_claude_oauth():
         total = True
 
     # OAS-05: openclaw-adapter (Path C session-binding hook).

--- a/integrations/openclaw/tokenpak-inject.sh
+++ b/integrations/openclaw/tokenpak-inject.sh
@@ -557,21 +557,31 @@ def refresh_native_claude_oauth():
     profile_key = "tokenpak-claude-code:manual"
 
     # Top-level governor profile.
+    #
+    # IMPORTANT — schema is strict: openclaw.json ``auth.profiles[*]``
+    # accepts ONLY ``{provider, mode}``. Any of {type, access, refresh,
+    # expires, accountId, ...} triggers OpenClaw's config validator with
+    # ``Unrecognized keys`` and crashes every cycle until the entry is
+    # cleaned. The actual token material lives in the per-agent
+    # ``agents/*/agent/auth-profiles.json`` (handled below) — that file
+    # tolerates the full bundle.
+    #
+    # 2026-04-29 incident reproduced this: the original Path A
+    # implementation wrote the full bundle into both layers; cycles
+    # 11:00, 11:30, 12:00 all exited 1 in <15s with
+    # ``Invalid input (allowed: "api_key", "oauth", "token") +
+    # Unrecognized keys: "type", "access", "refresh", "expires"``. Fixed
+    # by restricting the top-level write to the schema-legal pair.
     if MAIN_CONFIG.exists():
         try:
             cfg = load_json(MAIN_CONFIG)
             profiles = cfg.setdefault("auth", {}).setdefault("profiles", {})
             existing = profiles.get(profile_key, {})
-            if existing.get("access") != access:
-                profiles[profile_key] = {
-                    "provider": "tokenpak-claude-code",
-                    "type": "oauth",
-                    "access": access,
-                    "refresh": refresh or existing.get("refresh", ""),
-                    "expires": expires_ms or existing.get("expires", 0),
-                }
+            desired = {"provider": "tokenpak-claude-code", "mode": "oauth"}
+            if existing != desired:
+                profiles[profile_key] = desired
                 save_json(MAIN_CONFIG, cfg)
-                log(f"Refreshed Claude OAuth in top-level {profile_key}")
+                log(f"Set top-level {profile_key} stub (provider+mode only)")
                 changed += 1
         except Exception as e:
             log(f"Warning: top-level claude oauth sync: {e}")

--- a/tests/services/routing/test_openclaw_extract_path_c.py
+++ b/tests/services/routing/test_openclaw_extract_path_c.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OAS-11 — Path C ``_openclaw_extract`` reads ``active.json``.
+
+Per ``initiative 2026-04-28-openclaw-adapter-session-binding`` and
+``feedback_status_attribution_contract`` (never over-claim). These tests
+pin Kevin's six verification gates from the OAS-11 task spec:
+
+  G1 — User-Agent gate: only ``openclaw*`` UAs trigger an active.json read.
+  G2 — Schema validation: ``schema_version`` and ``session_uuid`` must match.
+  G3 — Stale TTL: age > ``OPENCLAW_ACTIVE_TTL_SEC`` (default 300) → anonymous.
+  G4 — Malformed/missing falls back to anonymous.
+  G5 — ``attribution_source`` always set on OpenClaw-UA returns.
+  G6 — No FS access for non-OpenClaw UAs.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tokenpak.services.routing_service import platform_bridge as pb
+
+
+_FRESH_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+def _write_active(tmp_active: Path, **fields) -> None:
+    payload = {
+        "schema_version": "1.0",
+        "session_uuid": _FRESH_UUID,
+        "last_event": "message:received",
+        "last_event_ts": int(time.time()),
+        "event_count": 1,
+        "agent": "trix-test",
+    }
+    payload.update(fields)
+    tmp_active.parent.mkdir(parents=True, exist_ok=True)
+    tmp_active.write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def isolated_active(tmp_path, monkeypatch):
+    """Redirect ``_ACTIVE_FILE`` into tmp + clear the 1s mtime cache."""
+    target = tmp_path / "active.json"
+    monkeypatch.setattr(pb, "_ACTIVE_FILE", target)
+    pb._active_cache.update({"mtime": 0.0, "payload": None, "read_ts": 0.0})
+    yield target
+    pb._active_cache.update({"mtime": 0.0, "payload": None, "read_ts": 0.0})
+
+
+# ── G1: User-Agent gate ──────────────────────────────────────────────
+
+
+def test_g1_openclaw_ua_triggers_file_read(isolated_active):
+    _write_active(isolated_active)
+    with patch.object(pb, "_read_active_json", wraps=pb._read_active_json) as m:
+        origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.platform_name == "openclaw"
+    assert origin.session_id == _FRESH_UUID
+    assert m.call_count == 1
+
+
+def test_g1_openclaw_gateway_ua_triggers_file_read(isolated_active):
+    _write_active(isolated_active)
+    origin = pb._openclaw_extract({"user-agent": "OpenClaw-Gateway/1.0"})
+    assert origin is not None
+    assert origin.session_id == _FRESH_UUID
+
+
+# ── G6: No FS access for non-OpenClaw traffic ───────────────────────
+
+
+def test_g6_non_openclaw_ua_skips_fs(isolated_active):
+    _write_active(isolated_active)
+    with patch.object(pb, "_read_active_json") as m:
+        for ua in ("claude-cli/1.0", "python-requests/2.31", "curl/8", ""):
+            origin = pb._openclaw_extract({"user-agent": ua})
+            assert origin is None, f"non-openclaw UA {ua!r} matched"
+    assert m.call_count == 0, "non-openclaw UA must not trigger active.json read"
+
+
+def test_g6_explicit_session_header_does_not_read_file(isolated_active):
+    """X-OpenClaw-Session is the explicit-session bypass; no FS read."""
+    _write_active(isolated_active)
+    with patch.object(pb, "_read_active_json") as m:
+        origin = pb._openclaw_extract({"x-openclaw-session": "sess-abc"})
+    assert origin is not None
+    assert origin.session_id == "sess-abc"
+    assert m.call_count == 0
+
+
+# ── G2: Schema validation ───────────────────────────────────────────
+
+
+def test_g2_wrong_schema_version_falls_back(isolated_active):
+    _write_active(isolated_active, schema_version="2.0")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g2_missing_session_uuid_falls_back(isolated_active):
+    payload = {
+        "schema_version": "1.0",
+        "last_event": "message:received",
+        "last_event_ts": int(time.time()),
+    }
+    isolated_active.parent.mkdir(parents=True, exist_ok=True)
+    isolated_active.write_text(json.dumps(payload), encoding="utf-8")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g2_non_uuid_session_uuid_falls_back(isolated_active):
+    _write_active(isolated_active, session_uuid="not-a-uuid")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+# ── G3: Stale TTL ───────────────────────────────────────────────────
+
+
+def test_g3_stale_active_falls_back(isolated_active, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_ACTIVE_TTL_SEC", "300")
+    _write_active(isolated_active, last_event_ts=int(time.time()) - 301)
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g3_negative_age_falls_back(isolated_active):
+    """Clock skew (last_event_ts > now) → anonymous (suspicious)."""
+    _write_active(isolated_active, last_event_ts=int(time.time()) + 60)
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g3_env_override_extends_ttl(isolated_active, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_ACTIVE_TTL_SEC", "600")
+    _write_active(isolated_active, last_event_ts=int(time.time()) - 400)
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id == _FRESH_UUID
+    assert origin.attribution_source == "openclaw_active_session_file"
+
+
+# ── G4: Malformed/missing fallback ──────────────────────────────────
+
+
+def test_g4_missing_file_falls_back(isolated_active):
+    assert not isolated_active.exists()
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g4_empty_file_falls_back(isolated_active):
+    isolated_active.parent.mkdir(parents=True, exist_ok=True)
+    isolated_active.write_text("", encoding="utf-8")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g4_invalid_json_falls_back(isolated_active):
+    isolated_active.parent.mkdir(parents=True, exist_ok=True)
+    isolated_active.write_text("{not valid json", encoding="utf-8")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+def test_g4_payload_not_dict_falls_back(isolated_active):
+    isolated_active.parent.mkdir(parents=True, exist_ok=True)
+    isolated_active.write_text("[1, 2, 3]", encoding="utf-8")
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.session_id is None
+    assert origin.attribution_source == "anonymous_user_agent_only"
+
+
+# ── G5: attribution_source always set ───────────────────────────────
+
+
+def test_g5_happy_path_sets_active_session_file(isolated_active):
+    _write_active(isolated_active)
+    origin = pb._openclaw_extract({"user-agent": "openclaw"})
+    assert origin is not None
+    assert origin.attribution_source == "openclaw_active_session_file"
+
+
+def test_g5_every_openclaw_ua_return_has_attribution(isolated_active, monkeypatch):
+    """Enumerate every fall-through and assert attribution_source is one
+    of the two ratified values — never None, never 'unknown'."""
+    monkeypatch.setenv("OPENCLAW_ACTIVE_TTL_SEC", "300")
+    cases = [
+        # missing
+        lambda: None,
+        # malformed
+        lambda: isolated_active.write_text("{bad", encoding="utf-8"),
+        # wrong schema
+        lambda: _write_active(isolated_active, schema_version="0.9"),
+        # bad uuid
+        lambda: _write_active(isolated_active, session_uuid="x"),
+        # stale
+        lambda: _write_active(isolated_active, last_event_ts=int(time.time()) - 9999),
+        # happy
+        lambda: _write_active(isolated_active),
+    ]
+    for setup in cases:
+        # reset cache + state for each iteration
+        if isolated_active.exists():
+            isolated_active.unlink()
+        pb._active_cache.update({"mtime": 0.0, "payload": None, "read_ts": 0.0})
+        if setup is not None:
+            setup()
+        origin = pb._openclaw_extract({"user-agent": "openclaw"})
+        assert origin is not None
+        assert origin.attribution_source in (
+            "openclaw_active_session_file",
+            "anonymous_user_agent_only",
+        ), f"unexpected attribution_source={origin.attribution_source!r}"
+
+
+# ── Cache ───────────────────────────────────────────────────────────
+
+
+def test_mtime_cache_avoids_thrash(isolated_active):
+    _write_active(isolated_active)
+    real_open = Path.open
+    call_count = {"n": 0}
+
+    def counting_open(self, *args, **kwargs):
+        if self == isolated_active:
+            call_count["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    with patch.object(Path, "open", counting_open):
+        pb._openclaw_extract({"user-agent": "openclaw"})
+        pb._openclaw_extract({"user-agent": "openclaw"})
+        pb._openclaw_extract({"user-agent": "openclaw"})
+    # First call opens the file; subsequent calls within 1s + same mtime
+    # serve from cache.
+    assert call_count["n"] == 1, f"opened {call_count['n']}× — cache leaks"
+
+
+# ── Backward compat: existing dataclass + UA tests still hold ───────
+
+
+def test_platform_origin_default_attribution_is_unknown():
+    o = pb.PlatformOrigin(platform_name="x")
+    assert o.attribution_source == "unknown"
+
+
+def test_codex_extract_unaffected():
+    origin = pb.detect_origin({"Authorization": "Bearer eyJtest"})
+    assert origin is not None
+    assert origin.platform_name == "codex"
+    assert origin.attribution_source == "unknown"

--- a/tests/services/routing/test_openclaw_extract_path_c.py
+++ b/tests/services/routing/test_openclaw_extract_path_c.py
@@ -24,7 +24,6 @@ import pytest
 
 from tokenpak.services.routing_service import platform_bridge as pb
 
-
 _FRESH_UUID = "11111111-2222-3333-4444-555555555555"
 
 

--- a/tokenpak/integrations/openclaw/hooks/openclaw-adapter/HOOK.md
+++ b/tokenpak/integrations/openclaw/hooks/openclaw-adapter/HOOK.md
@@ -1,5 +1,6 @@
 ---
 name: openclaw-adapter
+version: 1.0
 description: "Bind OpenClaw session UUIDs to tokenpak proxy journal.db via filesystem rendezvous (active.json) — Path C design"
 homepage: https://docs.openclaw.ai/automation/hooks
 metadata:

--- a/tokenpak/integrations/openclaw/hooks/openclaw-adapter/HOOK.md
+++ b/tokenpak/integrations/openclaw/hooks/openclaw-adapter/HOOK.md
@@ -1,0 +1,84 @@
+---
+name: openclaw-adapter
+description: "Bind OpenClaw session UUIDs to tokenpak proxy journal.db via filesystem rendezvous (active.json) — Path C design"
+homepage: https://docs.openclaw.ai/automation/hooks
+metadata:
+  {
+    "openclaw": {
+      "emoji": "🔗",
+      "events": ["message:received", "message:sent"],
+      "requires": { "bins": ["node"] }
+    }
+  }
+---
+
+# openclaw-adapter
+
+Path C session-binding hook. OpenClaw v2026.3.23-2 has no outbound-request mutation surface (per the 2026-04-28 PHASE-A-MEMO investigation), so this hook uses a message-event + filesystem rendezvous pattern instead.
+
+## What it does
+
+On every `message:received` and `message:sent` event, this hook reads `event.sessionKey` (OpenClaw's per-conversation key) and writes a JSON record to `~/.openclaw/sessions/active.json`. The tokenpak proxy reads that file when traffic arrives with `User-Agent: openclaw*` and uses the UUID as `journal.db.session_id` for cross-platform attribution.
+
+## active.json schema
+
+```json
+{
+  "schema_version": "1.0",
+  "session_uuid": "9f449869-e72a-4d19-9f0b-1a46305a62dd",
+  "last_event": "message:received",
+  "last_event_ts": 1714312345,
+  "event_count": 42,
+  "agent": "trixbot"
+}
+```
+
+- `session_uuid` — UUID v4 from `event.sessionKey`. Refuses to write if not UUID-shaped.
+- `last_event_ts` — unix seconds at write time. Proxy uses this for stale-TTL check.
+- `event_count` — monotonic counter; preserved across writes (read-prior-incr-write).
+- `agent` — from `OPENCLAW_AGENT_NAME` env or `hostname()`.
+
+## Hook event subscriptions
+
+- `message:received` — PRIMARY. Fires when a user→agent message arrives, before LLM dispatch.
+- `message:sent` — keeps `last_event_ts` fresh during long conversations.
+
+## Safeguards
+
+1. Atomic write — `<file>.tmp.<pid>.<ts>` → `renameSync`.
+2. Schema validation — refuses to write if `session_uuid` doesn't match UUID regex.
+3. File permissions 0600 — set immediately after rename.
+4. Stale TTL — handler does NOT enforce; proxy reader does (`now - last_event_ts > 300s` → fall back to anonymous).
+5. Never throws — try/catch every entry point with `console.warn`.
+6. Tmp file cleanup — strays older than 60s removed at write time.
+
+## Multi-session race-condition note
+
+If two conversations on the same agent host fire concurrently, the second write wins. Acceptable for the typical single-active-Telegram-conversation pattern. Sharded multi-session (one active.json per session) is future work.
+
+## Failure mode
+
+- Missing `event.sessionKey` → no-op (does not inject, does not throw)
+- Malformed UUID → no-op (refused by validation)
+- Disk full / permission denied → console.warn, hook returns cleanly
+- Rename failure → tmp file retained, target unchanged
+
+## Compatibility
+
+- OpenClaw runtime ≥ v2026.3.23-2 (uses `event.sessionKey` from `HookEvent` ctx; verified via PHASE-A-MEMO.md investigation)
+- Coexists with `tokenpak-telemetry` (separate event handlers; both subscribe to `message:received` independently)
+
+## Source of truth
+
+- Repo: `tokenpak/integrations/openclaw/hooks/openclaw-adapter/`
+- Initiative: `2026-04-28-openclaw-adapter-session-binding` (Path C)
+- Phase A finding: `PHASE-A-MEMO.md`
+- Spec: `03-SPEC.md §Component 1`
+- Proxy-side reader: OAS-11 (`platform_bridge.py _openclaw_extract`)
+
+## Revert
+
+```bash
+openclaw hooks disable openclaw-adapter
+systemctl --user restart openclaw-gateway
+```

--- a/tokenpak/integrations/openclaw/hooks/openclaw-adapter/handler.js
+++ b/tokenpak/integrations/openclaw/hooks/openclaw-adapter/handler.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// openclaw-adapter handler.js — Path C session-binding hook.
+//
+// Per OAS-02 (initiative 2026-04-28-openclaw-adapter-session-binding) and
+// PHASE-A-MEMO.md: OpenClaw v2026.3.23-2 has no outbound-request mutation
+// hook surface. Instead, this hook subscribes to message-level events and
+// writes the active session UUID to ~/.openclaw/sessions/active.json. The
+// tokenpak proxy reads that file when traffic arrives with
+// User-Agent: openclaw* and uses the UUID as journal.db.session_id.
+//
+// Safeguards (Kevin's non-negotiables, 2026-04-28):
+//   1. Atomic file write: tmp.<pid>.<ts> → fs.renameSync to final
+//   2. JSON schema validation: UUID regex check before write
+//   3. File permissions 0600 (owner-only) immediately after rename
+//   4. Stale-TTL: handler does NOT enforce; OAS-11 proxy reader does
+//   5. Malformed/missing fallback: validation fail → silent no-op
+//   6. Multi-session race documented (last write wins; OK for typical
+//      single-active-Telegram-conversation pattern)
+//   7. Telemetry attribution_source flag: set by proxy (OAS-11), not here
+//
+// Hook event subscriptions:
+//   - message:received — PRIMARY (fires before LLM dispatch)
+//   - message:sent     — SECONDARY (keeps last_event_ts fresh)
+//
+// Author: tokenpak <hello@tokenpak.ai>
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const PLUGIN_NAME = "[openclaw-adapter]";
+const SCHEMA_VERSION = "1.0";
+const TARGET_DIR = path.join(os.homedir(), ".openclaw", "sessions");
+const TARGET_FILE = path.join(TARGET_DIR, "active.json");
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+let eventCounter = 0;
+
+function readPriorCount() {
+  try {
+    const prior = JSON.parse(fs.readFileSync(TARGET_FILE, "utf8"));
+    return Number.isInteger(prior.event_count) ? prior.event_count : 0;
+  } catch (_) {
+    return 0;
+  }
+}
+
+function writeActiveJson(sessionUuid, eventType) {
+  try {
+    if (typeof sessionUuid !== "string" || !UUID_RE.test(sessionUuid)) {
+      // Sanity check failed — refuse to write
+      return;
+    }
+    fs.mkdirSync(TARGET_DIR, { recursive: true, mode: 0o700 });
+
+    if (eventCounter === 0) eventCounter = readPriorCount();
+    eventCounter += 1;
+
+    const payload = {
+      schema_version: SCHEMA_VERSION,
+      session_uuid: sessionUuid,
+      last_event: eventType,
+      last_event_ts: Math.floor(Date.now() / 1000),
+      event_count: eventCounter,
+      agent: process.env.OPENCLAW_AGENT_NAME || os.hostname(),
+    };
+
+    const tmpFile = `${TARGET_FILE}.tmp.${process.pid}.${Date.now()}`;
+    fs.writeFileSync(tmpFile, JSON.stringify(payload, null, 2), { mode: 0o600 });
+    fs.renameSync(tmpFile, TARGET_FILE); // atomic on same filesystem
+    fs.chmodSync(TARGET_FILE, 0o600);
+
+    // Cleanup stray tmp files from prior crashes (older than 60s)
+    for (const f of fs.readdirSync(TARGET_DIR)) {
+      if (f.startsWith("active.json.tmp.")) {
+        try {
+          const stat = fs.statSync(path.join(TARGET_DIR, f));
+          if (Date.now() - stat.mtimeMs > 60_000) {
+            fs.unlinkSync(path.join(TARGET_DIR, f));
+          }
+        } catch (_) {
+          // ignore — file may have been cleaned by another instance
+        }
+      }
+    }
+  } catch (e) {
+    console.warn(`${PLUGIN_NAME} active.json write failed:`, e?.message);
+  }
+}
+
+/**
+ * OpenClaw managed-hook handler. Subscribes to message:received and
+ * message:sent events; writes the active session UUID to active.json
+ * for the tokenpak proxy to consume.
+ */
+const handler = async (event) => {
+  try {
+    const { type, action, sessionKey } = event || {};
+    if (type !== "message") return;
+    if (action !== "received" && action !== "sent") return;
+    if (!sessionKey) return;
+    writeActiveJson(sessionKey, `${type}:${action}`);
+  } catch (e) {
+    console.warn(`${PLUGIN_NAME} handler error:`, e?.message);
+  }
+};
+
+module.exports = handler;
+module.exports.default = handler;

--- a/tokenpak/integrations/openclaw/hooks/openclaw-adapter/tests/test-active-json.js
+++ b/tokenpak/integrations/openclaw/hooks/openclaw-adapter/tests/test-active-json.js
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// openclaw-adapter smoke test — 8 cases covering all 6 Path C safeguards.
+// Zero-dependency Node; isolated to os.tmpdir() (no real ~/.openclaw write).
+//
+// Per OAS-04 (initiative 2026-04-28-openclaw-adapter-session-binding).
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const TEST_HOME = path.join(os.tmpdir(), `openclaw-adapter-test-${process.pid}`);
+process.env.HOME = TEST_HOME;
+process.env.OPENCLAW_AGENT_NAME = "trix-test";
+
+// Import handler AFTER setting HOME so module-load sees the test env
+const handler = require(path.join(__dirname, "..", "handler.js"));
+
+const ACTIVE = path.join(TEST_HOME, ".openclaw", "sessions", "active.json");
+
+function reset() {
+  if (fs.existsSync(TEST_HOME)) {
+    fs.rmSync(TEST_HOME, { recursive: true, force: true });
+  }
+}
+
+const cases = [
+  {
+    name: "happy path — message:received writes well-formed active.json",
+    run: async () => {
+      reset();
+      await handler({
+        type: "message",
+        action: "received",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      assert.ok(fs.existsSync(ACTIVE), "active.json missing");
+      const j = JSON.parse(fs.readFileSync(ACTIVE, "utf8"));
+      assert.equal(j.schema_version, "1.0");
+      assert.equal(j.session_uuid, "11111111-2222-3333-4444-555555555555");
+      assert.equal(j.last_event, "message:received");
+      assert.equal(typeof j.last_event_ts, "number");
+      assert.equal(j.agent, "trix-test");
+      assert.ok(j.event_count >= 1);
+    },
+  },
+  {
+    name: "0600 perms — file is owner-only-readable",
+    run: async () => {
+      reset();
+      await handler({
+        type: "message",
+        action: "received",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      const stat = fs.statSync(ACTIVE);
+      const mode = stat.mode & 0o777;
+      assert.equal(mode, 0o600, `mode is ${mode.toString(8)}, expected 600`);
+    },
+  },
+  {
+    name: "schema validation — refuses non-UUID sessionKey",
+    run: async () => {
+      reset();
+      await handler({
+        type: "message",
+        action: "received",
+        sessionKey: "not-a-uuid",
+      });
+      assert.ok(
+        !fs.existsSync(ACTIVE),
+        "active.json should NOT exist when sessionKey is invalid"
+      );
+    },
+  },
+  {
+    name: "non-message events — no write",
+    run: async () => {
+      reset();
+      await handler({
+        type: "gateway",
+        action: "startup",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      assert.ok(
+        !fs.existsSync(ACTIVE),
+        "active.json should NOT exist for gateway:startup"
+      );
+    },
+  },
+  {
+    name: "missing sessionKey — graceful no-op",
+    run: async () => {
+      reset();
+      await handler({ type: "message", action: "received" });
+      assert.ok(
+        !fs.existsSync(ACTIVE),
+        "active.json should NOT exist when sessionKey absent"
+      );
+    },
+  },
+  {
+    name: "atomic write — no .tmp.* files left behind on success",
+    run: async () => {
+      reset();
+      await handler({
+        type: "message",
+        action: "received",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      const dir = path.dirname(ACTIVE);
+      const stray = fs.readdirSync(dir).filter((f) =>
+        f.startsWith("active.json.tmp.")
+      );
+      assert.equal(stray.length, 0, `stray tmp files: ${stray.join(", ")}`);
+    },
+  },
+  {
+    name: "monotonic event_count — second write increments",
+    run: async () => {
+      reset();
+      await handler({
+        type: "message",
+        action: "received",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      const c1 = JSON.parse(fs.readFileSync(ACTIVE, "utf8")).event_count;
+      await handler({
+        type: "message",
+        action: "sent",
+        sessionKey: "11111111-2222-3333-4444-555555555555",
+      });
+      const c2 = JSON.parse(fs.readFileSync(ACTIVE, "utf8")).event_count;
+      assert.ok(c2 > c1, `expected c2 > c1, got c1=${c1} c2=${c2}`);
+    },
+  },
+  {
+    name: "throw resistance — handler doesn't propagate errors",
+    run: async () => {
+      reset();
+      try {
+        await handler(null);
+        await handler(undefined);
+        await handler({});
+        await handler({ type: "message" });
+      } catch (e) {
+        assert.fail(`handler threw: ${e.message}`);
+      }
+    },
+  },
+];
+
+(async () => {
+  let pass = 0;
+  let fail = 0;
+  for (const c of cases) {
+    try {
+      await c.run();
+      console.log(`PASS  ${c.name}`);
+      pass++;
+    } catch (e) {
+      console.log(`FAIL  ${c.name} — ${e.message}`);
+      fail++;
+    }
+  }
+  reset();
+  console.log(`\n${pass} passed, ${fail} failed.`);
+  process.exit(fail > 0 ? 1 : 0);
+})();

--- a/tokenpak/proxy/monitor.py
+++ b/tokenpak/proxy/monitor.py
@@ -81,8 +81,8 @@ def _db_writer_worker():
                            (timestamp,model,request_type,input_tokens,output_tokens,estimated_cost,
                             latency_ms,status_code,endpoint,compilation_mode,protected_tokens,
                             compressed_tokens,injected_tokens,injected_sources,cache_read_tokens,cache_creation_tokens,
-                            would_have_saved,cache_origin)
-                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                            would_have_saved,cache_origin,attribution_source)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                         insert_params,
                     )
                     conn.commit()
@@ -176,6 +176,12 @@ class Monitor:
             conn.execute("ALTER TABLE requests ADD COLUMN cache_origin TEXT DEFAULT 'unknown'")
         except sqlite3.OperationalError:
             pass
+        try:
+            conn.execute(
+                "ALTER TABLE requests ADD COLUMN attribution_source TEXT DEFAULT 'unknown'"
+            )
+        except sqlite3.OperationalError:
+            pass
         conn.commit()
         conn.execute("""
             CREATE TABLE IF NOT EXISTS budget_alerts (
@@ -234,6 +240,7 @@ class Monitor:
         would_have_saved=0,
         cache_origin="unknown",
         request_id=None,
+        attribution_source="unknown",
     ):
         # SC-02: forward a TIP-shaped row to any installed conformance
         # observer before the DB write. No-op when no observer is
@@ -300,6 +307,7 @@ class Monitor:
             cache_creation_tokens,
             would_have_saved,
             cache_origin,
+            attribution_source if isinstance(attribution_source, str) else "unknown",
         )
         _queued = False
         try:
@@ -311,8 +319,8 @@ class Monitor:
                 "INSERT INTO requests (timestamp, model, request_type, input_tokens, output_tokens, "
                 "estimated_cost, latency_ms, status_code, endpoint, compilation_mode, protected_tokens, "
                 "compressed_tokens, injected_tokens, injected_sources, cache_read_tokens, cache_creation_tokens, "
-                "would_have_saved, cache_origin) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "would_have_saved, cache_origin, attribution_source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 insert_params,
             )
             _conn.commit()

--- a/tokenpak/services/routing_service/platform_bridge.py
+++ b/tokenpak/services/routing_service/platform_bridge.py
@@ -55,8 +55,13 @@ Kevin's ratification 2026-04-24:
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import time
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Mapping, Optional
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 HeaderMap = Mapping[str, str]
 
@@ -69,13 +74,20 @@ class PlatformOrigin:
     session id. ``declared_provider`` is the tokenpak provider name the
     caller claims (``tokenpak-claude-code`` / ``tokenpak-anthropic`` /
     ``tokenpak-openai-codex`` / etc.); when absent, the selector falls
-    back to the platform's default_provider.
+    back to the platform's default_provider. ``attribution_source``
+    follows the never-over-claim rule from
+    ``feedback_status_attribution_contract`` — set to a definite source
+    when one is available, otherwise ``"unknown"``. For OpenClaw-UA
+    traffic the value is one of:
+    ``"openclaw_active_session_file"`` (read fresh + valid active.json)
+    or ``"anonymous_user_agent_only"`` (no file / stale / malformed).
     """
 
     platform_name: str
     session_id: Optional[str] = None
     declared_provider: Optional[str] = None
     extra: Dict[str, str] = field(default_factory=dict)
+    attribution_source: str = "unknown"
 
 
 @dataclass(frozen=True)
@@ -151,6 +163,7 @@ def detect_origin(headers: HeaderMap) -> Optional[PlatformOrigin]:
                 session_id=origin.session_id,
                 declared_provider=explicit_provider,
                 extra=origin.extra,
+                attribution_source=origin.attribution_source,
             )
         return origin
     return None
@@ -163,11 +176,64 @@ def detect_origin(headers: HeaderMap) -> Optional[PlatformOrigin]:
 # the call site.
 
 
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_ACTIVE_FILE = Path.home() / ".openclaw" / "sessions" / "active.json"
+
+
+def _active_ttl_sec() -> int:
+    """Stale-TTL cutoff in seconds; configurable via env."""
+    try:
+        return int(os.environ.get("OPENCLAW_ACTIVE_TTL_SEC", "300"))
+    except (TypeError, ValueError):
+        return 300
+
+
+# 1-second mtime-keyed cache to avoid hammering the filesystem on burst
+# traffic. ``payload`` is the parsed JSON (or sentinel ``False`` when the
+# last read failed parse / schema). Reset by setting ``read_ts=0``.
+_active_cache: Dict[str, Any] = {"mtime": 0.0, "payload": None, "read_ts": 0.0}
+
+
+def _read_active_json() -> Optional[dict]:
+    """Read ``~/.openclaw/sessions/active.json`` with a 1s mtime cache.
+
+    Returns the parsed dict on success, ``None`` on any failure
+    (missing, permission denied, malformed, IO error). Never raises.
+    """
+    try:
+        st = _ACTIVE_FILE.stat()
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    now = time.time()
+    if (
+        _active_cache["payload"] is not None
+        and _active_cache["mtime"] == st.st_mtime
+        and now - _active_cache["read_ts"] < 1.0
+    ):
+        cached = _active_cache["payload"]
+        return cached if isinstance(cached, dict) else None
+    try:
+        with _ACTIVE_FILE.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (FileNotFoundError, PermissionError, json.JSONDecodeError, OSError):
+        _active_cache["mtime"] = st.st_mtime
+        _active_cache["payload"] = None
+        _active_cache["read_ts"] = now
+        return None
+    _active_cache["mtime"] = st.st_mtime
+    _active_cache["payload"] = payload if isinstance(payload, dict) else None
+    _active_cache["read_ts"] = now
+    return payload if isinstance(payload, dict) else None
+
+
 def _openclaw_extract(headers: HeaderMap) -> Optional[PlatformOrigin]:
-    # Highest-confidence signal: explicit session header (aspirational;
-    # real OpenClaw traffic doesn't currently set this, but adapters
-    # that wrap OpenClaw can, and we preserve it for session-mapper
-    # integration).
+    # Highest-confidence per-request signal: explicit session header.
+    # Real OpenClaw traffic doesn't currently set this, but it stays
+    # supported for adapters that wrap OpenClaw and for tests that
+    # need to bypass the file-rendezvous path.
     session_id = headers.get("x-openclaw-session", "").strip()
     if session_id:
         return PlatformOrigin(
@@ -180,13 +246,56 @@ def _openclaw_extract(headers: HeaderMap) -> Optional[PlatformOrigin]:
     # The inspection was done against the installed binary at
     # /home/sue/.nvm/.../openclaw/dist — no other client uses this UA.
     ua = headers.get("user-agent", "").strip().lower()
-    if ua.startswith("openclaw"):
+    if not ua.startswith("openclaw"):
+        return None  # not OpenClaw — no FS access (G6)
+
+    # OAS-11 Path C: User-Agent says openclaw → the openclaw-adapter
+    # hook (OAS-02) writes ~/.openclaw/sessions/active.json on every
+    # message:received/sent event with the live session UUID. Read it,
+    # validate, and bind the session_id. On any failure mode we
+    # degrade to anonymous attribution rather than over-claim.
+    payload = _read_active_json()
+    if payload is None:
         return PlatformOrigin(
             platform_name="openclaw",
-            session_id=None,  # no per-request session to map
+            session_id=None,
             declared_provider=None,
+            attribution_source="anonymous_user_agent_only",
         )
-    return None
+    if payload.get("schema_version") != "1.0":
+        return PlatformOrigin(
+            platform_name="openclaw",
+            session_id=None,
+            declared_provider=None,
+            attribution_source="anonymous_user_agent_only",
+        )
+    uuid = payload.get("session_uuid")
+    if not isinstance(uuid, str) or not _UUID_RE.match(uuid):
+        return PlatformOrigin(
+            platform_name="openclaw",
+            session_id=None,
+            declared_provider=None,
+            attribution_source="anonymous_user_agent_only",
+        )
+    last_ts = payload.get("last_event_ts", 0)
+    try:
+        last_ts_f = float(last_ts)
+    except (TypeError, ValueError):
+        last_ts_f = 0.0
+    age = time.time() - last_ts_f
+    if age > _active_ttl_sec() or age < 0:
+        return PlatformOrigin(
+            platform_name="openclaw",
+            session_id=None,
+            declared_provider=None,
+            attribution_source="anonymous_user_agent_only",
+        )
+    return PlatformOrigin(
+        platform_name="openclaw",
+        session_id=uuid,
+        declared_provider=None,
+        attribution_source="openclaw_active_session_file",
+    )
 
 
 def _codex_extract(headers: HeaderMap) -> Optional[PlatformOrigin]:


### PR DESCRIPTION
## Summary

Bundles five tightly-coupled commits that wire OpenClaw's built-in `gpt-5.5 → claude-opus-4-7` model-failover end-to-end. Originally developed on `feat/governor-failover-provisioning` (2026-04-28 → 2026-04-29) and validated live against the Sue host's OpenClaw governor before being rebased onto current `main`.

The pieces depend on each other (OAS hook framework → adapter install → OAuth refresh → profile-shape fix), so they ship together.

## What's in it

| Commit | Subject | Why |
|---|---|---|
| `51526136d0` | feat(integrations/openclaw): OAS-02/03/04 Path C session-binding adapter | New `tokenpak/integrations/openclaw/hooks/openclaw-adapter/` directory with `HOOK.md` + `handler.js` + `tests/test-active-json.js`. The hook writes `active.json` so the proxy can route per-session. |
| `f45755fe04` | feat(services/routing_service): `_openclaw_extract` reads `active.json` (Path C, OAS-11) | Routing-side complement — `_openclaw_extract` consults `active.json` to bind requests to the right OpenClaw session. New tests in `tests/services/routing/test_openclaw_extract_path_c.py`. |
| `d1b86ac2c0` | feat(integrations/openclaw): `tokenpak-inject.sh` installs openclaw-adapter bundle (OAS-05) | Inject script copies the adapter into OpenClaw's hooks dir during `tokenpak inject`. |
| `41a08b403b` | feat(integrations/openclaw): refresh Claude OAuth in governor profile | Adds `refresh_native_claude_oauth()` to `tokenpak-inject.sh`. Mirrors `~/.claude/.credentials.json` → `tokenpak-claude-code:manual` profile (top-level `openclaw.json` + per-agent `auth-profiles.json`). Mirrors the existing `refresh_native_codex_profile()` pattern. **Same-host single-machine only** — kill-switch `TOKENPAK_GOVERNOR_FAILOVER_DISABLED=1`. |
| `3895f7a798` | fix(integrations/openclaw): top-level claude profile must be `{provider, mode}` | Bug-fix on the previous commit — top-level `openclaw.json` profile shape was wrong; OpenClaw expects exactly `{provider, mode}`, not the per-agent oauth blob. |

## Why now

Without this batch, OpenClaw's `agents.list[main].model.fallbacks = ["tokenpak-claude-code/claude-opus-4-7"]` detects Codex rate-limit and selects the fallback candidate, then throws `FailoverError` because the per-agent profile has no live OAuth. This batch provisions the failover credentials so the *existing* failover machinery actually works — no new wrapper-layer logic needed.

## Risk

- **Authority:** same-host single-machine credential mirroring only. Multi-host mirroring is empirically uncharacterised on single-host and is *not* enabled by this PR (per `feedback_never_mirror_claude_creds`).
- **Reversibility:** kill-switch `TOKENPAK_GOVERNOR_FAILOVER_DISABLED=1` skips the sync entirely — verified with no profile mutation.
- **Coverage:** OAS-02/03/04 + OAS-11 ship with their own JS + Python tests.

## What's NOT in this PR

The full `feat/governor-failover-provisioning` branch had 19 commits ahead of `main`. The other 14 (TCM-02/03/04/05/07 retrieval port, TCV2 EmbeddingIndexer prototype, VDS-01 vault.yaml schema, Fix 2 companion session_id, Fix 3 BlockStore default-on, connection_pool conflict resolve, 6 Suki auto-commits) are not coupled to governor failover and are queued for separate PRs.

## Test plan

- [x] All 5 commits cherry-pick cleanly onto current `main` (`0d154c2944`)
- [ ] CI green (`Lint (Ruff)`, `Test (Python 3.10–3.13)`, `bandit`, `cli-docs-in-sync`, `headline-benchmark`, `Import contracts`, `self-conformance (blocking)`, `Repo Hygiene Check`)
- [ ] Live re-verification: governor failover trips Codex rate-limit → routes to claude-opus-4-7 with valid OAuth (already verified pre-rebase 2026-04-29; CI can't reproduce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)