### PR TITLE
ci(release): record-publish job for post-publish gate-state sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,3 +287,58 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Step 5: Record clean publish event for the release-gate state cache
+  # ─────────────────────────────────────────────────────────────────────
+  #
+  # Post-publish gate-state sync:
+  #
+  # The canonical release-gate state cache lives on the operator host
+  # outside the repo. This job uploads a small artifact recording the
+  # publish event ({tag, sha, run_id, timestamp}); a separate operator-side
+  # helper polls the GitHub API for completed Release TokenPak runs,
+  # downloads the artifact, and idempotently writes the corresponding
+  # increment row + updates the cache row.
+  #
+  # Idempotency contract: the operator-side helper inserts only if no row
+  # exists for this tag with cause='auto_publish_clean'. Re-running the
+  # helper (or re-uploading the artifact) is a no-op.
+  #
+  # Gate parity: this job MUST run only when `publish` ran (i.e., real tag
+  # push, non-prerelease). Manual workflow_dispatch preflight runs and
+  # rc/alpha/beta tag pushes do NOT record a publish event — the gate
+  # counter only decrements on real, clean, non-prerelease publishes.
+  record-publish:
+    name: Record Publish Event
+    runs-on: ubuntu-latest
+    needs: publish
+    if: ${{ github.event_name == 'push' && !contains(github.ref, 'rc') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
+    steps:
+      - name: Compose publish-event payload
+        id: payload
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          SHA="${GITHUB_SHA}"
+          RUN_ID="${GITHUB_RUN_ID}"
+          TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          mkdir -p publish-event
+          cat > publish-event/event.json <<EOF
+          {
+            "tag": "${TAG}",
+            "sha": "${SHA}",
+            "run_id": "${RUN_ID}",
+            "timestamp": "${TIMESTAMP}",
+            "cause": "auto_publish_clean"
+          }
+          EOF
+          echo "Publish event:"
+          cat publish-event/event.json
+
+      - name: Upload publish-event artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-event
+          path: publish-event/
+          retention-days: 90


### PR DESCRIPTION
## Purpose

Adds a small post-publish `record-publish` job to the Release TokenPak workflow that uploads a `publish-event` artifact (`{tag, sha, run_id, timestamp, cause}`). An operator-side helper polls completed runs, downloads the artifact, and idempotently records the increment in the canonical release-gate state cache.

## Why

Today, the post-publish gate-state cache update is a manual one-row insert. Automating it via artifact-pickup eliminates the manual step and keeps the cache in sync with PyPI's view of clean publishes.

## Architectural choice — artifact + cron pickup

- No SSH secrets in Actions
- No inbound network exposure to the operator host
- Naturally resilient to operator-side downtime (the polling loop catches up)
- Latency ~5 min — acceptable for an eventually-consistent gate-state sync

## Gate parity

Same `if:` condition as the `publish` job — only real, clean, non-prerelease tag pushes record a publish event. `workflow_dispatch` preflight runs and rc/alpha/beta tags do NOT.

## Idempotency contract

The operator-side helper inserts only if no row exists for this tag with `cause='auto_publish_clean'`. Re-running is a no-op. The cache update is keyed on `last_auto_publish_tag != tag` so it's also a no-op on re-process.

## v1.5.5 backfill (no double-decrement)

v1.5.5 was already manually synced and currently has a `cause='manual_sync'` row. When the new automation first runs against v1.5.5's existing GitHub Actions run, it would notice "no `auto_publish_clean` row for v1.5.5" and insert one — but the cache update guard (`last_auto_publish_tag != 'v1.5.5'`) makes the cache write a no-op, so the gate counter is NOT decremented a second time. Net counter delta on a re-process of v1.5.5 = 0. The first event the cron processes against the live counter will be the next clean release.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/release.yml` | +55 lines — new `record-publish` job after `publish` |

No package-behavior changes. No release. No tag. No version bump. No publish.

## Verification

- YAML loads cleanly via `yaml.safe_load`.
- Job graph: `test → build → release → publish → record-publish`. Same `if:` gate on `publish` and `record-publish`.
- Identity-language scan: 0 hits.
- Staging verification complete.

## Rollback

`git revert` on main → re-push. Workflow drops back to the pre-this-PR shape; operator-side helper lives independently and can be removed without affecting the workflow.

## Acceptance

- [ ] Public CI green
- [ ] Kevin merge approval