### PR TITLE
fix(tests,telemetry): TSR-04 — restore missing exports and ghost-path fixes

### DIFF
--- a/tests/cli/test_consumption_mode_detect.py
+++ b/tests/cli/test_consumption_mode_detect.py
@@ -1,0 +1,124 @@
+"""TSR-04 / WS-D — `detect_consumption_mode()` exercise tests.
+
+Carved out from `tests/cli/test_metrics_mode_fields.py` so the
+`detect_consumption_mode()` function (restored in the same TSR-04 PR)
+can be verified independently of the closed-source `tokenpak._internal`
+namespace that the parent file's TSR-01-followup guard requires.
+
+These tests probe the environment-heuristic logic only. They do not
+record metrics, do not touch the SQLite store, and do not need
+`tokenpak._internal`. The matching `test_record_stores_*_mode` cases
+remain in the parent file (they use the `_record_request` helper,
+which mocks `tokenpak._internal.config.get_metrics_enabled`) and route
+to TSR-07 / WS-F when the boundary policy lands.
+
+Covered modes: cli, tmux, sdk, ide (vscode / cursor / Windsurf), cron.
+TUI is not env-detected — it is provided explicitly by the caller, so
+no detect-test exists for it (the canonical TUI assertion is in the
+parent file's `TestModeTui::test_record_stores_tui_mode`).
+
+Restoration provenance:
+- `27f30ec2fd` / `3a5b63cd58` (2026-04-08, CCI-21) — function shipped
+- `88d3d9deb0` (2026-04-10, `_internal/` cleanup refactor) — reverted
+  along with the closed-source helpers (same regression as TSR-03's
+  schema fields)
+- TSR-04 (this PR, 2026-05-08) — function restored verbatim from
+  CCI-21; environment heuristics match `tokenpak-status/check.sh`
+  CCI-09 logic; no private API used.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from tokenpak.telemetry.anon_metrics import detect_consumption_mode
+
+
+def _clean_env() -> dict:
+    """Return os.environ minus the env vars the heuristic looks at."""
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("CRON_INVOCATION", "TERM_PROGRAM", "TMUX")
+    }
+
+
+class TestDetectCli:
+    def test_plain_terminal_returns_cli(self):
+        """Interactive tty with no special env vars → 'cli'."""
+        with mock.patch.dict(os.environ, _clean_env(), clear=True), \
+             mock.patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            assert detect_consumption_mode() == "cli"
+
+
+class TestDetectTmux:
+    def test_tmux_env_var_set(self):
+        """TMUX=… → 'tmux' (overrides interactive tty heuristic)."""
+        with mock.patch.dict(
+            os.environ, {"TMUX": "/tmp/tmux-1000/default,1234,0"}, clear=False
+        ):
+            assert detect_consumption_mode() == "tmux"
+
+
+class TestDetectSdk:
+    def test_non_interactive_stdin_returns_sdk(self):
+        """Non-tty stdin (claude -p, piped) → 'sdk'."""
+        with mock.patch.dict(os.environ, _clean_env(), clear=True), \
+             mock.patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert detect_consumption_mode() == "sdk"
+
+
+class TestDetectIde:
+    @pytest.mark.parametrize("term_program", ["vscode", "cursor", "Windsurf"])
+    def test_term_program_indicates_ide(self, term_program):
+        """TERM_PROGRAM ∈ {vscode, cursor, Windsurf} → 'ide'."""
+        with mock.patch.dict(
+            os.environ, {"TERM_PROGRAM": term_program}, clear=False
+        ):
+            assert detect_consumption_mode() == "ide"
+
+
+class TestDetectCron:
+    def test_cron_invocation_set(self):
+        """CRON_INVOCATION=1 → 'cron' (highest priority — checked first)."""
+        with mock.patch.dict(
+            os.environ, {"CRON_INVOCATION": "1"}, clear=False
+        ):
+            assert detect_consumption_mode() == "cron"
+
+
+class TestDetectPriority:
+    """Cross-mode priority — first match wins (cron > ide > tmux > sdk > cli)."""
+
+    def test_cron_wins_over_tmux(self):
+        with mock.patch.dict(
+            os.environ,
+            {"CRON_INVOCATION": "1", "TMUX": "/tmp/tmux/s"},
+            clear=False,
+        ):
+            assert detect_consumption_mode() == "cron"
+
+    def test_ide_wins_over_tmux(self):
+        with mock.patch.dict(
+            os.environ,
+            {"TERM_PROGRAM": "vscode", "TMUX": "/tmp/tmux/s"},
+            clear=False,
+        ):
+            assert detect_consumption_mode() == "ide"
+
+
+class TestDetectNeverRaises:
+    """Function contract: never raises, returns empty string on failure."""
+
+    def test_returns_string_under_clean_env(self):
+        with mock.patch.dict(os.environ, _clean_env(), clear=True), \
+             mock.patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            result = detect_consumption_mode()
+        assert isinstance(result, str)
+        assert result in ("cli", "tui", "tmux", "sdk", "ide", "cron", "")

--- a/tests/integrations/test_openclaw.py
+++ b/tests/integrations/test_openclaw.py
@@ -402,7 +402,12 @@ class TestRateLimitHandling:
 
     def test_rate_limit_backoff_wait_time_increases(self):
         """RateLimitBackoff wait time grows with each attempt."""
-        from tokenpak.handlers.rate_limit import RateLimitBackoff
+        # WS-D path restoration — TSR-04. The handlers tree relocated
+        # from tokenpak.handlers/ to tokenpak.proxy.handlers/ in commit
+        # 837514caff (2026-04-20). The backwards-compat shim was removed
+        # in the subsequent 17-module consolidation refactor
+        # (fbea4b1079). Update to the canonical location.
+        from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff
 
         backoff = RateLimitBackoff(base_wait=1.0, max_wait=60.0, jitter_factor=0.0)
         waits = [backoff.wait_time(attempt) for attempt in range(4)]
@@ -415,7 +420,12 @@ class TestRateLimitHandling:
 
     def test_rate_limit_backoff_respects_max_wait(self):
         """RateLimitBackoff never exceeds max_wait."""
-        from tokenpak.handlers.rate_limit import RateLimitBackoff
+        # WS-D path restoration — TSR-04. The handlers tree relocated
+        # from tokenpak.handlers/ to tokenpak.proxy.handlers/ in commit
+        # 837514caff (2026-04-20). The backwards-compat shim was removed
+        # in the subsequent 17-module consolidation refactor
+        # (fbea4b1079). Update to the canonical location.
+        from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff
 
         backoff = RateLimitBackoff(base_wait=1.0, max_wait=5.0, jitter_factor=0.0)
         for attempt in range(10):
@@ -424,7 +434,12 @@ class TestRateLimitHandling:
 
     def test_rate_limit_backoff_uses_retry_after(self):
         """Retry-After header value is respected when provided."""
-        from tokenpak.handlers.rate_limit import RateLimitBackoff
+        # WS-D path restoration — TSR-04. The handlers tree relocated
+        # from tokenpak.handlers/ to tokenpak.proxy.handlers/ in commit
+        # 837514caff (2026-04-20). The backwards-compat shim was removed
+        # in the subsequent 17-module consolidation refactor
+        # (fbea4b1079). Update to the canonical location.
+        from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff
 
         backoff = RateLimitBackoff(base_wait=1.0, max_wait=60.0, jitter_factor=0.0)
         wait = backoff.wait_time(0, retry_after=30.0)

--- a/tests/test_handoff_protocol.py
+++ b/tests/test_handoff_protocol.py
@@ -247,10 +247,34 @@ def test_crewai_unknown_agents_no_crash(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    not __import__('importlib').util.find_spec('autogen_tokenpak'),
-    reason='autogen_tokenpak package not installed'
+def _autogen_assistant_unavailable() -> bool:
+    """True iff autogen_tokenpak.TokenPakAssistant cannot be imported.
+
+    WS-D guard refinement — TSR-04. The previous `@skipif` checked only
+    that the `autogen_tokenpak` package was installed; it didn't catch
+    the case where the package is installed but the `TokenPakAssistant`
+    symbol is not re-exported (because the optional `tokenpak_agents`
+    dep is absent — see autogen_tokenpak/__init__.py's try/except
+    re-export). Result: tests fail at the per-test `from
+    autogen_tokenpak import TokenPakAssistant` instead of skipping.
+
+    Probe the actual import path so the skip predicate matches the
+    symbol the tests need.
+    """
+    try:
+        from autogen_tokenpak import TokenPakAssistant  # noqa: F401
+        return False
+    except ImportError:
+        return True
+
+
+_AUTOGEN_SKIP = pytest.mark.skipif(
+    _autogen_assistant_unavailable(),
+    reason="autogen_tokenpak.TokenPakAssistant not exposed (needs tokenpak_agents installed)",
 )
+
+
+@_AUTOGEN_SKIP
 def test_autogen_assistant_creation():
     from autogen_tokenpak import TokenPakAssistant
     a = TokenPakAssistant(name="alice", budget=2000)
@@ -258,11 +282,7 @@ def test_autogen_assistant_creation():
     assert a.budget == 2000
 
 
-
-@pytest.mark.skipif(
-    not __import__('importlib').util.find_spec('autogen_tokenpak'),
-    reason='autogen_tokenpak package not installed'
-)
+@_AUTOGEN_SKIP
 def test_autogen_receive_and_compress():
     from autogen_tokenpak import TokenPakAssistant
     a = TokenPakAssistant(name="alice", budget=2000)
@@ -272,11 +292,7 @@ def test_autogen_receive_and_compress():
     assert len(msgs) >= 1
 
 
-
-@pytest.mark.skipif(
-    not __import__('importlib').util.find_spec('autogen_tokenpak'),
-    reason='autogen_tokenpak package not installed'
-)
+@_AUTOGEN_SKIP
 def test_autogen_prepare_apply_handoff(tmp_path):
     from autogen_tokenpak import TokenPakAssistant
     from tokenpak.agentic.handoff import HandoffManager
@@ -299,11 +315,7 @@ def test_autogen_prepare_apply_handoff(tmp_path):
     assert any("quantum" in m.get("content", "") for m in msgs)
 
 
-
-@pytest.mark.skipif(
-    not __import__('importlib').util.find_spec('autogen_tokenpak'),
-    reason='autogen_tokenpak package not installed'
-)
+@_AUTOGEN_SKIP
 def test_autogen_handoff_wire_round_trip(tmp_path):
     from autogen_tokenpak import TokenPakAssistant
     from tokenpak import HandoffBlock, Handoff

--- a/tokenpak/telemetry/anon_metrics.py
+++ b/tokenpak/telemetry/anon_metrics.py
@@ -280,6 +280,37 @@ class MetricsStore:
 _store: Optional[MetricsStore] = None
 
 
+def detect_consumption_mode() -> str:
+    """Best-effort detection of the current consumption mode.
+
+    Returns one of: cli, tui, tmux, sdk, ide, cron, or empty string if unknown.
+    Mirrors the shell logic in tokenpak-status/check.sh (CCI-09 heuristic).
+    Never raises.
+
+    TSR-04 / WS-D restoration: this function shipped in commit 3a5b63cd58
+    (CCI-21, 2026-04-08) and was reverted by commit 88d3d9deb0 (the same
+    `_internal/` tree cleanup that reverted the v1.1 schema fields TSR-03
+    restored). Function logic is canonical CCI-21 verbatim; environment
+    heuristics match `tokenpak-status/check.sh`. No private API used.
+    """
+    try:
+        if os.environ.get("CRON_INVOCATION"):
+            return "cron"
+        term_program = os.environ.get("TERM_PROGRAM", "")
+        if term_program in ("cursor", "Windsurf"):
+            return "ide"
+        if term_program == "vscode":
+            return "ide"
+        if os.environ.get("TMUX"):
+            return "tmux"
+        import sys
+        if not sys.stdin.isatty():
+            return "sdk"
+        return "cli"
+    except Exception:
+        return ""
+
+
 def get_store() -> MetricsStore:
     global _store
     if _store is None:


### PR DESCRIPTION
## Summary

Three independent missing-export / ghost-path fixes from the WS-D residue. Each scoped strictly per the TSR-04 directive: no schema drift, no boundary policy work, no closed-source `_internal` recreation.

| # | Target | Type | Fix shape |
|---|---|---|---|
| A | `tokenpak.handlers.rate_limit.RateLimitBackoff` | **Renamed path** | Update 3 in-test imports to canonical `tokenpak.proxy.handlers.rate_limit` |
| B | `detect_consumption_mode` | **Proven regression** (same `88d3d9deb0` revert family as TSR-03) | Restore function from CCI-21 + carve out 10 detect-mode tests |
| C | `autogen_tokenpak.TokenPakAssistant` | **Conditional re-export** + wrong skip predicate | Replace 4 `@skipif` decorators with one that probes the actual symbol |

**Diff:** 4 files / +203 / −21 lines. 1 production change (Target B, function restoration). 3 test changes.

## Target A — `tokenpak.handlers.rate_limit` renamed path

**Investigation:**
- The `RateLimitBackoff` class **does** exist in OSS — at `tokenpak/proxy/handlers/rate_limit.py:19`
- The handlers tree was relocated by commit `837514caff` (2026-04-20, "feat(d1): two more bites — handlers + middleware → proxy/")
- A backwards-compat shim with `DeprecationWarning` was left at `tokenpak/handlers/` per the commit message, slated for removal at TIP-2.0
- The shim was deleted earlier than planned by the 17-module consolidation refactor (`fbea4b1079`)
- The 3 in-test imports at `tests/integrations/test_openclaw.py:405,418,427` still reference the legacy path

**Fix:** Update the 3 imports to `from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff`. Each updated import has a one-comment provenance note citing the relocation history. **Test fix only — no production change** (the canonical path was already in place; only the tests were stale).

**Verification:** 3/3 `TestRateLimitHandling::test_rate_limit_backoff_*` tests pass locally via the canonical path.

## Target B — `detect_consumption_mode` proven regression

**Investigation:**
- Function was added in CCI-21 commit `3a5b63cd58` (2026-04-08): `def detect_consumption_mode() -> str:` returning one of `cli`/`tui`/`tmux`/`sdk`/`ide`/`cron`/`""`
- Reverted by commit `88d3d9deb0` (2026-04-10, "refactor: delete deprecated agent/ + _internal/ trees") — the same commit that stripped the v1.1 schema fields TSR-03 restored
- Function is **public-OSS by design**: only reads environment variables (`CRON_INVOCATION`, `TERM_PROGRAM`, `TMUX`) and `sys.stdin.isatty()`. No private API. No PII. Heuristic mirrors `tokenpak-status/check.sh` CCI-09 logic.

**Fix:** Restore the function verbatim from `3a5b63cd58` into `tokenpak/telemetry/anon_metrics.py` with a provenance comment citing the regression history.

**Carve-out tests** (`tests/cli/test_consumption_mode_detect.py`, new file, 10 test cases):
- The 6 mode-detect tests in `tests/cli/test_metrics_mode_fields.py` are blocked by the TSR-01-followup module-level guard (which requires both `tokenpak._internal` AND `detect_consumption_mode`). Even after this PR restores `detect_consumption_mode`, the parent file still skips on slim OSS because `_internal` remains closed-source per Std 25 §1.1 (TSR-07 territory).
- To make the function's behavior verifiable in slim-OSS CI today, carve the 6 detect cases out into a dedicated file with **no boundary coupling**. Same pattern as TSR-03's schema carve-out.
- Added 4 reinforcing cases: 2 priority tests (`cron > tmux`, `ide > tmux`) + 1 never-raises contract test + 1 string-validity test. All exercise the restored path.

**Verification:** 10/10 pass locally.

## Target C — `autogen_tokenpak.TokenPakAssistant` skip-predicate refinement

**Investigation:**
- `autogen_tokenpak/__init__.py` does:
  ```python
  try:
      from tokenpak_agents.autogen.assistant import TokenPakAssistant
      __all__.append("TokenPakAssistant")
  except ImportError:
      pass
  ```
  i.e. `TokenPakAssistant` is re-exported only when `tokenpak_agents` is also installed.
- The 4 tests' `@pytest.mark.skipif(not find_spec('autogen_tokenpak'), reason=...)` checks **package presence**, not symbol presence.
- In CI, `autogen_tokenpak` is installed but `tokenpak_agents` is not — so `find_spec` returns True (skip not triggered), then the per-test `from autogen_tokenpak import TokenPakAssistant` fails with `ImportError`. Tests fail instead of skipping.

**Fix:** Replace the 4 individual `@skipif` decorators with one shared `_AUTOGEN_SKIP` whose predicate probes the actual import path:

```python
def _autogen_assistant_unavailable() -> bool:
    try:
        from autogen_tokenpak import TokenPakAssistant  # noqa: F401
        return False
    except ImportError:
        return True

_AUTOGEN_SKIP = pytest.mark.skipif(
    _autogen_assistant_unavailable(),
    reason="autogen_tokenpak.TokenPakAssistant not exposed (needs tokenpak_agents installed)",
)
```

**Test fix only — no production change** to either `autogen_tokenpak` or `tokenpak_agents` packaging. The packaging-level coupling is its own concern; this PR just makes the test gate honor reality.

**Verification:** 4/4 tests now SKIP cleanly (instead of failing) under the slim configuration.

## Constraints honored

- ✅ **Missing exports / ghost paths only.** No new test logic, no new feature behavior.
- ✅ **No schema drift bundled.** TSR-03 work is complete; this PR doesn't touch `MetricsRecord` shape.
- ✅ **No internal/OSS boundary policy work.** `tokenpak._internal` references in `test_metrics_mode_fields.py` remain unguarded by this PR — those route to TSR-07.
- ✅ **No closed-source `_internal` recreation.** The `_internal.config` helpers (`get_active_profile`, `get_consumption_mode`) are NOT restored. Production `record_request()` accepts the kwargs but does not auto-detect via `_internal`.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.

## Verification matrix

| Target | Local result | CI delta expected |
|---|---|---|
| A: rate_limit imports | 3/3 pass | Removes 3 `Integration Tests` failures cross-version (was `tokenpak.handlers` ModuleNotFoundError) |
| B: `detect_consumption_mode` carve-out | 10/10 pass | +10 net-new passing tests cross-version |
| C: autogen `@skipif` refinement | 4/4 skip cleanly | Removes 4 `Test (Python 3.x)` failures cross-version (was per-test ImportError) |

Ruff: project-wide 23 → 23 (no regression).

## What remains for `test_metrics_mode_fields.py`

The parent file's TSR-01-followup guard requires both `tokenpak._internal` (still closed-source, TSR-07 territory) and `detect_consumption_mode` (restored by this PR). After this PR lands, the file will still skip on slim OSS — the `_internal` requirement keeps it locked. Resolution path: **TSR-07 (WS-F internal/OSS boundary)** relocates the `_internal`-touching tests to `tests/_internal/` and excludes them from the OSS gate via `pyproject.toml` config. At that point the parent file becomes a thin shell that uses only the public OSS surface, and the schema + detect tests inside it become observable too (in addition to the carve-out files this PR + TSR-03 added).

## Std 21 §9.8 informational treatment

Pre-existing red CI debt unchanged by this PR. This PR introduces zero new failures and adds 14 net-new outcomes (10 passing + 4 cleanly skipping) that were previously hard-failing.

Closes the TSR-04 (WS-D) work item from [#106](https://github.com/tokenpak/tokenpak/issues/106). Remaining workstreams: TSR-05 (WS-E real test bugs), TSR-06 (WS-G perf), TSR-07 (WS-F internal/OSS boundary).
