### PR TITLE
ci(release): add workflow_dispatch trigger for preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual-dispatch entry point for pre-tag preflight runs against any branch
+  # (typically `main` immediately before pushing a tag). The dispatch uses the
+  # same test → build → dist-purity assert → checksum job graph as a real tag
+  # push; only the publish-to-PyPI job is skipped (see the publish job's `if:`).
+  # Use:
+  #   gh workflow run "Release TokenPak" --ref main
+  # Then verify the run is green before `git push <tag>`.
+  workflow_dispatch:
 
 permissions:
   contents: write  # Required for creating releases
@@ -158,6 +166,10 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
+    # Only create the GitHub Release on real tag pushes. Manual dispatch runs
+    # (workflow_dispatch) are preflight only — they exercise test → build →
+    # dist-purity assert → checksum but MUST NOT cut a GitHub Release.
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -235,8 +247,10 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: release
-    # Only publish on non-prerelease tags (no rc/alpha/beta)
-    if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
+    # Only publish on non-prerelease tag pushes. Manual dispatch runs
+    # (workflow_dispatch) are preflight only — they exercise test → build →
+    # dist-purity assert → checksum but MUST NOT publish to PyPI.
+    if: ${{ github.event_name == 'push' && !contains(github.ref, 'rc') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
     environment: pypi
     permissions:
       id-token: write  # Required for Trusted Publisher (OIDC)


### PR DESCRIPTION
## Summary

Adds a manual-dispatch entry point to the Release TokenPak workflow so a maintainer can run the test → build → dist-purity assert → checksum job graph against any branch (typically `main` immediately before pushing a tag), without modifying public main.

## Diff (1 file, +16/-2)

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Adds `workflow_dispatch:` trigger; gates `release` job on `event_name == 'push'`; gates `publish` job on `event_name == 'push'` (in addition to existing prerelease check) |

## Why this PR

v1.5.5 published successfully but its planned dispatch preflight could not run because the workflow lacked `workflow_dispatch:`. A local manual preflight was substituted. Future releases can run the preflight via dispatch per the canonical procedure.

## Behavior on dispatch

A dispatch run executes:
- ✅ Run Tests
- ✅ Build Distribution (incl. dist-purity assert)
- ✅ Generate SHA256SUMS
- ⏭ Create GitHub Release  (skipped via `if:`)
- ⏭ Publish to PyPI  (skipped via `if:`)

Real tag pushes continue to execute all 4 jobs as before.

## Staging verification

Same diff was squash-merged to staging/main as `e149522f5b97507a85fa6ba76136bd4f30be7b1b` 2026-05-10. Staging CI runs that fired (push-triggered): Repo Hygiene Check ✅, Determinism Tests ✅. Other staging workflows are PR-triggered and gated by the staging repo's PR-opened workflow approval; expected to fire on staging/main push within minutes.

## Reviewer

Suki for PATCH-style review (no version bump in this PR — CI hygiene change only).

## Held for Kevin merge approval

Per master directive 2026-05-09 Decision 8: this PR is held for Kevin merge approval after public CI settles.