### PR TITLE
ci: drop --cov-fail-under=80 from integration-only job (#153 bucket 4)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,13 +27,18 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run integration tests
+        # Integration tests focus on integration-path coverage and don't
+        # exercise enough of the codebase to hit 80% on their own (last
+        # observed: ~2%). The combined-coverage gate in the
+        # 'Combined Coverage' job below enforces the 80% bar on the full
+        # test suite. Removing the per-job gate eliminates the false
+        # failure without weakening the overall coverage requirement.
         run: |
           pytest tests/integrations/ -v --tb=short \
             -m integration \
             --cov=tokenpak \
             --cov-report=xml:coverage-integration.xml \
-            --cov-report=term-missing \
-            --cov-fail-under=80
+            --cov-report=term-missing
         env:
           # No real API keys — tests use mocks only
           TOKENPAK_TEST_MODE: "1"


### PR DESCRIPTION
**#153 bucket 4 (re-scoped to Integration Tests)** — get the `Integration Tests` job green.

## Root cause

The integration job was running:
```
pytest tests/integrations/ -v --tb=short -m integration \
  --cov=tokenpak \
  --cov-fail-under=80
```

Tests themselves all pass. The threshold gate fails because integration tests only exercise integration paths (~2% of the codebase) — they're not a coverage-broad surface by design.

## Fix

Drop `--cov-fail-under=80` from the per-job integration run. The `Combined Coverage` job (line 135) already enforces 80% on the full test suite, which is the proper place for the gate.

## Effect

- **Removed:** false failure of `Integration Tests (3.10/3.11/3.12)` jobs that were tanking on coverage threshold despite tests all passing.
- **Retained:** combined 80% coverage gate on the full `pytest tests/` run.
- **Unchanged:** integration test bodies, integration markers, codecov upload step.

## Constraints honored

- ✅ `release.yml` not touched
- ✅ No release-gate weakening
- ✅ Combined coverage threshold (80% on full suite) preserved
- ✅ Not bundled with MultiPak Pro / cloud / sync / pricing

This is the **last bucket** of #153.