### PR TITLE
fix(tests): TSR-05l — deterministic InstructionTable warmup for compression regression tests

### DIFF
--- a/scripts/compute_compression_baselines.py
+++ b/scripts/compute_compression_baselines.py
@@ -1,97 +1,153 @@
 #!/usr/bin/env python3
 """
 Compute baseline compression ratios for all test payloads.
+
 Usage:
-    python3 scripts/compute_compression_baselines.py
+    python3 scripts/compute_compression_baselines.py [--out PATH]
+
+State assumptions (TSR-05l, 2026-05-08):
+    `CompressionPipeline.run()` is the canonical OSS API. Its strongest
+    stage — `InstructionTable` — is a stateful learning compressor that
+    only emits a `[INSTRUCTION:POLICY_NN]` tag once a content hash has
+    been observed at least `min_occurrences` (= 2) times.
+
+    A first call against a fresh table can never compress: it can only
+    observe. To produce reproducible "warm-table" baselines, this
+    script runs each payload through the pipeline twice before
+    recording its ratio.
+
+    To stay hermetic, the script uses a temp-dir-backed instruction
+    table (does NOT touch the user's `~/.tokenpak/instruction_table.json`).
+
+History note: prior versions of this script called `pipeline.compress()`
+which never existed on OSS `CompressionPipeline` (only `.run()` ever has).
+The bare-except swallowed the resulting `AttributeError` and the script
+silently emitted no baselines. The committed `tests/regression/baselines.json`
+therefore came from a different code path (likely a vault-internal
+predecessor) and the values must be regenerated whenever the pipeline's
+deterministic behavior actually changes.
 """
 
-import json
-import os
-from pathlib import Path
+from __future__ import annotations
 
-# Add tokenpak to path
+import argparse
+import json
 import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# Add tokenpak to path so the script can run from a checkout without install.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from tokenpak.compression.pipeline import CompressionPipeline
+from tokenpak.compression.pipeline import CompressionPipeline  # noqa: E402
 
-def compute_payload_size(payload):
-    """Compute size of a payload (in bytes when JSON-encoded)"""
-    return len(json.dumps(payload, separators=(',', ':')))
 
-def compress_payload(pipeline, payload):
-    """Compress a payload using the pipeline"""
-    try:
-        # Pipeline expects messages format
-        if "messages" in payload:
-            result = pipeline.compress(payload["messages"])
-            return result
-    except Exception as e:
-        print(f"  ⚠️  Compression error: {e}")
-        return None
-    return None
+def compute_payload_size(payload: Any) -> int:
+    """Size (in bytes) of a payload encoded as compact JSON."""
+    return len(json.dumps(payload, separators=(",", ":")))
 
-def main():
-    payloads_dir = Path(__file__).parent.parent / "tests" / "regression" / "payloads"
-    baselines_path = payloads_dir.parent / "baselines.json"
-    
-    if not payloads_dir.exists():
-        print(f"❌ Payloads directory not found: {payloads_dir}")
-        return
-    
-    # Load all payloads
-    payload_files = sorted(payloads_dir.glob("*.json"))
-    print(f"📦 Found {len(payload_files)} payloads")
-    
-    # Initialize compression pipeline
-    pipeline = CompressionPipeline()
-    print("✨ Pipeline ready\n")
-    
-    baselines = {}
-    
+
+def compress_payload(pipeline: CompressionPipeline, payload: dict) -> Any:
+    """Run the pipeline against a single payload's messages.
+
+    Errors are intentionally NOT swallowed — fail loudly so a refactored
+    or renamed API doesn't silently produce zero-baseline output (TSR-05l
+    history note in the module docstring).
+    """
+    if "messages" not in payload:
+        raise ValueError("payload missing 'messages' key")
+    result = pipeline.run(payload["messages"])
+    return result.messages
+
+
+def warm_pipeline(pipeline: CompressionPipeline, payload_files: list) -> None:
+    """Warm the InstructionTable so each payload's content reaches
+    seen_count >= 2 (the threshold for ID allocation)."""
     for payload_file in payload_files:
-        payload_name = payload_file.stem
-        print(f"Processing {payload_name}...")
-        
         with open(payload_file) as f:
             payload = json.load(f)
-        
-        # Compute original size
-        original_size = compute_payload_size(payload)
-        print(f"  Original size: {original_size} bytes")
-        
-        # Compress
-        compressed = compress_payload(pipeline, payload)
-        
-        if compressed is None:
-            print(f"  ❌ Compression failed, skipping")
+        if "messages" not in payload:
             continue
-        
-        # Compute compressed size
-        compressed_size = compute_payload_size(compressed)
-        print(f"  Compressed size: {compressed_size} bytes")
-        
-        # Compute ratio
-        ratio = (original_size - compressed_size) / original_size if original_size > 0 else 0
-        ratio = max(0, min(1, ratio))  # Clamp to [0, 1]
-        
-        print(f"  Ratio: {ratio:.1%}\n")
-        
-        baselines[payload_name] = {
-            "original_size": original_size,
-            "compressed_size": compressed_size,
-            "ratio": round(ratio, 4),
-            "file": str(payload_file.relative_to(payloads_dir.parent.parent))
-        }
-    
-    # Save baselines
+        # Two passes: first observes, second observes again → ID is
+        # allocated mid-run, then compression fires.
+        for _ in range(2):
+            pipeline.run(payload["messages"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output baselines.json path (default: tests/regression/baselines.json)",
+    )
+    args = parser.parse_args()
+
+    payloads_dir = Path(__file__).parent.parent / "tests" / "regression" / "payloads"
+    baselines_path = args.out or (payloads_dir.parent / "baselines.json")
+
+    if not payloads_dir.exists():
+        print(f"❌ Payloads directory not found: {payloads_dir}", file=sys.stderr)
+        return 1
+
+    payload_files = sorted(payloads_dir.glob("*.json"))
+    print(f"📦 Found {len(payload_files)} payloads")
+
+    # Hermetic instruction table: temp dir, not ~/.tokenpak/.
+    with tempfile.TemporaryDirectory(prefix="tsr05l_baseline_") as tmpdir:
+        table_path = Path(tmpdir) / "instruction_table.json"
+        pipeline = CompressionPipeline(instruction_table_path=str(table_path))
+        print(f"✨ Pipeline ready (instruction_table → {table_path})")
+
+        # Warmup so InstructionTable can compress on the measured run.
+        print("🔥 Warming InstructionTable (2 passes per payload)...")
+        warm_pipeline(pipeline, payload_files)
+
+        baselines = {}
+        for payload_file in payload_files:
+            payload_name = payload_file.stem
+            print(f"\nProcessing {payload_name}...")
+
+            with open(payload_file) as f:
+                payload = json.load(f)
+
+            original_size = compute_payload_size(payload)
+            print(f"  Original size: {original_size} bytes")
+
+            compressed = compress_payload(pipeline, payload)
+
+            compressed_size = compute_payload_size(compressed)
+            print(f"  Compressed size: {compressed_size} bytes")
+
+            ratio = (
+                (original_size - compressed_size) / original_size
+                if original_size > 0
+                else 0
+            )
+            ratio = max(0.0, min(1.0, ratio))
+            print(f"  Ratio: {ratio:.1%}")
+
+            baselines[payload_name] = {
+                "original_size": original_size,
+                "compressed_size": compressed_size,
+                "ratio": round(ratio, 4),
+                "file": str(payload_file.relative_to(payloads_dir.parent.parent)),
+            }
+
+    baselines_path.parent.mkdir(parents=True, exist_ok=True)
     with open(baselines_path, "w") as f:
         json.dump(baselines, f, indent=2)
-    
-    print(f"✅ Baselines saved to {baselines_path}")
-    print(f"\nSummary:")
+        f.write("\n")
+
+    print(f"\n✅ Baselines saved to {baselines_path}")
+    print("\nSummary:")
     for name, data in baselines.items():
         print(f"  {name}: {data['ratio']:.1%}")
 
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_compression_regression.py
+++ b/tests/test_compression_regression.py
@@ -52,13 +52,58 @@ def compress_payload(pipeline, payload):
 
 
 class TestCompressionRegression:
-    """Regression tests for compression quality"""
-    
-    @pytest.fixture
-    def pipeline(self):
-        """Initialize compression pipeline"""
-        return CompressionPipeline()
-    
+    """Regression tests for compression quality.
+
+    Implementation note (TSR-05l, 2026-05-08)
+    ─────────────────────────────────────────
+    The compression pipeline's `InstructionTable` stage is a stateful learning
+    compressor — content must be observed at least `min_occurrences` (= 2)
+    times before an instruction ID is allocated and the content is replaced
+    with a `[INSTRUCTION:POLICY_NN]` tag. A fresh table cannot compress on the
+    first call. Without deterministic warmup, this test passes only on dev
+    machines whose `~/.tokenpak/instruction_table.json` happens to have
+    accumulated entries for these exact payloads (a host-state pollution bug).
+
+    The fixture below makes the test hermetic:
+      1. The pipeline is constructed with `instruction_table_path` pointing
+         at a per-class temp directory — no read/write of the user's real
+         `~/.tokenpak/instruction_table.json`.
+      2. Each payload is run through the pipeline **twice** before measuring.
+         First pass: `_observe_text()` increments `seen_count` to 1.
+         Second pass: `seen_count` reaches `min_occurrences=2`, an ID is
+         allocated, and subsequent measurement calls emit compression tags.
+
+    This produces a deterministic "warm-table" baseline that matches what
+    real users see after the proxy has been running long enough for repeated
+    patterns to be learned. It does NOT measure cold-table compression
+    (which would always be ~1% by design — the table can't compress what
+    it has never seen).
+
+    See `tokenpak/compression/instruction_table.py:124-157` for the
+    observation / ID-allocation contract.
+    """
+
+    @pytest.fixture(scope="class")
+    def pipeline(self, tmp_path_factory):
+        """Pipeline with isolated, warmed InstructionTable (see class docstring)."""
+        # Per-class temp dir → no host state pollution.
+        table_dir = tmp_path_factory.mktemp("tsr05l_instruction_table")
+        table_path = table_dir / "instruction_table.json"
+        p = CompressionPipeline(instruction_table_path=str(table_path))
+
+        # Warmup: each payload's content must reach seen_count >= 2 before
+        # the InstructionTable can compress. Two passes is the minimum.
+        for payload_file in get_payload_files():
+            with open(payload_file) as f:
+                payload = json.load(f)
+            messages = payload.get("messages")
+            if not messages:
+                continue
+            for _ in range(2):
+                p.run(messages)
+
+        return p
+
     @pytest.fixture
     def baselines(self):
         """Load baseline ratios"""


### PR DESCRIPTION
## Scope

`tests/test_compression_regression.py` (fixture) + `scripts/compute_compression_baselines.py` (rewrite). **No production change. No baseline change.**

## Root cause (per #106 [issuecomment-4411057149](https://github.com/tokenpak/tokenpak/issues/106#issuecomment-4411057149))

The 80% → 1% drop is a **stateful-compressor / deterministic-baseline mismatch**, not a product regression:

- `CompressionPipeline.run()`'s strongest stage, `InstructionTable`, requires `seen_count >= min_occurrences (=2)` before allocating an ID and emitting a `[INSTRUCTION:POLICY_NN]` tag.
- A fresh instruction table cannot compress on the first call.
- Without deterministic warmup, the test passed only on dev machines whose `~/.tokenpak/instruction_table.json` happened to have accumulated entries — host-state pollution.
- Reproduced: with a cleared table on my dev box, `03_code_block` dropped to 1.3% (matches CI). Re-running with a warmed table returned to 86.7% (matches baseline 86.78%).

## Fix (Path A — Kevin-approved)

### 1. Test fixture (`tests/test_compression_regression.py`)

- `pipeline` fixture is now **class-scoped** and uses `tmp_path_factory`.
- Constructs `CompressionPipeline(instruction_table_path=...)` pointing at a per-class temp dir — **never reads or writes** the user's real `~/.tokenpak/instruction_table.json`.
- Runs each payload through the pipeline **twice** before measurement so every observed text reaches `seen_count >= 2` and gets an ID allocated.
- Class docstring documents the contract and points at `tokenpak/compression/instruction_table.py:124-157`.

### 2. Baseline-compute script (`scripts/compute_compression_baselines.py`)

Rewritten:

- Uses `pipeline.run()` (the canonical OSS API). Prior version called `pipeline.compress()` which **never existed** on `CompressionPipeline` in OSS history.
- **Fails loudly** on API errors. Prior bare-`except` silently swallowed the `AttributeError` from the missing `compress()` and produced empty baselines.
- Hermetic: instruction table goes to a `tempfile.TemporaryDirectory`.
- Same 2-pass warmup contract as the test fixture.
- Module docstring records the history note + warm-state assumption.

## Verification

| Check | Result |
|---|---|
| 7 failures resolved | ✅ all 11 tests pass |
| Hermetic from clean state | ✅ tested with cleared `~/.tokenpak/instruction_table.json` — still 11/11 pass |
| No host-state pollution | ✅ real instruction_table.json untouched (0 entries after run) |
| Coverage preserved | ✅ same `baselines.json` (no change to file) |
| No baseline update to ~1% | ✅ baselines.json untouched |
| InstructionTable still tested | ✅ active in pipeline.run() during measurement |
| No production behavior change | ✅ only `tests/` and `scripts/` modified |
| Rewritten script reproduces baselines | ✅ byte-for-byte match against committed `baselines.json` |
| Collection | ✅ 6195 tests, 0 errors |
| MultiPak Phase 0/1 | ✅ 54/54 |

## Constraint check

- ✅ Scoped: 2 files; no production change; no baseline change.
- ✅ No `--ignore` / xfail / skip sweeps.
- ✅ No release.yml bypasses.
- ✅ No MultiPak Pro / cloud / sync / pricing language.
- ✅ v1.5.2 release artifacts untouched.
- ✅ Coverage of compression engine **not weakened** — InstructionTable still measured.
- ✅ No "deciding the 80% → 1% drop is acceptable" — the drop is a fixture artifact; we fixed the fixture, kept the contract.

Refs #106 (TSR-05l).