### PR TITLE
fix(tests): TSR-05 — fix Python scope bug in test_lifecycle.py

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -96,6 +96,14 @@ def proxy_port():
 @pytest.fixture
 def live_proxy(proxy_port):
     """Start a proxy server on a free port; mark ready; yield; stop."""
+    # TSR-05 / WS-E (2026-05-08) — Python scope fix. Without `global`,
+    # `_proxy_ready = True` below shadows the module-level name with a
+    # local assignment, leaving the module global unchanged. Tests that
+    # assert `_proxy_ready is True` after this fixture runs see False
+    # and fail. Same bug repeated in every other site that assigns to
+    # `_proxy_ready` or `_active_request_count`. `_shutdown_event` is
+    # safe — only `.set()`/`.clear()` are called on it, not reassignment.
+    global _proxy_ready
     server = HTTPServer(("127.0.0.1", proxy_port), ForwardProxyHandler)
     _proxy_ready = True
     _shutdown_event.clear()
@@ -152,6 +160,8 @@ class TestStartup:
 
     def test_ready_flag_initially_false(self):
         """_proxy_ready must be False before server starts."""
+        # TSR-05 / WS-E — Python scope fix (see live_proxy fixture).
+        global _proxy_ready
         original = _proxy_ready
         _proxy_ready = False
         assert _proxy_ready is False
@@ -182,6 +192,8 @@ class TestShutdown:
     @pytest.mark.needs_proxy
     def test_shutdown_event_clears_ready_flag(self, live_proxy):
         """Simulating shutdown: _proxy_ready → False, _shutdown_event set."""
+        # TSR-05 / WS-E — Python scope fix (see live_proxy fixture).
+        global _proxy_ready
         server, port = live_proxy
         # Simulate signal handler
         _proxy_ready = False
@@ -198,6 +210,8 @@ class TestShutdown:
     @pytest.mark.needs_proxy
     def test_ready_503_during_shutdown(self, live_proxy):
         """GET /ready → 503 during shutdown."""
+        # TSR-05 / WS-E — Python scope fix (see live_proxy fixture).
+        global _proxy_ready
         server, port = live_proxy
         _shutdown_event.set()
         _proxy_ready = False
@@ -232,6 +246,8 @@ class TestShutdown:
     @pytest.mark.needs_proxy
     def test_no_orphan_after_shutdown(self, proxy_port):
         """After server.shutdown(), nothing should be listening on the port."""
+        # TSR-05 / WS-E — Python scope fix (see live_proxy fixture).
+        global _proxy_ready
         server = HTTPServer(("127.0.0.1", proxy_port), ForwardProxyHandler)
         _proxy_ready = True
         _shutdown_event.clear()
@@ -303,6 +319,8 @@ class TestKillRecovery:
 
     def test_active_count_zero_at_start(self):
         """_active_request_count must be 0 on fresh module state."""
+        # TSR-05 / WS-E — Python scope fix (see live_proxy fixture).
+        global _active_request_count
         # Reset to known state
         original = _active_request_count
         _active_request_count = 0


### PR DESCRIPTION
## Summary

Fix a classic Python scope bug in `tests/test_lifecycle.py` that's been silently breaking 6 tests since the modular tree migration. Single file, +18 lines, no production change.

## Root cause

The test file declares three module-level globals at lines 48-50:

```python
_proxy_ready: bool = False
_shutdown_event = threading.Event()
_active_request_count: int = 0
```

and then assigns to them inside fixture / test functions without a `global` declaration:

```python
@pytest.fixture
def live_proxy(proxy_port):
    _proxy_ready = True   # ← LOCAL assignment, shadows the global!
    ...
    _proxy_ready = False  # ← also local
```

Without `global _proxy_ready`, Python treats the name as **local** throughout the function from the first assignment onward, so:

- **Reads-before-assignment** raise `UnboundLocalError: cannot access local variable '_proxy_ready' where it is not associated with a value`.
- The supposed **mutation never reaches the module global** — the assignment writes to a local that's discarded at function exit.
- Downstream asserts that read the module global see the original `False` value and fail with `assert False is True`.

`_shutdown_event` is unaffected — only `.set()` and `.clear()` are called on it, never reassignment, and method calls on existing objects do not require `global`.

## Fix

Add `global _proxy_ready` (and `global _active_request_count` where needed) at the top of every site that assigns to those names:

| Site | What it does | Was failing as |
|---|---|---|
| `live_proxy` fixture (line 96) | Sets `_proxy_ready = True` on entry, `False` on exit | Silent no-op — fixture appeared to work but didn't mutate the global |
| `test_ready_flag_initially_false` (line 153) | Probes initial `_proxy_ready` value | `UnboundLocalError` |
| `test_shutdown_event_clears_ready_flag` (line 183) | Sets `_proxy_ready = False` to simulate signal | Silent no-op + downstream RemoteDisconnected |
| `test_ready_503_during_shutdown` (line 199) | Same | Same |
| `test_no_orphan_after_shutdown` (line 233) | Sets up + tears down `_proxy_ready` around shutdown probe | Silent no-op |
| `test_active_count_zero_at_start` (line 304) | Probes initial `_active_request_count` value | `UnboundLocalError` |

Each addition has a one-line provenance comment citing TSR-05 / WS-E.

## Local impact verified

```
Before: 6 tests failing in test_lifecycle.py
        - 2× UnboundLocalError
        - 1× assert False is True
        - 3× http.client.RemoteDisconnected (downstream symptom)

After:  3 tests passing, 3 still failing
        ✅ test_ready_flag_initially_false (was UnboundLocalError)
        ✅ test_ready_true_after_server_starts (was assert False)
        ✅ test_active_count_zero_at_start (was UnboundLocalError)
        ❌ test_ready_endpoint_200_after_start
        ❌ test_shutdown_event_clears_ready_flag
        ❌ test_ready_503_during_shutdown
```

## Why 3 tests still fail (deferred to TSR-05b)

The 3 remaining failures share a different root cause:

```
AttributeError: 'HTTPServer' object has no attribute 'proxy_server'
  in tokenpak/proxy/server.py:541 (do_GET handler)
```

The `live_proxy` fixture constructs a vanilla `HTTPServer(addr, ForwardProxyHandler)`. But `ForwardProxyHandler.do_GET` accesses `self.server.proxy_server` — which is set by the modular tree's `ProxyServer` wrapper, not by `HTTPServer` directly. The fixture is therefore mis-constructing the server for the modular handler.

This is a real bug too (test fixture incompatible with the post-monolith handler), but it's a **structural** fixture redesign — fixing it requires either:

1. Changing the fixture to instantiate `tokenpak.proxy.server.ProxyServer` instead of vanilla `HTTPServer`, or
2. Adding a synthetic `proxy_server` attribute to the test's HTTPServer instance.

Per the TSR-05 directive ("scattered fixture/setUp logic failures" but "case-by-case investigation"), bundling that with a Python scope fix would mix two distinct bugs in one PR. Surfaced for **TSR-05b** as a separate focused slice.

## Constraints honored

- ✅ Real test bug only (Python scope rules).
- ✅ No production code change — `git diff --stat tokenpak/` is empty.
- ✅ No perf benchmark change (TSR-06 territory).
- ✅ No internal/OSS boundary change (TSR-07 already shipped).
- ✅ No schema-drift / missing-export / boundary bundling.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.
- ✅ Ruff: project-wide 4 → 4 errors (the pre-existing I001 import-block + F401 issues in this file are unaffected by my edits).

## Expected CI delta

- 3 tests change from FAIL → PASS in `Test (Python 3.x)` cross-version
- Total `Test (Python 3.x)` failures: **−3 cross-version** (210 → 207, or whatever the post-#114 baseline becomes)
- 0 new failures introduced
- MultiPak Phase 0/1: unchanged green ✅

## Std 21 §9.8 informational treatment

Pre-existing red CI debt unchanged by this PR. This is a focused single-file fix; remaining residue routes to TSR-05b (fixture misconstruction in this same file), TSR-05c+ (other test files), and TSR-06 (perf).

Closes the most obvious real test bug from the TSR-05 inventory listed in [#106](https://github.com/tokenpak/tokenpak/issues/106). Remaining real-bug residue tracked under TSR-05b/c follow-up slices.
