### PR TITLE
fix(tests): TSR-05z — skip test_cache_write_safety in test_concurrency.py

### DIFF
--- a/tests/integration/test_concurrency.py
+++ b/tests/integration/test_concurrency.py
@@ -9,6 +9,21 @@ Tests verify TokenPak handles concurrent requests correctly:
 
 import pytest
 import threading
+
+
+# TSR-05z speculative-contract skip reason (grep-able)
+# ─────────────────────────────────────────────
+# `test_cache_write_safety` calls `CacheManager.get_stats()`, which never
+# existed in `tokenpak/cache/cache_manager.py` git history (`git log -S 'def
+# get_stats' --all -- tokenpak/cache/cache_manager.py` → 0 hits). Same
+# speculative-contract pattern as **TSR-05r (#131)** which skipped the
+# `TestCacheStatistics` class in `tests/integration/test_caching.py` for
+# the identical reason; this is the same `CacheManager.get_stats()` call
+# in a different file.
+SKIP_CACHE_MANAGER_SPECULATIVE_API = (
+    "Test calls `CacheManager.get_stats()` which never existed on the "
+    "class. Speculative contract; same Path B pattern as TSR-05r (#131)."
+)
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import MagicMock, patch
@@ -172,6 +187,7 @@ class TestConcurrentCaching:
         # All reads should return the same response
         assert all(r == expected_response for r in results)
 
+    @pytest.mark.skip(reason=SKIP_CACHE_MANAGER_SPECULATIVE_API)
     def test_cache_write_safety(self):
         """Test concurrent cache writes are safe."""
         try:


### PR DESCRIPTION
## Scope

`tests/integration/test_concurrency.py` only — no production changes.

## Root cause: same speculative `CacheManager.get_stats()` as TSR-05r (#131)

`test_cache_write_safety` (line 197) calls `CacheManager.get_stats()`, which never existed in `tokenpak/cache/cache_manager.py` git history:

```bash
git log -S 'def get_stats' --all -- tokenpak/cache/cache_manager.py   # 0 hits
```

This is the **same call in a different file** as TSR-05r — that PR skipped `TestCacheStatistics` in `tests/integration/test_caching.py` for the identical reason.

## What's skipped

`SKIP_CACHE_MANAGER_SPECULATIVE_API`:
- `TestConcurrentCaching::test_cache_write_safety`

## What's still live

All 10 other concurrency tests in this file.

## CI delta (local)

| Metric | Pre | Post | Δ |
|---|---:|---:|---:|
| `tests/integration/test_concurrency.py` failed | 1 | **0** | **−1** ✅ |
| Skipped | 5 | 6 | +1 |
| Collection errors | 0 | **0** | — |
| MultiPak Phase 0/1 | 54 ✅ | **54 ✅** | — |

## Constraint check

- ✅ Scoped: 1 file, +16 lines.
- ✅ No production behavior change.
- ✅ Same Path B pattern as TSR-05r — no new approach.
- ✅ No `--ignore` / xfail sweeping.
- ✅ No bundling.

Refs #106.