### PR TITLE
fix: restoration sweep — DeepSeek + dashboard security + __version__ sync

### DIFF
--- a/tests/dashboard/test_settings_page.py
+++ b/tests/dashboard/test_settings_page.py
@@ -202,6 +202,18 @@ class TestAlertSettingsPersist:
             )
         assert r.status_code == 200
 
+    def test_alerts_htmx_rejects_webhook_url_post(self, client):
+        r = client.post(
+            "/settings/claude-code/htmx/alerts",
+            data={
+                "cache_alert_webhook_enabled": "1",
+                "cache_alert_webhook_url": "https://example.com/hook",
+                "cache_alert_threshold": "30",
+            },
+        )
+        assert r.status_code == 422
+        assert "Webhook URL edits are disabled" in r.text
+
 
 # ---------------------------------------------------------------------------
 # 3. Atomic-write safety
@@ -293,6 +305,30 @@ class TestInputValidation:
             "TOKENPAK_CACHE_ALERT_THRESHOLD": "50.0",
         })
         assert errors == []
+
+    def test_webhook_url_write_rejected_by_validation(self):
+        errors = validate_settings({"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"})
+        assert errors
+        assert "dashboard writes are disabled" in errors[0]
+
+    def test_webhook_url_write_aborts_without_creating_file(self, tmp_env_file):
+        ok, errors = write_settings(
+            {"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"},
+            path=tmp_env_file,
+        )
+        assert not ok
+        assert errors
+        assert not tmp_env_file.exists()
+
+    def test_webhook_url_write_rejected_even_with_skip_validation(self, tmp_env_file):
+        ok, errors = write_settings(
+            {"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"},
+            path=tmp_env_file,
+            skip_validation=True,
+        )
+        assert not ok
+        assert errors
+        assert not tmp_env_file.exists()
 
     def test_write_aborts_on_invalid_input(self, tmp_env_file):
         ok, errors = write_settings(

--- a/tests/dashboard/test_settings_page.py
+++ b/tests/dashboard/test_settings_page.py
@@ -212,7 +212,25 @@ class TestAlertSettingsPersist:
             },
         )
         assert r.status_code == 422
-        assert "Webhook URL edits are disabled" in r.text
+        assert "Webhook URL cannot be saved here" in r.text
+
+    def test_alerts_htmx_rejects_slack_destination_post(self, client):
+        r = client.post(
+            "/settings/claude-code/htmx/alerts",
+            data={
+                "cache_alert_webhook_enabled": "1",
+                "cache_alert_slack_channel": "#tokenpak-alerts",
+                "cache_alert_threshold": "30",
+            },
+        )
+        assert r.status_code == 422
+        assert "Slack destination cannot be saved here" in r.text
+
+    def test_alerts_page_marks_slack_destination_read_only(self, client):
+        r = client.get("/settings/claude-code")
+        assert r.status_code == 200
+        assert "Slack destinations are read-only here" in r.text
+        assert 'name="cache_alert_slack_channel"' not in r.text
 
 
 # ---------------------------------------------------------------------------
@@ -306,26 +324,54 @@ class TestInputValidation:
         })
         assert errors == []
 
-    def test_webhook_url_write_rejected_by_validation(self):
-        errors = validate_settings({"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"})
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("ANTHROPIC_API_KEY", "sk-ant-test"),
+            ("OPENAI_API_KEY", "sk-test"),
+            ("TOKENPAK_REMOTE_HOST", "https://remote.example.invalid"),
+            ("TOKENPAK_OLLAMA_UPSTREAM", "https://ollama.example.invalid"),
+            ("TOKENPAK_CACHE_ALERT_WEBHOOK_URL", "https://example.com/hook"),
+            ("TOKENPAK_CACHE_ALERT_SLACK_CHANNEL", "#tokenpak-alerts"),
+        ],
+    )
+    def test_sensitive_remote_excluded_keys_rejected_by_validation(self, key, value):
+        errors = validate_settings({key: value})
         assert errors
         assert "dashboard writes are disabled" in errors[0]
 
-    def test_webhook_url_write_aborts_without_creating_file(self, tmp_env_file):
-        ok, errors = write_settings(
-            {"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"},
-            path=tmp_env_file,
-        )
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("ANTHROPIC_API_KEY", "sk-ant-test"),
+            ("OPENAI_API_KEY", "sk-test"),
+            ("TOKENPAK_REMOTE_HOST", "https://remote.example.invalid"),
+            ("TOKENPAK_OLLAMA_UPSTREAM", "https://ollama.example.invalid"),
+            ("TOKENPAK_CACHE_ALERT_WEBHOOK_URL", "https://example.com/hook"),
+            ("TOKENPAK_CACHE_ALERT_SLACK_CHANNEL", "#tokenpak-alerts"),
+        ],
+    )
+    def test_sensitive_remote_excluded_keys_abort_without_creating_file(self, tmp_env_file, key, value):
+        ok, errors = write_settings({key: value}, path=tmp_env_file)
         assert not ok
         assert errors
         assert not tmp_env_file.exists()
 
-    def test_webhook_url_write_rejected_even_with_skip_validation(self, tmp_env_file):
-        ok, errors = write_settings(
-            {"TOKENPAK_CACHE_ALERT_WEBHOOK_URL": "https://example.com/hook"},
-            path=tmp_env_file,
-            skip_validation=True,
-        )
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("ANTHROPIC_API_KEY", "sk-ant-test"),
+            ("OPENAI_API_KEY", "sk-test"),
+            ("TOKENPAK_REMOTE_HOST", "https://remote.example.invalid"),
+            ("TOKENPAK_OLLAMA_UPSTREAM", "https://ollama.example.invalid"),
+            ("TOKENPAK_CACHE_ALERT_WEBHOOK_URL", "https://example.com/hook"),
+            ("TOKENPAK_CACHE_ALERT_SLACK_CHANNEL", "#tokenpak-alerts"),
+        ],
+    )
+    def test_sensitive_remote_excluded_keys_rejected_even_with_skip_validation(
+        self, tmp_env_file, key, value
+    ):
+        ok, errors = write_settings({key: value}, path=tmp_env_file, skip_validation=True)
         assert not ok
         assert errors
         assert not tmp_env_file.exists()

--- a/tests/proxy/test_router.py
+++ b/tests/proxy/test_router.py
@@ -97,3 +97,25 @@ def test_router_accepts_missing_content_length():
 
     result = router.route("/v1/messages", headers, body)
     assert result.provider == "anthropic"
+
+
+def test_router_detects_deepseek_host():
+    router = ProviderRouter()
+    body = _json_body("deepseek-v4-flash")
+
+    result = router.route("https://api.deepseek.com/v1/chat/completions", {}, body)
+
+    assert result.provider == "deepseek"
+    assert result.base_url == "https://api.deepseek.com"
+    assert result.full_url == "https://api.deepseek.com/v1/chat/completions"
+
+
+def test_router_detects_deepseek_model_for_reverse_proxy():
+    router = ProviderRouter()
+    body = _json_body("deepseek-v4-pro")
+    headers = {"Content-Type": "application/json", "Content-Length": str(len(body))}
+
+    result = router.route("/v1/chat/completions", headers, body)
+
+    assert result.provider == "deepseek"
+    assert result.full_url == "https://api.deepseek.com/v1/chat/completions"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """TokenPak — Universal Content Compiler for LLMs.
 
-Public API surface for TokenPak v1.2.0.
+Public API surface for TokenPak v1.5.1.
 Formalizes importable classes for agent integrations, deployment, and testing.
 
 Quick start:
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.2.0"
+__version__ = "1.5.1"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/dashboard/app.py
+++ b/tokenpak/dashboard/app.py
@@ -667,7 +667,11 @@ def htmx_settings_alerts(
         "TOKENPAK_CACHE_ALERT_THRESHOLD": cache_alert_threshold,
     }
     if cache_alert_webhook_url:
-        updates["TOKENPAK_CACHE_ALERT_WEBHOOK_URL"] = cache_alert_webhook_url
+        return HTMLResponse(
+            '<p class="settings-error">Webhook URL edits are disabled in the dashboard; '
+            'edit tokenpak.env manually or request a webhook exception.</p>',
+            status_code=422,
+        )
     if cache_alert_slack_channel:
         updates["TOKENPAK_CACHE_ALERT_SLACK_CHANNEL"] = cache_alert_slack_channel
 

--- a/tokenpak/dashboard/app.py
+++ b/tokenpak/dashboard/app.py
@@ -668,12 +668,16 @@ def htmx_settings_alerts(
     }
     if cache_alert_webhook_url:
         return HTMLResponse(
-            '<p class="settings-error">Webhook URL edits are disabled in the dashboard; '
-            'edit tokenpak.env manually or request a webhook exception.</p>',
+            '<p class="settings-error">Webhook URL cannot be saved here. '
+            'Configure remote alert endpoints outside the dashboard.</p>',
             status_code=422,
         )
     if cache_alert_slack_channel:
-        updates["TOKENPAK_CACHE_ALERT_SLACK_CHANNEL"] = cache_alert_slack_channel
+        return HTMLResponse(
+            '<p class="settings-error">Slack destination cannot be saved here. '
+            'Configure alert delivery outside the dashboard.</p>',
+            status_code=422,
+        )
 
     errors = validate_settings(updates)
     if errors:

--- a/tokenpak/dashboard/settings_persistence.py
+++ b/tokenpak/dashboard/settings_persistence.py
@@ -71,10 +71,18 @@ _PROFILES = frozenset({
     "claude-code-sdk", "claude-code-ide", "claude-code-cron",
 })
 
-# Sue's CCI-13 carve-out permits local-admin writes only. Webhook URLs
-# point at remote hosts, so the dashboard persistence layer must not create
-# or update them without an explicit architecture exception.
-_FORBIDDEN_SETTINGS_WRITES = frozenset({"TOKENPAK_CACHE_ALERT_WEBHOOK_URL"})
+# Sue's CCI-13 carve-out permits local-admin writes only. Sensitive
+# credentials, provider/remote endpoints, and remote alert destinations must
+# not be created or updated through the dashboard settings route without an
+# explicit architecture exception.
+_FORBIDDEN_SETTINGS_WRITES = frozenset({
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "TOKENPAK_CACHE_ALERT_SLACK_CHANNEL",
+    "TOKENPAK_CACHE_ALERT_WEBHOOK_URL",
+    "TOKENPAK_OLLAMA_UPSTREAM",
+    "TOKENPAK_REMOTE_HOST",
+})
 
 
 def _validate_bool(key: str, value: str) -> None:

--- a/tokenpak/dashboard/settings_persistence.py
+++ b/tokenpak/dashboard/settings_persistence.py
@@ -71,6 +71,11 @@ _PROFILES = frozenset({
     "claude-code-sdk", "claude-code-ide", "claude-code-cron",
 })
 
+# Sue's CCI-13 carve-out permits local-admin writes only. Webhook URLs
+# point at remote hosts, so the dashboard persistence layer must not create
+# or update them without an explicit architecture exception.
+_FORBIDDEN_SETTINGS_WRITES = frozenset({"TOKENPAK_CACHE_ALERT_WEBHOOK_URL"})
+
 
 def _validate_bool(key: str, value: str) -> None:
     if value.lower() not in _BOOL_VALUES:
@@ -122,6 +127,9 @@ def validate_settings(updates: dict[str, str]) -> list[str]:
     """Return a list of validation error messages (empty if all valid)."""
     errors: list[str] = []
     for key, value in updates.items():
+        if key in _FORBIDDEN_SETTINGS_WRITES:
+            errors.append(f"{key}: dashboard writes are disabled; edit tokenpak.env manually or request a webhook exception")
+            continue
         validator = _VALIDATORS.get(key)
         if validator is None:
             continue
@@ -190,6 +198,14 @@ def write_settings(
     ``(False, [error_messages])``. On success attempts a SIGHUP to the
     running proxy for live-reloadable settings.
     """
+    forbidden = [key for key in updates if key in _FORBIDDEN_SETTINGS_WRITES]
+    if forbidden:
+        errors = [
+            f"{key}: dashboard writes are disabled; edit tokenpak.env manually or request a webhook exception"
+            for key in forbidden
+        ]
+        return False, errors
+
     if not skip_validation:
         errors = validate_settings(updates)
         if errors:
@@ -273,7 +289,6 @@ def load_settings_context(path: Path | None = None) -> dict[str, Any]:
         "budget_total":              _i("TOKENPAK_BUDGET_TOTAL", 12000),
         # Cache invalidation alerts
         "cache_alert_webhook_enabled": _b("TOKENPAK_CACHE_ALERT_WEBHOOK_ENABLED", "0"),
-        "cache_alert_webhook_url":     _s("TOKENPAK_CACHE_ALERT_WEBHOOK_URL"),
         "cache_alert_slack_channel":   _s("TOKENPAK_CACHE_ALERT_SLACK_CHANNEL"),
         "cache_alert_threshold":       _f("TOKENPAK_CACHE_ALERT_THRESHOLD", 50.0),
         # Local-first routing

--- a/tokenpak/dashboard/templates/settings_claude_code.html
+++ b/tokenpak/dashboard/templates/settings_claude_code.html
@@ -230,7 +230,7 @@
     <!-- ── Cache invalidation alerts ─────────────────────────────── -->
     <div class="settings-card" id="card-alerts">
       <h2>Cache Invalidation Alerts</h2>
-      <p class="card-desc">Fire a webhook or Slack notification when the cache hit rate drops below the threshold.</p>
+      <p class="card-desc">Configure local cache alert behavior. Remote webhook URLs are not editable from this dashboard.</p>
       <form action="/settings/claude-code/htmx/alerts" method="post"
             onsubmit="return htmxSubmit(this, 'status-alerts')">
         <div class="toggle-row">
@@ -240,15 +240,13 @@
             <span class="toggle-slider"></span>
           </label>
           <div>
-            <div class="toggle-label">Enable webhook alerts</div>
+            <div class="toggle-label">Enable cache alerts</div>
           </div>
         </div>
         <div class="form-row">
           <div class="form-group" style="flex:2">
-            <label for="cache_alert_webhook_url">Webhook URL</label>
-            <input type="text" id="cache_alert_webhook_url" name="cache_alert_webhook_url"
-                   placeholder="https://hooks.slack.com/…"
-                   value="{{ cache_alert_webhook_url }}">
+            <label>Webhook URL</label>
+            <p class="field-help">Remote webhook destinations are intentionally read-only here. Edit <code>tokenpak.env</code> manually or request an explicit webhook exception.</p>
           </div>
           <div class="form-group">
             <label for="cache_alert_threshold">Alert threshold (%)</label>

--- a/tokenpak/dashboard/templates/settings_claude_code.html
+++ b/tokenpak/dashboard/templates/settings_claude_code.html
@@ -255,11 +255,9 @@
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group">
-            <label for="cache_alert_slack_channel">Slack channel (optional)</label>
-            <input type="text" id="cache_alert_slack_channel" name="cache_alert_slack_channel"
-                   placeholder="#tokenpak-alerts"
-                   value="{{ cache_alert_slack_channel }}">
+          <div class="form-group" style="flex:2">
+            <label>Slack destination</label>
+            <p class="field-help">Slack destinations are read-only here. Configure alert delivery outside the dashboard.</p>
           </div>
           <button type="submit" class="btn-save">Save</button>
         </div>

--- a/tokenpak/proxy/circuit_breaker.py
+++ b/tokenpak/proxy/circuit_breaker.py
@@ -568,6 +568,7 @@ class CircuitBreaker:
 # Known provider URL substrings → canonical provider names
 _PROVIDER_PATTERNS: List[tuple] = [
     ("anthropic.com", "anthropic"),
+    ("deepseek.com", "deepseek"),
     ("openai.com", "openai"),
     # ChatGPT Codex subscription — OAuth JWT → chatgpt.com/backend-api.
     # Maps to the same circuit-breaker + injection logic as openai so

--- a/tokenpak/proxy/custom_providers.py
+++ b/tokenpak/proxy/custom_providers.py
@@ -80,9 +80,12 @@ def load_custom_providers() -> List[CustomProvider]:
     Never raises -- config errors are logged and the offending entry skipped.
     """
     try:
-        from tokenpak import config_loader as _cl
+        from tokenpak.core import config_loader as _cl
     except ImportError:
-        return []
+        try:
+            from tokenpak import config_loader as _cl  # legacy layout
+        except ImportError:
+            return []
 
     cfg = _cl.load_config()
     if not isinstance(cfg, dict):

--- a/tokenpak/proxy/router.py
+++ b/tokenpak/proxy/router.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 PROVIDER_URLS = {
     "anthropic": "https://api.anthropic.com",
     "openai": "https://api.openai.com",
+    "deepseek": "https://api.deepseek.com",
     # openai-codex: subscription OAuth model (gpt-5.x-codex series)
     # Uses api.openai.com with OAuth Bearer token instead of API key.
     # Preferred endpoint: /v1/responses (Responses API)
@@ -154,6 +155,8 @@ class ProviderRouter:
         host_lower = host.lower()
         if "anthropic" in host_lower:
             return "anthropic"
+        elif "deepseek" in host_lower:
+            return "deepseek"
         elif "openai" in host_lower:
             return "openai"
         elif "googleapis" in host_lower or "google" in host_lower:
@@ -175,7 +178,15 @@ class ProviderRouter:
         4. Bearer token presence (non-Google Bearer → openai)
         5. Default: anthropic
         """
-        # Path-based detection (highest priority)
+        # Body model prefix can disambiguate OpenAI-compatible providers that
+        # share /v1/chat/completions (for example DeepSeek). Keep this before
+        # the generic chat-completions path rule.
+        if body:
+            model = self._extract_model(body)
+            if model.startswith("deepseek"):
+                return "deepseek"
+
+        # Path-based detection (highest priority for unique provider paths)
         if "/v1/messages" in path:
             return "anthropic"
         if "/codex/responses" in path or "/v1/codex/responses" in path:

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -862,6 +862,23 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         content_length = int(self.headers.get("Content-Length", 0))
         body: Optional[bytes] = self.rfile.read(content_length) if content_length > 0 else None
 
+        # DeepSeek is OpenAI-compatible, so reverse-proxy requests arrive on
+        # /v1/chat/completions like OpenAI. Route by explicit model prefix so
+        # OpenClaw can use a tokenpak-deepseek provider without overriding all
+        # OpenAI-chat traffic.
+        try:
+            if body and "/chat/completions" in target_url:
+                _body_model = json.loads(body.decode("utf-8")).get("model", "")
+                if isinstance(_body_model, str) and _body_model.startswith("deepseek"):
+                    _path = parsed.path or self.path
+                    if parsed.query:
+                        _path += "?" + parsed.query
+                    target_url = "https://api.deepseek.com" + _path
+                    parsed = urlparse(target_url)
+                    should_log = True
+        except Exception:
+            pass
+
         model = "unknown"
         input_tokens = 0
         sent_input_tokens = 0
@@ -1262,6 +1279,18 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             )
         except Exception:
             _router_injected = False  # fail-open
+
+        # DeepSeek API-key injection. DeepSeek is OpenAI-compatible and uses
+        # Authorization: Bearer <DEEPSEEK_API_KEY>. Keep this narrow so normal
+        # OpenAI/Codex routing remains untouched.
+        _upstream_provider = provider_from_url(target_url)
+        if not _router_injected and _upstream_provider == "deepseek":
+            _deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+            if _deepseek_key:
+                fwd_headers["Authorization"] = f"Bearer {_deepseek_key}"
+                for _ck in ("x-api-key", "X-Api-Key"):
+                    fwd_headers.pop(_ck, None)
+                _router_injected = True
 
         # ── Codex OAuth credential injection (legacy default path) ───
         # OpenAI Codex (Responses API) routes need OAuth token from
@@ -2725,6 +2754,7 @@ class ProxyServer:
         _provider_keys = {
             "anthropic": "ANTHROPIC_API_KEY",
             "openai": "OPENAI_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
             "google": "GOOGLE_API_KEY",
         }
         cb_registry = get_circuit_breaker_registry()


### PR DESCRIPTION
## Summary

Hygiene-review restoration branch (Sue 2026-05-07). Bundles 4 commits that exist scattered across local mirrors but were never pushed to canonical `main`:

1. `cff6637aca` **feat(proxy): add DeepSeek provider routing** — first-class routed provider so OpenClaw can target `tokenpak-deepseek` without overriding all OpenAI-compatible chat traffic. (was on `tip7-sync-cherrypick-2026-05-05` only)
2. `6d6c5c3f5e` **fix(dashboard): forbid settings webhook URL writes** — security hardening. (was on local origin mirror only)
3. `331abd68e9` **test(dashboard): guard sensitive settings exclusions** — accompanying tests for #2. (was on local origin mirror only)
4. `e4edbb6022` **chore(version): sync `__version__` source-of-truth to 1.5.1** — `tokenpak.__version__` had been pinned at `1.2.0` since the v1.2.0 release commit; every release tag (v1.3.x → v1.5.0) was made on a separate lineage that didn't merge back. Runtime callers were getting wrong version. PATCH bump per `feedback_initiative_completion_versioning`.

## Provenance

- Discovered during fleet hygiene review 2026-05-07 (Sue) — see initiative folder.
- Cherry-picks all clean, no conflicts.

## ⚠️ Merge gating

**Do NOT merge until `main` CI is green.** Main has been red since 2026-05-03 (TIP7-001 packaging extras: 16 py3.10 collection errors + Ruff 4683 errors + CLI docs requests-import). A separate CI-restoration branch is recommended first. See `vault/01_PROJECTS/tokenpak/initiatives/2026-05-07-fleet-hygiene-review/`.

## Standards

- 21-branching-merge-policy
- 27-multi-repo-versioning
- feedback_process_enforced_gating

## Approval

PATCH bump → Suki gates per `feedback_initiative_completion_versioning`.