### PR TITLE
ci(release): tag-source validation + action pin + checksum dist-purity guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
             echo "::error::Tag ${{ github.ref }} (sha ${{ github.sha }}) is not reachable from origin/main." >&2
             echo "::error::Public release tags MUST be on commits already merged to main via the documented promotion path." >&2
-            echo "::error::Per Std 21 §9.4: workbench → staging → public → tag/publish." >&2
+            echo "::error::Required path: workbench → staging → public → tag/publish (see CONTRIBUTING.md)." >&2
             exit 1
           fi
           echo "::notice::Tag ${{ github.ref }} verified on origin/main."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,53 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ───────────────────────────────────────────────────────────────
+      # Release-gate hardening: action pin enforcement.
+      #
+      # Verifies that every `uses: <owner>/<repo>@<ref>` reference in
+      # .github/workflows/*.yml is either a full 40-char commit SHA or
+      # a non-hex floating ref (version tag, branch, slashed ref).
+      # Abbreviated SHA pins (7–39 hex chars) are rejected — see the
+      # script header for the rationale.
+      #
+      # Runs unconditionally on every release-workflow invocation
+      # (tag push or workflow_dispatch preflight) so an abbreviated-SHA
+      # pin that slips through PR review still fails before any build,
+      # release artifact, or PyPI publish.
+      # ───────────────────────────────────────────────────────────────
+      - name: Check action pins (peeled-commit or floating-tag only)
+        run: bash scripts/check-action-pins.sh
+
+      # ───────────────────────────────────────────────────────────────
+      # Release-gate hardening: tag-source validation.
+      #
+      # Public release tags MUST sit on a commit reachable from
+      # origin/main. The documented promotion path is:
+      #
+      #     workbench → staging PR → public PR → public main → tag
+      #
+      # A tag pushed against a feature branch (never merged) would
+      # otherwise auto-publish to PyPI without the public-PR gate.
+      # This step fails fast on that pattern.
+      #
+      # Skipped on `workflow_dispatch` preflight runs (no tag ref) and
+      # on non-`v*` tag pushes (e.g. release-rehearsal `rehearsal-*`
+      # tags, which are explicitly out of `on.push.tags` anyway but
+      # the guard is doubly safe).
+      # ───────────────────────────────────────────────────────────────
+      - name: Validate tag source (public-main ancestry)
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=200
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref }} (sha ${{ github.sha }}) is not reachable from origin/main." >&2
+            echo "::error::Public release tags MUST be on commits already merged to main via the documented promotion path." >&2
+            echo "::error::Per Std 21 §9.4: workbench → staging → public → tag/publish." >&2
+            exit 1
+          fi
+          echo "::notice::Tag ${{ github.ref }} verified on origin/main."
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
@@ -146,6 +193,34 @@ jobs:
           # See dist-purity contract on the build job.
           ( cd dist && sha256sum *.whl *.tar.gz ) > SHA256SUMS
           cat SHA256SUMS
+
+      # ───────────────────────────────────────────────────────────────
+      # Release-gate hardening: dist-purity ratchet on the checksum
+      # path. SHA256SUMS MUST live at repo root, never inside dist/.
+      # This is the exact v1.5.3 regression pattern (checksum file
+      # ended up in dist/, PyPI publish rejected the directory).
+      #
+      # The build-job `Assert dist/ purity` step already covers the
+      # general case (only .whl / .tar.gz in dist/); this step is a
+      # narrower, named guard against the specific SHA256SUMS-in-dist
+      # failure mode so the regression — if it ever recurs — produces
+      # a diagnostic message that names the failure rather than a
+      # generic "non-distribution files" line.
+      # ───────────────────────────────────────────────────────────────
+      - name: Assert SHA256SUMS outside dist/
+        run: |
+          set -euo pipefail
+          if [ -f dist/SHA256SUMS ]; then
+            echo "::error::SHA256SUMS detected inside dist/ — this is the v1.5.3 regression pattern." >&2
+            echo "       Checksum file MUST live at repo root, not inside dist/." >&2
+            ls -la dist/ >&2
+            exit 1
+          fi
+          if [ ! -f SHA256SUMS ]; then
+            echo "::error::SHA256SUMS missing from repo root after checksum generation." >&2
+            exit 1
+          fi
+          echo "::notice::SHA256SUMS is at repo root (outside dist/); dist-purity preserved on the checksum path."
 
       - name: Upload dist artifact (wheels + sdist only)
         uses: actions/upload-artifact@v4

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-action-pins.sh — peeled-commit pin enforcement.
+#
+# Scans `.github/workflows/*.yml` for `uses: <owner>/<repo>...@<ref>` entries
+# and asserts that any SHA-pinned reference is a full 40-character hex
+# commit SHA. Floating refs (version tags like `v4`, branch names like
+# `main`, slashed refs like `release/v1`) are allowed.
+#
+# Why this matters:
+#
+#   • An abbreviated SHA pin (e.g. `@abc1234`) gives weaker security
+#     guarantees than a full peeled commit — short refs are vulnerable
+#     to SHA collisions and to Git's silent prefix-matching behavior.
+#
+#   • A pinned action is supposed to be cryptographically immutable.
+#     Abbreviating the SHA partly undoes the immutability claim.
+#
+#   • Version-tag pins (`@v4`) are mutable by the upstream maintainer,
+#     but at least they're unambiguous about the trust model: you're
+#     trusting the maintainer to not point the tag at a malicious sha.
+#     A 7-char hex pin trusts neither — it's just careless.
+#
+# Exit codes:
+#
+#   0 — all action refs are either full SHAs (40 hex chars) or
+#       non-hex floating refs (allowed).
+#   1 — at least one ref is hex but not 40 chars (abbreviated SHA).
+#   2 — environmental error (no workflow files, bash version, etc.).
+#
+# Usage:
+#
+#   bash scripts/check-action-pins.sh
+#
+# Reference: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+set -euo pipefail
+shopt -s nullglob
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+
+if [ ! -d "$WORKFLOWS_DIR" ]; then
+    echo "ERROR: $WORKFLOWS_DIR does not exist." >&2
+    exit 2
+fi
+
+fail=0
+checked=0
+
+for wf in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
+    [ -f "$wf" ] || continue
+    # Match: any line with "uses: <owner>/<name>...@<ref>"
+    # We rely on a tolerant regex; YAML inline-mapping forms are uncommon
+    # in GitHub Actions workflows and not worth special-casing here.
+    while IFS= read -r line; do
+        # Strip everything up to and including the first `@` after `uses:`.
+        ref="${line#*@}"
+        # Trim any trailing whitespace / comment.
+        ref="${ref%%[[:space:]]*}"
+        ref="${ref%%#*}"
+        [ -n "$ref" ] || continue
+        checked=$((checked + 1))
+        # Non-hex (contains a non-[0-9a-f] character) → floating ref, allowed.
+        if [[ "$ref" =~ [^0-9a-f] ]]; then
+            continue
+        fi
+        # Pure-hex ref: must be exactly 40 chars (full peeled commit).
+        if [ "${#ref}" -ne 40 ]; then
+            echo "::error file=$wf::Abbreviated SHA pin '@$ref' (length ${#ref}, required 40). Use the full 40-char commit SHA or a floating version-tag ref."
+            fail=1
+        fi
+    done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+[A-Za-z0-9_.-]+/[^@]+@' "$wf" || true)
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo
+    echo "FAIL: one or more action references are pinned to an abbreviated SHA." >&2
+    echo "      Replace each abbreviated pin with the full 40-character commit SHA," >&2
+    echo "      or use a floating version-tag ref (e.g. @v4) if the maintainer's" >&2
+    echo "      release policy is acceptable for this workflow." >&2
+    exit 1
+fi
+
+echo "Action pin check OK: $checked uses-ref(s) verified across workflows."

--- a/tokenpak/_snapshots/workflow-steps.json
+++ b/tokenpak/_snapshots/workflow-steps.json
@@ -634,54 +634,75 @@
     "job": "build",
     "step_idx": 1,
     "step_id": null,
-    "step_name": "Set up Python 3.12"
+    "step_name": "Check action pins (peeled-commit or floating-tag only)"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 2,
     "step_id": null,
-    "step_name": "Install build tools"
+    "step_name": "Validate tag source (public-main ancestry)"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 3,
     "step_id": null,
-    "step_name": "Build wheel and sdist"
+    "step_name": "Set up Python 3.12"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 4,
     "step_id": null,
-    "step_name": "Verify package"
+    "step_name": "Install build tools"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 5,
     "step_id": null,
-    "step_name": "Assert dist/ purity (only .whl + .tar.gz)"
+    "step_name": "Build wheel and sdist"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 6,
     "step_id": null,
-    "step_name": "Generate checksums (outside dist/)"
+    "step_name": "Verify package"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 7,
     "step_id": null,
-    "step_name": "Upload dist artifact (wheels + sdist only)"
+    "step_name": "Assert dist/ purity (only .whl + .tar.gz)"
   },
   {
     "workflow": "release.yml",
     "job": "build",
     "step_idx": 8,
+    "step_id": null,
+    "step_name": "Generate checksums (outside dist/)"
+  },
+  {
+    "workflow": "release.yml",
+    "job": "build",
+    "step_idx": 9,
+    "step_id": null,
+    "step_name": "Assert SHA256SUMS outside dist/"
+  },
+  {
+    "workflow": "release.yml",
+    "job": "build",
+    "step_idx": 10,
+    "step_id": null,
+    "step_name": "Upload dist artifact (wheels + sdist only)"
+  },
+  {
+    "workflow": "release.yml",
+    "job": "build",
+    "step_idx": 11,
     "step_id": null,
     "step_name": "Upload checksums artifact (SHA256SUMS only)"
   },


### PR DESCRIPTION
## Summary

Release-gate hardening — three workflow-level guards on `Release TokenPak`:

1. **Tag-source validation.** Public release tags must point to a commit reachable from `origin/main`. Prevents a tag pushed against a feature branch from auto-publishing to PyPI. Skipped on `workflow_dispatch` preflight and on non-`v*` tags (rehearsal tags).
2. **Action pin enforcement.** New `scripts/check-action-pins.sh` scans every `uses:` reference and rejects abbreviated SHA pins (7–39 hex chars). Full 40-char commit SHAs and floating version-tag refs (`@v4`) remain allowed.
3. **Dist-purity checksum guard.** Named guard against the v1.5.3 regression pattern — `SHA256SUMS` inside `dist/`. Asserts `SHA256SUMS` is at repo root, not inside `dist/`.

All three steps are non-publishing — they run before `release` / `publish` and fail the workflow early if violated. No behavior change on tag/publish for a correctly-prepared release.

## Files

- `.github/workflows/release.yml` — three new steps + a tag-source-aware comment.
- `scripts/check-action-pins.sh` — pin-enforcement script (57 refs verified on this branch).
- `tokenpak/_snapshots/workflow-steps.json` — workflow-step ratchet snapshot updated to cover the three new steps.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → valid.
- `bash scripts/check-action-pins.sh` → 57 refs OK.
- `python3 scripts/snapshot-workflow-steps.py --check` → exit 0.
- Identity & language scan clean on changed files.
- Public layout check clean.

## Risk / rollback

- Tag-source validation step is gated on `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')`, so `workflow_dispatch` preflight and rehearsal tags are unaffected.
- No version bump, no tag, no PyPI activity introduced.
- Rollback: revert this PR. No artifact has been published.

## Promotion path

workbench → `tokenpak/tokenpak-staging#17` (green) → this public PR.
