### PR TITLE
fix(tests,release): TSR-01 — guard tomllib for Python 3.10 collection (Phase 1 of #106)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
   #     `try: ... except ImportError as exc: pytest.skip(..., allow_module_level=True)`.
   #     `importorskip` on the bare namespace returns truthy and won't help here.
   #
+  #   • Python-version-dependent stdlib modules (e.g. `tomllib` is stdlib only
+  #     on 3.11+; absent on 3.10) → same `pytest.importorskip("tomllib", ...)`
+  #     pattern. The test runs on the matrix versions where the stdlib module
+  #     is available; coverage stays adequate via the supported-version matrix.
+  #
   # When this gate is red, do NOT bypass it via `--ignore=...`. Either fix
   # the failing test's import guard or add the missing extra to this step.
   test:

--- a/tests/test_dependencies_extras.py
+++ b/tests/test_dependencies_extras.py
@@ -14,10 +14,15 @@ out of the slim core and into named optional extras.
 from __future__ import annotations
 
 import sys
-import tomllib
 from pathlib import Path
 
 import pytest
+
+# tomllib is stdlib only on Python 3.11+. On 3.10 it doesn't exist, so the
+# slim release test gate must skip cleanly there. This test file's purpose
+# (validate pyproject extras shape) is Python-version-independent —
+# running it on 3.11/3.12/3.13 is sufficient coverage of the invariant.
+tomllib = pytest.importorskip("tomllib", reason="tomllib is stdlib in Python 3.11+; this test runs on 3.11/3.12/3.13")
 
 PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 

--- a/tests/test_extras_import_guard.py
+++ b/tests/test_extras_import_guard.py
@@ -23,7 +23,15 @@ from __future__ import annotations
 import importlib
 import pathlib
 import sys
-import tomllib
+
+import pytest
+
+# tomllib is stdlib only on Python 3.11+. On 3.10 it doesn't exist, so the
+# slim release test gate must skip cleanly there. This test file's purpose
+# (post-demotion guarded-import smoke) is Python-version-independent —
+# running it on 3.11/3.12/3.13 is sufficient coverage of the invariant.
+tomllib = pytest.importorskip("tomllib", reason="tomllib is stdlib in Python 3.11+; this test runs on 3.11/3.12/3.13")
+
 import types
 import unittest
 from unittest.mock import patch


### PR DESCRIPTION
## TSR-01 — restore collection stability (Phase 1 of #106)

**This PR fixes collection stability only. It does NOT restore the full auto-publish path.** Subsequent phases (TSR-02..08) cover API drift, schema drift, missing exports, runtime test bugs, internal/OSS boundary, perf regressions, and end-to-end auto-publish verification — they are tracked separately in [#106](https://github.com/tokenpak/tokenpak/issues/106) and the [vault initiative](../../../tokenpak/tokenpak/blob/main/_vault/01_PROJECTS/tokenpak/initiatives/2026-05-08-release-test-suite-recovery/_index.md).

## Scope correction surfaced during execution

While building TSR-01 I confirmed empirically that **PR #105 already restored most collection stability** — Python 3.11/3.12/3.13 had 0 collection errors on a slim `[dev]`-only install after #105 merged. The `~36 remaining import-guard cases` I cited in the initiative plan was a **misclassification** of CI summary line `36 errors`: those are **test-runtime ERROR statuses** (fixture / setUp failures with `[N%]` progress markers), not collection-time errors. They categorically belong in TSR-02 (API drift), TSR-04 (missing exports), and TSR-05 (real test bugs), not TSR-01.

The actual remaining TSR-01 scope was **2 files on Python 3.10 only**, both unconditionally importing `tomllib` (stdlib in Python 3.11+, absent on 3.10):

- `tests/test_dependencies_extras.py:17` — `import tomllib`
- `tests/test_extras_import_guard.py:26` — `import tomllib`

Verified via cross-job CI inspection of [run #25562433231](https://github.com/tokenpak/tokenpak/actions/runs/25562433231) — `Test (Python 3.10)` had 2 `ERROR collecting` entries; 3.11/3.12/3.13 had 0 each.

Updating the initiative `_index.md` to reflect the corrected scope is a separate (docs-only) follow-up; this PR ships the code fix.

## What landed

### `tests/test_dependencies_extras.py` + `tests/test_extras_import_guard.py`

Both files now skip cleanly on Python 3.10 via the canonical PR #105 guard:

```python
import pytest

# tomllib is stdlib only on Python 3.11+. On 3.10 it doesn't exist, so the
# slim release test gate must skip cleanly there. This test file's purpose
# (validate pyproject extras shape / TIP7-002 post-demotion guarded-import smoke)
# is Python-version-independent — running it on 3.11/3.12/3.13 is sufficient.
tomllib = pytest.importorskip("tomllib", reason="tomllib is stdlib in Python 3.11+; this test runs on 3.11/3.12/3.13")
```

### `.github/workflows/release.yml` — new dependency-category note

The `test` job's comment block (added by PR #105) now documents the **Python-version-dependent stdlib** category:

> • Python-version-dependent stdlib modules (e.g. `tomllib` is stdlib only on 3.11+; absent on 3.10) → same `pytest.importorskip("tomllib", ...)` pattern. The test runs on the matrix versions where the stdlib module is available; coverage stays adequate via the supported-version matrix.

This satisfies the TSR-01 acceptance criterion *"Canonical import-guard pattern is documented if new dependency categories are found."*

## Acceptance

| # | Criterion | Status |
|---|---|---|
| 1 | `pytest tests/ --collect-only -q` completes with 0 collection errors on slim `[dev]`-only install | ✅ Locally verified on Python 3.12: **5941 tests collected, 0 errors**. CI verification across 3.10/3.11/3.12/3.13 follows on this PR. |
| 2 | Remaining runtime failures reported but not fixed in TSR-01 | ✅ ~36 test-runtime ERRORs + ~477 FAILED tests deferred to TSR-02..06 per the initiative phasing. None caused by TSR-01 changes. |
| 3 | Canonical import-guard pattern documented if new categories found | ✅ Python-version-dependent stdlib added to `release.yml` comment block. |
| 4 | MultiPak Phase 0/1 tests remain green | ✅ **154/154 passing** (54 contracts + 100 surfaces) verified locally. |
| 5 | PR body clearly states this fixes collection stability only | ✅ stated explicitly above. |

## What this PR does NOT do (reaffirmed)

- ❌ No API drift fixes (TSR-02)
- ❌ No schema drift fixes (TSR-03)
- ❌ No missing-export restorations (TSR-04)
- ❌ No real-test-bug fixes (TSR-05)
- ❌ No perf-regression triage (TSR-06)
- ❌ No internal/OSS boundary relocation (TSR-07)
- ❌ No `release.yml` test-bypass via `--ignore` / `--ignore-glob`
- ❌ No MultiPak Pro implementation (Std 25 §9.3 still gates)
- ❌ No cloud/sync/pricing surface
- ❌ No edits to v1.5.2 tag / artifacts / release notes (preserved)

## Verification commands

```bash
# Slim [dev]-only install (mirrors CI):
python3 -m venv /tmp/tsr01-slim
/tmp/tsr01-slim/bin/pip install -e ".[dev]"

# Acceptance:
/tmp/tsr01-slim/bin/python -m pytest tests/ --collect-only -q | tail -3
# expect: 5941 tests collected (0 errors)

# Phase 0/1 invariant:
/tmp/tsr01-slim/bin/python -m pytest tests/tip/test_multipak_contracts.py \
  tests/tip/test_vault_pak_adapter.py tests/companion/test_pak_aware_journal.py \
  tests/cli/test_pak_command.py tests/proxy/test_pak_endpoints.py -q
# expect: 154 passed
```

## Initiative + standards

- Initiative: `~/vault/01_PROJECTS/tokenpak/initiatives/2026-05-08-release-test-suite-recovery/_index.md`
- Task packet: `06-tasks/TSR-01-restore-collection-stability.md`
- Tracking issue: [#106](https://github.com/tokenpak/tokenpak/issues/106)
- Standards: 21 §9.8 (process-enforced gating), 02 §9 (dependencies)
- Memory: `feedback_process_enforced_gating`, `feedback_release_path_hardening`

Until #106 closes (after TSR-08 verifies auto-publish end-to-end), manual `twine` recovery via `feedback_release_path_hardening` remains the documented fallback for v1.5.3+.
