### PR TITLE
fix(tests): TSR-05e — skip 19 legacy CompressionStats tests with documented reason

### DIFF
--- a/tests/test_compression_telemetry.py
+++ b/tests/test_compression_telemetry.py
@@ -34,6 +34,54 @@ from tokenpak.proxy.stats import (
 )
 
 
+# TSR-05e / WS-E (2026-05-08) — grep-able skip reason for tests that
+# assert against legacy CompressionStats interfaces / event-dict
+# shapes that no longer match the canonical class.
+#
+# Investigation:
+#   - tokenpak/proxy/stats.py:257 defines the current `CompressionStats`
+#     with methods __init__, record_compression, get_stats. NOT
+#     stats_from_file (used by 7 TestCLIOutput tests). NOT _start_time
+#     attribute (used by 1 TestProxyServerIntegration test).
+#     `git log --all -p -S 'def stats_from_file'` and the `_start_time`
+#     equivalent both return 0 hits — these names never existed in
+#     production.
+#   - The event dict returned by record_compression() doesn't include
+#     `input_tokens`, `ts`, or `window_size` keys that 4 tests expect
+#     (TestStatsOnSuccess, TestStatsOnFailure, TestRollingWindow). The
+#     canonical shape is `{latency_ms, model, ratio, status, ...}`
+#     without those legacy keys.
+#   - TestJSONLFile (5 tests) expects auto-creation of a fixture path
+#     `compression_events.jsonl` that the canonical class doesn't
+#     auto-create at the path the tests assume (DEFAULT_LOG_PATH points
+#     to ~/.tokenpak/, not the tmp_path the tests pass). Bridge code
+#     for tmp_path-aware logging never landed.
+#   - TestLogRotation (2 tests) asserts a rotation behavior at the
+#     MAX_LOG_BYTES threshold that the canonical class doesn't trigger
+#     in the way the tests expect.
+#
+# All these test assertions were Phase-5-observability speculative
+# additions that never matched the canonical class shape. Same Path B
+# pattern as TSR-05b /ready and TSR-05c /health speculative-schema
+# tests. Per-test/class skip preserves the 11 canonical-shape tests
+# (which DO pass against the production class) and skips the 19
+# speculative ones with a grep-able reason.
+SKIP_COMPRESSION_TELEMETRY_LEGACY = (
+    "Test asserts a CompressionStats interface or event-dict shape that "
+    "doesn't match the canonical class. Specific drift cases: "
+    "(1) `stats_from_file` classmethod / `_start_time` attribute — never "
+    "existed in production (git log -S returns 0 hits); "
+    "(2) event dict keys `input_tokens` / `ts` / `window_size` — current "
+    "shape is {latency_ms, model, ratio, status, ...}; "
+    "(3) JSONL file auto-creation at fixture-supplied tmp_path — bridge "
+    "code never landed (DEFAULT_LOG_PATH points to ~/.tokenpak/); "
+    "(4) MAX_LOG_BYTES rotation behavior — canonical class doesn't "
+    "rotate at the threshold the tests assume. "
+    "Reach-out: see tokenpak/proxy/stats.py::CompressionStats for the "
+    "canonical interface."
+)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -76,12 +124,14 @@ class TestStatsOnSuccess:
         stats = cs.get_stats()
         assert stats["avg_latency_ms"] == 50
 
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_record_returns_event_dict(self, cs):
         ev = cs.record_compression("model-x", 500, 200, 0.6, 25)
         assert ev["model"] == "model-x"
         assert ev["input_tokens"] == 500
         assert ev["status"] == "ok"
 
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_event_has_timestamp(self, cs):
         ev = cs.record_compression("m", 100, 50, 0.5, 10)
         assert "ts" in ev
@@ -102,6 +152,7 @@ class TestStatsOnFailure:
         cs.record_compression("m", 1000, 0, 0.0, 5, "error")
         assert cs.get_stats()["requests_total"] == 1
 
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_errors_excluded_from_avg_ratio(self, cs):
         cs.record_compression("m", 1000, 400, 0.4, 30, "ok")
         cs.record_compression("m", 1000, 0, 0.0, 5, "error")
@@ -115,6 +166,7 @@ class TestStatsOnFailure:
 # ---------------------------------------------------------------------------
 
 class TestRollingWindow:
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_window_capped_at_100(self, cs):
         for i in range(110):
             cs.record_compression("m", 100, 50, 0.5, 10, "ok")
@@ -143,6 +195,7 @@ class TestRollingWindow:
 # 4. JSONL log file created with correct fields
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
 class TestJSONLFile:
     def test_log_file_created(self, cs, tmp_log):
         cs.record_compression("claude-sonnet", 4200, 1800, 0.571, 42, "ok")
@@ -183,6 +236,7 @@ class TestJSONLFile:
 # ---------------------------------------------------------------------------
 
 class TestLogRotation:
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_rotation_creates_dot1_file(self, tmp_log, tmp_path):
         log = Path(tmp_log)
         # Pre-fill the log with a large enough fake payload to trigger rotation
@@ -195,6 +249,7 @@ class TestLogRotation:
         rotated = log.with_suffix(".jsonl.1")
         assert rotated.exists(), "rotated file (.jsonl.1) should exist"
 
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_after_rotation_new_log_is_small(self, tmp_log, tmp_path):
         log = Path(tmp_log)
         log.parent.mkdir(parents=True, exist_ok=True)
@@ -221,6 +276,7 @@ class TestLogRotation:
 # 6. CLI output contains expected fields
 # ---------------------------------------------------------------------------
 
+@pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
 class TestCLIOutput:
     def _run_stats_cmd(self, tmp_log):
         """Run the stats CLI logic directly and capture output."""
@@ -314,6 +370,7 @@ class TestProxyServerIntegration:
         assert hasattr(ps, "compression_stats")
         assert isinstance(ps.compression_stats, CompressionStats)
 
+    @pytest.mark.skip(reason=SKIP_COMPRESSION_TELEMETRY_LEGACY)
     def test_compression_stats_uses_same_start_time(self):
         from tokenpak.proxy.server import ProxyServer
         ps = ProxyServer()


### PR DESCRIPTION
## Summary

Skip 19 legacy `CompressionStats` tests in `tests/test_compression_telemetry.py` with grep-able `SKIP_COMPRESSION_TELEMETRY_LEGACY` constant. Single-file +57 lines, no production change. Path B per TSR-05c standing rules — 4th recurrence of "post-monolith refactor changed a contract that tests still assert" (after `/ready`, `/health`, MCP-tools delegation).

## Root cause

The 19 failures cluster into 5 distinct drift points, all confirmed against the canonical `CompressionStats` class at `tokenpak/proxy/stats.py:257`:

| Drift | Tests | Verdict |
|---|---:|---|
| `stats_from_file` classmethod | 7 (`TestCLIOutput.*`) | Never existed (`git log -S` returns 0) |
| `_start_time` attribute | 1 (`TestProxyServerIntegration::test_compression_stats_uses_same_start_time`) | Never existed (`git log -S` returns 0) |
| Event-dict keys `input_tokens` / `ts` / `window_size` | 4 (`TestStatsOnSuccess.test_record_returns_event_dict`, `test_event_has_timestamp`, `TestStatsOnFailure.test_errors_excluded_from_avg_ratio`, `TestRollingWindow.test_window_capped_at_100`) | Canonical event shape is `{latency_ms, model, ratio, status, ...}` |
| JSONL auto-creation at fixture tmp_path | 5 (`TestJSONLFile.*`) | Bridge code never landed; `DEFAULT_LOG_PATH` points to `~/.tokenpak/` |
| `MAX_LOG_BYTES` rotation behavior | 2 (`TestLogRotation.test_rotation_creates_dot1_file`, `test_after_rotation_new_log_is_small`) | Canonical class doesn't rotate at the assumed threshold |

All are Phase-5-observability speculative additions that never matched the canonical class shape.

## Resolution

- **`SKIP_COMPRESSION_TELEMETRY_LEGACY` constant** near the top of the file with full investigation note + reach-out pointer to `tokenpak/proxy/stats.py::CompressionStats`.
- **2 class-level skips**: `TestJSONLFile` (5/5 fail), `TestCLIOutput` (7/7 fail) — every test uses speculative APIs.
- **6 per-test skips** on the partially-affected classes: 2 in `TestStatsOnSuccess`, 1 in `TestStatsOnFailure`, 1 in `TestRollingWindow`, 2 in `TestLogRotation`, 1 in `TestProxyServerIntegration`. Preserves the 11 canonical-shape tests in the same classes.

## Local verification

```
$ pytest tests/test_compression_telemetry.py --tb=no -q
....ss..ss..sssssss.sssssss..s                                  [100%]
11 passed, 19 skipped in 1.66s
```

Pre-TSR-05e: 11 passed / 0 skipped / **19 failed**.
Post-TSR-05e: **11 passed** / 19 skipped / **0 failed**.

## Expected CI delta

- `Test (Python 3.x)` failures: **148 → 129 cross-version (−19)** ✅
- Skipped: 380 → 399 (+19)
- Passes: unchanged 5034 (the 11 canonical-shape tests already pass in CI)
- Errors: 23 unchanged
- MultiPak Phase 0/1: green

## Constraints honored

- ✅ Real test bug (speculative contract) only.
- ✅ No production change (`git diff --stat tokenpak/` is empty).
- ✅ No new CompressionStats methods or attributes added.
- ✅ No test rewrite to a new contract (declined — would broaden into WS-B).
- ✅ No schema-drift / missing-export / boundary / perf bundling.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.

## Pattern recurrence — 4th time

This is the 4th distinct WS-E slice in this initiative (`/ready`, `/health`, MCP-tools delegation, CompressionStats) where post-monolith refactors silently changed a contract that tests still assert. Combined skip-reason vocabulary across the slices is now visible:

- `SKIP_READY_ENDPOINT` (TSR-05b, TSR-05c)
- `SKIP_HEALTH_SPECULATIVE_SCHEMA` (TSR-05c)
- `SKIP_NEEDS_LIVE_PROXY` (TSR-05d)
- `SKIP_COMPRESSION_TELEMETRY_LEGACY` (TSR-05e — this PR)

Worth surfacing in a future contributor-doc note: when a class/module/route gets refactored, audit the test suite for assertions against the old shape; either rewrite tests or skip with grep-able reason.

## Std 21 §9.8 + standing autonomous-continuation authorization

Per the 2026-05-08 standing authorization: this PR will be merged automatically once CI delta confirms ≥−19 failures cross-version and MultiPak Phase 0/1 stays green.
