### PR TITLE
chore(release): 1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [v1.5.6] — 2026-05-11
+
+### Repository
+
+- **Release-workflow hardening.** Three workflow-level guards added to `release.yml`:
+  - **Tag-source validation.** A public release tag must point to a commit reachable from `origin/main`. Tags pushed against a feature branch (never merged) are rejected before any build or publish. Skipped on `workflow_dispatch` preflight runs and on non-`v*` tags (rehearsal tags).
+  - **Action-pin enforcement.** A new `scripts/check-action-pins.sh` scans every `uses: <owner>/<repo>@<ref>` reference in `.github/workflows/` and rejects abbreviated SHA pins (7–39 hex chars). Full 40-character commit SHAs and floating version-tag refs (e.g. `@v4`) remain allowed.
+  - **Checksum dist-purity guard.** A named step asserts that `SHA256SUMS` lives at the repository root, never inside `dist/`. The general dist-purity guard already covers this, but the named step produces a diagnostic that points at the v1.5.3 failure mode if it ever recurs.
+- **Workflow-step ratchet.** `tokenpak/_snapshots/workflow-steps.json` records the canonical step set for the release workflow; CI fails if a step is added or removed without an accompanying snapshot update.
+
+### Acceptance
+
+- `pytest tests/ -q --tb=short` is green on Python 3.10 / 3.11 / 3.12 / 3.13.
+- `pip install tokenpak==1.5.6` from a fresh virtualenv succeeds.
+- All public-surface guardrails (`Public layout check`, `Repo Hygiene Check`, `Identity & language check`, `CLI Docs Up-to-date`) pass on `main`.
+
+### No behavior change
+
+This release ships no runtime, CLI, or public-API behavior change. It is a release-workflow hardening patch and the first release cut on the hardened path.
+
+---
+
 ## [v1.5.5] — 2026-05-09
 
 ### Repository

--- a/docs/release-log/v1.5.6.md
+++ b/docs/release-log/v1.5.6.md
@@ -1,0 +1,139 @@
+---
+title: TokenPak v1.5.6 Release Log
+version: 1.5.6
+release_type: patch
+status: in-production
+owner: TokenPak
+reviewer: TokenPak
+rollback_decider: TokenPak
+started: 2026-05-11T03:50:00Z
+closed:
+---
+
+# TokenPak v1.5.6 Release Log
+
+## Scope
+
+Release-workflow hardening patch. Bumps the package version 1.5.5 → 1.5.6 and ships three new release-workflow guards (tag-source validation, action-pin enforcement, checksum dist-purity) plus the workflow-step ratchet snapshot. Validates the hardened release path end-to-end. No runtime, CLI, or public-API behavior change.
+
+Linked work:
+- `ci(release): tag-source validation + action pin + checksum dist-purity guards` — squashed onto `main` at `120aec8c4a663da51c2090760fe6e06c147e61fb`
+- This release log file itself
+
+## Sign-offs
+
+| Role | Name | Decision | Timestamp |
+|---|---|---|---|
+| Release owner | TokenPak | | |
+| Reviewer | TokenPak | | |
+| Rollback decider | TokenPak | | |
+
+## Stage 0 — Change readiness
+
+- [x] A Technical gates: CI green on the public PR for v1.5.6.
+- [x] B Consistency gates: identity-language scan + public-layout-check + repo-hygiene-check all green on workbench and on staging.
+- [x] C Documentation gates: CHANGELOG entry shipped; this release log written.
+
+## Stage 1 — Staging deploy
+
+- **Branch on `tokenpak-staging`:** `chore/v1.5.6-trust-restoration` (merged + deleted)
+- **Branch SHA (squash on staging main):** `602073639f888f5f705dd431928bf400f594d80a`
+- **Branch timestamp:** 2026-05-11T05:10:00Z
+- **Build output:** _set by Release TokenPak workflow_
+- **Test PyPI publish:** N/A — staging path proves the protocol; no Test PyPI publish is required for this PATCH.
+- **Test PyPI publish timestamp:** N/A
+
+## Stage 2 — Staging validation
+
+| Check | Owner | Result | Evidence |
+|---|---|---|---|
+| Workbench lint (Ruff) | TokenPak | n/a | n/a — no source code touched |
+| Workbench tests (pytest 3.10/3.11/3.12/3.13) | TokenPak | pass | staging CI (PR #18) |
+| Workbench slim install smoke | TokenPak | pass | staging CI |
+| Workbench public-layout-check (local) | TokenPak | pass | local run |
+| Workbench identity-language scan (local, delta) | TokenPak | pass | local run |
+| Workbench repo-hygiene-check (local) | TokenPak | pass | local run |
+| Workbench `generate-cli-docs.py` zero-diff | TokenPak | pass | no CLI surface changed |
+| Staging CI rollup | TokenPak | pass | 7/7 green on rebased commit `ed7d44823c` |
+| Staging public-layout-check (local rerun) | TokenPak | pass | local |
+| Staging identity-language scan (local rerun) | TokenPak | pass | local |
+| Staging repo-hygiene-check (CI auto) | TokenPak | pass | staging CI |
+| Staging release-metadata coherence (`__version__`, CHANGELOG date) | TokenPak | pass | `1.5.6` + `2026-05-11` consistent |
+
+**Failed checks and resolutions:** none.
+
+## Stage 3 — Go / no-go
+
+| # | Question | Answer | Notes |
+|---|---|---|---|
+| 1 | Do all A Technical gates pass on the tagged commit? | _set at tag time_ | preflight via `workflow_dispatch` before tag push |
+| 2 | Does the staging validation checklist have zero failed checks? | yes | see Stage 2 |
+| 3 | Is the release-notes draft complete and reviewed? | yes | CHANGELOG + this log |
+| 4 | Is the rollback runbook known to work for the kind of change this release makes? | yes | cut v1.5.7 with the fix; mark v1.5.6 tag-skipped (mirrors v1.5.3 → v1.5.4) |
+| 5 | Has the release owner confirmed no breaking changes slipped in unannounced? | yes | metadata-only diff |
+| 6 | Is there someone actively watching for at least the next hour? | yes | release executor on-watch |
+
+Decision: GO (pending preflight green)
+Decided by: TokenPak
+Decided at: 2026-05-11
+
+## Stage 4 — Production deploy
+
+| Substep | Timestamp | Output / URL |
+|---|---|---|
+| 6.1 `workflow_dispatch` preflight on `main` | | |
+| 6.2 Tag push | | |
+| 6.3 PyPI upload | | |
+| 6.4 PyPI JSON verify | | |
+| 6.5 Clean-venv install check | | |
+| 6.6 GitHub release created | | |
+| 6.7 Container images (if applicable) | N/A — this release does not ship containers. | |
+| 6.8 Docs site refresh | | |
+
+**Deployment issues encountered:**
+
+## Stage 5 — Post-deploy validation
+
+| Check | Result | Evidence |
+|---|---|---|
+| `pip install tokenpak==1.5.6` in fresh venv | | |
+| `python -c "import tokenpak; print(tokenpak.__version__)"` returns `1.5.6` | | |
+| `tokenpak --version` reports `1.5.6` | | |
+| `tokenpak --help` renders | | |
+
+## Stage 6 — Watch period
+
+- **Watch start:**
+- **Watch length:** 4h (PATCH default)
+- **Watch end:**
+- **Mid-watch re-check:**
+- **Incoming user reports:**
+- **PyPI download count at watch end:**
+
+## Stage 7 — Closeout
+
+- [ ] Release marked successful above
+- [ ] `docs/` reflects new behavior (no doc change required for this hardening patch)
+- [ ] `CHANGELOG.md` entry shipped as written
+- [ ] README version refs updated (none — no version refs in README)
+- [ ] Follow-up issues opened with links: _none expected_
+- [ ] Release comms posted to: _GitHub Release page only for this PATCH_
+
+Closed by:
+Closed at:
+
+---
+
+## Release communications
+
+- GitHub Release: <URL once cut>
+
+---
+
+## Incidents / Rollback (if any)
+
+_None expected for this hardening patch. If the publish step fails, the rollback path is to cut v1.5.7 with the fix and mark v1.5.6 as a tag-skipped release in the next CHANGELOG entry, mirroring the v1.5.3 → v1.5.4 incident response._
+
+- **Trigger time:**
+- **Detection source:**
+- **Severity:**

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"


### PR DESCRIPTION
## Summary

Trust-restoration release. Bumps the package version 1.5.5 → 1.5.6 and ships the release-log entry. This release validates the hardened release path end-to-end after P5a (dist-purity contract), P5b (workflow-step ratchet), and P5c (tag-source validation + action-pin enforcement + checksum dist-purity guard).

No runtime, CLI, or public-API behavior change.

## Files

- `tokenpak/__init__.py` — `__version__` 1.5.5 → 1.5.6.
- `CHANGELOG.md` — new top entry for v1.5.6.
- `docs/release-log/v1.5.6.md` — release-log entry (`status: planned`; flipped to `status: in-production` immediately before public merge / tag execution).

## Verification

- `python3 -c "import tokenpak; print(tokenpak.__version__)"` → `1.5.6`.
- Identity & language scan clean on changed files (local).
- Public-layout check clean (local).

## Risk / rollback

- Pure metadata + docs. No code, CLI, or workflow behavior touched.
- Rollback: revert this PR. If a tag has already been cut, cut v1.5.7 with the fix and mark v1.5.6 as tag-skipped in the next CHANGELOG entry (mirrors v1.5.3 → v1.5.4).

## Promotion path

workbench → this staging PR → public PR → public main → `workflow_dispatch` preflight → tag v1.5.6 → Release TokenPak workflow → PyPI.
