### PR TITLE
feat(proxy): add DeepSeek provider routing

### DIFF
--- a/tests/proxy/test_router.py
+++ b/tests/proxy/test_router.py
@@ -97,3 +97,25 @@ def test_router_accepts_missing_content_length():
 
     result = router.route("/v1/messages", headers, body)
     assert result.provider == "anthropic"
+
+
+def test_router_detects_deepseek_host():
+    router = ProviderRouter()
+    body = _json_body("deepseek-v4-flash")
+
+    result = router.route("https://api.deepseek.com/v1/chat/completions", {}, body)
+
+    assert result.provider == "deepseek"
+    assert result.base_url == "https://api.deepseek.com"
+    assert result.full_url == "https://api.deepseek.com/v1/chat/completions"
+
+
+def test_router_detects_deepseek_model_for_reverse_proxy():
+    router = ProviderRouter()
+    body = _json_body("deepseek-v4-pro")
+    headers = {"Content-Type": "application/json", "Content-Length": str(len(body))}
+
+    result = router.route("/v1/chat/completions", headers, body)
+
+    assert result.provider == "deepseek"
+    assert result.full_url == "https://api.deepseek.com/v1/chat/completions"

--- a/tokenpak/proxy/circuit_breaker.py
+++ b/tokenpak/proxy/circuit_breaker.py
@@ -568,6 +568,7 @@ class CircuitBreaker:
 # Known provider URL substrings → canonical provider names
 _PROVIDER_PATTERNS: List[tuple] = [
     ("anthropic.com", "anthropic"),
+    ("deepseek.com", "deepseek"),
     ("openai.com", "openai"),
     # ChatGPT Codex subscription — OAuth JWT → chatgpt.com/backend-api.
     # Maps to the same circuit-breaker + injection logic as openai so

--- a/tokenpak/proxy/custom_providers.py
+++ b/tokenpak/proxy/custom_providers.py
@@ -80,9 +80,12 @@ def load_custom_providers() -> List[CustomProvider]:
     Never raises -- config errors are logged and the offending entry skipped.
     """
     try:
-        from tokenpak import config_loader as _cl
+        from tokenpak.core import config_loader as _cl
     except ImportError:
-        return []
+        try:
+            from tokenpak import config_loader as _cl  # legacy layout
+        except ImportError:
+            return []
 
     cfg = _cl.load_config()
     if not isinstance(cfg, dict):

--- a/tokenpak/proxy/router.py
+++ b/tokenpak/proxy/router.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 PROVIDER_URLS = {
     "anthropic": "https://api.anthropic.com",
     "openai": "https://api.openai.com",
+    "deepseek": "https://api.deepseek.com",
     # openai-codex: subscription OAuth model (gpt-5.x-codex series)
     # Uses api.openai.com with OAuth Bearer token instead of API key.
     # Preferred endpoint: /v1/responses (Responses API)
@@ -154,6 +155,8 @@ class ProviderRouter:
         host_lower = host.lower()
         if "anthropic" in host_lower:
             return "anthropic"
+        elif "deepseek" in host_lower:
+            return "deepseek"
         elif "openai" in host_lower:
             return "openai"
         elif "googleapis" in host_lower or "google" in host_lower:
@@ -175,7 +178,15 @@ class ProviderRouter:
         4. Bearer token presence (non-Google Bearer → openai)
         5. Default: anthropic
         """
-        # Path-based detection (highest priority)
+        # Body model prefix can disambiguate OpenAI-compatible providers that
+        # share /v1/chat/completions (for example DeepSeek). Keep this before
+        # the generic chat-completions path rule.
+        if body:
+            model = self._extract_model(body)
+            if model.startswith("deepseek"):
+                return "deepseek"
+
+        # Path-based detection (highest priority for unique provider paths)
         if "/v1/messages" in path:
             return "anthropic"
         if "/codex/responses" in path or "/v1/codex/responses" in path:

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -862,6 +862,23 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         content_length = int(self.headers.get("Content-Length", 0))
         body: Optional[bytes] = self.rfile.read(content_length) if content_length > 0 else None
 
+        # DeepSeek is OpenAI-compatible, so reverse-proxy requests arrive on
+        # /v1/chat/completions like OpenAI. Route by explicit model prefix so
+        # OpenClaw can use a tokenpak-deepseek provider without overriding all
+        # OpenAI-chat traffic.
+        try:
+            if body and "/chat/completions" in target_url:
+                _body_model = json.loads(body.decode("utf-8")).get("model", "")
+                if isinstance(_body_model, str) and _body_model.startswith("deepseek"):
+                    _path = parsed.path or self.path
+                    if parsed.query:
+                        _path += "?" + parsed.query
+                    target_url = "https://api.deepseek.com" + _path
+                    parsed = urlparse(target_url)
+                    should_log = True
+        except Exception:
+            pass
+
         model = "unknown"
         input_tokens = 0
         sent_input_tokens = 0
@@ -1262,6 +1279,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             )
         except Exception:
             _router_injected = False  # fail-open
+
+        # DeepSeek API-key injection. DeepSeek is OpenAI-compatible and uses
+        # Authorization: Bearer <DEEPSEEK_API_KEY>. Keep this narrow so normal
+        # OpenAI/Codex routing remains untouched.
+        _upstream_provider = provider_from_url(target_url)
+        if not _router_injected and _upstream_provider == "deepseek":
+            _deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+            if _deepseek_key:
+                fwd_headers["Authorization"] = f"Bearer {_deepseek_key}"
+                for _ck in ("x-api-key", "X-Api-Key"):
+                    fwd_headers.pop(_ck, None)
+                _router_injected = True
 
         # ── Codex OAuth credential injection (legacy default path) ───
         # OpenAI Codex (Responses API) routes need OAuth token from
@@ -2725,6 +2754,7 @@ class ProxyServer:
         _provider_keys = {
             "anthropic": "ANTHROPIC_API_KEY",
             "openai": "OPENAI_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
             "google": "GOOGLE_API_KEY",
         }
         cb_registry = get_circuit_breaker_registry()


### PR DESCRIPTION
## Summary\n- add DeepSeek provider routing support through custom provider metadata\n- add DeepSeek router test coverage\n- keep work against canonical origin/main / GitHub main only\n\n## Validation\n- targeted router tests: 7/7 passing\n- pre-existing unrelated audit-log failure remains out of scope: missing tokenpak.pro\n\n## Review\nSuki review required before merge.\n\n## Fleet note\nGitHub main was aligned to canonical origin/main after archiving previous GitHub main at archive/github-main-pre-canonical-2026-05-06. github-staging/main remains deprecated/archived; no DeepSeek hand-port was attempted.