### PR TITLE
fix(telemetry): TSR-03 — restore CCI-21 schema (v1.1) on MetricsRecord

### DIFF
--- a/tests/cli/test_anon_metrics_schema.py
+++ b/tests/cli/test_anon_metrics_schema.py
@@ -1,0 +1,139 @@
+"""TSR-03 / CCI-21 schema-drift tests.
+
+Carved out from `tests/cli/test_metrics_mode_fields.py` so the v1.1
+schema invariants on `MetricsRecord` can be verified independently of
+the closed-source `tokenpak._internal` namespace and the WS-D
+`detect_consumption_mode` symbol that the parent file guards at module
+level. Both of those route to TSR-04 / TSR-07; neither is needed by
+the pure-schema tests below.
+
+Covered invariants (all unbundled from missing-export / boundary work):
+  - `_ALLOWED_FIELDS` contains `active_profile` + `consumption_mode`
+  - `MetricsRecord(active_profile=..., consumption_mode=...)` accepts
+    the kwargs and round-trips through `to_upload_dict()`
+  - `to_upload_dict()` omits the new fields when empty (payload
+    minimalism for old installs)
+  - `SCHEMA_VERSION == "1.1"` and new instances inherit it
+  - `MetricsStore._ensure_schema()` migrates a v1.0 SQLite database to
+    add the new columns (idempotent)
+
+If a future TSR-04 lands `detect_consumption_mode` and a future
+TSR-07 lands the `_internal` boundary fix, the broader test surface
+in `test_metrics_mode_fields.py` becomes observable too. Until then,
+this file alone exercises the canonical CCI-21 schema on slim OSS.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from tokenpak.telemetry.anon_metrics import (
+    SCHEMA_VERSION,
+    MetricsRecord,
+    MetricsStore,
+)
+
+
+class TestModeFieldsSchema:
+    """Verify the new fields are included in the upload payload."""
+
+    def test_allowed_fields_includes_new_fields(self):
+        assert "active_profile" in MetricsRecord._ALLOWED_FIELDS
+        assert "consumption_mode" in MetricsRecord._ALLOWED_FIELDS
+
+    def test_to_upload_dict_includes_fields_when_set(self):
+        rec = MetricsRecord(active_profile="agentic", consumption_mode="tmux")
+        d = rec.to_upload_dict()
+        assert d["active_profile"] == "agentic"
+        assert d["consumption_mode"] == "tmux"
+
+    def test_to_upload_dict_omits_empty_fields(self):
+        rec = MetricsRecord()
+        d = rec.to_upload_dict()
+        # Empty strings should be omitted to keep payload minimal
+        assert "active_profile" not in d
+        assert "consumption_mode" not in d
+
+    def test_schema_version_bumped_to_1_1(self):
+        assert SCHEMA_VERSION == "1.1"
+        rec = MetricsRecord()
+        assert rec.schema_version == "1.1"
+
+    def test_sqlite_migration_adds_columns(self, tmp_path):
+        """MetricsStore migrates an existing v1.0 DB to add the new columns."""
+        db_path = tmp_path / "metrics.db"
+
+        # Simulate an old v1.0 database without the new columns
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE metrics (
+                local_id TEXT PRIMARY KEY,
+                date_utc TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                tokens_saved INTEGER NOT NULL DEFAULT 0,
+                compression_ratio REAL NOT NULL DEFAULT 0.0,
+                latency_ms REAL NOT NULL DEFAULT 0.0,
+                model TEXT NOT NULL DEFAULT '',
+                schema_version TEXT NOT NULL DEFAULT '1.0',
+                synced INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Opening the store should migrate it
+        store = MetricsStore(db_path=db_path)  # noqa: F841 — instantiation triggers migration
+
+        conn = sqlite3.connect(str(db_path))
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(metrics)").fetchall()}
+        conn.close()
+
+        assert "active_profile" in cols
+        assert "consumption_mode" in cols
+
+    def test_migration_idempotent(self, tmp_path):
+        """Running _ensure_schema twice on a v1.0 DB must not raise."""
+        db_path = tmp_path / "metrics.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE metrics (
+                local_id TEXT PRIMARY KEY,
+                date_utc TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                tokens_saved INTEGER NOT NULL DEFAULT 0,
+                compression_ratio REAL NOT NULL DEFAULT 0.0,
+                latency_ms REAL NOT NULL DEFAULT 0.0,
+                model TEXT NOT NULL DEFAULT '',
+                schema_version TEXT NOT NULL DEFAULT '1.0',
+                synced INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # First instantiation migrates
+        MetricsStore(db_path=db_path)
+        # Second instantiation must be a no-op (ALTER TABLE would raise
+        # "duplicate column" without the existing-cols guard)
+        MetricsStore(db_path=db_path)
+
+    def test_record_round_trip_with_new_fields(self, tmp_path):
+        """Insert + fetch a record with both new fields populated."""
+        store = MetricsStore(db_path=tmp_path / "metrics.db")
+        rec = MetricsRecord(
+            input_tokens=100,
+            output_tokens=20,
+            tokens_saved=30,
+            latency_ms=42.0,
+            model="claude-haiku-4-5",
+            active_profile="balanced",
+            consumption_mode="cli",
+        )
+        store.record(rec)
+        pending = store.get_pending()
+        assert len(pending) == 1
+        assert pending[0].active_profile == "balanced"
+        assert pending[0].consumption_mode == "cli"
+        assert pending[0].schema_version == "1.1"

--- a/tokenpak/telemetry/anon_metrics.py
+++ b/tokenpak/telemetry/anon_metrics.py
@@ -6,6 +6,8 @@ Collects only:
   - compression ratio
   - latency_ms
   - date (UTC day bucket — no timestamp precision below day)
+  - active_profile (loaded profile name, e.g. "balanced", "agentic")
+  - consumption_mode (auto-detected mode: cli/tui/tmux/sdk/ide/cron)
 
 NO prompt content, NO response content, NO user-identifiable data.
 
@@ -26,7 +28,13 @@ from typing import List, Optional
 METRICS_DB = Path(os.path.expanduser("~/.tokenpak/metrics.db"))
 
 # Version tag lets the ingest endpoint evolve schemas without breakage.
-SCHEMA_VERSION = "1.0"
+# v1.1 — TSR-03 / CCI-21 restoration (2026-05-08): adds active_profile +
+# consumption_mode fields. Original commit 3a5b63cd58 was reverted by
+# refactor 88d3d9deb0 ("delete deprecated agent/ + _internal/ trees").
+# Schema is restored here; the _internal.config helpers + the
+# detect_consumption_mode() function live separately and are not part
+# of TSR-03's scope.
+SCHEMA_VERSION = "1.1"
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +66,10 @@ class MetricsRecord:
     # Routing
     model: str = ""
 
+    # Consumption context (CCI-21 restored — anonymous categorical, no PII)
+    active_profile: str = ""      # loaded profile name (e.g. "balanced", "agentic", "claude-code-cli")
+    consumption_mode: str = ""    # auto-detected mode (cli/tui/tmux/sdk/ide/cron) — may differ from profile
+
     # Schema version
     schema_version: str = SCHEMA_VERSION
 
@@ -74,10 +86,16 @@ class MetricsRecord:
         # Strip local-only fields
         d.pop("local_id", None)
         d.pop("synced", None)
+        # Omit empty mode fields to keep payload minimal for old installs
+        if not d.get("active_profile"):
+            d.pop("active_profile", None)
+        if not d.get("consumption_mode"):
+            d.pop("consumption_mode", None)
         return d
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "MetricsRecord":
+        keys = row.keys()
         return cls(
             local_id=row["local_id"],
             date_utc=row["date_utc"],
@@ -87,6 +105,8 @@ class MetricsRecord:
             compression_ratio=row["compression_ratio"],
             latency_ms=row["latency_ms"],
             model=row["model"],
+            active_profile=row["active_profile"] if "active_profile" in keys else "",
+            consumption_mode=row["consumption_mode"] if "consumption_mode" in keys else "",
             schema_version=row["schema_version"],
             synced=bool(row["synced"]),
         )
@@ -102,6 +122,8 @@ class MetricsRecord:
             "compression_ratio",
             "latency_ms",
             "model",
+            "active_profile",
+            "consumption_mode",
             "schema_version",
             "synced",
         }
@@ -144,10 +166,26 @@ class MetricsStore:
                     compression_ratio REAL NOT NULL DEFAULT 0.0,
                     latency_ms      REAL NOT NULL DEFAULT 0.0,
                     model           TEXT NOT NULL DEFAULT '',
-                    schema_version  TEXT NOT NULL DEFAULT '1.0',
+                    active_profile  TEXT NOT NULL DEFAULT '',
+                    consumption_mode TEXT NOT NULL DEFAULT '',
+                    schema_version  TEXT NOT NULL DEFAULT '1.1',
                     synced          INTEGER NOT NULL DEFAULT 0
                 )
             """)
+            # CCI-21 restoration migration: add the two new columns to
+            # databases that were created against the v1.0 schema.
+            existing = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(metrics)").fetchall()
+            }
+            if "active_profile" not in existing:
+                conn.execute(
+                    "ALTER TABLE metrics ADD COLUMN active_profile TEXT NOT NULL DEFAULT ''"
+                )
+            if "consumption_mode" not in existing:
+                conn.execute(
+                    "ALTER TABLE metrics ADD COLUMN consumption_mode TEXT NOT NULL DEFAULT ''"
+                )
             conn.commit()
 
     def record(self, rec: MetricsRecord) -> None:
@@ -157,8 +195,9 @@ class MetricsStore:
                 """
                 INSERT OR IGNORE INTO metrics
                     (local_id, date_utc, input_tokens, output_tokens, tokens_saved,
-                     compression_ratio, latency_ms, model, schema_version, synced)
-                VALUES (?,?,?,?,?,?,?,?,?,0)
+                     compression_ratio, latency_ms, model,
+                     active_profile, consumption_mode, schema_version, synced)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,0)
                 """,
                 (
                     rec.local_id,
@@ -169,6 +208,8 @@ class MetricsStore:
                     rec.compression_ratio,
                     rec.latency_ms,
                     rec.model,
+                    rec.active_profile,
+                    rec.consumption_mode,
                     rec.schema_version,
                 ),
             )
@@ -253,8 +294,17 @@ def record_request(
     tokens_saved: int,
     latency_ms: float,
     model: str,
+    active_profile: str = "",
+    consumption_mode: str = "",
 ) -> None:
-    """Record one request. No-op if metrics are disabled. Never raises."""
+    """Record one request. No-op if metrics are disabled. Never raises.
+
+    `active_profile` and `consumption_mode` are CCI-21 schema fields
+    (v1.1). Callers pass them explicitly when known; auto-detection
+    helpers (e.g. detect_consumption_mode, get_active_profile) live
+    separately and are not wired in here. Empty strings default to
+    omission from the upload payload via to_upload_dict().
+    """
     try:
         from tokenpak.core.config import get_metrics_enabled
 
@@ -268,6 +318,8 @@ def record_request(
             compression_ratio=compression_ratio,
             latency_ms=round(latency_ms, 1),
             model=model,
+            active_profile=active_profile,
+            consumption_mode=consumption_mode,
         )
         get_store().record(rec)
         # Also write to local JSONL file when TOKENPAK_TELEMETRY_MODE=local (default).


### PR DESCRIPTION
## Summary

Restore the **CCI-21 v1.1 schema** on `MetricsRecord` that was unintentionally reverted by the namespace-cleanup refactor. Production change is the minimum required to make the WS-C schema-drift tests pass; no missing-export, boundary-policy, or auto-detect work is bundled.

## Root cause

| Commit | What | Schema state |
|---|---|---|
| `27f30ec2fd` (2026-03-31) | Initial CCI-21: schema bump + new fields + migration + helpers | shipped v1.1 |
| `3a5b63cd58` (2026-04-08) | CCI-21 (resync) — same diff, different SHA | shipped v1.1 |
| **`88d3d9deb0`** (2026-04-10) | "refactor: delete deprecated agent/ + _internal/ trees, rescue unique modules" | **reverted v1.1 → v1.0** |

The refactor was correct in deleting the `_internal/` tree (closed-source per Std 25 §1.1 — belongs in `tokenpak-paid`), but it also stripped the public-OSS schema fields and helper hooks from `tokenpak/telemetry/anon_metrics.py`. The schema fields are anonymous categorical (no PII) and ship with the OSS surface; their loss was the regression.

`tests/cli/test_metrics_mode_fields.py::TestModeFieldsSchema` codified the canonical v1.1 contract; those 5 tests have been failing on `main` ever since.

## Changes

### Production (`tokenpak/telemetry/anon_metrics.py`)

- `SCHEMA_VERSION` → `"1.1"`, with provenance comment citing the regression history
- `MetricsRecord` adds two fields:
  - `active_profile: str = ""` — loaded profile name (e.g. `"balanced"`, `"agentic"`, `"claude-code-cli"`)
  - `consumption_mode: str = ""` — auto-detected mode (`cli`/`tui`/`tmux`/`sdk`/`ide`/`cron`); may differ from profile
- `_ALLOWED_FIELDS` frozenset extended (the existing `__post_init__` guard still rejects any unknown field)
- `to_upload_dict()` omits empty `active_profile` / `consumption_mode` to keep wire payload minimal for old installs
- `from_row()` reads both columns when present, falls back to `""` when absent (back-compat for v1.0 DBs mid-migration)
- `_ensure_schema()` ships a v1.1 `CREATE TABLE` and runs an idempotent `ALTER TABLE` migration for any pre-existing v1.0 row's columns (`PRAGMA table_info` guard prevents duplicate-column errors)
- `record()` `INSERT` statement covers both new columns
- `record_request()` accepts `active_profile=""` and `consumption_mode=""` kwargs and passes them through. **No auto-detect.** Callers that know the values (e.g. the proxy pipeline once WS-D / WS-F land) pass them explicitly. Empty defaults remain wire-suppressed by `to_upload_dict()`.

**Diff size:** +57 / −5 lines, single file. No new imports.

### Test (`tests/cli/test_anon_metrics_schema.py` — new file, 138 lines)

Carves the 5 pure-schema invariants out of `tests/cli/test_metrics_mode_fields.py` into a dedicated file with **no boundary or missing-export coupling**, so the schema fix is observable in slim-OSS CI today (rather than being hidden behind the WS-D / WS-F guard on the parent file).

| Test | What it asserts |
|---|---|
| `test_allowed_fields_includes_new_fields` | `_ALLOWED_FIELDS` contains both `active_profile` + `consumption_mode` |
| `test_to_upload_dict_includes_fields_when_set` | Set values round-trip to upload payload |
| `test_to_upload_dict_omits_empty_fields` | Empty values are stripped (payload minimalism) |
| `test_schema_version_bumped_to_1_1` | `SCHEMA_VERSION == "1.1"`; new instances inherit it |
| `test_sqlite_migration_adds_columns` | Opening a v1.0 DB triggers `ALTER TABLE` for both columns |
| `test_migration_idempotent` (NEW) | Second `MetricsStore(db_path)` is a no-op (`existing` guard prevents duplicate-column error) |
| `test_record_round_trip_with_new_fields` (NEW) | `INSERT` + `SELECT` preserves both fields and the v1.1 version tag |

Local run: **7/7 pass**.

The parent file (`test_metrics_mode_fields.py`) remains module-level skipped on slim OSS by its existing TSR-01-followup guard (closed-source `_internal` + missing-export `detect_consumption_mode`). Once WS-D / TSR-04 lands `detect_consumption_mode` and WS-F / TSR-07 resolves the boundary, the parent file's broader test surface (including the same schema invariants again) becomes observable. Until then, this file alone exercises the canonical CCI-21 schema in CI.

## What is **not** in this PR (per directive)

- ❌ `detect_consumption_mode()` function — WS-D / TSR-04
- ❌ `tokenpak._internal.config.get_active_profile` / `get_consumption_mode` helpers — WS-F / TSR-07 (closed-source per Std 25 §1.1)
- ❌ Auto-detect logic in `record_request()` (the original CCI-21 path that called `detect_consumption_mode()` and read `TOKENPAK_PROFILE` env)
- ❌ Metrics-worker backend schema migration files (CALI-07 backend, separate repo)
- ❌ `docs/metrics.html` public counter page
- ❌ `agent/__init__.py` shim — module was intentionally deleted by `88d3d9deb0`; re-creating it is out of scope
- ❌ `tokenpak.handlers` ghost module — separate WS-D / TSR-04 item

## Constraints honored

- ✅ **Schema drift only.**
- ✅ **No bundling of missing exports** from the same file (`detect_consumption_mode` left for TSR-04).
- ✅ **No bundling of internal/OSS boundary failures** from the same file (`tokenpak._internal` import path left for TSR-07).
- ✅ **Production change is justified by proven regression** — `git log -S 'active_profile' -- tokenpak/telemetry/anon_metrics.py` shows commit `3a5b63cd58` shipped the fields; `git show 88d3d9deb0 -- tokenpak/telemetry/anon_metrics.py` shows the revert.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved (no tag / artifact changes).

## Verification

Local:

```bash
$ python3 -m pytest tests/cli/test_anon_metrics_schema.py -v
7 passed in 2.25s
```

End-to-end probe of the restored invariants:

```python
from tokenpak.telemetry.anon_metrics import MetricsRecord, SCHEMA_VERSION
assert SCHEMA_VERSION == "1.1"
rec = MetricsRecord(active_profile="agentic", consumption_mode="tmux")
assert rec.to_upload_dict()["active_profile"] == "agentic"
assert MetricsRecord().to_upload_dict() == {  # empty record — no mode fields
    "date_utc": ..., "input_tokens": 0, "output_tokens": 0, ...
}
```

Ruff: clean on both edited files; project-wide count unchanged.

## Std 21 §9.8 informational treatment

Pre-existing red CI debt on `main` (`Lint`, `CLI Docs`, `Compile Latency`, `Integration & Chaos`, residual `Test (Python 3.x)` failures from other workstreams) is unchanged by this PR. This PR introduces no new failures and adds 7 net-new passing tests.

Closes the TSR-03 (WS-C) work item from [#106](https://github.com/tokenpak/tokenpak/issues/106). The remaining failures in `test_metrics_mode_fields.py` route to TSR-04 and TSR-07.
