### PR TITLE
fix(tests,config): TSR-07 — relocate _internal-dependent tests to tests/_internal/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,13 @@ python_files = [
 ]
 norecursedirs = [
     "tests/archive",
+    # TSR-07 / WS-F (2026-05-08) — closed-source / `_internal`-dependent
+    # tests live in tests/_internal/. Excluded from the default OSS gate
+    # per Std 25 §1.1 (closed-source boundary). To run, invoke
+    # `pytest tests/_internal/` explicitly on a Pro daemon-equipped
+    # install (or override-ini norecursedirs= in a Pro-side CI config).
+    # See `tests/_internal/README.md`.
+    "tests/_internal",
     ".git",
     "__pycache__",
     "*.egg-info",

--- a/tests/_internal/README.md
+++ b/tests/_internal/README.md
@@ -1,0 +1,58 @@
+# `tests/_internal/` — Internal-only test surface
+
+## Purpose
+
+This directory holds tests that **cannot run on a slim OSS install** because they depend on the closed-source `tokenpak._internal/*` namespace (governed by Std 25 §1.1) at runtime — for module-level imports, `mock.patch("tokenpak._internal.config.…")` calls, fixtures that read `_internal.config` helpers, or any other unreplaceable runtime tie to the closed-source surface.
+
+This is **not** a "tests of internal features" directory. The tests here largely exercise public OSS features (anonymous metrics, proxy budget enforcement, stats footer rendering); they live here because their *implementation* depends on `_internal.config` for things like opt-in gating or runtime config reads, and that dependency cannot be mocked away without rewriting the test from scratch.
+
+## How exclusion works
+
+`pyproject.toml` adds `tests/_internal` to `[tool.pytest.ini_options].norecursedirs`. Pytest never collects from this tree on the default OSS gate. No CLI `--ignore` flag is used; the exclusion is config-driven and visible in source.
+
+Result on a slim `[dev]` install:
+
+```bash
+pytest tests/                                   # collects only OSS tests
+pytest tests/ --ignore-glob='**/_internal/**'   # same set; no-op
+```
+
+## How to run these tests on a Pro / dev-with-extras install
+
+When `tokenpak._internal` is present (Pro daemon-equipped install or developer dev-with-extras), invoke pytest with `tests/_internal/` explicitly:
+
+```bash
+pytest tests/_internal/ -q
+```
+
+A future Pro-side CI matrix can run the union by overriding `norecursedirs` in a separate config file or by passing `--override-ini='norecursedirs='` (scoped, not a broad bypass).
+
+## What lives here today
+
+| File | Purpose | Why it's internal-only |
+|---|---|---|
+| `test_stats_footer.py` | OSS stats-footer rendering tests | Reads `tokenpak._internal.config.get_stats_footer_enabled()` |
+| `test_metrics_reporter.py` | OSS anonymous-metrics reporter tests | `mock.patch("tokenpak._internal.config.get_metrics_enabled")` |
+| `proxy/test_budget_enforcement.py` | OSS proxy budget-enforcement tests | Reads `tokenpak._internal.config.BUDGET_*` constants |
+| `cli/test_metrics_mode_fields.py` | OSS metrics mode-detection tests (record-stores-mode subset; the schema and pure-detect carve-outs live at `tests/cli/test_anon_metrics_schema.py` and `tests/cli/test_consumption_mode_detect.py` per TSR-03 + TSR-04) | `mock.patch("tokenpak._internal.config.get_metrics_enabled")` plus `from tokenpak._internal.config import get_active_profile` |
+
+## What does NOT live here
+
+Tests that have only a **partial** runtime dependency on `_internal` (where most of the file is OSS-public and only a few specific tests need closed-source) stay in their original location with **per-test** `pytest.importorskip("tokenpak._internal")` guards — see `tests/test_quick_suite.py` for the canonical example. Moving such files wholesale would lose OSS-public coverage on the unaffected tests.
+
+## Authority
+
+- **Std 25 §1.1** — declares `tokenpak._internal/*` closed-source per the Pro-tier boundary
+- **Std 32 §1.3** — slim-OSS surface excludes `tokenpak._internal/*`
+- **Initiative `2026-05-08-release-test-suite-recovery` Phase 4** (TSR-07) — relocated this directory + added the `pyproject.toml` `norecursedirs` exclusion
+
+## Lessons recorded
+
+The `88d3d9deb0` `_internal/` cleanup refactor stripped public-OSS adjacent code on two distinct occasions:
+
+1. **TSR-03** — `MetricsRecord` v1.1 schema fields (`active_profile`, `consumption_mode`, `SCHEMA_VERSION="1.1"`, SQLite migration)
+2. **TSR-04** — `tokenpak.telemetry.anon_metrics.detect_consumption_mode()` function
+
+Both restorations are now complete. Std 25 §1.4 amendment proposal queued at `~/vault/02_COMMAND_CENTER/proposals/2026-05-08-std-25-boundary-refactor-safety-amendment.md` to formalize the refactor-safety rule that would have prevented these regressions.
+
+**Future namespace-cleanup refactors must verify they do not strip ANY public-OSS surface — dataclasses, helper functions, migrations, or constants — adjacent to the closed-source code being deleted.**

--- a/tests/_internal/cli/test_metrics_mode_fields.py
+++ b/tests/_internal/cli/test_metrics_mode_fields.py
@@ -16,28 +16,22 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
+import pytest  # noqa: F401 — kept for downstream pytest fixtures + markers
 
-# WS-A residual import guard — TSR-01-followup.
-# Two distinct import-time prerequisites must both hold for any test in
-# this file to run:
-#   1. tokenpak._internal — closed-source namespace per Std 25 §1.1;
-#      every helper here mocks tokenpak._internal.config.* attributes
-#      and fails at runtime if the namespace is absent.
-#   2. detect_consumption_mode — referenced as a symbol on
-#      tokenpak.telemetry.anon_metrics; not currently exported on the
-#      slim or full OSS surface (a separate WS-D / TSR-04 item).
-# Skip cleanly when either is unavailable. The WS-C schema-drift and
-# WS-D missing-export work for this file remain unbundled per the
-# TSR-01-followup scope rules.
-try:
-    import tokenpak._internal  # noqa: F401
-    from tokenpak.telemetry.anon_metrics import detect_consumption_mode  # noqa: F401
-except ImportError as _exc:
-    pytest.skip(
-        f"slim OSS: required closed-source / unexported symbol ({_exc})",
-        allow_module_level=True,
-    )
+# TSR-07 / WS-F (2026-05-08) — relocated to tests/_internal/cli/.
+# Default OSS gate excludes this directory via pyproject.toml
+# `norecursedirs`; the previous TSR-01-followup try/except module-
+# level skip is no longer needed.
+#
+# Note: the schema-drift and pure-detect carve-outs from this file
+# (created by TSR-03 and TSR-04 respectively) remain at the public
+# locations:
+#   - tests/cli/test_anon_metrics_schema.py — 7 schema invariants
+#   - tests/cli/test_consumption_mode_detect.py — 10 detect cases
+# Those carve-outs continue to verify the public contract on slim OSS.
+# The tests in THIS file (record_stores_*_mode + TestConfigHelpers)
+# all depend on tokenpak._internal at runtime — hence the relocation.
+# See tests/_internal/README.md.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/_internal/proxy/test_budget_enforcement.py
+++ b/tests/_internal/proxy/test_budget_enforcement.py
@@ -21,16 +21,12 @@ import time
 from http.client import HTTPConnection
 from pathlib import Path
 
-import pytest
+import pytest  # noqa: F401 — kept for downstream pytest fixtures + markers
 
-# WS-A residual import guard — TSR-01-followup.
-# Budget-enforcement tests reach into tokenpak._internal during the
-# standalone-proxy import path (closed-source per Std 25 §1.1).
-# Skip cleanly on slim install.
-pytest.importorskip(
-    "tokenpak._internal",
-    reason="tokenpak._internal is closed-source per Std 25 §1.1 — absent on slim OSS",
-)
+# TSR-07 / WS-F (2026-05-08) — relocated to tests/_internal/proxy/.
+# Default OSS gate excludes this directory via pyproject.toml
+# `norecursedirs`; the previous TSR-01-followup module-level
+# importorskip is no longer needed. See tests/_internal/README.md.
 
 # ---------------------------------------------------------------------------
 # Repo root + path to the standalone proxy.py

--- a/tests/_internal/test_metrics_reporter.py
+++ b/tests/_internal/test_metrics_reporter.py
@@ -18,16 +18,12 @@ import threading
 from pathlib import Path
 from unittest import mock
 
-import pytest
+import pytest  # noqa: F401 — kept for downstream pytest fixtures + markers
 
-# WS-A residual import guard — TSR-01-followup.
-# The metrics reporter tests transitively reach into tokenpak._internal
-# (closed-source per Std 25 §1.1 + Std 32 §1.3). On slim [dev] install
-# the per-test imports raise ModuleNotFoundError. Skip cleanly.
-pytest.importorskip(
-    "tokenpak._internal",
-    reason="tokenpak._internal is closed-source per Std 25 §1.1 — absent on slim OSS",
-)
+# TSR-07 / WS-F (2026-05-08) — relocated to tests/_internal/.
+# Default OSS gate excludes this directory via pyproject.toml
+# `norecursedirs`; the previous TSR-01-followup module-level
+# importorskip is no longer needed. See tests/_internal/README.md.
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/_internal/test_stats_footer.py
+++ b/tests/_internal/test_stats_footer.py
@@ -24,17 +24,15 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
+import pytest  # noqa: F401 — kept for downstream pytest fixtures + markers
 
-# WS-A residual import guard — TSR-01-followup.
-# tokenpak._internal is the canonical closed-source namespace per
-# Std 25 §1.1 + Std 32 §1.3 (slim OSS surface excludes
-# `tokenpak._internal/*`). Tests in this file reach into it via the
-# stats-footer integration test; skip cleanly on slim install.
-pytest.importorskip(
-    "tokenpak._internal",
-    reason="tokenpak._internal is closed-source per Std 25 §1.1 — absent on slim OSS",
-)
+# TSR-07 / WS-F (2026-05-08) — this file lives in tests/_internal/.
+# The directory is excluded from the default OSS pytest collection via
+# pyproject.toml `norecursedirs`, so the prior TSR-01-followup
+# `pytest.importorskip("tokenpak._internal")` module-level guard is
+# now redundant and removed. To run, invoke `pytest tests/_internal/`
+# explicitly on an install that provides `tokenpak._internal`
+# (Pro daemon-equipped or dev-with-extras). See `tests/_internal/README.md`.
 
 from tokenpak.telemetry.proxy_collector import RequestStats, TelemetryCollector
 from tokenpak.telemetry.footer import (


### PR DESCRIPTION
## Summary

WS-F internal/OSS boundary cleanup. 4 test files that depend on the closed-source `tokenpak._internal` namespace at runtime are relocated to a new `tests/_internal/` tree, which is excluded from the default OSS pytest collection via `pyproject.toml`'s `norecursedirs`. No closed-source surface is recreated in OSS. No `tokenpak-paid` surface is restored. No CLI `--ignore` bypass.

## What moves

| Old path | New path |
|---|---|
| `tests/test_stats_footer.py` | `tests/_internal/test_stats_footer.py` |
| `tests/test_metrics_reporter.py` | `tests/_internal/test_metrics_reporter.py` |
| `tests/proxy/test_budget_enforcement.py` | `tests/_internal/proxy/test_budget_enforcement.py` |
| `tests/cli/test_metrics_mode_fields.py` | `tests/_internal/cli/test_metrics_mode_fields.py` |

(`git mv` preserves history; the showing as A/D in `git status` is a side-effect of removing the redundant `importorskip` guard inside each file at the same time as the move — `git log --follow` retains the lineage.)

In each moved file, the now-redundant module-level TSR-01-followup `pytest.importorskip("tokenpak._internal")` guard has been removed; the directory exclusion supersedes it.

## What stays in place

| File | Why not relocated |
|---|---|
| `tests/test_quick_suite.py` | Has **per-test** `pytest.importorskip("tokenpak._internal")` guards on 7 of its tests; the other ~25 tests don't depend on `_internal` and exercise public OSS surface (proxy, cache, vault). Moving the whole file would lose that coverage. |
| `tests/cli/test_anon_metrics_schema.py` | TSR-03 carve-out — pure schema tests; no `_internal` dependency. |
| `tests/cli/test_consumption_mode_detect.py` | TSR-04 carve-out — pure detect-mode tests; no `_internal` dependency. |

## Config change

`pyproject.toml` `[tool.pytest.ini_options].norecursedirs` adds:

```toml
norecursedirs = [
    "tests/archive",
    # TSR-07 / WS-F (2026-05-08) — closed-source / _internal-dependent
    # tests live in tests/_internal/. Excluded from the default OSS gate
    # per Std 25 §1.1 (closed-source boundary). To run, invoke
    # `pytest tests/_internal/` explicitly on a Pro daemon-equipped
    # install (or override-ini norecursedirs= in a Pro-side CI config).
    # See `tests/_internal/README.md`.
    "tests/_internal",
    ...
]
```

## New `tests/_internal/README.md`

Explains:
- The directory's semantics ("tests requiring `tokenpak._internal` at runtime", not "tests targeting closed-source")
- How the exclusion works (`norecursedirs` config; no CLI bypass)
- How to run these tests on a Pro / dev-with-extras install (`pytest tests/_internal/` explicitly, or override-ini in a Pro-side CI config)
- What's deliberately NOT relocated (per-test-guarded files stay in place)
- Cross-refs to Std 25 §1.1, Std 32 §1.3, the TSR-03 + TSR-04 schema/missing-export restorations, and the queued Std 25 §1.4 refactor-safety amendment proposal

## Verification

| Check | Result |
|---|---|
| `pytest tests/ --collect-only -q` (default OSS gate) | 6195 tests collected, **0** under `tests/_internal/` |
| `pytest tests/_internal/ --collect-only -q` (explicit) | 84 tests collected from moved tree |
| Compile-check | 4/4 OK on moved files; `pyproject.toml` valid TOML |
| Ruff (4 affected files) | 22 → 20 errors (**−2**, redundant guards removed) |
| `tests/cli/test_anon_metrics_schema.py` (TSR-03 carry-over) | 7/7 pass ✅ |
| `tests/cli/test_consumption_mode_detect.py` (TSR-04 carry-over) | 10/10 pass ✅ |

## Constraints honored

- ✅ Resolves `tokenpak._internal.*` runtime references via relocation.
- ✅ No closed-source `_internal` recreation in OSS.
- ✅ No `tokenpak-paid` surface restoration into OSS.
- ✅ Config-driven exclusion only (`pyproject.toml norecursedirs`); no `--ignore` / `--ignore-glob` CLI bypass.
- ✅ No `release.yml` modifications.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.

## Expected CI delta

Failure count on `Test (Python 3.x)` should be **unchanged** (202 / 202 / 202 / 202) — these tests were already module-level skipping on slim OSS via the TSR-01-followup guards, so they didn't contribute to the failure tally. The structural change is:

- **Skipped count drops** by ~30 cross-version (from `pytest.skip` calls in the relocated files to deselected/uncollected; cleaner CI summary)
- **Collected count drops** by 84 cross-version (the relocated tests are no longer in the default collection set)
- **Passed count drops** by 0 (the relocated tests weren't passing on slim OSS in the first place; they were skipping)

Net signal: **noise reduction**, not failure-count reduction. Per directive: "reduce noise before tackling real test bugs in TSR-05".

## What this PR does NOT address (per directive scope)

- **TSR-05 (WS-E real test bugs)** — `tests/companion/test_*` proxy-unreachable, `test_health.py` `RemoteDisconnected`, `test_proxy_error_paths` 401s, `test_lifecycle.py` `UnboundLocalError`, etc.
- **TSR-06 (WS-G perf)** — `test_compression_benchmarks` 3-4× baseline
- Pre-existing red workflows (`Lint (Ruff)`, `CLI Docs Up-to-date`, `Compile Latency`, `Integration Tests` coverage gate) — separate scope

## Std 21 §9.8 informational treatment

This PR introduces zero new failures, removes zero passing tests from the default OSS gate (the relocated tests were skipping), and reduces ruff project-wide count by 2.

Closes the TSR-07 (WS-F) work item from [#106](https://github.com/tokenpak/tokenpak/issues/106). Remaining workstreams: TSR-05 (real test bugs), TSR-06 (perf).
