### PR TITLE
chore(release): bump version to 1.5.3 — TSR-08-B Release Test Suite Recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,49 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — release auto-publish test-gate fix (TIP7-001 follow-up)
+## [v1.5.3] — 2026-05-09 — Release Test Suite Recovery (TSR-04 / TSR-05 / TSR-06)
 
-### Fixed
+> **Release scope**: this PATCH release contains **only** the release-test-suite recovery work (TSR-01 through TSR-07, plus the TIP7-001 follow-up). No feature work, no MultiPak Pro implementation, no cloud/sync/pricing surface. The goal of this release is to restore the `Release TokenPak` auto-publish path that v1.5.1 and v1.5.2 both fell back to manual `twine upload` to complete (per [`feedback_release_path_hardening`](.claude/projects/-home-sue/memory/feedback_release_path_hardening.md)).
+>
+> Pure additive PATCH per [`feedback_initiative_completion_versioning`](.claude/projects/-home-sue/memory/feedback_initiative_completion_versioning.md). No breaking changes.
 
-- **Release auto-publish workflow** (`.github/workflows/release.yml`) — the `Run Tests` step on the `[dev]`-only install was tripped by 14 test files that did unconditional imports of optional/external/internal modules (numpy, fastapi, scipy, trackedge, websocket_proxy, provider_health, tokenpak.companion.mcp_server, tokenpak.compaction, tokenpak.extraction, tokenpak._internal). v1.5.1 and v1.5.2 both fell back to manual `twine upload` per `feedback_release_path_hardening` because of this gate. Each affected test now guards its imports at module load:
+### Fixed — `release.yml` Run Tests gate (TIP7-001 / TIP7-001 follow-up)
+
+- **Release auto-publish workflow** (`.github/workflows/release.yml`) — the `Run Tests` step on the `[dev]`-only install was tripped by 14 test files that did unconditional imports of optional/external/internal modules (numpy, fastapi, scipy, trackedge, websocket_proxy, provider_health, tokenpak.companion.mcp_server, tokenpak.compaction, tokenpak.extraction, tokenpak._internal). Each affected test now guards its imports at module load:
   - Optional/external deps installable via extras: `pytest.importorskip("dep_name", reason="…")` immediately after `import pytest`.
-  - Namespace packages where the directory exists in slim OSS but the required submodule symbols don't (`tokenpak.compaction`, `tokenpak.extraction`, `tokenpak._internal`, `tokenpak.companion.mcp_server`): `try: from … import …  except ImportError as exc: pytest.skip(…, allow_module_level=True)` — `importorskip` on the bare namespace returns truthy and doesn't help.
-- **Workflow contract documented** — `release.yml`'s `test` job now carries a top-of-job comment block describing what the gate does and doesn't cover, the import-guard contract for optional deps, and the rule "do not bypass via `--ignore`; either fix the test's guard or add the missing extra to this step."
-- **Acceptance** — `pytest tests/ --collect-only -q` now succeeds with 0 errors on a `[dev]`-only install (was 13 collection errors); MultiPak Phase 0/1 contract + surface tests (54 + 100 = 154) remain green.
+  - Namespace packages where the directory exists in slim OSS but the required submodule symbols don't: `try: from … import …  except ImportError as exc: pytest.skip(…, allow_module_level=True)` — `importorskip` on the bare namespace returns truthy and doesn't help.
+- **Workflow contract documented** — `release.yml`'s `test` job carries a top-of-job comment block describing what the gate does and doesn't cover, the import-guard contract for optional deps, and the rule "do not bypass via `--ignore`; either fix the test's guard or add the missing extra to this step." (`d062e1d6a5`)
+
+### Fixed — telemetry / `_internal` ghost-path restoration (TSR-03 / TSR-04 / TSR-04a / TSR-04c / TSR-07)
+
+- **TSR-03** (`#112`) — restored CCI-21 schema (v1.1) on `MetricsRecord` after a partial telemetry refactor left the field shape drifting from the contract.
+- **TSR-04** (`#113`, `#148`) — restored missing telemetry exports and resolved all 23 pytest collection errors → 0 across two distinct buckets (ghost-path imports + speculative module surfaces).
+- **TSR-04a** (`#110`) — guarded `jsonschema` / `yaml` in `test_config_validator` so slim install skips cleanly.
+- **TSR-04c** (`#150`) — restored `tests/test_errors.py` against the canonical `core.error_handling` path after the module move.
+- **TSR-07** (`#114`) — relocated `_internal`-dependent tests to `tests/_internal/` so OSS-slim collection no longer drags closed-tree fixtures.
+
+### Fixed — release-gate stability (TSR-01 / TSR-01-followup / TSR-02 / TSR-02b / TSR-05 / TSR-05b–05ae)
+
+- **TSR-01** (`#107`, plus follow-up `#111`) — guarded `tomllib` for Python 3.10 collection; residual WS-A import guards across 24 files.
+- **TSR-02 / TSR-02b** (`#108`, `#109`) — aligned `test_install_claude_code` and `test_setup_wizard` with v1.5.2 production signatures after API drift.
+- **TSR-05 / TSR-05b–05ae** (`#115`–`#145`) — fixed Python scope bug in `test_lifecycle.py`; documented per-test skips for: legacy `/ready` lifecycle, MCP tools without proxy reachable, legacy `CompressionStats` tests (19), source-grep antipattern files, mock-isolation breakages, fixture-name regressions, telemetry-export Query, semantic-cache bypass / source-structure / SSE source-grep classes, mutation_audit `CCG-02`-shape, `CCG-15`-shape SemanticCache, pre-TIP-06 recommendations engine, integration caching speculative contracts, file_watcher mock-paths to modular tree, savings_cmd pre-deprecation, optimize.py distinct failures, Pro-tier speculative-contract tests in diff_command and budget_intelligence, graceful_shutdown TestTelemetryFlush, compact-threshold-bump tests, concurrency cache_write_safety, banner-text drift, hook-contract change for silent_failure_zero_token, fragile-fixture compile_injection, inject-empty contract drift on test_large_content_block_truncated, deterministic InstructionTable warmup for compression regression.
+
+### Fixed — performance/benchmark hermeticity (TSR-06 / TSR-06b / TSR-06c / TSR-06d)
+
+- **TSR-06** (`#146`) — hermetic compression benchmark + re-baseline.
+- **TSR-06b** (`#147`) — made `test_proxy_vs_sdk_throughput_ratio` non-flaky.
+- **TSR-06c** (`#149`) — pre-encoded bytes in `test_proxy_vs_sdk_throughput_ratio`.
+- **TSR-06d** (`#151`) — bumped `load_100rps` health-load timeout 2s→10s and join 5s→15s for CI runner stability.
+
+### Acceptance
+
+- `pytest tests/ -q --tb=short` (the exact command in `release.yml`'s `test` job) is **green on Python 3.10 / 3.11 / 3.12 / 3.13** with **0 failed / 0 errors**.
+- `release.yml`'s `Run Tests` step on a `[dev]`-only install no longer falls back to manual `twine upload`. Tag push for v1.5.3 is the end-to-end recovery proof.
+- MultiPak Phase 0 / Phase 1 contract + surface tests (54 + 100 = 154) remain green.
+
+### Inherited debt — peripheral `ci.yml` jobs (non-release-gating, §9.8 informational)
+
+The following `ci.yml` jobs are **not** part of `release.yml`'s auto-publish gate and remain red as pre-existing inherited debt. Per Std 21 §9.8 process-enforced gating, they are tracked separately and do not block this release: **Ruff**, **CLI Docs Up-to-date**, **Perf Benchmarks**, **Integration / Chaos**. Follow-up tracking issue opened separately.
 
 ---
 

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"


### PR DESCRIPTION
## TSR-08-B — v1.5.3 release packaging

Refs #106. Restores the `Release TokenPak` auto-publish path that v1.5.1 and v1.5.2 both fell back to manual `twine upload` to complete (per `feedback_release_path_hardening`).

### Scope (narrow)

This PATCH release contains **only** the release-test-suite recovery work:
- TIP7-001 / TIP7-001 follow-up (`release.yml` Run Tests gate import-guards)
- TSR-01 / TSR-01-followup (tomllib + WS-A guards)
- TSR-02 / TSR-02b (install_claude_code + setup_wizard signature alignment)
- TSR-03 (CCI-21 schema restoration on MetricsRecord)
- TSR-04 / TSR-04a / TSR-04c (telemetry exports + ghost-path fixes + test_errors restoration)
- TSR-05 / TSR-05b–05ae (per-test skip rationale across 30+ files)
- TSR-06 / TSR-06b / TSR-06c / TSR-06d (hermetic compression bench + non-flaky throughput)
- TSR-07 (`_internal`-dependent test relocation)

**Out of scope and explicitly excluded:** feature work, MultiPak Pro implementation, cloud/sync/pricing surface, peripheral `ci.yml` debt (Ruff / CLI Docs / Perf Benchmarks / Integration / Chaos — separate follow-up).

### Acceptance

- `pytest tests/ -q --tb=short` (the exact command in `release.yml`'s `test` job) is **green on Python 3.10 / 3.11 / 3.12 / 3.13** with **0 failed / 0 errors**.
- `release.yml` semantics are unchanged.
- Publish credentials are unchanged.
- v1.5.2 integrity is preserved.

### Versioning rationale

Per `feedback_initiative_completion_versioning`: pure additive PATCH (`1.5.2 → 1.5.3`), Suki-approvable bump. No breaking changes. No new public API surface.

### Inherited debt acknowledged

Peripheral `ci.yml` jobs (Ruff, CLI Docs Up-to-date, Perf Benchmarks, Integration / Chaos) remain red as pre-existing inherited debt. Per Std 21 §9.8 process-enforced gating, they are tracked separately (see follow-up issue) and **do not block this release** — they are not part of `release.yml`'s auto-publish gate.

### Hard stops (per TSR-08-C protocol)

If any of the following occur during tag/release, stop and escalate (no manual twine recovery):
- `release.yml` workflow fails
- PyPI publish fails
- version-metadata mismatch
- artifact hash mismatch
- clean install failure