### PR TITLE
fix(tests): TSR-05b — skip 3 legacy /ready lifecycle tests with documented reason

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -49,6 +49,37 @@ _proxy_ready: bool = False
 _shutdown_event = threading.Event()
 _active_request_count: int = 0
 
+# TSR-05b / WS-E (2026-05-08) — grep-able skip reason for 3 lifecycle
+# tests that probe a legacy `/ready` endpoint. Investigation:
+#   1. The `live_proxy` fixture builds vanilla HTTPServer(addr,
+#      ForwardProxyHandler), which masks the deeper issue: it doesn't
+#      set `server.proxy_server` — the canonical attribute that
+#      `ProxyServer.start()` injects at tokenpak/proxy/server.py:2569.
+#      First-layer symptom: AttributeError in ForwardProxyHandler.do_GET.
+#   2. Even with the fixture corrected to set `server.proxy_server`,
+#      the tests still cannot pass: GET /ready returns 404. The
+#      production `do_GET` handles /health, /status, /metrics,
+#      /metrics/dashboard, /dashboard*, /degradation, /circuit-breakers,
+#      /stats, /stats/last, /stats/session, plus /tpk/v1/* via
+#      app_endpoints — but not /ready.
+#   3. Git history (`git log --all -p -G '== "/ready"|"/ready":|/ready"' --all`)
+#      shows /ready never existed as a handled endpoint in any
+#      production file. Only matches were in unrelated TIP-03
+#      optimization-policy code and an archived proxy_v4 file deleted
+#      in the 2026-04-09 cleanup.
+# Conclusion: the 3 tests assert against an intended-but-never-built
+# contract. Adding /ready to production would be feature creep based
+# on speculative tests. Rewriting the tests to a new lifecycle API
+# would broaden this slice into API/test-contract redesign (WS-B).
+# Cleanest scoped fix: permanent skip with documented reason. Lifecycle
+# readiness is canonically observable via ProxyServer.shutdown state +
+# the supported /health surface; the 3 covered scenarios remain
+# testable through that contract if/when a focused redesign happens.
+SKIP_READY_ENDPOINT = (
+    "/ready endpoint never existed in modular proxy; lifecycle readiness "
+    "is covered by ProxyServer shutdown state / supported health surfaces."
+)
+
 
 def _startup_preflight(port: int) -> None:
     """Compat shim for _startup_preflight.
@@ -173,6 +204,7 @@ class TestStartup:
         _, _ = live_proxy
         assert _proxy_ready is True
 
+    @pytest.mark.skip(reason=SKIP_READY_ENDPOINT)
     @pytest.mark.needs_proxy
     def test_ready_endpoint_200_after_start(self, live_proxy):
         """GET /ready → 200 after startup."""
@@ -189,6 +221,7 @@ class TestStartup:
 class TestShutdown:
     """Validate SIGTERM/SIGINT handling and in-flight drain."""
 
+    @pytest.mark.skip(reason=SKIP_READY_ENDPOINT)
     @pytest.mark.needs_proxy
     def test_shutdown_event_clears_ready_flag(self, live_proxy):
         """Simulating shutdown: _proxy_ready → False, _shutdown_event set."""
@@ -207,6 +240,7 @@ class TestShutdown:
             _proxy_ready = True
             _shutdown_event.clear()
 
+    @pytest.mark.skip(reason=SKIP_READY_ENDPOINT)
     @pytest.mark.needs_proxy
     def test_ready_503_during_shutdown(self, live_proxy):
         """GET /ready → 503 during shutdown."""


### PR DESCRIPTION
## Summary

Resolve the 3 remaining `tests/test_lifecycle.py` failures by permanently skipping them with a grep-able reason. Single-file +34 lines, no production change.

## Investigation outcome

Initial scoping identified the failure as a fixture-construction issue (vanilla `HTTPServer` doesn't set `server.proxy_server`). Investigation showed the bug is **two-layer**:

### Layer 1 — fixture (real but partial)

The `live_proxy` fixture builds:

```python
server = HTTPServer(("127.0.0.1", proxy_port), ForwardProxyHandler)
```

`ForwardProxyHandler.do_GET` accesses `self.server.proxy_server` — the back-reference set by `ProxyServer.start()` at `tokenpak/proxy/server.py:2569`:

```python
server = _ThreadedHTTPServer((self.host, self.port), _ProxyHandler)
server.proxy_server = self  # inject back-reference
```

Vanilla `HTTPServer` doesn't auto-set this. First-layer symptom: `AttributeError`.

### Layer 2 — endpoint (the deeper blocker)

Even with the fixture corrected to set `server.proxy_server`, the tests still cannot pass: `GET /ready` returns 404. `do_GET` in `tokenpak/proxy/server.py` handles `/health`, `/status`, `/metrics`, `/metrics/dashboard`, `/dashboard*`, `/degradation`, `/circuit-breakers`, `/stats`, `/stats/last`, `/stats/session`, plus `/tpk/v1/*` via `app_endpoints` — **but not `/ready`**. The fallthrough is `self.send_error(404)`.

Git history confirms `/ready` never existed as a handled endpoint in production:

```bash
$ git log --all -p -G '== "/ready"|"/ready":|/ready"' --all
# Only matches: unrelated TIP-03 optimization-policy code +
# an archived proxy_v4 file deleted in the 2026-04-09 cleanup.
```

The 3 tests assert against an **intended-but-never-built contract**.

## Resolution: Path B (permanent skip with documented reason)

Per Kevin's classification (2026-05-08), Path B was selected over:
- **Path A** — rewrite tests to use `/health` + `ProxyServer.shutdown.is_shutting_down`. Broadens this slice into WS-B API/test-contract redesign.
- **Path C** — add `/ready` endpoint to production. Feature creep based on speculative tests.

Path B is the cleanest scoped fix:

1. Added grep-able `SKIP_READY_ENDPOINT` constant near the top of `tests/test_lifecycle.py` with a 25-line investigation note (paths handled by `do_GET`, `ProxyServer.start()` injection mechanism, git evidence summary, lessons learned).
2. Applied `@pytest.mark.skip(reason=SKIP_READY_ENDPOINT)` to the 3 invalid tests, layered on top of the existing `@pytest.mark.needs_proxy`.
3. No fixture change — the fixture stays exactly as TSR-05 left it (with `global` declarations correctly mutating `_proxy_ready`); the other 4 lifecycle tests that use `live_proxy` continue to pass.
4. No production change.

## Tests affected

| Test | Was | Now |
|---|---|---|
| `TestStartup::test_ready_endpoint_200_after_start` | FAIL (404 vs 200 expected) | SKIP |
| `TestShutdown::test_shutdown_event_clears_ready_flag` | FAIL (404 vs 503 expected) | SKIP |
| `TestShutdown::test_ready_503_during_shutdown` | FAIL (404 vs 503 expected) | SKIP |

## Local verification

```
$ pytest tests/test_lifecycle.py -v
======================== 14 passed, 3 skipped, 1 warning in 8.39s ========================

$ pytest tests/test_lifecycle.py -rs    # show skip reasons
SKIPPED [1] tests/test_lifecycle.py:207: /ready endpoint never existed in modular
proxy; lifecycle readiness is covered by ProxyServer shutdown state / supported
health surfaces.
SKIPPED [1] tests/test_lifecycle.py:224: /ready endpoint never existed in modular
proxy; lifecycle readiness is covered by ProxyServer shutdown state / supported
health surfaces.
SKIPPED [1] tests/test_lifecycle.py:243: /ready endpoint never existed in modular
proxy; lifecycle readiness is covered by ProxyServer shutdown state / supported
health surfaces.
```

Pre-TSR-05b: 14 passed, **3 failed**, 0 skipped.
Post-TSR-05b: 14 passed, **0 failed**, 3 skipped.

Acceptance criteria from the directive:

- ✅ The 3 invalid `/ready` tests are skipped with the documented reason.
- ✅ `pytest tests/test_lifecycle.py -q` shows the prior fixed tests passing and the 3 `/ready` tests skipped.
- ✅ Collection remains 0.
- ✅ MultiPak Phase 0/1 tests remain green (independent code path; not touched).
- ✅ PR body clearly states this is legacy/speculative-test cleanup, not a production endpoint change.

## Constraints honored

- ✅ Test-only fix.
- ✅ No production changes — `git diff --stat tokenpak/` is empty.
- ✅ No schema drift, missing-export, internal/OSS boundary, or perf changes bundled.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.
- ✅ Ruff: project-wide unchanged (4 pre-existing errors in this file, all unrelated to my edits).

## Expected CI delta

- 3 tests change from FAIL → SKIP in `Test (Python 3.x)` cross-version.
- Total `Test (Python 3.x)` failures: **−3 cross-version** (199 → 196).
- 0 new failures introduced.

## What's deliberately deferred

The lifecycle readiness contract that `/ready` was supposed to expose is canonically observable today via:
- `ProxyServer.shutdown.is_shutting_down` (boolean state)
- The supported `/health` endpoint (returns the same shape during normal vs shutdown)

If a future test suite needs to exercise that contract, **a focused redesign PR** can rewrite the 3 skipped tests to use the canonical surface (Path A from the investigation). Out of TSR-05b scope per the directive.

## Std 21 §9.8 informational treatment

Pre-existing red CI debt unchanged by this PR. This is a focused single-file fix; the legacy/speculative-test cleanup pattern is mirrored in TSR-02b's `pytest.skip` markers for feature-gap coverage (per `feedback_continuous_execution_mode` and the WS-B precedent).

Closes the lifecycle file's WS-E residue completely. The remaining 196 cross-version failures route to TSR-05c/d/e+ (other files) and TSR-06 (perf).
