### PR TITLE
fix(core/config_validator): wire ANTHROPIC_API_KEY env-var bypass

### DIFF
--- a/tokenpak/core/config_validator.py
+++ b/tokenpak/core/config_validator.py
@@ -97,17 +97,39 @@ class ConfigValidator:
         return self.errors
 
     def _validate_required_fields(self, config: Dict[str, Any]) -> None:
-        """Check that all required fields are present or set via environment variables."""
+        """Check that all required fields are present or set via environment variables.
+
+        ``api_keys`` is satisfied by ANY of:
+          - present in the config dict
+          - one of the canonical env vars set
+            (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``GOOGLE_API_KEY``,
+            ``GEMINI_API_KEY``)
+          - byte-passthrough mode is in use (the proxy never injects its own
+            keys — caller-supplied auth is forwarded verbatim, so the field
+            is not actually required for runtime operation).
+
+        The previous implementation defined ``_has_env_api_key`` but never
+        called it, leaving the env-var bypass advertised in the suggestion
+        message dead code. Fixed 2026-05-07.
+        """
         for field in self.REQUIRED_FIELDS:
             if field not in config:
                 if field == "api_keys":
+                    # Honor the documented env-var bypass.
+                    if self._has_env_api_key():
+                        continue
                     self.errors.append(
                         ConfigValidationError(
                             field=field,
-                            expected="present in config",
-                            actual="missing",
+                            expected="present in config or env var set",
+                            actual="missing (and no env var set)",
                             message="Required field 'api_keys' is missing",
-                            suggestion='Add api_keys to config (e.g., {"anthropic": "sk-..."}) or set ANTHROPIC_API_KEY env var',
+                            suggestion=(
+                                'Add api_keys to config (e.g., {"anthropic": "sk-..."}), '
+                                'set ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY '
+                                'env var, or — if using byte-passthrough — use a placeholder '
+                                'value (the proxy forwards caller-supplied auth verbatim).'
+                            ),
                         )
                     )
                 else:

--- a/tokenpak/tests/test_config_validator.py
+++ b/tokenpak/tests/test_config_validator.py
@@ -82,16 +82,44 @@ class TestRequiredFields:
         errors = v.validate(MINIMAL_VALID)
         assert errors == []
 
-    def test_missing_api_keys_returns_error(self):
+    def test_missing_api_keys_returns_error(self, monkeypatch):
+        # Isolate from the dev environment — clear any provider env vars.
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
         v = make_validator()
         errors = v.validate({})
         assert any(e.field == "api_keys" for e in errors)
 
-    def test_missing_api_keys_suggestion_mentions_env(self):
+    def test_missing_api_keys_suggestion_mentions_env(self, monkeypatch):
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
         v = make_validator()
         errors = v.validate({})
         err = next(e for e in errors if e.field == "api_keys")
         assert "ANTHROPIC_API_KEY" in err.suggestion or "api_keys" in err.suggestion
+
+    def test_env_var_bypasses_api_keys_requirement(self, monkeypatch):
+        """Regression: prior to 2026-05-07 the validator advertised an
+        env-var bypass that was never wired in. Setting ANTHROPIC_API_KEY
+        (or any provider key) MUST silence the missing-api_keys error."""
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-not-used")
+        v = make_validator()
+        errors = v.validate({})
+        assert not any(e.field == "api_keys" for e in errors)
+
+    def test_env_var_bypass_each_provider(self, monkeypatch):
+        """Each canonical provider env var must satisfy the requirement."""
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+            for clear in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+                monkeypatch.delenv(clear, raising=False)
+            monkeypatch.setenv(var, "test-value")
+            v = make_validator()
+            errors = v.validate({})
+            assert not any(e.field == "api_keys" for e in errors), (
+                f"Setting {var} should have bypassed the api_keys requirement"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The validator advertised an env-var bypass in the missing-`api_keys` suggestion ("or set `ANTHROPIC_API_KEY` env var") but the bypass was never wired in. `_has_env_api_key()` was defined as a static method and never called by `_validate_required_fields`, so users who followed the documented workflow still got `Required field api_keys is missing` errors and `tokenpak start` refused to launch.

## What this fixes

- `tokenpak/core/config_validator.py` — call `self._has_env_api_key()` in the `api_keys` branch of `_validate_required_fields`; sharpen the suggestion to mention all three accepted bypass paths (in-config dict / env var / byte-passthrough placeholder).
- `tokenpak/tests/test_config_validator.py` — 2 new regression tests cover the env-var bypass (one for `ANTHROPIC_API_KEY`, one across all four provider env vars). Existing tests hardened with `monkeypatch.delenv` so they don't false-pass when the dev shell has a key set.

## Verification

```
$ tokenpak start                                    # no env var, no api_keys in config
✗ Config validation failed: Required field 'api_keys' is missing
  (clean error with updated suggestion)

$ ANTHROPIC_API_KEY=sk-test tokenpak start          # env var set
Proxy launched (PID xxxxx, port 8766) — waiting for startup...
```

40 tests in `test_config_validator.py` green (was 38 + 2 new).

## Discovery context

Surfaced while restarting the proxy after the TIP Spend Guard merge prep (PR #97 / initiative `2026-05-07-tip-spend-guard-oss`). Independent fix; lands as its own PR for clean review.

— Sue