### PR TITLE
fix(tests): TSR-04 — resolve all 23 pytest errors → 0 (two buckets)

### DIFF
--- a/tests/cli/test_per_session_policy.py
+++ b/tests/cli/test_per_session_policy.py
@@ -19,6 +19,40 @@ from types import SimpleNamespace
 
 import pytest
 
+
+# TSR-04 module-level skip — superseded design (grep-able)
+# ─────────────────────────────────────────────
+# CCG-12 (db0f08c6e5, 2026-04-10) shipped a proxy-side per-session policy
+# feature: a `session_policies` SQLite table + three CLI commands
+# (`cmd_session_budget_set`, `cmd_session_mode_set`, `cmd_session_route_pin`)
+# + `_lookup_session_policy()` / `_get_session_spend()` helpers in proxy.py.
+#
+# That whole feature has since been **removed from production** in favor of
+# the companion-side advisory budget (per Std 32, Glossary 08 entry
+# "advisory budget (companion)" — "stored in ~/.tokenpak/companion/budget.db").
+# Verification:
+#   - `grep -rn 'session_policies' tokenpak/`           → 0 results
+#   - `grep -rn 'def cmd_session_' tokenpak/`           → 0 results
+#   - `grep -rn '_lookup_session_policy' tokenpak/`     → 0 results
+#
+# The test's 10 ERRORs (post-#147 baseline) all stem from monkeypatching a
+# CLI helper that exists under a different name (`_get_monitor_db` →
+# `_get_monitor_db_path`) AND from importing `cmd_session_budget_set` /
+# `cmd_session_mode_set` / `cmd_session_route_pin` from `tokenpak.cli`,
+# none of which exist on the public surface anymore.
+#
+# Skipping the entire module is correct: the contract is gone by design,
+# not regressed. The advisory-budget path has its own tests under
+# `tests/companion/`. Same Path B pattern as TSR-05t (deprecated `tokenpak
+# savings`) — superseded API/wire-format, not a real test bug.
+pytest.skip(
+    "CCG-12 per-session policy feature superseded by companion advisory "
+    "budget (Std 32 / Glossary 08). Production removed `cmd_session_*` "
+    "and `session_policies` table; this test asserts a contract that no "
+    "longer exists. See TSR-04 / #106.",
+    allow_module_level=True,
+)
+
 # Make sure the tokenpak package is importable from the repo root.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_REPO_ROOT) not in sys.path:
@@ -45,7 +79,7 @@ def tmp_monitor_db(tmp_path, monkeypatch):
     monkeypatch.setenv("TOKENPAK_DB", db_path)
     # Patch the CLI helper to return this path directly.
     import tokenpak.cli as _cli
-    monkeypatch.setattr(_cli, "_get_monitor_db", lambda: db_path)
+    monkeypatch.setattr(_cli, "_get_monitor_db_path", lambda: Path(db_path))
     return db_path
 
 

--- a/tests/test_dashboard_route_smoke.py
+++ b/tests/test_dashboard_route_smoke.py
@@ -26,7 +26,25 @@ is out of scope per task constraints).
 from __future__ import annotations
 
 import pytest
-from starlette.testclient import TestClient
+
+# TSR-04: fastapi/starlette are in the optional `[serve]` / `[telemetry]`
+# extras (see pyproject.toml). Slim install does not pull them. Without
+# these guards, the test module raises ModuleNotFoundError 13 times at
+# collection-time (one per parametrized case + class-level helpers), each
+# becoming a pytest ERROR status that blocks the release.yml auto-publish
+# gate. Canonical guard pattern matches tests/test_phase5b_query_api.py,
+# tests/test_telemetry_server.py, tests/dashboard/test_per_mode_panels.py,
+# tests/dashboard/test_settings_page.py.
+pytest.importorskip(
+    "fastapi",
+    reason="fastapi is optional (install [serve] or [telemetry] extra)",
+)
+pytest.importorskip(
+    "starlette",
+    reason="starlette is a fastapi dep; same optional-extra guard",
+)
+
+from starlette.testclient import TestClient  # noqa: E402
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope

`tests/cli/test_per_session_policy.py` + `tests/test_dashboard_route_smoke.py` only — no production change. **Reduces pytest errors from 23 → 0 across all 4 Python versions.** Restores the release.yml auto-publish gate to a green-able state.

## Bucket A (10 errors): `tests/cli/test_per_session_policy.py` — superseded design

The CCG-12 per-session policy feature (commit `db0f08c6e5`, 2026-04-10) has been **removed from production**. The CLI commands (`cmd_session_budget_set`, `cmd_session_mode_set`, `cmd_session_route_pin`), the underlying `session_policies` SQLite table, and the proxy-side `_lookup_session_policy()` / `_get_session_spend()` helpers are all gone. The feature was **superseded** by the companion-side advisory budget per:

- Std 32 (multipak-pro-architecture)
- Glossary 08 entry "advisory budget (companion)" — *"stored in ~/.tokenpak/companion/budget.db"*

Verification of removal:

```bash
grep -rn 'session_policies'      tokenpak/   #  0 results
grep -rn 'def cmd_session_'      tokenpak/   #  0 results
grep -rn '_lookup_session_policy' tokenpak/  #  0 results
```

The test fixture monkeypatches `tokenpak.cli._get_monitor_db` (renamed to `_get_monitor_db_path` post-CCG-12) **and** imports `cmd_session_*` symbols that no longer exist on the public surface — yielding the 10 ERRORs.

**Fix**: module-level `pytest.skip(allow_module_level=True)` with grep-able reason. Same Path B pattern as TSR-05t (deprecated `tokenpak savings`) — superseded API, not a real test bug. The advisory-budget path has its own tests under `tests/companion/`.

## Bucket B (13 errors): `tests/test_dashboard_route_smoke.py` — optional dep

`fastapi` (and its starlette dep) are in the optional `[serve]` / `[telemetry]` extras per `pyproject.toml`; slim install does not pull them. Without import guards, the test module raised `ModuleNotFoundError` 13 times at collection-time.

**Fix**: canonical `pytest.importorskip("fastapi", ...)` + `pytest.importorskip("starlette", ...)` at module level. Pattern matches existing tests:

- `tests/test_phase5b_query_api.py`
- `tests/test_telemetry_server.py`
- `tests/dashboard/test_per_mode_panels.py`
- `tests/dashboard/test_settings_page.py`

## Verification

| Check | Result |
|---|---|
| 13 dashboard tests pass when fastapi installed (dev box) | ✅ |
| Per-session module skipped with documented grep-able reason | ✅ |
| Collection: 6195 → 6185 (10 superseded tests no longer collected) | ✅ 0 errors |
| MultiPak Phase 0/1: 54/54 | ✅ |
| No production change | ✅ |
| No release.yml change | ✅ |
| No `tokenpak-paid` / `_internal` surface | ✅ |

## Acceptance criteria (per TSR-04 directive)

- ✅ Errors 23 → 0 expected
- ✅ Test failures stay 0
- ✅ Collection 0 errors
- ✅ MultiPak green
- ✅ No release gate weakening (no release.yml change)
- ✅ Restored public surface justified — **none restored**; both buckets resolved by stale-test-skip + optional-dep-guard, NOT by adding new public APIs
- ✅ Skipped tests have documented grep-able reasons

Per the user's classification rubric:
- Bucket A: **stale test reference to removed/non-public surface** → skip with grep-able reason ✅ (proven invalid via grep + glossary citation)
- Bucket B: **optional dependency missing in slim install** → canonical import-guard ✅

Refs #106 (TSR-04).