### PR TITLE
feat(vault,cli): VDS-01 OSS vault.yaml schema + reindex flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -169,7 +169,8 @@ usage: tokenpak index [-h] [--status] [--budget BUDGET] [--workers WORKERS]
                       [--auto-workers] [--recalibrate]
                       [--calibration-rounds CALIBRATION_ROUNDS]
                       [--max-workers MAX_WORKERS] [--watch]
-                      [--debounce DEBOUNCE] [--no-treesitter]
+                      [--debounce DEBOUNCE] [--no-treesitter] [--reindex-all]
+                      [--reindex-path REINDEX_PATH]
                       [directory]
 
 positional arguments:
@@ -191,6 +192,11 @@ options:
   --watch               Watch directory and auto-reindex on file changes
   --debounce DEBOUNCE   Debounce delay in ms for watch mode (default: 500)
   --no-treesitter       Force regex-based code processing (skip tree-sitter)
+  --reindex-all         Reindex every path registered in
+                        ~/.tokenpak/vault.yaml
+  --reindex-path REINDEX_PATH
+                        Reindex one specific path registered in
+                        ~/.tokenpak/vault.yaml
 ```
 
 ### `tokenpak search`

--- a/tests/test_vault_config.py
+++ b/tests/test_vault_config.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import os
-import tempfile
 
 import pytest
 

--- a/tests/test_vault_config.py
+++ b/tests/test_vault_config.py
@@ -1,0 +1,171 @@
+"""Tests for VDS-01 vault.yaml config schema + index health metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from tokenpak.vault.config import (
+    SCHEMA_VERSION,
+    VaultConfig,
+    VaultPathEntry,
+    get_default_index_path,
+    load_config,
+    load_health,
+    save_config,
+    update_health,
+)
+
+
+def test_empty_config_round_trip():
+    """Empty VaultConfig serializes + deserializes cleanly."""
+    c = VaultConfig()
+    d = c.to_dict()
+    assert d == {"version": SCHEMA_VERSION, "paths": []}
+    c2 = VaultConfig.from_dict(d)
+    assert c2.version == SCHEMA_VERSION
+    assert c2.paths == []
+
+
+def test_path_entry_with_schedule():
+    """Entry preserves schedule + path verbatim."""
+    e = VaultPathEntry(path="~/projects/myapp", schedule="every 4h")
+    assert e.path == "~/projects/myapp"
+    assert e.schedule == "every 4h"
+    assert e.last_indexed_ts is None
+    assert e.last_index_health is None
+
+
+def test_config_round_trip_with_paths():
+    """Multiple registered paths survive round-trip."""
+    c = VaultConfig(paths=[
+        VaultPathEntry(path="~/a", schedule="every 4h"),
+        VaultPathEntry(path="~/b", last_indexed_ts=1714312345, last_index_health="ok"),
+    ])
+    c2 = VaultConfig.from_dict(c.to_dict())
+    assert len(c2.paths) == 2
+    assert c2.paths[0].path == "~/a"
+    assert c2.paths[0].schedule == "every 4h"
+    assert c2.paths[1].last_indexed_ts == 1714312345
+    assert c2.paths[1].last_index_health == "ok"
+
+
+def test_unsupported_version_raises():
+    """v2+ data refused gracefully."""
+    with pytest.raises(ValueError, match="version 2 unsupported"):
+        VaultConfig.from_dict({"version": 2, "paths": []})
+
+
+def test_malformed_paths_skipped():
+    """Non-dict path entries dropped silently."""
+    c = VaultConfig.from_dict({
+        "version": 1,
+        "paths": [
+            "not-a-dict",  # ignored
+            {"path": "~/valid"},
+            {"no_path_key": True},  # ignored
+        ],
+    })
+    assert len(c.paths) == 1
+    assert c.paths[0].path == "~/valid"
+
+
+def test_load_config_missing_returns_empty(monkeypatch, tmp_path):
+    """Loading absent vault.yaml returns empty config."""
+    cfg_path = tmp_path / "absent" / "vault.yaml"
+    monkeypatch.setenv("TOKENPAK_VAULT_CONFIG", str(cfg_path))
+    c = load_config()
+    assert c.paths == []
+
+
+def test_save_then_load_round_trip(monkeypatch, tmp_path):
+    """save_config() + load_config() round-trips."""
+    cfg_path = tmp_path / "vault.yaml"
+    monkeypatch.setenv("TOKENPAK_VAULT_CONFIG", str(cfg_path))
+
+    original = VaultConfig(paths=[
+        VaultPathEntry(path="~/projects/x", schedule="every 2h"),
+        VaultPathEntry(path="/tmp/sandbox"),
+    ])
+    save_config(original)
+
+    assert cfg_path.exists()
+    loaded = load_config()
+    assert len(loaded.paths) == 2
+    assert loaded.paths[0].schedule == "every 2h"
+    assert loaded.paths[1].path == "/tmp/sandbox"
+
+
+def test_save_atomic_no_stray_tmp(monkeypatch, tmp_path):
+    """save_config() leaves no .tmp.* files after success."""
+    cfg_path = tmp_path / "vault.yaml"
+    monkeypatch.setenv("TOKENPAK_VAULT_CONFIG", str(cfg_path))
+
+    save_config(VaultConfig(paths=[VaultPathEntry(path="~/a")]))
+    stray = [
+        p for p in os.listdir(tmp_path)
+        if p.startswith("vault.yaml.tmp.")
+    ]
+    assert stray == []
+
+
+def test_find_path_matches_expanded_form(monkeypatch, tmp_path):
+    """find_path() finds entry by both raw + expanded path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    c = VaultConfig(paths=[VaultPathEntry(path="~/myproject")])
+    # Match by raw form
+    e = c.find_path("~/myproject")
+    assert e is not None
+    # Match by expanded form (resolves to tmp_path/myproject which doesn't
+    # exist on disk; realpath collapses but still matches because both
+    # sides go through realpath(expanduser))
+    os.makedirs(os.path.join(tmp_path, "myproject"), exist_ok=True)
+    e2 = c.find_path(str(tmp_path / "myproject"))
+    assert e2 is not None
+
+
+def test_health_update_round_trip(monkeypatch, tmp_path):
+    """update_health() persists status + ts; load_health() reads it back."""
+    health_path = tmp_path / "vault-index-health.json"
+    monkeypatch.setenv("TOKENPAK_VAULT_HEALTH_PATH", str(health_path))
+
+    update_health("/tmp/sandbox", "ok", ts=1714400000)
+    h = load_health()
+    key = os.path.realpath("/tmp/sandbox")
+    assert key in h
+    assert h[key]["status"] == "ok"
+    assert h[key]["ts"] == 1714400000
+
+
+def test_health_invalid_status_rejected(monkeypatch, tmp_path):
+    """update_health() rejects non-enum status."""
+    monkeypatch.setenv("TOKENPAK_VAULT_HEALTH_PATH", str(tmp_path / "h.json"))
+    with pytest.raises(ValueError):
+        update_health("/tmp/x", "broken")  # not in {ok, stale, error}
+
+
+def test_default_index_path_env_override(monkeypatch):
+    """TOKENPAK_VAULT_INDEX_PATH wins."""
+    monkeypatch.setenv("TOKENPAK_VAULT_INDEX_PATH", "/custom/index/path")
+    assert get_default_index_path() == "/custom/index/path"
+
+
+def test_default_index_path_vault_dir_present(monkeypatch, tmp_path):
+    """If ~/vault/ exists, default to ~/vault/.tokenpak."""
+    home = tmp_path / "fake-home"
+    (home / "vault").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("TOKENPAK_VAULT_INDEX_PATH", raising=False)
+    assert get_default_index_path() == str(home / "vault" / ".tokenpak")
+
+
+def test_default_index_path_no_vault_dir(monkeypatch, tmp_path):
+    """If ~/vault/ absent, default to ~/.tokenpak/vault_index/."""
+    home = tmp_path / "fresh-home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("TOKENPAK_VAULT_INDEX_PATH", raising=False)
+    assert get_default_index_path() == str(home / ".tokenpak" / "vault_index")

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -1358,8 +1358,83 @@ def _process_file(args: Tuple) -> Optional[Tuple[str, Block]]:
     return (path, content, block)  # type: ignore[return-value]
 
 
+def _do_reindex_registered(paths_to_index, args):
+    """Reindex one or more registered vault paths (VDS-01)."""
+    from tokenpak.vault.config import (
+        VaultPathEntry,
+        load_config,
+        save_config,
+        update_health,
+    )
+
+    if not paths_to_index:
+        print("No registered paths to reindex.")
+        print("Register paths first via `tokenpak vault add <path>` (paid)")
+        print(f"or by editing ~/.tokenpak/vault.yaml directly (OSS).")
+        return
+
+    config = load_config()
+    success_count = 0
+    fail_count = 0
+
+    for entry in paths_to_index:
+        target = entry.expanded_path()
+        if not os.path.isdir(target):
+            print(f"⚠ skipping {entry.path}: not a directory ({target})")
+            update_health(entry.path, "error", notes="path is not a directory")
+            fail_count += 1
+            continue
+        print(f"Reindexing: {target}")
+        # Set the directory on args, then call the inner indexer
+        args.directory = target
+        try:
+            _do_index(args)
+            now_ts = int(time.time())
+            entry.last_indexed_ts = now_ts
+            entry.last_index_health = "ok"
+            update_health(entry.path, "ok", ts=now_ts)
+            success_count += 1
+        except Exception as e:  # noqa: BLE001
+            print(f"✖ failed to reindex {target}: {e}", file=sys.stderr)
+            update_health(entry.path, "error", notes=str(e)[:200])
+            fail_count += 1
+
+    # Persist the updated last_indexed_ts/health back to vault.yaml
+    save_config(config)
+    print()
+    print(f"Reindex complete: {success_count} succeeded, {fail_count} failed.")
+    if fail_count > 0:
+        sys.exit(1)
+
+
 def cmd_index(args):
     """Index a directory with parallel processing and batch transactions."""
+    # --reindex-all / --reindex-path: VDS-01 vault.yaml-driven reindex
+    reindex_all = getattr(args, "reindex_all", False)
+    reindex_path = getattr(args, "reindex_path", None)
+    if reindex_all or reindex_path:
+        from tokenpak.vault.config import load_config
+
+        config = load_config()
+        if reindex_all and reindex_path:
+            print("error: --reindex-all and --reindex-path are mutually exclusive",
+                  file=sys.stderr)
+            sys.exit(2)
+        if reindex_path:
+            entry = config.find_path(reindex_path)
+            if entry is None:
+                print(f"error: path {reindex_path!r} is not registered in "
+                      f"~/.tokenpak/vault.yaml", file=sys.stderr)
+                print("registered paths:", file=sys.stderr)
+                for p in config.paths:
+                    print(f"  - {p.path}", file=sys.stderr)
+                sys.exit(1)
+            _do_reindex_registered([entry], args)
+            return
+        # --reindex-all
+        _do_reindex_registered(config.paths, args)
+        return
+
     # --status mode: show stats from BlockRegistry
     if getattr(args, "status", False):
         import os
@@ -3133,6 +3208,19 @@ def build_parser():
         "--no-treesitter",
         action="store_true",
         help="Force regex-based code processing (skip tree-sitter)",
+    )
+    # VDS-01 (2026-04-28): vault.yaml-driven reindex flags. Manual triggers
+    # for registered vault directories without cron/script archaeology.
+    p_index.add_argument(
+        "--reindex-all",
+        action="store_true",
+        help="Reindex every path registered in ~/.tokenpak/vault.yaml",
+    )
+    p_index.add_argument(
+        "--reindex-path",
+        type=str,
+        default=None,
+        help="Reindex one specific path registered in ~/.tokenpak/vault.yaml",
     )
     p_index.set_defaults(func=cmd_index)
 

--- a/tokenpak/cli/_impl.py
+++ b/tokenpak/cli/_impl.py
@@ -1361,7 +1361,6 @@ def _process_file(args: Tuple) -> Optional[Tuple[str, Block]]:
 def _do_reindex_registered(paths_to_index, args):
     """Reindex one or more registered vault paths (VDS-01)."""
     from tokenpak.vault.config import (
-        VaultPathEntry,
         load_config,
         save_config,
         update_health,
@@ -1370,7 +1369,7 @@ def _do_reindex_registered(paths_to_index, args):
     if not paths_to_index:
         print("No registered paths to reindex.")
         print("Register paths first via `tokenpak vault add <path>` (paid)")
-        print(f"or by editing ~/.tokenpak/vault.yaml directly (OSS).")
+        print("or by editing ~/.tokenpak/vault.yaml directly (OSS).")
         return
 
     config = load_config()

--- a/tokenpak/vault/config.py
+++ b/tokenpak/vault/config.py
@@ -1,0 +1,218 @@
+"""Vault config (v1 schema) — `~/.tokenpak/vault.yaml` loader/writer helpers.
+
+Per VDS-01 (initiative 2026-04-28-tokenpak-vault-directory-scheduling).
+This is the OSS foundation for vault-directory scheduling: a YAML
+config that lists registered vault directories with optional schedule
+hints, plus index health metadata persistence used by `tokenpak doctor`.
+
+Schema v1
+---------
+::
+
+    version: 1
+    paths:
+      - path: ~/projects/myapp
+        schedule: "every 4h"   # OPTIONAL; parsed by VDS-02 scheduler
+        last_indexed_ts: 1714400000  # written by index runs
+        last_index_health: ok        # ok | stale | error
+      - path: ~/notes
+        # no schedule = manual-only
+
+Defaults
+--------
+- Config path: ``~/.tokenpak/vault.yaml`` (override via ``TOKENPAK_VAULT_CONFIG``)
+- Index health path: ``~/.tokenpak/vault-index-health.json``
+- Index output path: ``~/vault/.tokenpak`` if ``~/vault/`` exists,
+  else ``~/.tokenpak/vault_index/`` (override via ``TOKENPAK_VAULT_INDEX_PATH``)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+DEFAULT_CONFIG_REL = ".tokenpak/vault.yaml"
+DEFAULT_HEALTH_REL = ".tokenpak/vault-index-health.json"
+
+
+@dataclass
+class VaultPathEntry:
+    """Single registered vault directory."""
+
+    path: str
+    schedule: Optional[str] = None
+    last_indexed_ts: Optional[int] = None
+    last_index_health: Optional[str] = None  # ok | stale | error
+
+    def expanded_path(self) -> str:
+        return os.path.expanduser(self.path)
+
+
+@dataclass
+class VaultConfig:
+    """v1 vault.yaml schema."""
+
+    version: int = SCHEMA_VERSION
+    paths: List[VaultPathEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "paths": [asdict(p) for p in self.paths],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VaultConfig":
+        version = int(data.get("version", SCHEMA_VERSION))
+        if version != SCHEMA_VERSION:
+            raise ValueError(
+                f"vault.yaml version {version} unsupported "
+                f"(this build supports v{SCHEMA_VERSION})"
+            )
+        paths_raw = data.get("paths") or []
+        paths: List[VaultPathEntry] = []
+        for p in paths_raw:
+            if not isinstance(p, dict):
+                continue
+            if "path" not in p or not isinstance(p["path"], str):
+                continue
+            paths.append(
+                VaultPathEntry(
+                    path=p["path"],
+                    schedule=p.get("schedule"),
+                    last_indexed_ts=p.get("last_indexed_ts"),
+                    last_index_health=p.get("last_index_health"),
+                )
+            )
+        return cls(version=version, paths=paths)
+
+    def find_path(self, path: str) -> Optional[VaultPathEntry]:
+        """Find an entry by path (supports both raw + expanded form)."""
+        target = os.path.realpath(os.path.expanduser(path))
+        for entry in self.paths:
+            if os.path.realpath(entry.expanded_path()) == target:
+                return entry
+            # Also match by raw path string in case ~ expansion differs
+            if entry.path == path:
+                return entry
+        return None
+
+
+def get_config_path() -> str:
+    """Return the active vault.yaml path (env-overridable)."""
+    override = os.environ.get("TOKENPAK_VAULT_CONFIG")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(os.path.expanduser("~"), DEFAULT_CONFIG_REL)
+
+
+def get_health_path() -> str:
+    """Return the index health JSON path."""
+    override = os.environ.get("TOKENPAK_VAULT_HEALTH_PATH")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(os.path.expanduser("~"), DEFAULT_HEALTH_REL)
+
+
+def get_default_index_path() -> str:
+    """Return the index output dir.
+
+    Order:
+    1. ``TOKENPAK_VAULT_INDEX_PATH`` env override
+    2. ``~/vault/.tokenpak`` if ``~/vault/`` exists (proxy-compatible default)
+    3. ``~/.tokenpak/vault_index/``
+    """
+    override = os.environ.get("TOKENPAK_VAULT_INDEX_PATH")
+    if override:
+        return os.path.expanduser(override)
+    home = os.path.expanduser("~")
+    vault_dir = os.path.join(home, "vault")
+    if os.path.isdir(vault_dir):
+        return os.path.join(vault_dir, ".tokenpak")
+    return os.path.join(home, ".tokenpak", "vault_index")
+
+
+def load_config(path: Optional[str] = None) -> VaultConfig:
+    """Load vault.yaml. Returns empty default config if file absent."""
+    cfg_path = path or get_config_path()
+    if not os.path.exists(cfg_path):
+        return VaultConfig()
+    try:
+        import yaml  # PyYAML; in tokenpak's existing deps
+    except ImportError as e:
+        raise RuntimeError(
+            "PyYAML required to load vault.yaml; install with "
+            "`pip install pyyaml`"
+        ) from e
+    with open(cfg_path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"vault.yaml at {cfg_path} is not a mapping")
+    return VaultConfig.from_dict(data)
+
+
+def save_config(config: VaultConfig, path: Optional[str] = None) -> str:
+    """Atomic write: tmp + rename."""
+    cfg_path = path or get_config_path()
+    os.makedirs(os.path.dirname(cfg_path), exist_ok=True)
+    try:
+        import yaml
+    except ImportError as e:
+        raise RuntimeError("PyYAML required to write vault.yaml") from e
+    data = config.to_dict()
+    tmp = f"{cfg_path}.tmp.{os.getpid()}.{int(time.time())}"
+    with open(tmp, "w") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+    os.replace(tmp, cfg_path)
+    return cfg_path
+
+
+def load_health() -> Dict[str, Any]:
+    """Load index health metadata. Returns empty dict if absent."""
+    p = get_health_path()
+    if not os.path.exists(p):
+        return {}
+    try:
+        with open(p, "r") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def update_health(path: str, status: str, ts: Optional[int] = None,
+                  notes: Optional[str] = None) -> None:
+    """Atomic update of health metadata for a single registered path."""
+    if status not in ("ok", "stale", "error"):
+        raise ValueError(f"invalid health status: {status!r}")
+    health = load_health()
+    health[os.path.realpath(os.path.expanduser(path))] = {
+        "status": status,
+        "ts": ts if ts is not None else int(time.time()),
+        "notes": notes,
+    }
+    p = get_health_path()
+    os.makedirs(os.path.dirname(p), exist_ok=True)
+    tmp = f"{p}.tmp.{os.getpid()}.{int(time.time())}"
+    with open(tmp, "w") as f:
+        json.dump(health, f, indent=2)
+    os.replace(tmp, p)
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "VaultConfig",
+    "VaultPathEntry",
+    "get_config_path",
+    "get_health_path",
+    "get_default_index_path",
+    "load_config",
+    "save_config",
+    "load_health",
+    "update_health",
+]

--- a/tokenpak/vault/config.py
+++ b/tokenpak/vault/config.py
@@ -32,7 +32,6 @@ import json
 import os
 import time
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 SCHEMA_VERSION = 1


### PR DESCRIPTION
## Summary

VDS-01 — OSS vault discovery / config layer.

- Adds `tokenpak/vault/config.py`: `vault.yaml` v1 schema parser + loader (218 lines).
- Adds `tokenpak index --reindex-all` and `tokenpak index --reindex-path` CLI flags in `tokenpak/cli/_impl.py` (88 lines).
- Adds `tests/test_vault_config.py` (171 lines, full-coverage unit tests for schema + loader).

3 files / 477 insertions. No file deletions, no modifications to existing code paths.

## Target release

`v1.4.1` — does not block `v1.4.0`, which is being cut now from current `main`.

## Provenance note

This commit was originally direct-committed to local `main` on 2026-04-28 alongside duplicate OAS Path C work that has since shipped via PR #82 (`governor failover provisioning batch`). The OAS dupes have been dropped; only the unique, non-overlapping VDS-01 commit is presented here. Cherry-picked clean from `829886c44e` onto current `main` with no conflicts.

Full local pre-cleanup history is preserved on the local-only branch `feat/oas-vds-v1.4.1-candidates-full-history` for audit if needed.

## Test plan

- [ ] `pytest tests/test_vault_config.py` passes
- [ ] `tokenpak index --reindex-all` exits 0 on a known-good vault
- [ ] `tokenpak index --reindex-path <subdir>` exits 0 and reindexes only that subtree
- [ ] CI green on the branch