### PR TITLE
fix(tests): TSR-05r — skip 4 speculative-contract tests in integration/test_caching.py

### DIFF
--- a/tests/integration/test_caching.py
+++ b/tests/integration/test_caching.py
@@ -12,6 +12,38 @@ import time
 from unittest.mock import patch, MagicMock, call
 
 
+# TSR-05r speculative-contract skip reason (grep-able)
+# ─────────────────────────────────────────────
+# Four tests below assert against `CacheManager` API surface that **never
+# existed** in `tokenpak/cache/cache_manager.py` git history:
+#
+#   - `CacheManager(ttl=...)` kwarg in `__init__`            (never existed)
+#   - `cache.invalidate(model=...)` method                   (never existed)
+#   - `cache.get_stats()` method                             (never existed)
+#
+# Verified via `git log -S 'def invalidate' --all -- tokenpak/cache/cache_manager.py`
+# (0 hits) and `git log -S 'def get_stats' --all -- tokenpak/cache/cache_manager.py`
+# (0 hits). The actual `CacheManager` interface is `__init__(volatile_cache,
+# stable_cache, volatile_threshold)` + `get / set / delete / clear` +
+# `volatile / stable` properties — no `ttl` kwarg, no `invalidate`, no
+# `get_stats`.
+#
+# These were added in the "comprehensive integration test suite" sweep
+# (commit 84f4f19b90 / 28a1448d2f) and encoded a speculative contract that
+# never landed in production. Same Path B pattern as TSR-05b's `/ready`
+# endpoint skip — assertions against an intended-but-never-built surface.
+#
+# `test_cache_manual_invalidation` (only uses `cache.clear()`, which DOES
+# exist) is unaffected and remains live, as do the 4 tests in
+# TestCacheHitDetection / TestCacheTokenReduction / TestCacheResponseTime
+# that aren't skipped or already-`pytest.skip`-guarded.
+SKIP_CACHE_MANAGER_SPECULATIVE_API = (
+    "Test asserts CacheManager API (ttl= kwarg, invalidate(), get_stats()) "
+    "that never existed in cache_manager.py git history. Speculative "
+    "contract — see TSR-05b for the same pattern (Path B skip)."
+)
+
+
 class TestCacheHitDetection:
     """Test cache hit detection."""
 
@@ -202,6 +234,7 @@ class TestCacheResponseTime:
 class TestCacheInvalidation:
     """Test cache invalidation behavior."""
 
+    @pytest.mark.skip(reason=SKIP_CACHE_MANAGER_SPECULATIVE_API)
     def test_cache_ttl_expiration(self):
         """Test cache entries expire after TTL."""
         try:
@@ -240,6 +273,7 @@ class TestCacheInvalidation:
         cache.clear()
         assert cache.get(request) is None
 
+    @pytest.mark.skip(reason=SKIP_CACHE_MANAGER_SPECULATIVE_API)
     def test_cache_selective_invalidation(self):
         """Test selective cache invalidation by key pattern."""
         try:
@@ -266,6 +300,7 @@ class TestCacheInvalidation:
         assert cache.get(req2) is not None
 
 
+@pytest.mark.skip(reason=SKIP_CACHE_MANAGER_SPECULATIVE_API)
 class TestCacheStatistics:
     """Test cache statistics collection."""
 


### PR DESCRIPTION
## Scope

`tests/integration/test_caching.py` only — no production changes.

## Root cause: speculative contract that never existed

Four tests assert against `CacheManager` API surface that **never existed** in `tokenpak/cache/cache_manager.py` git history:

- `CacheManager(ttl=...)` kwarg in `__init__`           (never existed)
- `cache.invalidate(model=...)` method                  (never existed)
- `cache.get_stats()` method                            (never existed)

Verified:
```bash
git log -S 'def invalidate' --all -- tokenpak/cache/cache_manager.py  # 0 hits
git log -S 'def get_stats' --all -- tokenpak/cache/cache_manager.py   # 0 hits
```

The actual interface is `__init__(volatile_cache, stable_cache, volatile_threshold)` + `get/set/delete/clear` + `volatile/stable` properties.

These tests came in via the "comprehensive integration test suite" sweep (commits 84f4f19b90 / 28a1448d2f) which encoded a contract that never landed in production. **Same Path B pattern as TSR-05b's `/ready` endpoint skip** — assertions against an intended-but-never-built surface.

## What's skipped

`SKIP_CACHE_MANAGER_SPECULATIVE_API`:

- `TestCacheInvalidation::test_cache_ttl_expiration` — uses `ttl=` kwarg
- `TestCacheInvalidation::test_cache_selective_invalidation` — uses `invalidate()`
- `TestCacheStatistics` (class-level, 2 tests) — both use `get_stats()`

## What's still live (5 tests)

- `TestCacheInvalidation::test_cache_manual_invalidation` — only uses `cache.clear()`, which exists.
- Plus the live tests in `TestCacheHitDetection`, `TestCacheTokenReduction`, `TestCacheResponseTime` that aren't already `pytest.skip`-guarded.

## CI delta (local)

| Metric | Pre | Post | Δ |
|---|---:|---:|---:|
| `tests/integration/test_caching.py` failed | 4 | **0** | **−4** ✅ |
| `tests/integration/test_caching.py` passed | 5 | 5 | — |
| `tests/integration/test_caching.py` skipped | 3 | 7 | +4 |
| Collection errors (full suite) | 0 | **0** | — |
| MultiPak Phase 0/1 | 54 ✅ | **54 ✅** | — |

## Constraint check

- ✅ Scoped: 1 file, +35 lines (skip-reason constant + 3 decorators).
- ✅ No production behavior change.
- ✅ No public API / HTTP route / CLI contract change.
- ✅ Release gate not weakened.
- ✅ No `--ignore` / `--ignore-glob` / xfail sweeping.
- ✅ Touches no release/publish/credentials/tags.
- ✅ No MultiPak Pro / cloud / sync / pricing / `_internal` surface change.
- ✅ No bundling.

Refs #106.