### PR TITLE
fix(release): SHA256SUMS outside dist/ + dist-purity guard (TSR-08-D, v1.5.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,30 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Step 2: Build distribution artifacts
   # ─────────────────────────────────────────────────────────────────────
+  #
+  # Dist-purity contract (TSR-08-D / 2026-05-09 v1.5.3 burn lesson):
+  #
+  # The `dist/` directory uploaded as the `dist` artifact MUST contain only
+  # valid Python distribution files: `*.whl` and `*.tar.gz`. Nothing else.
+  #
+  # `pypa/gh-action-pypi-publish` enumerates `dist/*` and uploads each entry
+  # to PyPI. Any non-distribution file (e.g. SHA256SUMS, RELEASE_NOTES.md)
+  # is rejected with `InvalidDistribution: Unknown distribution format` and
+  # the entire publish fails. This was the v1.5.3 failure mode and the same
+  # defect documented in `feedback_release_path_hardening` ("SHA256SUMS
+  # outside dist/").
+  #
+  # Therefore:
+  #   • SHA256SUMS is generated at the repo root (./SHA256SUMS), NEVER inside dist/.
+  #   • Checksums are uploaded as a separate `checksums` artifact.
+  #   • The `release` job downloads both `dist` and `checksums` to attach
+  #     everything to the GitHub Release.
+  #   • The `publish` job downloads ONLY the `dist` artifact and runs a
+  #     pre-publish guard that fails if `dist/` contains anything other than
+  #     `*.whl` or `*.tar.gz`.
+  #
+  # If you add a new release artifact, give it its own artifact name; do
+  # NOT drop it into `dist/`.
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
@@ -88,17 +112,44 @@ jobs:
       - name: Verify package
         run: twine check dist/*
 
-      - name: Generate checksums
+      - name: Assert dist/ purity (only .whl + .tar.gz)
         run: |
-          cd dist
-          sha256sum * > SHA256SUMS
+          set -euo pipefail
+          shopt -s nullglob
+          extras=()
+          for f in dist/*; do
+            base="$(basename "$f")"
+            case "$base" in
+              *.whl|*.tar.gz) ;;
+              *) extras+=("$base") ;;
+            esac
+          done
+          if [ "${#extras[@]}" -gt 0 ]; then
+            echo "ERROR: dist/ contains non-distribution files: ${extras[*]}" >&2
+            echo "       PyPI publish would fail. See dist-purity contract above." >&2
+            exit 1
+          fi
+          echo "dist/ purity check OK:"
+          ls -la dist/
+
+      - name: Generate checksums (outside dist/)
+        run: |
+          # SHA256SUMS lives at repo root, NEVER inside dist/.
+          # See dist-purity contract on the build job.
+          ( cd dist && sha256sum *.whl *.tar.gz ) > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Upload artifacts
+      - name: Upload dist artifact (wheels + sdist only)
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Upload checksums artifact (SHA256SUMS only)
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksums
+          path: SHA256SUMS
 
   # ─────────────────────────────────────────────────────────────────────
   # Step 3: Create GitHub Release with artifacts
@@ -110,11 +161,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download artifacts
+      - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Download checksums artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: checksums
+          path: .
 
       - name: Extract version from tag
         id: version
@@ -124,13 +181,13 @@ jobs:
         id: notes
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
-          
+
           # Try to extract section from CHANGELOG.md
           if [ -f CHANGELOG.md ]; then
             # Extract the section for this version
             NOTES=$(awk "/## \[$VERSION\]|## $VERSION/{flag=1; next} /## \[|## [0-9]/{flag=0} flag" CHANGELOG.md)
           fi
-          
+
           # Fallback if no changelog entry
           if [ -z "$NOTES" ]; then
             NOTES="Release v$VERSION
@@ -148,11 +205,11 @@ jobs:
           ## Checksums
 
           \`\`\`
-          $(cat dist/SHA256SUMS)
+          $(cat SHA256SUMS)
           \`\`\`
           "
           fi
-          
+
           # Write to file for the release action
           echo "$NOTES" > RELEASE_NOTES.md
           cat RELEASE_NOTES.md
@@ -167,7 +224,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/SHA256SUMS
+            SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -184,11 +241,35 @@ jobs:
     permissions:
       id-token: write  # Required for Trusted Publisher (OIDC)
     steps:
-      - name: Download artifacts
+      - name: Download dist artifact only
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Pre-publish dist/ purity guard
+        # Re-asserts the dist-purity contract immediately before the upload
+        # action enumerates dist/*. If anything other than .whl or .tar.gz
+        # appears here, fail loudly rather than letting twine produce a
+        # confusing `InvalidDistribution` error.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          extras=()
+          for f in dist/*; do
+            base="$(basename "$f")"
+            case "$base" in
+              *.whl|*.tar.gz) ;;
+              *) extras+=("$base") ;;
+            esac
+          done
+          if [ "${#extras[@]}" -gt 0 ]; then
+            echo "ERROR: dist/ has non-distribution files entering the publish action: ${extras[*]}" >&2
+            echo "       This is the v1.5.3 failure mode. See dist-purity contract in this workflow." >&2
+            exit 1
+          fi
+          echo "Pre-publish dist/ purity OK:"
+          ls -la dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,38 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [v1.5.4] — 2026-05-09 — `release.yml` SHA256SUMS-in-`dist/` defect fix (TSR-08-D)
+
+> **Release scope**: this PATCH release supersedes v1.5.3 for PyPI. v1.5.3 itself was tagged and the `Release TokenPak` workflow's `Run Tests`, `Build Distribution`, and `Create GitHub Release` jobs all completed green — proving the TSR-04/05/06 test-suite recovery work landed correctly — but the final `Publish to PyPI` step failed with `InvalidDistribution: Unknown distribution format: 'SHA256SUMS'`. Root cause: `SHA256SUMS` was generated inside `dist/`, and `pypa/gh-action-pypi-publish` enumerates `dist/*` and rejects every non-`.whl`/`.tar.gz` entry. This is the same defect documented in [`feedback_release_path_hardening`](.claude/projects/-home-sue/memory/feedback_release_path_hardening.md) ("SHA256SUMS outside dist/") that bit the v1.3.3–v1.3.5 burn arc; the lesson was captured but never enforced at the workflow level.
+>
+> v1.5.3 is retained as a historical GitHub-tag-only release; **v1.5.4 is the first version of the TSR-08 line published to PyPI**.
+>
+> Pure additive PATCH per [`feedback_initiative_completion_versioning`](.claude/projects/-home-sue/memory/feedback_initiative_completion_versioning.md). No breaking changes. No new public API surface. All TSR-04/05/06 content from v1.5.3 carries forward unchanged.
+
+### Fixed — `release.yml` dist-purity contract (TSR-08-D)
+
+- **`.github/workflows/release.yml` `build` job** — `SHA256SUMS` now generated at the **repo root** (`./SHA256SUMS`), never inside `dist/`. Two separate artifacts uploaded: `dist` (wheels + sdist only) and `checksums` (SHA256SUMS only).
+- **`build` job pre-upload guard** — explicit assertion that `dist/` contains only `*.whl` and `*.tar.gz`; any other file fails the build with a pointer to the dist-purity contract comment block.
+- **`release` job** — downloads both artifacts; GitHub Release attaches `dist/*.whl` + `dist/*.tar.gz` + `SHA256SUMS` (the last from the repo root, not from `dist/`).
+- **`publish` job** — downloads only the `dist` artifact and runs a **second** dist-purity guard immediately before invoking `pypa/gh-action-pypi-publish@release/v1`. Defense-in-depth: if a future change ever lets a non-distribution file slip into `dist/`, the publish step fails with a clear message instead of an opaque `InvalidDistribution` error.
+- **Workflow-hardening contract documented** — top of the `build` job now carries a "Dist-purity contract" comment block: `dist/` MUST contain only `*.whl` and `*.tar.gz`; SHA256SUMS lives at repo root; new release artifacts get their own artifact name and never go into `dist/`. References the v1.5.3 burn explicitly.
+
+### Acceptance
+
+- `pytest tests/ -q --tb=short` (the `release.yml` `Run Tests` gate) is **green on Python 3.10 / 3.11 / 3.12 / 3.13** — unchanged from v1.5.3.
+- `Release TokenPak` workflow completes **without manual `twine` recovery** end-to-end on the v1.5.4 tag.
+- `pip install tokenpak==1.5.4` from a fresh venv succeeds.
+- GitHub Release attaches `SHA256SUMS` alongside the wheel and sdist; PyPI receives only the wheel and sdist.
+
+### Carried forward from v1.5.3 (unchanged)
+
+All Release Test Suite Recovery content (TIP7-001, TSR-01..07, TSR-05b–05ae, TSR-06b/c/d) — see the v1.5.3 entry below for the full per-PR breakdown.
+
+---
+
 ## [v1.5.3] — 2026-05-09 — Release Test Suite Recovery (TSR-04 / TSR-05 / TSR-06)
+
+> **Status**: GitHub-tag-only release. The `Release TokenPak` workflow's `Publish to PyPI` step failed on a pre-existing `release.yml` defect (`SHA256SUMS` inside `dist/`); see v1.5.4 above for the workflow fix and the actual PyPI release. v1.5.3 is **not on PyPI**; install with `pip install tokenpak==1.5.4` instead.
 
 > **Release scope**: this PATCH release contains **only** the release-test-suite recovery work (TSR-01 through TSR-07, plus the TIP7-001 follow-up). No feature work, no MultiPak Pro implementation, no cloud/sync/pricing surface. The goal of this release is to restore the `Release TokenPak` auto-publish path that v1.5.1 and v1.5.2 both fell back to manual `twine upload` to complete (per [`feedback_release_path_hardening`](.claude/projects/-home-sue/memory/feedback_release_path_hardening.md)).
 >

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"


### PR DESCRIPTION
## TSR-08-D — `release.yml` SHA256SUMS-in-`dist/` defect fix

Refs #106. Fixes the **v1.5.3 PyPI publish failure** that surfaced under TSR-08's release-gate scrutiny:

```
Publish to PyPI step:
Checking dist/SHA256SUMS: ERROR InvalidDistribution: Unknown distribution format: 'SHA256SUMS'
```

### Root cause

`pypa/gh-action-pypi-publish@release/v1` enumerates `dist/*` and uploads each entry. Any non-distribution file is rejected. Prior `release.yml` placed `SHA256SUMS` **inside** `dist/` before upload, so every tag since v1.3.002 hit this defect. v1.5.1 and v1.5.2 worked around it via manual twine recovery. The lesson was captured in `feedback_release_path_hardening` ("SHA256SUMS outside dist/") but never enforced at the workflow level.

### Fix

| Job | Change |
|---|---|
| `build` | `SHA256SUMS` generated at **repo root** (`./SHA256SUMS`), never in `dist/`. Two artifacts uploaded separately: `dist` (`.whl` + `.tar.gz` only) and `checksums` (`SHA256SUMS` only). Pre-upload guard fails the build if `dist/` contains anything else. |
| `release` | Downloads **both** artifacts; GitHub Release attaches the wheel, sdist, and SHA256SUMS. |
| `publish` | Downloads **only** the `dist` artifact and runs a **second** dist-purity guard immediately before `pypa/gh-action-pypi-publish`. Defense-in-depth: future regressions fail loudly here, not opaquely inside twine. |

A new top-of-`build`-job **Dist-purity contract** comment block documents the rule: `dist/` MUST contain only `*.whl` + `*.tar.gz`; `SHA256SUMS` lives at repo root; new release artifacts get their own artifact name. References the v1.5.3 burn explicitly.

### Version bump

`1.5.3 → 1.5.4` (PATCH). Pure additive per `feedback_initiative_completion_versioning`.

### v1.5.3 disposition

- Tag `v1.5.3` retained — **not** retagged, **not** force-pushed.
- GitHub Release for v1.5.3 will be amended with a banner pointing users to v1.5.4 for PyPI.
- `v1.5.3` is **not on PyPI** and never will be.
- `v1.5.4` is the first TSR-08-line release that auto-publishes via `release.yml`.

### Acceptance

- `pytest tests/ -q --tb=short` (the `Run Tests` gate) green on Python 3.10/3.11/3.12/3.13.
- After merge + tag, `Release TokenPak` workflow completes end-to-end **without manual twine recovery**.
- `pip install tokenpak==1.5.4` succeeds in a fresh venv.
- GitHub Release attaches `SHA256SUMS`; PyPI receives only `.whl` + `.tar.gz`.

### Out of scope

- Peripheral `ci.yml` jobs (Ruff / CLI Docs / Perf Benchmarks / Integration / Chaos) remain tracked in #153.
- Redundant `publish.yml` workflow (broken SHA pins, never functional, fires on every tag) is **not** removed in this PR — that's a separate cleanup. Will track post-v1.5.4.
- No feature work, no MultiPak Pro implementation, no cloud/sync/pricing language.

### Constraints honored

- No release-gate weakening.
- No test bypasses.
- No credential changes.
- No destructive git history.
- No manual twine path.