### PR TITLE
fix(tests): TSR-05i — restore test_google_adapter_tools.py via rename + 4 skips + 1 regex fix

### DIFF
--- a/tests/test_google_adapter_tools.py
+++ b/tests/test_google_adapter_tools.py
@@ -9,6 +9,28 @@ from tokenpak.proxy.adapters import GoogleGenerativeAIAdapter
 from tokenpak.proxy.adapters.canonical import CanonicalRequest
 
 
+# TSR-05i / WS-E (2026-05-08) — grep-able skip reason for tests that
+# assert behaviors the canonical GoogleGenerativeAIAdapter never had:
+#   - Production accepts `$ref` and `["string","integer"]` multi-type
+#     unions silently (no ValueError raised) — tests expect raise.
+#   - Production strips $schema/additionalProperties/title/default but
+#     KEEPS `pattern` and `minLength` — test expects those stripped too.
+#   - Production omits `tools` from the request payload entirely when
+#     the canonical request has empty tools=[] — test expects
+#     `payload["tools"] == []`.
+# Verified via direct call against the live adapter on a current
+# install. None of these behaviors appear in git history (`git log -S`
+# for the speculative messages returns 0 hits).
+SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR = (
+    "Test asserts a GoogleGenerativeAIAdapter behavior that doesn't "
+    "match the canonical adapter: speculative ValueError raises ($ref, "
+    "multi-type union), speculative stripping (pattern, minLength), or "
+    "speculative empty-tools=[] preservation. Reach-out: see "
+    "tokenpak.proxy.adapters.GoogleGenerativeAIAdapter for the canonical "
+    "behavior."
+)
+
+
 class TestGoogleAdapterFunctionCalling:
     """Google adapter function calling: OpenAI and Anthropic tools → functionDeclarations."""
 
@@ -133,7 +155,7 @@ class TestGoogleAdapterFunctionCalling:
                 "an_array": {"type": "array", "items": {"type": "string"}},
             },
         }
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert frozen["type"] == "OBJECT"
         assert frozen["properties"]["a_string"]["type"] == "STRING"
         assert frozen["properties"]["a_number"]["type"] == "NUMBER"
@@ -203,7 +225,7 @@ class TestGoogleAdapterFunctionCalling:
                 },
             },
         }
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert frozen["properties"]["tags"]["type"] == "ARRAY"
         assert frozen["properties"]["tags"]["items"]["type"] == "STRING"
         assert frozen["properties"]["scores"]["items"]["type"] == "NUMBER"
@@ -213,7 +235,7 @@ class TestGoogleAdapterFunctionCalling:
     def test_nullable_type_union_translated(self):
         """["string", "null"] becomes type=STRING + nullable=true."""
         schema = {"type": ["string", "null"], "description": "Optional label"}
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert frozen["type"] == "STRING"
         assert frozen["nullable"] is True
         assert frozen["description"] == "Optional label"
@@ -221,12 +243,13 @@ class TestGoogleAdapterFunctionCalling:
     def test_null_only_type_becomes_string_nullable(self):
         """["null"] alone becomes type=STRING + nullable=true."""
         schema = {"type": ["null"]}
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert frozen["type"] == "STRING"
         assert frozen["nullable"] is True
 
     # --- unsupported schema features stripped --------------------------------
 
+    @pytest.mark.skip(reason=SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR)
     def test_unsupported_keys_stripped(self):
         """Unsupported JSON Schema keys are stripped without error."""
         schema = {
@@ -244,7 +267,7 @@ class TestGoogleAdapterFunctionCalling:
                 }
             },
         }
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert "$schema" not in frozen
         assert "additionalProperties" not in frozen
         assert "title" not in frozen
@@ -259,23 +282,25 @@ class TestGoogleAdapterFunctionCalling:
     def test_enum_preserved(self):
         """enum values are preserved in the frozen schema."""
         schema = {"type": "string", "enum": ["asc", "desc"]}
-        frozen = self.adapter._google_schema_freeze(schema)
+        frozen = self.adapter._freeze_schema_for_google(schema)
         assert frozen["enum"] == ["asc", "desc"]
         assert frozen["type"] == "STRING"
 
     # --- error cases --------------------------------------------------------
 
+    @pytest.mark.skip(reason=SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR)
     def test_ref_schema_raises_value_error(self):
         """$ref in schema raises ValueError with clear message."""
         schema = {"$ref": "#/definitions/MyType"}
         with pytest.raises(ValueError, match=r"\$ref"):
-            self.adapter._google_schema_freeze(schema)
+            self.adapter._freeze_schema_for_google(schema)
 
+    @pytest.mark.skip(reason=SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR)
     def test_multi_type_union_raises_value_error(self):
         """["string", "integer"] union raises ValueError (not a T|null union)."""
         schema = {"type": ["string", "integer"]}
         with pytest.raises(ValueError, match="multi-type union"):
-            self.adapter._google_schema_freeze(schema)
+            self.adapter._freeze_schema_for_google(schema)
 
     def test_unrecognized_tool_format_raises_value_error(self):
         """Tool with unrecognized format raises ValueError."""
@@ -289,7 +314,12 @@ class TestGoogleAdapterFunctionCalling:
             raw_extra={},
             source_format="google-generative-ai",
         )
-        with pytest.raises(ValueError, match="unrecognized tool format"):
+        # TSR-05i — regex updated to match canonical error message
+        # ("Cannot translate tool to Google functionDeclarations:
+        # unrecognized format..."). Earlier version expected
+        # "unrecognized tool format" verbatim; canonical phrasing is
+        # "unrecognized format" elsewhere in the same message.
+        with pytest.raises(ValueError, match="unrecognized format"):
             self.adapter.denormalize(canonical)
 
     # --- regression: no-tool and empty-tool paths ---------------------------
@@ -314,6 +344,7 @@ class TestGoogleAdapterFunctionCalling:
         assert payload["stream"] is False
         assert "tools" not in payload
 
+    @pytest.mark.skip(reason=SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR)
     def test_google_adapter_empty_tools_preserved(self):
         """Empty tools array is preserved as-is (backward compat)."""
         canonical = CanonicalRequest(


### PR DESCRIPTION
## Summary

Restore `tests/test_google_adapter_tools.py` from 10 cross-version failures via a mixed three-fix approach: method rename (5 tests), regex update (1 test), Path B skips on speculative behaviors (4 tests). Single-file +40/−9, no production change.

## Three drift categories

### 1. Method rename — 5 tests fixed (real coverage restored)

Production renamed `_google_schema_freeze` → `_freeze_schema_for_google`. Tests still call the old name. 8 call sites in the file:

```python
sed -i 's|self\.adapter\._google_schema_freeze|self.adapter._freeze_schema_for_google|g' tests/test_google_adapter_tools.py
```

Result: `test_schema_types_uppercased`, `test_array_items_recursively_translated`, `test_nullable_type_union_translated`, `test_null_only_type_becomes_string_nullable`, `test_enum_preserved` now pass with real coverage.

### 2. Stale regex — 1 test fixed (real coverage restored)

`test_unrecognized_tool_format_raises_value_error` expected `pytest.raises(ValueError, match="unrecognized tool format")`. Production raises:

```
"Cannot translate tool to Google functionDeclarations: unrecognized format
(keys: ['unknown_key']). Expected OpenAI..."
```

Production phrasing splits the words: "...tool to Google...: unrecognized format" — the regex "unrecognized tool format" doesn't match. Updated regex to "unrecognized format" (matches the canonical suffix).

### 3. Speculative behaviors — 4 tests skipped (Path B)

Verified each via direct call against the live adapter on a current install:

| Test | Speculative behavior |
|---|---|
| `test_ref_schema_raises_value_error` | Production accepts `$ref` silently (no ValueError raised) |
| `test_multi_type_union_raises_value_error` | Production accepts `["string","integer"]` multi-type unions silently |
| `test_unsupported_keys_stripped` | Production strips `$schema`/`additionalProperties`/`title`/`default` but **keeps** `pattern`/`minLength`; test expects both stripped |
| `test_google_adapter_empty_tools_preserved` | Production omits `tools` key entirely when canonical `tools=[]`; test expects `payload["tools"] == []` |

`SKIP_GOOGLE_ADAPTER_SPECULATIVE_BEHAVIOR` constant added near the top with reach-out pointer to `tokenpak.proxy.adapters.GoogleGenerativeAIAdapter`.

## Local verification

```
$ pytest tests/test_google_adapter_tools.py --tb=no -q
........s.ss..s                                                  [100%]
11 passed, 4 skipped in 0.53s
```

Pre-TSR-05i: 5 passed / 0 skipped / **10 failed**.
Post-TSR-05i: **11 passed** / 4 skipped / **0 failed** — **+6 net real coverage** plus 4 documented skips.

## Expected CI delta

- `Test (Python 3.x)` failures: **85 → 75 cross-version (−10)** ✅
- Passes: 5048 → 5054 (+6, real coverage restored from rename + regex fixes)
- Skipped: 429 → 433 (+4, speculative tests)
- Errors: 23 unchanged
- MultiPak Phase 0/1: green

## Mixed bug class

This slice combines two TSR-05 patterns in one PR:

- **TSR-05g style** (rename + regex = real coverage drift): 6 tests restored
- **TSR-05b/c/e/f style** (speculative contract = Path B skip): 4 tests skipped

The mixed treatment is appropriate because all 10 failures are in one file with one PR boundary; splitting into two PRs would be more friction than value.

## Constraints honored

- ✅ Real test bug + speculative-contract resolution only.
- ✅ No production change (`git diff --stat tokenpak/` is empty).
- ✅ No new methods or behaviors added.
- ✅ No schema-drift / missing-export / boundary / perf bundling.
- ✅ No `release.yml` modifications.
- ✅ No `--ignore` / `--ignore-glob` bypasses.
- ✅ No MultiPak Pro implementation.
- ✅ No cloud / sync / pricing language.
- ✅ v1.5.2 release integrity preserved.

## Std 21 §9.8 + standing autonomous-continuation authorization

Per the 2026-05-08 standing authorization: this PR will be merged automatically once CI delta confirms ≥−10 failures cross-version and MultiPak Phase 0/1 stays green.
