### PR TITLE
fix(tests): TSR-05g — restore fixture name strings in test_agent_registry.py

### DIFF
--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -40,22 +40,38 @@ def temp_registry():
 
 @pytest.fixture
 def populated_registry(temp_registry):
-    """Registry with 3 pre-registered agents."""
-    temp_registry.register("agent-1", "host-1", {
+    """Registry with 3 pre-registered agents.
+
+    TSR-05g / WS-E (2026-05-08) — fixture name strings restored. The
+    test assertions throughout this file use the agent NAMES "trix",
+    "sue", "cali" (e.g. `assert agent.name == 'sue'`); at some point
+    the fixture's name strings were generalized to "agent-1/2/3" but
+    the test assertions weren't updated to match. AgentRegistry.register's
+    first positional argument is `name` (see
+    tokenpak/orchestration/registry.py), so the agent's name is exactly
+    what's passed here. Reverting the fixture to the original names
+    makes the 14 assertion-mismatch failures clear with no test-body
+    changes.
+
+    Note: tests/ is not on the OSS surface; arbitrary test-fixture
+    names are not subject to `feedback_always_dynamic` (which governs
+    production enumerations, not test data).
+    """
+    temp_registry.register("trix", "host-1", {
         "gpu": False,
         "memory_gb": 4,
         "specialties": ["code", "execution"],
         "provider_access": ["anthropic", "openai"],
         "max_concurrent": 1,
     })
-    temp_registry.register("agent-2", "host-2", {
+    temp_registry.register("sue", "host-2", {
         "gpu": False,
         "memory_gb": 8,
         "specialties": ["orchestration", "qa"],
         "provider_access": ["anthropic"],
         "max_concurrent": 2,
     })
-    temp_registry.register("agent-3", "host-3", {
+    temp_registry.register("cali", "host-3", {
         "gpu": True,
         "memory_gb": 16,
         "specialties": ["data", "analysis", "code"],
@@ -142,7 +158,8 @@ class TestAgentRegistry:
         assert id1 != id2
 
     def test_get_agent(self, temp_registry):
-        agent_id = temp_registry.register("agent-2", "host-2", {"memory_gb": 8})
+        # TSR-05g — fixture name string aligned with assertion below.
+        agent_id = temp_registry.register("sue", "host-2", {"memory_gb": 8})
         agent = temp_registry.get(agent_id)
         assert agent is not None
         assert agent.name == "sue"


### PR DESCRIPTION
## Summary

Restore fixture name strings in `tests/test_agent_registry.py`. 14 cross-version failures resolve with a 3-line fixture rename + 1 inline test fix. **40/40 pass locally** (was 26/14).

## Root cause

This is a different bug class from the 5 prior WS-E slices: not a post-monolith contract drift, but a fixture-vs-assertion-mismatch bug.

`AgentRegistry.register(name, hostname, capabilities, ...)` takes the agent's name as its first positional argument. The fixture had been generalized:

```python
temp_registry.register("agent-1", "host-1", {...})   # name = "agent-1"
temp_registry.register("agent-2", "host-2", {...})   # name = "agent-2"
temp_registry.register("agent-3", "host-3", {...})   # name = "agent-3"
```

But the test assertions throughout the file still use the original names:

```python
assert agent.name == "sue"
assert temp_registry.list_all().keys() == {"cali", "sue", "trix"}
```

So 14 tests fail with `assert 'agent-2' == 'sue'` etc. The fix is to restore the fixture's name strings.

## Mapping (derived from individual test assertions)

- `agent-1` → `trix` (gpu=False, memory_gb=4, code/execution)
- `agent-2` → `sue` (gpu=False, memory_gb=8, orchestration/qa)
- `agent-3` → `cali` (gpu=True, memory_gb=16, data/analysis/code)

Verified via cross-checking the failures: `test_match_required_specialty` expects `{cali, trix}` for the "code" specialty; `test_match_min_memory` expects `{cali, sue}` for ≥8GB; etc.

## What changed

- Fixture (`populated_registry`): 3 string renames + a docstring note explaining the WS-E mismatch.
- 1 inline test (`test_get_agent` at line 161): renamed `"agent-2"` → `"sue"` to match its own assertion.

## Why test-fixture names ≠ `feedback_always_dynamic`

`feedback_always_dynamic` governs **production enumerations** ("never hardcode enumerations of models, providers, platforms..."). Test-fixture name strings are arbitrary test data, not enumerations of anything in production. `tests/` is not on the OSS surface. Using `cali`/`sue`/`trix` as test fixture names is not a violation.

## Local verification

```
$ pytest tests/test_agent_registry.py --tb=no -q
40 passed, 1 warning in 4.24s
```

Pre-TSR-05g: 26 passed / 14 failed.
Post-TSR-05g: **40 passed** / 0 failed.

## Expected CI delta

- `Test (Python 3.x)` failures: **112 → 98 cross-version (−14)** ✅
- Passes: 5034 → 5048 (+14, real coverage restored — not skips)
- Errors: 23 unchanged
- MultiPak Phase 0/1: green

## Constraints honored

- ✅ Real test bug (fixture-data drift) only.
- ✅ No production change (`git diff --stat tokenpak/` is empty).
- ✅ No schema-drift / missing-export / boundary / perf bundling.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.

## Different from prior slices

This is the 6th TSR-05 slice but the **first one** that doesn't fall into the "post-monolith refactor changed a contract" pattern. All 14 fixed tests RUN (not skipped) — they just have correct expectations now. Net coverage: +14 real passes (vs the +14-skips-with-grep-able-reasons pattern of TSR-05b/c/d/e/f).

## Std 21 §9.8 + standing autonomous-continuation authorization

Per the 2026-05-08 standing authorization: this PR will be merged automatically once CI delta confirms ≥−14 failures cross-version and MultiPak Phase 0/1 stays green.
