### PR TITLE
fix(tests): TSR-05m — skip 5 CCG-02-shape mutation_audit tests in test_db_schema.py

### DIFF
--- a/tests/proxy/test_db_schema.py
+++ b/tests/proxy/test_db_schema.py
@@ -19,6 +19,32 @@ from pathlib import Path
 import pytest
 
 
+# TSR-05m schema-drift skip reason (grep-able)
+# ─────────────────────────────────────────────
+# The CCG-02 commit (a36d799018, 2026-04-10) introduced this test alongside a
+# 7-column `mutation_audit` schema:
+#     id, timestamp, session_id, request_id, mutation_type, file_path, diff_summary
+# The schema was later replaced by the CCG-06 10-column shape now in
+# tokenpak/proxy/db.py (MUTATION_AUDIT_COLUMNS):
+#     id, request_id, session_id, timestamp, pre_hash, post_hash,
+#     rules_applied, cache_risk, rollback_possible, mode
+# The fields `mutation_type`, `file_path`, `diff_summary` were dropped, and
+# `insert_mutation_audit()` no longer accepts those kwargs. The 5 tests below
+# encode the old contract and now fail with `OperationalError: no such column:
+# mutation_type` and `TypeError: unexpected keyword argument 'mutation_type'`.
+# Rewriting the assertions to the CCG-06 shape is schema-drift work and
+# belongs to TSR-03 (schema drift), not TSR-05 (real test bugs). The other
+# 11 tests in this file exercise idempotency, indexes, session_id migration,
+# and Monitor integration against the real CCG-06 schema and remain live.
+SKIP_CCG02_SCHEMA_REPLACED_BY_CCG06 = (
+    "Test encodes the original CCG-02 mutation_audit schema "
+    "(mutation_type/file_path/diff_summary), which was replaced by the "
+    "CCG-06 10-column schema (pre_hash/post_hash/rules_applied/cache_risk/"
+    "rollback_possible/mode) in tokenpak/proxy/db.py. Rewriting these "
+    "assertions to the new shape is schema-drift work — see TSR-03."
+)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -60,6 +86,7 @@ def _create_legacy_requests(conn):
 
 
 class TestEnsureSchemaFreshDB:
+    @pytest.mark.skip(reason=SKIP_CCG02_SCHEMA_REPLACED_BY_CCG06)
     def test_mutation_audit_table_created(self, tmp_path):
         from tokenpak.proxy.db import ensure_schema
 
@@ -205,6 +232,7 @@ class TestEnsureSchemaMigrationFromLegacy:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skip(reason=SKIP_CCG02_SCHEMA_REPLACED_BY_CCG06)
 class TestMutationAuditInsert:
     def _setup(self, tmp_path):
         from tokenpak.proxy.db import ensure_schema


### PR DESCRIPTION
## Scope

`tests/proxy/test_db_schema.py` only — no production changes.

## Root cause: schema drift, not a real test bug

The CCG-02 commit ([a36d799018](https://github.com/tokenpak/tokenpak/commit/a36d799018), 2026-04-10) introduced this test alongside a **7-column** `mutation_audit` schema:

```
id, timestamp, session_id, request_id, mutation_type, file_path, diff_summary
```

The schema was later replaced by the **CCG-06 10-column** shape now in `tokenpak/proxy/db.py` (`MUTATION_AUDIT_COLUMNS`):

```
id, request_id, session_id, timestamp, pre_hash, post_hash,
rules_applied, cache_risk, rollback_possible, mode
```

The fields `mutation_type`, `file_path`, `diff_summary` were dropped, and `insert_mutation_audit()` no longer accepts those kwargs. Five tests encoded the old contract and failed cross-version with:

- `sqlite3.OperationalError: no such column: mutation_type`
- `TypeError: insert_mutation_audit() got an unexpected keyword argument 'mutation_type'`

Rewriting the assertions to the new shape is schema-drift work and belongs to **TSR-03 (schema drift)**, not TSR-05 (real test bugs). Following the TSR-05 pattern (cf. #117/#119/#121/#122/#125): skip with a grep-able reason that points to the right initiative bucket.

## What's skipped

Module-level constant `SKIP_CCG02_SCHEMA_REPLACED_BY_CCG06` applied to:

- `TestEnsureSchemaFreshDB::test_mutation_audit_table_created` (1 method-level skip; sibling tests `test_session_id_added_to_requests` + `test_indexes_created` still live — they assert real CCG-06 behavior)
- `TestMutationAuditInsert` (4 tests, class-level skip — every method passes the dropped kwargs)

## What's still live (11 tests)

- `TestEnsureSchemaFreshDB::test_session_id_added_to_requests`
- `TestEnsureSchemaFreshDB::test_indexes_created`
- `TestEnsureSchemaIdempotent` (2 tests)
- `TestEnsureSchemaMigrationFromLegacy` (3 tests)
- `TestMonitorInitDB` (4 tests)

These exercise idempotency, indexes, session_id migration, existing-row preservation, and Monitor integration against the **real CCG-06 schema** — not the dropped fields.

## CI delta (local)

| Metric | Pre | Post | Δ |
|---|---:|---:|---:|
| `tests/proxy/test_db_schema.py` failed | 5 | **0** | **−5** ✅ |
| `tests/proxy/test_db_schema.py` passed | 11 | 11 | — |
| `tests/proxy/test_db_schema.py` skipped | 0 | 5 | +5 |
| Collection errors (full suite) | 0 | **0** | — |
| MultiPak Phase 0/1 (`tests/tip/test_multipak_contracts.py`) | 54 ✅ | **54 ✅** | — |

## Constraint check

- ✅ Scoped: 1 file, +28 lines (skip-reason constant + 2 decorators).
- ✅ No production behavior change.
- ✅ No public API / HTTP route / CLI contract change.
- ✅ Release gate not weakened.
- ✅ No `--ignore` / `--ignore-glob` / xfail sweeping.
- ✅ Touches no release/publish/credentials/tags.
- ✅ No MultiPak Pro / cloud / sync / pricing / `_internal` surface change.
- ✅ No bundling — schema-drift cleanup explicitly deferred to TSR-03.

Refs #106.