### PR TITLE
release: TokenPak v1.5.2 — MultiPak Pro Phase 0 + Phase 1 OSS surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,22 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — MultiPak Pro Phase 1 OSS surface (Std 32)
+## [v1.5.2] — 2026-05-08 — MultiPak Pro Phase 0 + Phase 1 OSS surface (Std 32)
 
-### Added
+> **Release batching note**: this PATCH release ships both the Phase 0 TIP capability constants + `Pak`/`ContextPackage` data contracts (originally landed in PR #101) and the Phase 1 OSS surface (PR #102). Two-step v1.5.2 → v1.5.3 was originally intended; PR #102 merged immediately after PR #101 + the registry companion PR before a release-bump window opened, so the two phases ship together as a single batched PATCH per the release-protocol allowance.
+>
+> Both phases are pure additions; this is a normal additive PATCH per [`feedback_initiative_completion_versioning`](.claude/projects/-home-sue/memory/feedback_initiative_completion_versioning.md). No breaking changes.
 
-- **MultiPak Pro Phase 1 OSS surface** ([Std 32](standards/32-multipak-pro-architecture.md) §1.3 + §9). Pure additions; no behavior change in existing flows. `multipak.enabled=false` by default until 1-week soak per Std 32 §13.1 Decision #6. Phase 0 contracts (`tokenpak/tip/{pak,context_package,capabilities}.py`) shipped in the prior release; Phase 1 wires those contracts into the four OSS surfaces:
+### Added — Phase 0 (TIP capability + data contracts)
+
+- 10 new TIP capability constants under `tokenpak.tip.capabilities` (`tip.pak.{capture,index,recall,hydrate,promote}`, `tip.context.{package,handoff,resume,coverage,policy}`).
+- `Pak` + `ContextPackage` frozen dataclasses with full JSON round-trip in `tokenpak.tip.pak` and `tokenpak.tip.context_package`.
+- Companion `tokenpak/registry` 0.2.0 release: 10 capability-catalog entries + JSON Schemas (`pak-v1`, `context-package-v1`) + extended `profiles` enum admitting `tip-paid-local-daemon`.
+- 54 contract tests in `tests/tip/test_multipak_contracts.py`.
+
+### Added — Phase 1 (OSS surface)
+
+- **MultiPak Pro Phase 1 OSS surface** ([Std 32](standards/32-multipak-pro-architecture.md) §1.3 + §9). Pure additions; no behavior change in existing flows. `multipak.enabled=false` by default until 1-week soak per Std 32 §13.1 Decision #6. Wires the Phase 0 contracts (`tokenpak/tip/{pak,context_package,capabilities}.py`, shipped above in the same release) into the four OSS surfaces:
   - `tokenpak/vault/pak_adapter.py` — wraps `VaultIndex.search()` to produce `Pak` instances with `PakSubtype.VAULT`. Read-only; no daemon contact.
   - `tokenpak/companion/journal/pak_aware.py` — opt-in promotion-candidate marker + query helper. Auto-capture unchanged per Std 32 §4.4. Stub `journal_entry_to_pak_stub()` builds Interaction-Pak-shaped previews.
   - `tokenpak pak {inspect,export,import,status}` CLI subcommand. JSON output schema matches the `/pak/v1/status` HTTP endpoint exactly. Vault Paks served by OSS adapter; other subtypes return `pro_daemon_required` with exit 1.

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"


### PR DESCRIPTION
Batched PATCH release covering both Phase 0 (#101) and Phase 1 (#102) MultiPak Pro work.

## What's in v1.5.2

**Phase 0** (PR #101 + registry PR #4): TIP capability constants (10 new) + `Pak` / `ContextPackage` data contracts. 54 contract tests.

**Phase 1** (PR #102): Vault Pak adapter, companion Pak-aware journal, `tokenpak pak` CLI, `/pak/v1/*` proxy stubs, daemon probe, `pro.multipak.enabled` config flag. 100 surface tests.

Both phases are **pure additions** — no breaking changes, no removed fields, no renamed canonical types.

## Why batched (release-sequence note)

Two-step v1.5.2 → v1.5.3 was originally intended (Phase 0 → Phase 1 PATCH separation). PR #102 merged immediately after PR #101 + the registry companion PR landed, before a release-bump window opened. The two phases now ship together as a single batched PATCH per the release-protocol allowance.

CHANGELOG entry documents this rationale.

## Standards

- Std 32 §1.3 + §9 (Phase 0/1 boundary + phasing)
- Std 25 §1.1 (TIP capabilities land in OSS first) + §2.1 (daemon process model) + §3.4 (fallback contract)
- Std 31 §2 (additive capability rule)
- Std 03 §1 (CLI exit codes)
- `feedback_initiative_completion_versioning` (PATCH bump, Suki/Kevin approval gate; Kevin substitutes here under the 2026-05-07 fleet freeze)

## Approval

`Approved-by: Kevin (PATCH, substituting for paused Suki cycle, 2026-05-08)`