### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-05-03
+
+### Added — VDS-01 OSS vault discovery / config (PR #86)
+
+A user-facing config schema and CLI surface for managing tokenpak's vault paths without the paid `tokenpak vault add` command.
+
+- `tokenpak/vault/config.py` — `vault.yaml` v1 schema parser + loader.
+- `tokenpak index --reindex-all` — reindexes every registered vault path.
+- `tokenpak index --reindex-path <path>` — reindexes a single registered subtree.
+- `docs/reference/cli.md` regenerated to cover the new flags.
+
+OSS users can now hand-edit `~/.tokenpak/vault.yaml` and reindex via the CLI; paid users continue to use `tokenpak vault add` as the convenience entry point.
+
 ## [1.4.0] - 2026-05-03
 
 This release consolidates the work merged on `main` since `v1.3.22` (Apr 25). The previously-staged but never-tagged `1.3.23` content (Codex format adapter) is included here under "Codex format adapter restored." Three large initiatives shipped on top of it: **Intent Layer**, **Native Client Concurrency Parity (NCP)**, and **OpenClaw Path C session-binding via governor failover**.

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -15,7 +15,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __author__ = "TokenPak"
 __license__ = "Apache-2.0"
 __description__ = "Local proxy that compresses LLM context before it hits the API"


### PR DESCRIPTION
## Summary

Release cut for **v1.5.0**.

- Bumps `tokenpak.__version__` → `1.5.0`.
- Adds CHANGELOG entry covering VDS-01 (PR #86).

## Why minor (not patch)

VDS-01 introduces user-facing surfaces that did not exist in `v1.4.x`:
- `vault.yaml` v1 config schema (new file format under `~/.tokenpak/`)
- `tokenpak index --reindex-all` (new CLI flag)
- `tokenpak index --reindex-path <path>` (new CLI flag)

Per semver, new public functionality → minor bump.

## Status

- Tag `v1.5.0` already pushed (annotated, peeled to `aaed037d24`) — release+publish workflow firing on `push: tags: v*`.
- workflow_dispatch preflight on this branch passed (run `25288147179`): pin validation, tests, build all green.

## Test plan

- [x] Preflight: pin validation, tests, build all passed
- [ ] Release+publish workflow on `v1.5.0` tag completes successfully
- [ ] PyPI shows `tokenpak==1.5.0`
- [ ] GitHub Release page populated with notes