### PR TITLE
chore(spend-guard): derive soft threshold from model context

### DIFF
--- a/docs/spend-guard.md
+++ b/docs/spend-guard.md
@@ -30,7 +30,7 @@ spend_guard:
  enabled: true # global on/off
  warn_tokens: 100000 # advisory only — no UX surface yet
  warn_cost_usd: 2.0
- block_tokens: 500000 # holds the request, prompts user
+ block_tokens: 500000 # FALLBACK only — see "Dynamic block-tokens band" below
  block_cost_usd: 10.0
  hard_block_tokens: 1000000 # immutable ceiling
  hard_block_cost_usd: 50.0
@@ -43,6 +43,53 @@ spend_guard:
 Every key is overrideable via `TOKENPAK_SPEND_GUARD_*` environment variables (e.g. `TOKENPAK_SPEND_GUARD_BLOCK_COST_USD=5.0`).
 
 To disable entirely: `TOKENPAK_SPEND_GUARD_ENABLED=0` or `spend_guard.enabled: false`.
+
+### Dynamic block-tokens band
+
+The block-tokens threshold (the "hold the request, prompt user" band) **derives dynamically per request from the selected model's max context window**:
+
+```
+effective_block_tokens = floor(model_max_context_tokens * 0.80)
+```
+
+Examples (with the 0.80 default ratio):
+
+| Model max context | Derived block_tokens |
+|---|---|
+| 200,000 (Claude Opus/Sonnet/Haiku 4.x) | 160,000 |
+| 1,000,000 (Gemini 1.5/2.0/2.5 Flash; gpt-4.1) | 800,000 |
+| 2,000,000 (Gemini 1.5/2.0/2.5 Pro) | 1,600,000 — capped by `hard_block_tokens` to 1,000,000 |
+| 500,000 (hypothetical) | 400,000 |
+| 128,000 (gpt-4o) | 102,400 |
+
+**`block_tokens: 500000` in config is the conservative *fallback* used only when the model's context window is unavailable from the registry.** It is not the universal default. The fallback is intentionally conservative so an unknown model does not silently inherit a wide band.
+
+The hard `hard_block_tokens: 1000000` ceiling stays as an immutable safety cap on top of the derived band — even a 5M-context model never exceeds the 1M ceiling. The derived block value is bounded above by the hard ceiling; the hard-block check fires first if a request crosses 1M.
+
+When the dynamic path is unavailable (unknown model, lookup error), the audit row's `threshold_hit` field reads `block_tokens_fallback>=<N> ...` so operators can see that dynamic derivation didn't apply for that request.
+
+#### Currently-known frontier models
+
+The registry ships with context-window data for current frontier-class models:
+
+- **Anthropic Claude:** all 3.x and 4.x lines (Opus, Sonnet, Haiku) at 200K.
+- **OpenAI:** gpt-4.1 family at ~1M; gpt-4o at 128K; o1/o3/o4-mini at 200K; gpt-3.5-turbo at 16K; gpt-4 at 8K.
+- **Google Gemini:** Pro lines at 2M; Flash lines at 1M.
+
+Local/open-source models (Llama, Mistral, Phi, Gemma, Qwen, DeepSeek, etc.) are not in this registry — local-model context handling lives in the SDK's separate budgeting helper. For local-model traffic that flows through the proxy, the configured `block_tokens` fallback applies.
+
+#### Advanced override
+
+If you need a non-default ratio, the public API exposes `derive_block_threshold(max_context, ratio=0.80, fallback_tokens=None)` for testing and custom integrations:
+
+```python
+from tokenpak.proxy.spend_guard import derive_block_threshold
+derive_block_threshold(200_000)            # → 160_000
+derive_block_threshold(1_000_000, ratio=0.5)  # → 500_000
+derive_block_threshold(None, fallback_tokens=200_000)  # → 200_000
+```
+
+The default ratio 0.80 is published as `tokenpak.proxy.spend_guard.DEFAULT_BLOCK_RATIO`.
 
 ---
 

--- a/tokenpak/proxy/spend_guard/__init__.py
+++ b/tokenpak/proxy/spend_guard/__init__.py
@@ -28,6 +28,7 @@ Authority:
 
 from __future__ import annotations
 
+from ._context_window import get_model_max_context
 from .contracts import (
     GuardOutcome,
     PendingRequest,
@@ -36,7 +37,13 @@ from .contracts import (
     TIPDirective,
 )
 from .estimator import estimate as estimate_request
-from .policy import decide as decide_policy
+from .policy import (
+    DEFAULT_BLOCK_RATIO,
+    derive_block_threshold,
+)
+from .policy import (
+    decide as decide_policy,
+)
 
 __all__ = [
     "GuardOutcome",
@@ -46,6 +53,9 @@ __all__ = [
     "TIPDirective",
     "estimate_request",
     "decide_policy",
+    "derive_block_threshold",
+    "DEFAULT_BLOCK_RATIO",
+    "get_model_max_context",
     "evaluate",
 ]
 

--- a/tokenpak/proxy/spend_guard/_context_window.py
+++ b/tokenpak/proxy/spend_guard/_context_window.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model max-context-window registry for spend-guard threshold derivation.
+
+The spend guard's soft-block threshold derives dynamically from the selected
+model's context window (default 80% of max). When a model's context window
+is unknown, the caller falls back to the configured static fallback in
+``SpendGuardConfig.block_tokens`` rather than silently assuming a large
+window.
+
+This registry is intentionally narrow: it lists the frontier-class models
+whose context window matters for blocking large-batch traffic at the proxy
+seam (Anthropic Claude, OpenAI GPT/o-series, Google Gemini). Local-model
+context windows (Llama, Mistral, Phi, Gemma, Qwen, etc.) are handled by
+``tokenpak.sdk.local.auto_budget.MODEL_CONTEXT_LENGTHS`` for SDK budgeting
+and are not duplicated here.
+
+When in doubt, omit a model from this table — the spend guard will fall
+back to ``cfg.block_tokens`` and audit ``threshold_hit=block_tokens_fallback``
+so the operator can see that dynamic derivation was unavailable for the
+unknown model.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Max context windows, in tokens, for known frontier models.
+# Verify against the provider's published model card before adding entries.
+# Keys are matched case-insensitively against ``model_id`` after stripping
+# any provider prefix (``anthropic/claude-…``) and trailing date suffix
+# (``-20261015``); see :func:`get_model_max_context`.
+_MODEL_MAX_CONTEXT: dict[str, int] = {
+    # Anthropic Claude — all current frontier and 3.x lines: 200K
+    "claude-opus-4-7": 200_000,
+    "claude-opus-4-6": 200_000,
+    "claude-opus-4-5": 200_000,
+    "claude-opus-4": 200_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-sonnet-4-5": 200_000,
+    "claude-sonnet-4": 200_000,
+    "claude-haiku-4-5": 200_000,
+    "claude-haiku-4": 200_000,
+    "claude-3-7-sonnet": 200_000,
+    "claude-3-5-sonnet": 200_000,
+    "claude-3-5-haiku": 200_000,
+    "claude-3-opus": 200_000,
+    "claude-3-sonnet": 200_000,
+    "claude-3-haiku": 200_000,
+
+    # OpenAI — GPT and o-series. Verify per release; the 4.1 family ships
+    # with a 1M-effective window on the API.
+    "gpt-4.1": 1_047_576,
+    "gpt-4.1-mini": 1_047_576,
+    "gpt-4.1-nano": 1_047_576,
+    "gpt-4.5": 128_000,
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4": 8_192,
+    "gpt-3.5-turbo": 16_385,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+    "o1-preview": 128_000,
+    "o3": 200_000,
+    "o3-mini": 200_000,
+    "o4-mini": 200_000,
+
+    # Google Gemini — 1.5/2.0/2.5 lines. Pro ships at 2M effective; flash at 1M.
+    "gemini-2.5-pro": 2_000_000,
+    "gemini-2.5-flash": 1_000_000,
+    "gemini-2.0-pro": 2_000_000,
+    "gemini-2.0-flash": 1_000_000,
+    "gemini-1.5-pro": 2_000_000,
+    "gemini-1.5-flash": 1_000_000,
+}
+
+# Date suffixes like ``-20261015`` or ``-20241022`` are stripped before lookup.
+_DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
+
+
+def get_model_max_context(model_id: str | None) -> int | None:
+    """Resolve the max context window in tokens for a model id.
+
+    Returns ``None`` when the model is unknown — the caller is responsible
+    for falling back to the configured static threshold rather than silently
+    assuming a default.
+
+    Matching strategy (case-insensitive):
+
+    1. Exact match on ``model_id`` (lowercased, trimmed).
+    2. Strip provider prefix (``anthropic/``, ``openai/``, ``google/``,
+       etc.) and retry exact match.
+    3. Strip trailing 8-digit date suffix and retry exact match.
+    4. Longest-prefix match against the registry keys.
+
+    Examples::
+
+        get_model_max_context("claude-opus-4-7")             # → 200_000
+        get_model_max_context("anthropic/claude-opus-4-7")   # → 200_000
+        get_model_max_context("claude-opus-4-7-20261015")    # → 200_000
+        get_model_max_context("gpt-4.1")                     # → 1_047_576
+        get_model_max_context("gemini-1.5-pro")              # → 2_000_000
+        get_model_max_context("unknown-frontier-model")      # → None
+        get_model_max_context(None)                          # → None
+    """
+    if not model_id:
+        return None
+
+    m = model_id.lower().strip()
+    if not m:
+        return None
+
+    # 1. Exact match.
+    if m in _MODEL_MAX_CONTEXT:
+        return _MODEL_MAX_CONTEXT[m]
+
+    # 2. Strip provider prefix.
+    if "/" in m:
+        suffix = m.split("/", 1)[1]
+        if suffix in _MODEL_MAX_CONTEXT:
+            return _MODEL_MAX_CONTEXT[suffix]
+        m = suffix
+
+    # 3. Strip date suffix.
+    stripped = _DATE_SUFFIX_RE.sub("", m)
+    if stripped != m and stripped in _MODEL_MAX_CONTEXT:
+        return _MODEL_MAX_CONTEXT[stripped]
+
+    # 4. Longest-prefix match.
+    best_key: str | None = None
+    best_len = 0
+    for key in _MODEL_MAX_CONTEXT:
+        if (m.startswith(key) or stripped.startswith(key)) and len(key) > best_len:
+            best_key = key
+            best_len = len(key)
+    if best_key is not None:
+        return _MODEL_MAX_CONTEXT[best_key]
+
+    return None
+
+
+def known_models() -> list[str]:
+    """Return the registry's model-id keys (sorted). For diagnostics."""
+    return sorted(_MODEL_MAX_CONTEXT.keys())

--- a/tokenpak/proxy/spend_guard/orchestrator.py
+++ b/tokenpak/proxy/spend_guard/orchestrator.py
@@ -179,8 +179,22 @@ def evaluate(
             _log.debug("spend_guard: session_state lookup failed: %s", e)
             session_running = 0.0
 
-    decision = decide(est, cfg, tip=tip_directive,
-                      session_running_cost_usd=session_running)
+    # Resolve max context for THIS model so decide() can derive the
+    # block-tokens band as 80% of context. None → fallback path inside
+    # decide() (uses cfg.block_tokens). Lookup is best-effort; any error
+    # falls through to fallback.
+    model_max_context_tokens: Optional[int] = None
+    try:
+        from ._context_window import get_model_max_context
+        model_max_context_tokens = get_model_max_context(model)
+    except Exception as e:
+        _log.debug("spend_guard: context_window lookup failed: %s", e)
+
+    decision = decide(
+        est, cfg, tip=tip_directive,
+        session_running_cost_usd=session_running,
+        model_max_context_tokens=model_max_context_tokens,
+    )
 
     # ── [TIP: estimate=on] short-circuit (only when allowed by policy)
     if tip_directive is not None and tip_directive.estimate_only and decision.decision != "hard_block":

--- a/tokenpak/proxy/spend_guard/policy.py
+++ b/tokenpak/proxy/spend_guard/policy.py
@@ -12,10 +12,15 @@ projected tokens and projected cost against four configurable bands:
 - ``hard_block`` — cannot be released; even ``[TIP: bypass=on]`` does not
   override (proposal §4 second example).
 
-Defaults match Kevin's 2026-05-07 overrides on the published proposal:
+Default thresholds:
     warn:        100,000 tokens / $2.00
-    block:       500,000 tokens / $10.00     (proposal had 250,000 / $5)
-    hard_block: 1,000,000 tokens / $50.00
+    block:       derived dynamically — 80% of selected model's max context
+                 (e.g. 200K context → 160K block; 1M context → 800K block).
+                 The configured ``block_tokens`` value (default 500,000) is
+                 the conservative *fallback* used only when the model's
+                 context window is unavailable.
+    hard_block: 1,000,000 tokens / $50.00 — immutable safety cap on top of
+                 the derived block threshold.
 """
 
 from __future__ import annotations
@@ -24,6 +29,63 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .contracts import PreflightDecision, RiskEstimate, TIPDirective
+
+# Default fraction of a model's max context above which a request is held.
+# Centralized so callers (decide(), tests) reference one value.
+DEFAULT_BLOCK_RATIO: float = 0.80
+
+
+def derive_block_threshold(
+    model_max_context_tokens: Optional[int],
+    ratio: float = DEFAULT_BLOCK_RATIO,
+    fallback_tokens: Optional[int] = None,
+) -> Optional[int]:
+    """Derive the soft-block token threshold from a model's max context.
+
+    Pure function. No I/O. No global state. Trivially testable.
+
+    Returns ``floor(model_max_context_tokens * ratio)`` when the context is
+    known and positive. Returns ``fallback_tokens`` when the context is
+    unknown (``None`` or non-positive) — the caller is then responsible for
+    deciding what to do with the fallback (the spend guard's caller layers
+    a final ``hard_block_tokens`` cap on whichever value is returned).
+
+    The result is also bounded to never exceed ``model_max_context_tokens``
+    (a ``ratio > 1`` is clamped to the model's max).
+
+    Args:
+        model_max_context_tokens: Max input+output context the selected
+            model accepts, in tokens. ``None`` or non-positive → fallback.
+        ratio: Fraction of context above which to block.
+            Default :data:`DEFAULT_BLOCK_RATIO` (0.80). Must be in (0, 1]
+            for the dynamic path; values outside that range fall through
+            to ``fallback_tokens``.
+        fallback_tokens: Returned when the dynamic path can't apply. May
+            itself be ``None`` — caller handles.
+
+    Returns:
+        Integer token threshold, or ``fallback_tokens`` (which may be
+        ``None``).
+
+    Examples::
+
+        derive_block_threshold(1_000_000)   # → 800_000
+        derive_block_threshold(  200_000)   # → 160_000
+        derive_block_threshold(  500_000)   # → 400_000
+        derive_block_threshold(None, fallback_tokens=500_000)   # → 500_000
+        derive_block_threshold(0,    fallback_tokens=500_000)   # → 500_000
+    """
+    if not isinstance(ratio, (int, float)) or ratio <= 0 or ratio > 1:
+        return fallback_tokens
+    if model_max_context_tokens is None:
+        return fallback_tokens
+    if not isinstance(model_max_context_tokens, int) or model_max_context_tokens <= 0:
+        return fallback_tokens
+    derived = int(model_max_context_tokens * ratio)
+    # Never exceed the model's context (defensive against ratio rounding).
+    if derived > model_max_context_tokens:
+        derived = model_max_context_tokens
+    return derived
 
 
 @dataclass
@@ -37,8 +99,15 @@ class SpendGuardConfig:
     enabled: bool = True
     warn_tokens: int = 100_000
     warn_cost_usd: float = 2.0
-    block_tokens: int = 500_000          # Kevin override, was 250_000
-    block_cost_usd: float = 10.0         # Kevin override, was 5.0
+    # ``block_tokens`` is the *fallback* soft-block threshold used only when
+    # the selected model's max context window is unknown to the registry
+    # (see ``_context_window.get_model_max_context``). When the model's
+    # context window IS known, the effective threshold is derived
+    # dynamically as 80% of that context — e.g. 200K context → 160K block,
+    # 1M context → 800K block. The configured fallback is intentionally
+    # conservative so unknown models do not silently inherit a large band.
+    block_tokens: int = 500_000
+    block_cost_usd: float = 10.0
     hard_block_tokens: int = 1_000_000
     hard_block_cost_usd: float = 50.0
     pending_ttl_seconds: int = 600
@@ -151,6 +220,7 @@ def decide(
     tip: Optional[TIPDirective] = None,
     *,
     session_running_cost_usd: float = 0.0,
+    model_max_context_tokens: Optional[int] = None,
 ) -> PreflightDecision:
     """Compare the estimate to thresholds and return a verdict.
 
@@ -161,7 +231,13 @@ def decide(
     2. TIP-declared ceiling, if present and within hard-block band.
        ``[TIP: allow=once max=$X]`` lets the request through provided
        ``estimate.projected_cost_usd <= X`` and ``X < hard_block_cost_usd``.
-    3. ``block`` — if EITHER cost OR tokens cross the block band.
+    3. ``block`` — if EITHER cost OR tokens cross the block band. The
+       block-tokens band derives dynamically from ``model_max_context_tokens``
+       when supplied (``80% × max_context``). When ``model_max_context_tokens``
+       is ``None``, the configured ``cfg.block_tokens`` fallback applies.
+       The effective block-tokens value is then capped by
+       ``cfg.hard_block_tokens`` so a 2M-context model never out-runs the
+       safety ceiling.
     4. ``warn`` — advisory only.
     5. ``allow`` — default.
     """
@@ -170,6 +246,27 @@ def decide(
 
     cost = estimate.projected_cost_usd
     tokens = estimate.projected_input_tokens + estimate.projected_output_tokens
+
+    # Resolve the effective block-tokens band for THIS request.
+    # - dynamic path: 80% of model max context (when known).
+    # - fallback path: cfg.block_tokens (configured static fallback).
+    # In both cases, the result is bounded above by cfg.hard_block_tokens
+    # so the immutable safety ceiling always wins.
+    derived_block_tokens = derive_block_threshold(
+        model_max_context_tokens,
+        ratio=DEFAULT_BLOCK_RATIO,
+        fallback_tokens=cfg.block_tokens,
+    )
+    if derived_block_tokens is None:
+        # Both dynamic + fallback unavailable; degrade to hard ceiling.
+        effective_block_tokens = cfg.hard_block_tokens
+        threshold_source = "block_tokens_unresolved"
+    elif model_max_context_tokens is not None and model_max_context_tokens > 0:
+        effective_block_tokens = min(derived_block_tokens, cfg.hard_block_tokens)
+        threshold_source = "block_tokens_dynamic"
+    else:
+        effective_block_tokens = min(derived_block_tokens, cfg.hard_block_tokens)
+        threshold_source = "block_tokens_fallback"
 
     # 1. Hard-block (immutable ceiling)
     if cost >= cfg.hard_block_cost_usd:
@@ -201,7 +298,7 @@ def decide(
         # band so a bare bypass=on can't swallow $40 silently.
         if tip.bypass and tip.max_cost_usd is None and tip.max_tokens is None:
             cost_ok = cost < cfg.block_cost_usd
-            tokens_ok = tokens < cfg.block_tokens
+            tokens_ok = tokens < effective_block_tokens
         if cost_ok and tokens_ok:
             return PreflightDecision(
                 decision="allow",
@@ -249,12 +346,19 @@ def decide(
             threshold_hit=f"block_cost_usd>={cfg.block_cost_usd}",
             risk=estimate,
         )
-    if tokens >= cfg.block_tokens:
+    if tokens >= effective_block_tokens:
         return PreflightDecision(
             decision="block",
             reason="projected_tokens_exceeded",
             requires_approval=True,
-            threshold_hit=f"block_tokens>={cfg.block_tokens}",
+            threshold_hit=(
+                f"{threshold_source}>={effective_block_tokens}"
+                + (
+                    f" max_context={model_max_context_tokens}"
+                    if model_max_context_tokens
+                    else ""
+                )
+            ),
             risk=estimate,
         )
 

--- a/tokenpak/tests/test_spend_guard_context_window.py
+++ b/tokenpak/tests/test_spend_guard_context_window.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the spend-guard model max-context-window registry and the
+:func:`derive_block_threshold` pure function.
+
+The spend guard's soft-block band derives dynamically from the selected
+model's max context window — ``floor(max_context * 0.80)``. These tests
+pin the contract:
+
+* Known frontier-model context lookups return the right token count.
+* Unknown models return ``None`` (caller falls back to the configured
+  static threshold; the registry never silently invents a default).
+* :func:`derive_block_threshold` is a pure function with documented
+  behavior on edge cases (zero, negative, ratios outside (0, 1], unknown
+  fallback).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenpak.proxy.spend_guard import (
+    DEFAULT_BLOCK_RATIO,
+    derive_block_threshold,
+    get_model_max_context,
+)
+from tokenpak.proxy.spend_guard._context_window import known_models
+
+
+class TestKnownContextWindows:
+    """The published frontier models we ship lookups for."""
+
+    def test_claude_opus_4_7_is_200k(self):
+        assert get_model_max_context("claude-opus-4-7") == 200_000
+
+    def test_claude_sonnet_4_6_is_200k(self):
+        assert get_model_max_context("claude-sonnet-4-6") == 200_000
+
+    def test_claude_haiku_4_5_is_200k(self):
+        assert get_model_max_context("claude-haiku-4-5") == 200_000
+
+    def test_gpt_4_1_is_1m(self):
+        assert get_model_max_context("gpt-4.1") == 1_047_576
+
+    def test_gpt_4o_is_128k(self):
+        assert get_model_max_context("gpt-4o") == 128_000
+
+    def test_o1_is_200k(self):
+        assert get_model_max_context("o1") == 200_000
+
+    def test_gemini_2_5_pro_is_2m(self):
+        assert get_model_max_context("gemini-2.5-pro") == 2_000_000
+
+    def test_gemini_1_5_flash_is_1m(self):
+        assert get_model_max_context("gemini-1.5-flash") == 1_000_000
+
+
+class TestModelIdNormalization:
+    """Lookups handle case, provider prefixes, date suffixes, and prefix
+    matches the same way the proxy sees model ids."""
+
+    def test_uppercase_input(self):
+        assert get_model_max_context("Claude-Opus-4-7") == 200_000
+
+    def test_provider_prefix_is_stripped(self):
+        assert get_model_max_context("anthropic/claude-opus-4-7") == 200_000
+        assert get_model_max_context("openai/gpt-4o") == 128_000
+
+    def test_date_suffix_is_stripped(self):
+        assert get_model_max_context("claude-opus-4-7-20261015") == 200_000
+
+    def test_longest_prefix_match(self):
+        # A future variant like "claude-opus-4-7-canary" should still
+        # resolve to the base family's 200K window.
+        assert get_model_max_context("claude-opus-4-7-canary") == 200_000
+
+    def test_whitespace_is_trimmed(self):
+        assert get_model_max_context("  gpt-4o  ") == 128_000
+
+
+class TestUnknownContext:
+    """Unknown models return ``None`` — the registry never silently
+    invents a context window."""
+
+    def test_unknown_model_returns_none(self):
+        assert get_model_max_context("unknown-frontier-model") is None
+
+    def test_empty_string_returns_none(self):
+        assert get_model_max_context("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert get_model_max_context("   ") is None
+
+    def test_none_input_returns_none(self):
+        assert get_model_max_context(None) is None
+
+    def test_random_legacy_model_returns_none(self):
+        # Older models we don't carry context entries for.
+        assert get_model_max_context("text-davinci-003") is None
+        assert get_model_max_context("babbage") is None
+
+
+class TestKnownModelsList:
+    """Smoke check on the registry's public diagnostic surface."""
+
+    def test_known_models_returns_sorted_list(self):
+        models = known_models()
+        assert isinstance(models, list)
+        assert len(models) > 0
+        assert models == sorted(models)
+        assert "claude-opus-4-7" in models
+
+
+class TestDeriveBlockThreshold:
+    """:func:`derive_block_threshold` contract — a pure function."""
+
+    def test_default_ratio_is_eighty_percent(self):
+        assert DEFAULT_BLOCK_RATIO == 0.80
+
+    def test_one_million_context_yields_eight_hundred_k(self):
+        assert derive_block_threshold(1_000_000) == 800_000
+
+    def test_two_hundred_k_context_yields_one_sixty_k(self):
+        assert derive_block_threshold(200_000) == 160_000
+
+    def test_five_hundred_k_context_yields_four_hundred_k(self):
+        assert derive_block_threshold(500_000) == 400_000
+
+    def test_two_million_context_yields_one_point_six_million(self):
+        # Note: caller (decide()) caps this against hard_block_tokens.
+        assert derive_block_threshold(2_000_000) == 1_600_000
+
+    def test_custom_ratio_applies(self):
+        assert derive_block_threshold(1_000_000, ratio=0.5) == 500_000
+        assert derive_block_threshold(1_000_000, ratio=0.90) == 900_000
+
+    def test_floors_to_int(self):
+        # 333_333 * 0.80 = 266_666.4 → floor to 266_666
+        assert derive_block_threshold(333_333) == 266_666
+
+    def test_never_exceeds_max_context(self):
+        # Even a ratio of exactly 1.0 must not exceed the model's max.
+        assert derive_block_threshold(1_000_000, ratio=1.0) == 1_000_000
+
+
+class TestDeriveBlockThresholdFallback:
+    """Edge cases that fall through to ``fallback_tokens``."""
+
+    def test_none_max_context_uses_fallback(self):
+        assert derive_block_threshold(None, fallback_tokens=500_000) == 500_000
+
+    def test_none_max_context_no_fallback_returns_none(self):
+        assert derive_block_threshold(None) is None
+
+    def test_zero_max_context_uses_fallback(self):
+        assert derive_block_threshold(0, fallback_tokens=500_000) == 500_000
+
+    def test_negative_max_context_uses_fallback(self):
+        assert derive_block_threshold(-1, fallback_tokens=500_000) == 500_000
+
+    def test_ratio_zero_uses_fallback(self):
+        # A ratio of 0 is not meaningful — fall through.
+        assert derive_block_threshold(1_000_000, ratio=0, fallback_tokens=500_000) == 500_000
+
+    def test_ratio_above_one_uses_fallback(self):
+        assert derive_block_threshold(1_000_000, ratio=1.5, fallback_tokens=500_000) == 500_000
+
+    def test_negative_ratio_uses_fallback(self):
+        assert derive_block_threshold(1_000_000, ratio=-0.1, fallback_tokens=500_000) == 500_000
+
+    def test_non_int_max_context_uses_fallback(self):
+        assert derive_block_threshold("1M", fallback_tokens=500_000) == 500_000  # type: ignore[arg-type]
+
+
+class TestSelectedModelChangesThreshold:
+    """Switching the selected model changes the derived block threshold."""
+
+    @pytest.mark.parametrize("model_id, expected_ctx, expected_block", [
+        ("claude-opus-4-7", 200_000, 160_000),
+        ("claude-sonnet-4-6", 200_000, 160_000),
+        ("gpt-4o", 128_000, 102_400),
+        ("gpt-4.1", 1_047_576, 838_060),
+        ("o1", 200_000, 160_000),
+        ("gemini-2.5-pro", 2_000_000, 1_600_000),
+        ("gemini-1.5-flash", 1_000_000, 800_000),
+    ])
+    def test_model_switch_updates_block_threshold(self, model_id, expected_ctx, expected_block):
+        ctx = get_model_max_context(model_id)
+        assert ctx == expected_ctx
+        assert derive_block_threshold(ctx) == expected_block

--- a/tokenpak/tests/test_spend_guard_policy.py
+++ b/tokenpak/tests/test_spend_guard_policy.py
@@ -25,11 +25,14 @@ def _est(**kw) -> RiskEstimate:
     return RiskEstimate(**base)
 
 
-class TestKevinDefaults:
-    def test_block_thresholds_match_overrides(self):
+class TestConfigDefaults:
+    def test_static_fallback_thresholds(self):
         cfg = SpendGuardConfig()
-        assert cfg.block_tokens == 500_000      # Kevin override (was 250_000)
-        assert cfg.block_cost_usd == 10.0       # Kevin override (was 5.0)
+        # block_tokens is the *fallback* used only when the selected model's
+        # context window is unavailable. Frontier-model traffic gets the
+        # dynamic 80%-of-context derivation instead (see TestDynamicBlockThreshold).
+        assert cfg.block_tokens == 500_000
+        assert cfg.block_cost_usd == 10.0
         assert cfg.hard_block_tokens == 1_000_000
         assert cfg.hard_block_cost_usd == 50.0
 
@@ -166,3 +169,123 @@ class TestConfigDictLoad:
         assert cfg.block_cost_usd == 5.0
         # Unspecified keys keep defaults
         assert cfg.hard_block_cost_usd == 50.0
+
+
+class TestDynamicBlockThreshold:
+    """End-to-end behavior of the dynamic block-tokens band inside decide().
+
+    The block-tokens band derives as ``80% × model_max_context_tokens`` when
+    a context is supplied. When unsupplied (``None``), the configured
+    ``cfg.block_tokens`` fallback applies. The hard-block ceiling caps the
+    derived value as a safety net.
+    """
+
+    cfg = _per_request_cfg()
+
+    def test_200k_context_blocks_at_160k(self):
+        # Under 160K → allow; at/above 160K → block.
+        d_under = decide(
+            _est(projected_input_tokens=159_000, projected_output_tokens=500,
+                 projected_cost_usd=2.5),
+            self.cfg, model_max_context_tokens=200_000,
+        )
+        assert d_under.decision == "warn"  # in warn band but under 160K
+
+        d_over = decide(
+            _est(projected_input_tokens=160_500, projected_output_tokens=500,
+                 projected_cost_usd=2.5),
+            self.cfg, model_max_context_tokens=200_000,
+        )
+        assert d_over.decision == "block"
+        assert d_over.reason == "projected_tokens_exceeded"
+        assert "160000" in d_over.threshold_hit
+        assert "block_tokens_dynamic" in d_over.threshold_hit
+        assert "max_context=200000" in d_over.threshold_hit
+
+    def test_1m_context_blocks_at_800k(self):
+        d = decide(
+            _est(projected_input_tokens=800_500, projected_output_tokens=500,
+                 projected_cost_usd=8.0),
+            self.cfg, model_max_context_tokens=1_000_000,
+        )
+        assert d.decision == "block"
+        assert "800000" in d.threshold_hit
+        assert "block_tokens_dynamic" in d.threshold_hit
+
+    def test_500k_context_blocks_at_400k(self):
+        d = decide(
+            _est(projected_input_tokens=400_500, projected_output_tokens=500,
+                 projected_cost_usd=8.0),
+            self.cfg, model_max_context_tokens=500_000,
+        )
+        assert d.decision == "block"
+        assert "400000" in d.threshold_hit
+
+    def test_2m_context_capped_by_hard_block(self):
+        # 2M context → derived 1.6M → capped by hard_block_tokens=1M.
+        # A 1.6M-token request first trips hard_block (≥1M) before the
+        # block check ever fires; verify hard-block fires on a 1.05M request.
+        d = decide(
+            _est(projected_input_tokens=1_050_000, projected_output_tokens=10_000,
+                 projected_cost_usd=18.0),
+            self.cfg, model_max_context_tokens=2_000_000,
+        )
+        assert d.decision == "hard_block"
+
+    def test_unknown_context_falls_back_to_static_block_tokens(self):
+        # No model_max_context_tokens → fallback to cfg.block_tokens (500K).
+        d = decide(
+            _est(projected_input_tokens=500_500, projected_output_tokens=500,
+                 projected_cost_usd=8.0),
+            self.cfg, model_max_context_tokens=None,
+        )
+        assert d.decision == "block"
+        assert "500000" in d.threshold_hit
+        assert "block_tokens_fallback" in d.threshold_hit
+
+    def test_unknown_context_below_fallback_allowed(self):
+        d = decide(
+            _est(projected_input_tokens=400_000, projected_output_tokens=2000,
+                 projected_cost_usd=6.5),
+            self.cfg, model_max_context_tokens=None,
+        )
+        # 402K < 500K fallback → allow (cost also under block_cost_usd=10)
+        assert d.decision == "warn"
+
+    def test_model_switch_changes_effective_threshold(self):
+        # Same request, different model → different decision.
+        # 170K projected tokens.
+        est = _est(projected_input_tokens=169_500, projected_output_tokens=500,
+                   projected_cost_usd=2.6)
+
+        # 200K-context model: 170K > 160K block → block.
+        d_200k = decide(est, self.cfg, model_max_context_tokens=200_000)
+        assert d_200k.decision == "block"
+
+        # 1M-context model: 170K < 800K block → warn (it's in warn band by token count).
+        d_1m = decide(est, self.cfg, model_max_context_tokens=1_000_000)
+        assert d_1m.decision == "warn"
+
+    def test_dynamic_threshold_never_silently_assumes_one_million(self):
+        # Pin the documented behavior: 800K is NOT a default — it only
+        # results from a 1M context model. Unknown context with the
+        # default fallback (500K) blocks at 500K, not 800K.
+        d = decide(
+            _est(projected_input_tokens=800_000, projected_output_tokens=500,
+                 projected_cost_usd=8.0),
+            self.cfg, model_max_context_tokens=None,
+        )
+        assert d.decision == "block"
+        # Threshold message must reflect the fallback, not 800K.
+        assert "500000" in d.threshold_hit
+        assert "block_tokens_fallback" in d.threshold_hit
+
+    def test_hard_block_still_immutable_in_dynamic_path(self):
+        # Even if a model has 5M context (derived 4M), the hard 1M ceiling
+        # still wins on a 1.5M-token request.
+        d = decide(
+            _est(projected_input_tokens=1_500_000, projected_output_tokens=0,
+                 projected_cost_usd=22.0),
+            self.cfg, model_max_context_tokens=5_000_000,
+        )
+        assert d.decision == "hard_block"


### PR DESCRIPTION
## Purpose

Replaces the static `block_tokens=500_000` (now repurposed as fallback) with a per-request threshold **derived from the selected model's max context window**:

```
effective_block_tokens = floor(model_max_context_tokens * 0.80)
```

So 200K-context models block at 160K; 1M-context models at 800K; 500K-context at 400K. The hard 1M ceiling stays as an immutable cap on top of the derived band.

## How model max context is resolved

`tokenpak/proxy/spend_guard/_context_window.py::get_model_max_context(model_id)`

A small registry keyed on canonical model id, with case-insensitive matching, provider-prefix stripping (`anthropic/claude-…`), date-suffix stripping (`-20261015`), and longest-prefix fallback.

Currently-known frontier models:

| Family | Model | Max context |
|---|---|---|
| Anthropic Claude (3.x + 4.x) | opus / sonnet / haiku | 200,000 |
| OpenAI gpt-4.1 family | gpt-4.1 / -mini / -nano | 1,047,576 |
| OpenAI gpt-4o family | gpt-4o / -mini | 128,000 |
| OpenAI o-series | o1 / o3 / o3-mini / o4-mini | 200,000 |
| OpenAI gpt-3.5-turbo | | 16,385 |
| OpenAI gpt-4 | | 8,192 |
| Google Gemini Pro | 1.5 / 2.0 / 2.5 | 2,000,000 |
| Google Gemini Flash | 1.5 / 2.0 / 2.5 | 1,000,000 |

Local/open-source models (Llama, Mistral, etc.) live in the SDK's separate budgeting helper and are not duplicated here.

## Dynamic threshold formula

```python
from tokenpak.proxy.spend_guard import derive_block_threshold

derive_block_threshold(200_000)             # → 160_000
derive_block_threshold(1_000_000)           # → 800_000
derive_block_threshold(500_000)             # → 400_000
derive_block_threshold(None, fallback_tokens=500_000)  # → 500_000
```

Pure function. Validated:

- `model_max_context_tokens` must be a positive int — else fallback.
- `ratio` must be in `(0, 1]` — else fallback.
- result is floored to int.
- result never exceeds `model_max_context_tokens`.

The result is then capped against `cfg.hard_block_tokens` inside `decide()` so the hard 1M ceiling always wins on top of the derived value.

## Fallback behavior

When `get_model_max_context(model)` returns `None` (unknown model), `decide()` falls back to the configured `cfg.block_tokens` (default `500_000`, conservative). The audit row's `threshold_hit` field then reads `block_tokens_fallback>=<N>` so operators can see that dynamic derivation didn't apply for that request — there is no silent assumption.

| Path | `threshold_hit` prefix |
|---|---|
| Known model context | `block_tokens_dynamic>=<N> max_context=<M>` |
| Unknown model (fallback) | `block_tokens_fallback>=<N>` |
| Both unavailable (degraded) | `block_tokens_unresolved>=<N>` (uses hard ceiling) |

## Test results

```
$ python -m pytest tokenpak/tests/test_spend_guard_context_window.py tokenpak/tests/test_spend_guard_policy.py
68 passed in 1.5s

$ python -m pytest tokenpak/tests/test_spend_guard_*.py
129 passed, 3 skipped
```

New tests pin:

- 1M context → 800K block (the requested reference example).
- 200K context → 160K block.
- 500K context → 400K block.
- 2M context → derived 1.6M, **capped by hard 1M ceiling** above 1M-token requests.
- Unknown context → fallback path (NOT silent 1M assumption).
- Model switch changes threshold (parametrized over 7 frontier models).
- Hard ceiling immutability survives every dynamic path.

`derive_block_threshold` is independently unit-tested for: zero context, negative context, ratios outside (0, 1], non-int input, custom ratios, floors-to-int, never-exceeds-max contract.

## Docs update summary

`docs/spend-guard.md` adds a 'Dynamic block-tokens band' subsection covering: formula, derived-value examples table, fallback semantics, hard-ceiling cap rule, currently-known frontier models, advanced `derive_block_threshold()` override surface.

## Hard fixed thresholds — kept, repurposed, removed?

| Threshold | Status | Reason |
|---|---|---|
| `warn_tokens` (100,000) | KEPT — fixed | Advisory band; not blocking. |
| `warn_cost_usd` (\$2.00) | KEPT — fixed | Same. |
| `block_tokens` (500,000) | **REPURPOSED — fallback only** | No longer the universal soft block. Only used when the model's context window can't be resolved. Documented as fallback in the dataclass docstring + config YAML comment. |
| `block_cost_usd` (\$10.00) | KEPT — fixed | Cost band is independent of context window. |
| `hard_block_tokens` (1,000,000) | KEPT — fixed, immutable | Safety cap on top of the derived band. Even a 5M-context model never exceeds this. Also caps the dynamic-derived value (`min(derived, hard_ceiling)`). |
| `hard_block_cost_usd` (\$50.00) | KEPT — fixed, immutable | Same. |
| `session_block_cost_usd` (\$10.00) | KEPT — fixed | Death-by-1000-cuts defense; orthogonal to per-request context. |

## Files changed (7 files / +647 / -17)

```
docs/spend-guard.md                                |  49 +++++-
tokenpak/proxy/spend_guard/__init__.py             |  10 +-
tokenpak/proxy/spend_guard/_context_window.py      | 144 +++++++++++++++++   (NEW)
tokenpak/proxy/spend_guard/orchestrator.py         |  18 ++-
tokenpak/proxy/spend_guard/policy.py               | 123 ++++++++++++--
tokenpak/tests/test_spend_guard_context_window.py  | 189 ++++++++++++++++++++++   (NEW, 42 cases)
tokenpak/tests/test_spend_guard_policy.py          | 131 ++++++++++++-
```

## Verification

- All Python files pass `ast.parse`.
- 129 spend-guard tests pass; 3 unrelated skips.
- Identity-language scan: 0 hits across all touched files.
- No version bump. No tag. No PyPI publish. No package behavior changes outside spend-guard threshold derivation.

## Rollback

`git revert` on main → re-push. `block_tokens` reverts to plain static check. New module `_context_window.py` becomes dead code (harmless; no runtime effect once decide() reverts). Tests revert symmetrically.

## Acceptance

- [ ] Public CI green
- [ ] Kevin merge approval
