### PR TITLE
fix(tests): TSR-04c — restore tests/test_errors.py against canonical core.error_handling path

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,10 +2,16 @@
 
 
 import pytest
-pytest.importorskip("tokenpak.infrastructure.error_handling", reason="module not available in current build")
-import pytest
 
-from tokenpak.infrastructure.error_handling import (
+# TSR-04c: rename `tokenpak.infrastructure.error_handling` →
+# `tokenpak.core.error_handling`. The old path was a documentation/refactor
+# artifact that never landed (or got removed in a subsequent module-layout
+# pass). The `pytest.importorskip` against the old path was silently
+# skipping all 21 tests in this file, leaving `tokenpak/core/error_handling.py`
+# at 48% coverage and tripping the Python 3.11 Tier-1 coverage gate
+# (`--fail-under=50`). Restoring these tests against the canonical OSS
+# path raises measured coverage past 50% without weakening the gate.
+from tokenpak.core.error_handling import (
     CacheCorruptedError,
     ConfigValidationError,
     InvalidAPIKeyError,
@@ -19,9 +25,29 @@ from tokenpak.infrastructure.error_handling import (
 )
 
 
+# TSR-04c: API drift on 7 of the 21 tests below. The original
+# `tokenpak.infrastructure.error_handling` constructors accepted `code=`
+# kwargs and `retry_after_seconds=`; the renamed-and-refactored
+# `tokenpak.core.error_handling` uses different signatures (e.g.
+# `TokenPakError(message, detail=None, error_type=None)` with
+# `error_code` as a class attribute, not a constructor arg). Restoring
+# the dropped contracts is TSR-02 (API drift) territory, not TSR-04
+# coverage. Skip the 7 with a grep-able reason; the 14 still-valid
+# tests provide enough coverage of `tokenpak/core/error_handling.py`
+# to push the file past the 50% Tier-1 gate.
+SKIP_ERROR_HANDLING_API_DRIFT = (
+    "Test asserts pre-rename `tokenpak.infrastructure.error_handling` "
+    "constructor signatures (code= / retry_after_seconds= / TP-Exxx "
+    "format prefix). The canonical OSS module is `tokenpak.core."
+    "error_handling`; signatures changed during the rename. API drift — "
+    "see TSR-02."
+)
+
+
 class TestTokenPakError:
     """Test base error class."""
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_error_creation(self):
         """Test creating a TokenPak error."""
         error = TokenPakError(
@@ -35,6 +61,7 @@ class TestTokenPakError:
         assert error.suggestion == "Test fix"
         assert error.context == "test context"
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_error_string_representation(self):
         """Test error string format."""
         error = TokenPakError(
@@ -49,6 +76,7 @@ class TestTokenPakError:
         assert "Test fix" in s
         assert "test context" in s
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_error_to_dict(self):
         """Test error serialization to dict."""
         error = TokenPakError(
@@ -60,6 +88,7 @@ class TestTokenPakError:
         assert d["suggestion"] == "Fix"
         assert d["context"] == "ctx"
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_error_with_default_suggestion(self):
         """Test error with default suggestion."""
         error = TokenPakError(code="TP-E999", message="Test")
@@ -137,6 +166,7 @@ class TestRateLimitError:
         assert "TP-E301" in error.code
         assert "anthropic" in error.message
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_rate_limit_with_retry(self):
         """Test rate limit error with retry info."""
         error = RateLimitError("openai", retry_after_seconds=60)
@@ -159,6 +189,7 @@ class TestCacheErrors:
 class TestErrorFormatting:
     """Test error formatting utility."""
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_format_tokenpak_error(self):
         """Test formatting TokenPak error."""
         error = InvalidAPIKeyError("anthropic")
@@ -166,6 +197,7 @@ class TestErrorFormatting:
         assert "TP-E202" in formatted
         assert "anthropic" in formatted
 
+    @pytest.mark.skip(reason=SKIP_ERROR_HANDLING_API_DRIFT)
     def test_format_unknown_exception(self):
         """Test formatting unknown exception."""
         try:


### PR DESCRIPTION
## Scope

`tests/test_errors.py` only — no production change.

Resolves the Python 3.11 Tier-1 coverage gate failure surfaced by [PR #148](https://github.com/tokenpak/tokenpak/pull/148) when the 23 test errors stopped short-circuiting the workflow.

## Root cause

`tests/test_errors.py` opened with:

```python
pytest.importorskip("tokenpak.infrastructure.error_handling",
                     reason="module not available in current build")
```

`tokenpak.infrastructure.error_handling` was a documentation/refactor artifact that never landed (or got removed in a subsequent module-layout pass). The `importorskip` against the dead path **silently skipped all 21 tests** — leaving `tokenpak/core/error_handling.py` at 48% coverage, just below the 50% Tier-1 gate threshold.

The same module exists today as `tokenpak.core.error_handling` and exports all the symbols the test imports.

## Fix

1. Update the import path to `tokenpak.core.error_handling`.
2. **14 of 21 tests pass** against the new module unchanged → real coverage win.
3. **7 tests fail** because constructor signatures drifted during the rename:
   - `TokenPakError(code=...)` → `TokenPakError(message, detail, error_type)` (`error_code` is now a class attr)
   - `RateLimitError(retry_after_seconds=...)` no longer accepted
   - `format_error()` no longer prefixes `TP-Exxx`

Skipped with grep-able `SKIP_ERROR_HANDLING_API_DRIFT` reason pointing to TSR-02. Restoring those contracts is API-drift work, not coverage work.

## Coverage delta

| Measurement | Pre | Post |
|---|---:|---:|
| `tokenpak/core/error_handling.py` | **48%** | **66%** ✅ |
| Tier-1 gate threshold | 50% | 50% (unchanged) |
| Total tier-1 unfiltered (3 modules) | 41% | 44% |

## CI gate filter glob bug (noted, not fixed in this PR)

The Tier-1 coverage gate uses:
```bash
--include='*/tokenpak/core/validation*,*/tokenpak/core/error_handling*,*/tokenpak/cache*'
```

Coverage's fnmatch `*` does NOT span `/`, so:
- `*/tokenpak/cache*` → matches only `tokenpak/cache.py` (doesn't exist) — **excludes `tokenpak/cache/<file>.py`**.
- `*/tokenpak/core/validation*` → same problem with `tokenpak/core/validation/`.
- `*/tokenpak/core/error_handling*` → matches `tokenpak/core/error_handling.py` ✅.

The gate has been silently measuring only `tokenpak/core/error_handling.py`. Fixing the filter (`*/tokenpak/cache/*`, etc.) would expand the measurement basis to validation/ + cache/ directories — currently 41% across the wider set, below threshold.

That's a **coverage-policy decision** that needs Kevin's input — fixing the filter would either (a) require improving real coverage on validation/ + cache/ from current ~40% to ≥50% (substantial test-writing work), or (b) lower the threshold (which would be "weakening the release gate" per the standing rules).

This PR resolves the immediate failure (gate passes at 66%) without making that policy decision.

## Verification

| Check | Result |
|---|---|
| 14 passed, 7 skipped (was 21 silently skipped) | ✅ |
| Coverage of error_handling.py: 66% vs gate threshold 50% | ✅ |
| Collection: 6206 tests, 0 errors | ✅ |
| MultiPak Phase 0/1: 54/54 | ✅ |
| No production change | ✅ |
| No release gate threshold change | ✅ |
| No release.yml change | ✅ |

## Constraint check

- ✅ "Do not weaken the release gate" — threshold unchanged at 50%; coverage went UP from 48% to 66%.
- ✅ "Do not blindly update baselines" — no baseline change; restored real test coverage.
- ✅ Path B skips have documented grep-able reasons.

Refs #106 (TSR-04).