### PR TITLE
feat(proxy): OSS POST /pak/v1/promote forward route (Std 32 §4 / phase 2 slice 3c)

### DIFF
--- a/tests/proxy/test_pak_endpoints.py
+++ b/tests/proxy/test_pak_endpoints.py
@@ -337,6 +337,195 @@ def test_unknown_pak_post_returns_404():
 
 
 # ---------------------------------------------------------------------------
+# POST /pak/v1/promote — Pro daemon forward (Std 32 §4)
+# ---------------------------------------------------------------------------
+#
+# When the daemon is absent → 501 ``pro_daemon_required``.
+# When the daemon is present → forward request body to the daemon's
+# loopback port and proxy back the response.
+#
+# Tests use a minimal stub HTTP server in a thread to stand in for the
+# real Pro daemon (which is closed-source and not importable here).
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _DaemonStub:
+    """Tiny localhost HTTP server that records forwarded requests.
+
+    Returns ``self.canned_response`` (status, body) for every POST it
+    receives, regardless of path. Use the ``with`` form to manage
+    lifecycle::
+
+        with _DaemonStub(canned_status=201, canned_body={"pak_id": "x"}) as stub:
+            ...
+    """
+
+    def __init__(self, *, canned_status: int = 201, canned_body: dict | None = None):
+        self.canned_status = canned_status
+        self.canned_body = canned_body or {"promoted": True, "pak_id": "pak-int-stub"}
+        self.received_path: str | None = None
+        self.received_body: bytes | None = None
+        self.received_headers: dict[str, str] = {}
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> "_DaemonStub":
+        outer = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_a, **_kw):  # silence noise
+                pass
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0") or "0")
+                outer.received_path = self.path
+                outer.received_body = self.rfile.read(length) if length > 0 else b""
+                outer.received_headers = dict(self.headers.items())
+                resp = json.dumps(outer.canned_body).encode("utf-8")
+                self.send_response(outer.canned_status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(resp)))
+                self.end_headers()
+                self.wfile.write(resp)
+
+        self._server = HTTPServer(("127.0.0.1", 0), _Handler)
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_a):
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+
+
+def _write_sock_info(path: Path, port: int) -> None:
+    path.write_text(json.dumps({"port": port, "tip_version": "1.0", "started_at": 0}))
+
+
+def test_promote_returns_501_when_daemon_absent(tmp_path):
+    """No sock-info → daemon unavailable → 501 pro_daemon_required."""
+
+    missing = tmp_path / "absent.sock-info"
+    with patch.object(daemon_probe, "_SOCK_INFO_PATH", missing):
+        h = _post("/pak/v1/promote", body=b'{"any":"thing"}')
+    assert h.response_status() == 501
+    body = h.response_json()
+    assert body["error"] == "not_implemented"
+    assert body["reason"] == "pro_daemon_required"
+
+
+def test_promote_forwards_to_daemon_when_active(tmp_path):
+    """sock-info present + reachable → forward body, proxy response."""
+
+    sock_path = tmp_path / "daemon.sock-info"
+    payload = b'{"source":"llm_response","content":"hi everyone","captured_at":"2026-05-09T17:00:00+00:00","platform":"x"}'
+
+    with _DaemonStub(canned_status=201, canned_body={"promoted": True, "pak_id": "pak-int-abc123"}) as stub:
+        _write_sock_info(sock_path, stub.port)
+        with patch.object(daemon_probe, "_SOCK_INFO_PATH", sock_path):
+            h = _post("/pak/v1/promote", body=payload)
+
+    assert h.response_status() == 201
+    body = h.response_json()
+    assert body["promoted"] is True
+    assert body["pak_id"] == "pak-int-abc123"
+    # Confirm the body actually reached the daemon stub
+    assert stub.received_path == "/pak/v1/promote"
+    assert stub.received_body == payload
+
+
+def test_promote_forwards_skip_response_intact(tmp_path):
+    """Daemon's 200-with-promoted=false propagates verbatim."""
+
+    sock_path = tmp_path / "daemon.sock-info"
+    with _DaemonStub(
+        canned_status=200,
+        canned_body={"promoted": False, "filter_decision": "skip", "reason": "trivial"},
+    ) as stub:
+        _write_sock_info(sock_path, stub.port)
+        with patch.object(daemon_probe, "_SOCK_INFO_PATH", sock_path):
+            h = _post(
+                "/pak/v1/promote",
+                body=b'{"source":"llm_response","content":"thanks","captured_at":"2026-05-09T17:00:00+00:00","platform":"x"}',
+            )
+    assert h.response_status() == 200
+    body = h.response_json()
+    assert body["promoted"] is False
+    assert body["filter_decision"] == "skip"
+
+
+def test_promote_returns_503_when_daemon_dies_mid_flight(tmp_path):
+    """sock-info points at a dead port → daemon_unreachable.
+
+    Probe sees a live port (we wrote sock-info while the stub was up);
+    after closing the stub, the probe call will see the port as dead
+    too — so technically this test exercises a probe-failed path. The
+    503 path covers genuine TOCTOU where the daemon dies *between*
+    the probe and the forward; we trust http.client.HTTPConnection to
+    fail on connect for an empty port, which it does.
+
+    To exercise the real TOCTOU we'd need a deeper stub; this test
+    covers the closely-related "stale sock-info" case where the file
+    points at a port nobody owns.
+    """
+
+    sock_path = tmp_path / "daemon.sock-info"
+    # Pick a port and bind it just to discover it, then release.
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    dead_port = s.getsockname()[1]
+    s.close()
+
+    _write_sock_info(sock_path, dead_port)
+    with patch.object(daemon_probe, "_SOCK_INFO_PATH", sock_path):
+        h = _post("/pak/v1/promote", body=b"{}")
+
+    # Probe sees connection refused → "unavailable" → 501 (not 503).
+    # 503 path requires probe to succeed and forward to fail; that
+    # requires the daemon to die between two ops, which is hard to
+    # script. We accept either outcome here as long as it's a documented
+    # error.
+    assert h.response_status() in (501, 503)
+    body = h.response_json()
+    assert body["error"] in ("not_implemented", "daemon_unreachable")
+
+
+def test_promote_does_not_forward_auth_headers(tmp_path, monkeypatch):
+    """Caller's X-TPK-Key must NOT leak to the daemon (defense in depth).
+
+    The daemon is loopback-only and requires no auth; passing the OSS
+    proxy key through would expose it to the daemon's logs needlessly.
+    """
+
+    monkeypatch.setenv("TOKENPAK_PROXY_KEY", "secret-key-value")
+    sock_path = tmp_path / "daemon.sock-info"
+    with _DaemonStub(canned_status=201) as stub:
+        _write_sock_info(sock_path, stub.port)
+        # Build a handler with the matching X-TPK-Key so auth passes
+        from tokenpak.proxy.app_endpoints import try_handle_post
+
+        h = _StubHandler(
+            "/pak/v1/promote",
+            client_address=("127.0.0.1", 0),
+            body=b"{}",
+            headers={"Content-Length": "2", "X-TPK-Key": "secret-key-value"},
+        )
+        with patch.object(daemon_probe, "_SOCK_INFO_PATH", sock_path):
+            try_handle_post(h)
+
+    assert h.response_status() == 201
+    # No auth header reached the daemon
+    assert "X-TPK-Key" not in stub.received_headers
+    assert "x-tpk-key" not in stub.received_headers
+    # And the secret value isn't anywhere in the forwarded headers
+    assert not any("secret-key-value" in v for v in stub.received_headers.values())
+
+
+# ---------------------------------------------------------------------------
 # Integration with /tpk/v1/* — the new /pak/v1/* dispatch must not break
 # ---------------------------------------------------------------------------
 

--- a/tokenpak/proxy/app_endpoints.py
+++ b/tokenpak/proxy/app_endpoints.py
@@ -861,6 +861,15 @@ def _try_handle_pak_post(handler: Any, path: str) -> bool:
         _send_error(handler, 401, "unauthorized")
         return True
 
+    # ── POST /pak/v1/promote ────────────────────────────────────────────
+    # Pro-gated capture pipeline (Std 32 §4). When the Pro daemon is
+    # reachable, forward the request body to the daemon's loopback port
+    # and proxy the response back. When the daemon is absent or
+    # unreachable, return the standardized 501 ``pro_daemon_required``.
+    if path == "/pak/v1/promote":
+        _handle_pak_promote_forward(handler)
+        return True
+
     # ── POST /pak/v1/recall ─────────────────────────────────────────────
     # Pro-only per Std 32 §1.3 row 8. Always 501 in OSS; the daemon owns
     # ranking, hydration, and packaging.
@@ -879,6 +888,118 @@ def _try_handle_pak_post(handler: Any, path: str) -> bool:
         f"POST /pak/v1{path[len('/pak/v1'):]} not implemented yet",
     )
     return True
+
+
+def _handle_pak_promote_forward(handler: Any) -> None:
+    """Forward POST /pak/v1/promote to the Pro daemon's loopback port.
+
+    Std 32 §4 capture pipeline lives in the closed-source daemon. The
+    OSS proxy's job here is to:
+
+    1. Probe daemon presence via ``daemon_probe.detect_daemon_state``.
+    2. If absent → return 501 ``pro_daemon_required``.
+    3. If present → read the daemon's port from sock-info, POST the
+       request body to the daemon's ``/pak/v1/promote``, stream the
+       response back.
+
+    Defensive details:
+
+    - The auth headers from the caller are NOT forwarded to the daemon.
+      The daemon is loopback-only by construction (Std 25 §2.1), so
+      it requires no auth on /pak/v1/*; passing the OSS caller's auth
+      headers through would leak them into the daemon's logs needlessly.
+    - Short timeout (5s). The daemon is local; if it's not responding
+      within that, we treat it as TOCTOU race (probe said active,
+      daemon stopped between probe and forward) and return 503.
+    - Body is read once, fully, before forwarding. We don't stream —
+      the capture pipeline payloads are small (<<1MB).
+    """
+    import http.client
+
+    from tokenpak.licensing.daemon_probe import (
+        detect_daemon_state,
+        sock_info_path,
+    )
+
+    state = detect_daemon_state()
+    if state != "active":
+        _send_pak_not_implemented(
+            handler,
+            reason="pro_daemon_required",
+            detail=(
+                "Capture pipeline is a Pro-only feature; install tokenpak-paid "
+                "and start the daemon to enable."
+            ),
+        )
+        return
+
+    # Read sock-info to discover the daemon's port.
+    try:
+        info_raw = sock_info_path().read_text(encoding="utf-8")
+        info = json.loads(info_raw)
+        daemon_port = int(info["port"])
+    except (OSError, ValueError, KeyError, TypeError):
+        # Sock-info disappeared or malformed between probe and read.
+        _send_pak_not_implemented(
+            handler,
+            reason="pro_daemon_required",
+            detail="Daemon sock-info missing or malformed at forward time.",
+        )
+        return
+
+    # Read the inbound body.
+    try:
+        length = int(handler.headers.get("Content-Length", "0") or "0")
+    except ValueError:
+        length = 0
+    body = handler.rfile.read(length) if length > 0 else b""
+
+    # Forward to daemon. Auth headers are intentionally NOT propagated.
+    conn = http.client.HTTPConnection("127.0.0.1", daemon_port, timeout=5.0)
+    try:
+        conn.request(
+            "POST",
+            "/pak/v1/promote",
+            body=body,
+            headers={
+                "Content-Type": handler.headers.get("Content-Type", "application/json"),
+                "Content-Length": str(len(body)),
+            },
+        )
+        resp = conn.getresponse()
+        resp_body = resp.read()
+        # Mirror the daemon's status code and content-type.
+        handler.send_response(resp.status)
+        ct = resp.getheader("Content-Type") or "application/json; charset=utf-8"
+        handler.send_header("Content-Type", ct)
+        handler.send_header("Content-Length", str(len(resp_body)))
+        handler.send_header("X-TokenPak-Forwarded-From-Daemon", "1")
+        handler.end_headers()
+        handler.wfile.write(resp_body)
+    except (OSError, TimeoutError, http.client.HTTPException) as exc:
+        # TOCTOU — daemon went away between probe and forward, or
+        # connection failed. Treat as 503 so the caller can retry; not
+        # 501, because we KNOW the daemon should be there.
+        _send_json(
+            handler,
+            503,
+            {
+                "error": "daemon_unreachable",
+                "detail": (
+                    f"Pro daemon was reachable at probe time but request failed: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                "suggested_action": (
+                    "Retry the request; if the failure persists, restart the "
+                    "tokenpak-paid daemon."
+                ),
+            },
+        )
+    finally:
+        try:
+            conn.close()
+        except Exception:  # pragma: no cover — defensive
+            pass
 
 
 def _send_pak_not_implemented(


### PR DESCRIPTION
## MultiPak Pro Phase 2 — Slice 3c (OSS side)

OSS counterpart to `tokenpak-paid` PRs #3 + #4. Completes the end-to-end capture pipeline: external client → OSS proxy → Pro daemon → InteractionPakStore.

## Behavior

`POST /pak/v1/promote` on the OSS proxy:

| Daemon state | Response |
|---|---|
| **active** (sock-info present + reachable) | Forward body to `127.0.0.1:<daemon-port>/pak/v1/promote`. Mirror status + Content-Type back. Adds `X-TokenPak-Forwarded-From-Daemon: 1` header. |
| **unavailable** (no sock-info, malformed sock-info, port dead) | 501 `pro_daemon_required` (standardized via existing `_send_pak_not_implemented` helper). |
| **TOCTOU** (probe says active, forward fails) | 503 `daemon_unreachable` with retry guidance. |

## Defensive details

- **Caller's auth headers are NOT propagated** to the daemon. Daemon is loopback-only by construction (Std 25 §2.1); passing the OSS `X-TPK-Key` through would leak it into daemon logs needlessly. Tested.
- 5-second forward timeout. Daemon is local — anything slower is a TOCTOU race.
- Sock-info reread at forward time. If sock-info disappears between probe and read, fall back to 501 cleanly.

## Tests (5 new)

| Test | Verifies |
|---|---|
| `test_promote_returns_501_when_daemon_absent` | No sock-info → daemon unavailable → 501 `pro_daemon_required`. |
| `test_promote_forwards_to_daemon_when_active` | Stub HTTP server records the forwarded request; OSS returns 201 + the daemon's body verbatim. |
| `test_promote_forwards_skip_response_intact` | Daemon's 200-with-`promoted=false` propagates with status + body intact. |
| `test_promote_returns_503_when_daemon_dies_mid_flight` | Stale sock-info pointing at a dead port → 501 or 503 (both acceptable error shapes). |
| `test_promote_does_not_forward_auth_headers` | `TOKENPAK_PROXY_KEY` set + caller passes `X-TPK-Key` → OSS auth passes, but the daemon-side stub server confirms NO auth header reached it. |

```
pytest tests/proxy/test_pak_endpoints.py -q   -> 30 passed
ruff check (fresh-clone style)                 -> All checks passed!
```

## Cross-repo state

- ✅ `tokenpak-paid` slice 3a (daemon scaffolding): merged in PR #3
- ✅ `tokenpak-paid` slice 3b (promote handler): merged in PR #4
- 🔄 `tokenpak` slice 3c (this PR): completes the loop

## Constraints

- ✅ `release.yml` not touched.
- ✅ No release-gate weakening.
- ✅ No publish credentials changed.
- ✅ Not bundled with cloud / sync / pricing.
- ✅ `/pak/v1/promote` matches the existing `_send_pak_not_implemented` shape so OSS clients can detect daemon-absent uniformly across all Pro-gated endpoints.