### PR TITLE
fix(tests): TSR-05s — update 3 mock.patch paths in test_file_watcher.py to modular tree

### DIFF
--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -237,9 +237,14 @@ class TestReindex:
         mock_processor = MagicMock()
         mock_processor.process.return_value = "print('hello')"
 
-        with patch("tokenpak.registry.BlockRegistry", return_value=mock_registry), \
-             patch("tokenpak.processors.get_processor", return_value=mock_processor), \
-             patch("tokenpak.tokens.count_tokens", return_value=5):
+        # TSR-05s: import paths follow the modular tree — these previously
+        # patched `tokenpak.{registry,processors,tokens}.*` which were the
+        # pre-refactor monolith locations. The watcher's `_reindex()` now
+        # imports from `tokenpak.core.registry`, `tokenpak.compression.processors`,
+        # and `tokenpak.telemetry.tokens`. Patches updated to match.
+        with patch("tokenpak.core.registry.BlockRegistry", return_value=mock_registry), \
+             patch("tokenpak.compression.processors.get_processor", return_value=mock_processor), \
+             patch("tokenpak.telemetry.tokens.count_tokens", return_value=5):
 
             w = VaultWatcher(cfg, on_change=called.append)
             w._reindex([str(f)])
@@ -254,8 +259,8 @@ class TestReindex:
         mock_registry = MagicMock()
         mock_registry.has_changed.return_value = False  # no change
 
-        with patch("tokenpak.registry.BlockRegistry", return_value=mock_registry), \
-             patch("tokenpak.processors.get_processor", return_value=MagicMock()):
+        with patch("tokenpak.core.registry.BlockRegistry", return_value=mock_registry), \
+             patch("tokenpak.compression.processors.get_processor", return_value=MagicMock()):
             w = VaultWatcher(cfg)
             w._reindex([str(f)])
 
@@ -271,9 +276,9 @@ class TestReindex:
         mock_processor = MagicMock()
         mock_processor.process.return_value = "def foo(): pass"
 
-        with patch("tokenpak.registry.BlockRegistry", return_value=mock_registry), \
-             patch("tokenpak.processors.get_processor", return_value=mock_processor), \
-             patch("tokenpak.tokens.count_tokens", return_value=3):
+        with patch("tokenpak.core.registry.BlockRegistry", return_value=mock_registry), \
+             patch("tokenpak.compression.processors.get_processor", return_value=mock_processor), \
+             patch("tokenpak.telemetry.tokens.count_tokens", return_value=3):
             w = VaultWatcher(cfg)
             w._reindex([str(f)])
 


### PR DESCRIPTION
## Scope

`tests/test_file_watcher.py` only — no production changes. **Real test bug** — 3 stale mock-patch paths, surgical fix (not a skip).

## Root cause: stale mock.patch paths

Three tests in `TestReindex` patched pre-refactor monolith locations that no longer exist as Python modules:

| Test patch path                         | Actual import in `watcher._reindex()`     |
|---|---|
| `tokenpak.registry.BlockRegistry`         | `tokenpak.core.registry.BlockRegistry`        |
| `tokenpak.processors.get_processor`       | `tokenpak.compression.processors.get_processor` |
| `tokenpak.tokens.count_tokens`            | `tokenpak.telemetry.tokens.count_tokens`      |

All three patches resolved against missing modules → `AttributeError: module 'tokenpak' has no attribute 'registry'` at import time (`tokenpak/__init__.py:80` — the lazy-loader's fallback).

Updated to the modular-tree paths the watcher's `_reindex()` actually imports from (`tokenpak/vault/watcher.py:249-251`).

## What changed

3 patches updated × 3 tests = surgical edits. One short comment block explains why.

## What's still live (no skips added)

All 34 tests in the file pass. **Real fix**, not a skip — TSR-05 (real test bugs) sweet spot.

## CI delta (local)

| Metric | Pre | Post | Δ |
|---|---:|---:|---:|
| `tests/test_file_watcher.py` failed | 3 | **0** | **−3** ✅ |
| `tests/test_file_watcher.py` passed | 31 | **34** | **+3** ✅ |
| `tests/test_file_watcher.py` skipped | 0 | 0 | — |
| Collection errors (full suite) | 0 | **0** | — |
| MultiPak Phase 0/1 | 54 ✅ | **54 ✅** | — |

## Constraint check

- ✅ Scoped: 1 file, +13 / −8 lines (3 patch-path updates + comment block).
- ✅ No production behavior change.
- ✅ No public API / HTTP route / CLI contract change.
- ✅ Release gate not weakened.
- ✅ No `--ignore` / xfail / class-level skip — real fix.
- ✅ Touches no release/publish/credentials/tags.
- ✅ No MultiPak Pro / cloud / sync / pricing / `_internal` surface change.
- ✅ No bundling.

Refs #106.