### PR TITLE
feat(companion/recall): SQLite storage foundation + FTS5 + migration runner

### DIFF
--- a/tests/companion/recall/conftest.py
+++ b/tests/companion/recall/conftest.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for the recall storage foundation tests.
+
+The FTS5 fixture checks that the linked SQLite build has the FTS5
+extension compiled in. Production Debian 12 + GitHub Actions Ubuntu
+both ship it; this fixture exists so the suite degrades cleanly on a
+build that does not.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def fts5_available() -> bool:
+    """``True`` iff SQLite has FTS5 compiled in.
+
+    Tests that exercise the FTS5 virtual table use this to skip with a
+    clear reason rather than crash with an opaque SQL error.
+    """
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+    return True
+
+
+@pytest.fixture
+def require_fts5(fts5_available: bool) -> None:
+    """Skip the test if FTS5 is not available."""
+    if not fts5_available:
+        pytest.skip(
+            "FTS5 extension not compiled into this SQLite build; skipping recall FTS5 coverage."
+        )

--- a/tests/companion/recall/test_fts5.py
+++ b/tests/companion/recall/test_fts5.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FTS5 virtual-table availability and basic MATCH behaviour.
+
+PR 1 leaves the FTS5 table empty by default — no triggers, no writer.
+These tests insert directly into ``paks_fts`` to validate the table
+shape and tokenizer, not to lock in any insert-side contract.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import RecallStore
+
+
+def test_fts5_extension_detected(fts5_available: bool) -> None:
+    """The fixture must classify the build correctly.
+
+    This test runs even when FTS5 is missing — it's the signal-test that
+    confirms the skip path works.
+    """
+    if not fts5_available:
+        pytest.skip("FTS5 not compiled — confirmed; remaining tests will skip.")
+    # If we get here, FTS5 is present. Sanity-check the probe.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE t USING fts5(x)")
+    finally:
+        conn.close()
+
+
+def test_paks_fts_exists_after_open(tmp_path: Path, require_fts5: None) -> None:
+    """``paks_fts`` is registered as an fts5 virtual table after open."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        row = store.conn.execute("SELECT sql FROM sqlite_master WHERE name = 'paks_fts'").fetchone()
+    assert row is not None
+    assert "fts5" in row[0].lower()
+
+
+def test_match_returns_inserted_row(tmp_path: Path, require_fts5: None) -> None:
+    """Direct INSERT into paks_fts then MATCH returns the row."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.conn.execute(
+            "INSERT INTO paks_fts (pak_id, title, summary) VALUES (?, ?, ?)",
+            ("vault://a", "router-not-vault credential architecture", ""),
+        )
+        store.conn.execute(
+            "INSERT INTO paks_fts (pak_id, title, summary) VALUES (?, ?, ?)",
+            ("vault://b", "unrelated heading", "totally different content"),
+        )
+        store.conn.commit()
+        hit = store.conn.execute(
+            "SELECT pak_id FROM paks_fts WHERE paks_fts MATCH 'credential'"
+        ).fetchall()
+    assert [r[0] for r in hit] == ["vault://a"]
+
+
+def test_unicode61_remove_diacritics_tokenizer(tmp_path: Path, require_fts5: None) -> None:
+    """The DDL specifies ``unicode61 remove_diacritics 2`` — confirm it's live."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.conn.execute(
+            "INSERT INTO paks_fts (pak_id, title, summary) VALUES (?, ?, ?)",
+            ("vault://c", "café résumé", ""),
+        )
+        store.conn.commit()
+        # Without diacritics-stripping, 'cafe' would not match 'café'.
+        hit = store.conn.execute(
+            "SELECT pak_id FROM paks_fts WHERE paks_fts MATCH 'cafe'"
+        ).fetchall()
+    assert [r[0] for r in hit] == ["vault://c"]
+
+
+def test_empty_index_returns_no_rows(tmp_path: Path, require_fts5: None) -> None:
+    """A fresh DB has zero rows in ``paks_fts``; MATCH returns nothing."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        rows = store.conn.execute(
+            "SELECT pak_id FROM paks_fts WHERE paks_fts MATCH 'anything'"
+        ).fetchall()
+    assert rows == []

--- a/tests/companion/recall/test_migrations.py
+++ b/tests/companion/recall/test_migrations.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Forward-only migration runner tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import RecallStore
+from tokenpak.companion.recall.migrations import (
+    MIGRATIONS,
+    Migration,
+    apply_migrations,
+    current_version,
+)
+from tokenpak.companion.recall.schema import SCHEMA_VERSION
+
+
+def test_fresh_db_advances_to_latest(tmp_path: Path, require_fts5: None) -> None:
+    """A brand-new DB ends at the latest known version."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        assert store.schema_version == SCHEMA_VERSION
+
+
+def test_reopen_is_idempotent(tmp_path: Path, require_fts5: None) -> None:
+    """Opening the same DB twice doesn't rerun migrations or change rows."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as first:
+        first.conn.execute(
+            "INSERT INTO paks (pak_id, pak_type, source_type, authority, "
+            "title, content_hash, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "vault://b",
+                "vault",
+                "code",
+                "llm_generated",
+                "T",
+                "h",
+                "2026-05-11T00:00:00Z",
+                "2026-05-11T00:00:00Z",
+            ),
+        )
+        first.conn.commit()
+        version_after_seed = first.schema_version
+    # Reopen — should not advance the version and should not lose the row.
+    with RecallStore.open(db_path) as second:
+        assert second.schema_version == version_after_seed
+        n = second.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert n == 1
+
+
+def test_legacy_db_missing_schema_version_row_is_recovered(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A legacy DB with no version row is treated as v0 and migrated up."""
+    db_path = tmp_path / "recall.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Pretend an older build created the table but not the row.
+        conn.execute(
+            "CREATE TABLE schema_version ("
+            "  id INTEGER PRIMARY KEY CHECK (id = 1), "
+            "  version INTEGER NOT NULL, "
+            "  applied_at TEXT NOT NULL"
+            ")"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    with RecallStore.open(db_path) as store:
+        assert store.schema_version == SCHEMA_VERSION
+
+
+def test_apply_migrations_returns_final_version(tmp_path: Path, require_fts5: None) -> None:
+    """Direct ``apply_migrations`` call returns the new version number."""
+    db_path = tmp_path / "recall.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        final = apply_migrations(conn)
+    finally:
+        conn.close()
+    assert final == SCHEMA_VERSION
+
+
+def test_migrations_are_strictly_increasing_versions() -> None:
+    """The migration list must be ordered with strictly increasing versions."""
+    versions = [m.version for m in MIGRATIONS]
+    assert versions == sorted(versions)
+    assert len(set(versions)) == len(versions)
+    assert versions[0] == 1
+
+
+def test_failure_inside_migration_does_not_advance_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    require_fts5: None,
+) -> None:
+    """A SQL failure mid-migration leaves ``schema_version`` at the prior value."""
+    db_path = tmp_path / "recall.db"
+
+    bad_migration = Migration(
+        version=99,
+        name="deliberately_broken",
+        statements=("SELECT 1", "THIS IS NOT VALID SQL"),
+    )
+    # Replace MIGRATIONS for this test only, keeping the v1 baseline first.
+    monkeypatch.setattr(
+        "tokenpak.companion.recall.migrations.MIGRATIONS",
+        (*MIGRATIONS, bad_migration),
+    )
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # First call gets us to v1 cleanly (the bad migration is v99 only).
+        from tokenpak.companion.recall import migrations as mig
+
+        before = current_version(conn)
+        with pytest.raises(sqlite3.Error):
+            mig.apply_migrations(conn)
+        after = current_version(conn)
+    finally:
+        conn.close()
+    # The bad migration should NOT have advanced the version past v1.
+    assert before == 0
+    assert after == SCHEMA_VERSION  # v1 applied before v99 errored
+    assert after < 99
+
+
+def test_db_at_newer_version_than_code_is_left_alone(tmp_path: Path, require_fts5: None) -> None:
+    """If someone ran a newer build, an older build must not regress them."""
+    db_path = tmp_path / "recall.db"
+    # Initialise normally first, then bump the version artificially.
+    with RecallStore.open(db_path) as store:
+        store.conn.execute(
+            "UPDATE schema_version SET version = ?, applied_at = ? WHERE id = 1",
+            (999, "2099-01-01T00:00:00Z"),
+        )
+        store.conn.commit()
+    # Re-open with the current (older) code — must not regress.
+    with RecallStore.open(db_path) as store:
+        assert store.schema_version == 999

--- a/tests/companion/recall/test_schema.py
+++ b/tests/companion/recall/test_schema.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Schema-shape tests for the recall storage foundation.
+
+These tests open a fresh database, apply the migrations, and assert that
+the expected tables and indexes exist. They do not exercise any read or
+write behaviour — that's PR 2+.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import SCHEMA_VERSION, RecallStore
+from tokenpak.companion.recall.schema import (
+    ALL_DDL_V1,
+    EXPECTED_INDEXES_V1,
+    EXPECTED_TABLES_V1,
+)
+
+
+def _names(conn: sqlite3.Connection, kind: str) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type = ?", (kind,)).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_schema_version_constant_matches_latest_migration() -> None:
+    """``SCHEMA_VERSION`` constant must match the head of ``MIGRATIONS``."""
+    from tokenpak.companion.recall.migrations import MIGRATIONS
+
+    assert MIGRATIONS, "at least one migration must be registered"
+    assert MIGRATIONS[-1].version == SCHEMA_VERSION
+
+
+def test_open_creates_all_v1_tables(tmp_path: Path, require_fts5: None) -> None:
+    """Opening a fresh DB applies v1 and produces all expected tables."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        tables = _names(store.conn, "table") | _names(store.conn, "view")
+        # FTS5 backs its virtual table with shadow tables — check for the
+        # main name only (the virtual table is not type='table'; it's
+        # registered under sqlite_master as type='table' with a synthetic
+        # row, but a portable check is the SELECT below.)
+        present = {
+            r[0]
+            for r in store.conn.execute(
+                "SELECT name FROM sqlite_master WHERE name IN "
+                "('schema_version','paks','paks_fts','pak_anchors','pak_relations')"
+            ).fetchall()
+        }
+    assert EXPECTED_TABLES_V1.issubset(present)
+
+
+def test_open_creates_all_v1_indexes(tmp_path: Path, require_fts5: None) -> None:
+    """All named v1 indexes exist after open."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        indexes = _names(store.conn, "index")
+    missing = EXPECTED_INDEXES_V1 - indexes
+    assert not missing, f"missing indexes: {sorted(missing)}"
+
+
+def test_ddl_statements_are_individually_idempotent(tmp_path: Path, require_fts5: None) -> None:
+    """Each statement uses IF NOT EXISTS so re-applying is safe."""
+    db_path = tmp_path / "recall.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        for stmt in ALL_DDL_V1:
+            conn.execute(stmt)
+        # Second pass: every statement should still succeed.
+        for stmt in ALL_DDL_V1:
+            conn.execute(stmt)
+    finally:
+        conn.close()
+
+
+def test_paks_table_columns_match_contract(tmp_path: Path, require_fts5: None) -> None:
+    """The ``paks`` columns are the contract Pro daemon reads; lock them down."""
+    db_path = tmp_path / "recall.db"
+    expected = {
+        "pak_id",
+        "pak_type",
+        "project",
+        "topic",
+        "source_type",
+        "authority",
+        "title",
+        "summary",
+        "content_hash",
+        "created_at",
+        "updated_at",
+        "superseded_by",
+    }
+    with RecallStore.open(db_path) as store:
+        cols = {r[1] for r in store.conn.execute("PRAGMA table_info('paks')")}
+    assert cols == expected
+
+
+def test_pak_relations_supports_self_reference_via_pak_id(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """``pak_relations`` should accept (pak_id, related_pak_id) inserts after
+    parent rows exist; this is a structural smoke test only."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.conn.execute(
+            "INSERT INTO paks (pak_id, pak_type, source_type, authority, "
+            "title, content_hash, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "vault://block/a",
+                "vault",
+                "code",
+                "llm_generated",
+                "A",
+                "h1",
+                "2026-05-11T00:00:00Z",
+                "2026-05-11T00:00:00Z",
+            ),
+        )
+        store.conn.execute(
+            "INSERT INTO paks (pak_id, pak_type, source_type, authority, "
+            "title, content_hash, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "vault://block/b",
+                "vault",
+                "code",
+                "llm_generated",
+                "B",
+                "h2",
+                "2026-05-11T00:00:00Z",
+                "2026-05-11T00:00:00Z",
+            ),
+        )
+        store.conn.execute(
+            "INSERT INTO pak_relations (pak_id, related_pak_id, relation_type, "
+            "created_at) VALUES (?, ?, ?, ?)",
+            (
+                "vault://block/a",
+                "vault://block/b",
+                "supersedes",
+                "2026-05-11T00:00:00Z",
+            ),
+        )
+        store.conn.commit()
+        rows = store.conn.execute(
+            "SELECT pak_id, related_pak_id, relation_type FROM pak_relations"
+        ).fetchall()
+    assert rows == [("vault://block/a", "vault://block/b", "supersedes")]
+
+
+def test_foreign_keys_pragma_is_on(tmp_path: Path, require_fts5: None) -> None:
+    """FK enforcement must be ON so the schema's CASCADE / SET NULL works."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        row = store.conn.execute("PRAGMA foreign_keys").fetchone()
+    assert row[0] == 1
+
+
+def test_wal_journal_mode(tmp_path: Path, require_fts5: None) -> None:
+    """WAL is required for concurrent-reader / single-writer behaviour."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        row = store.conn.execute("PRAGMA journal_mode").fetchone()
+    assert row[0].lower() == "wal"

--- a/tests/companion/recall/test_store_open.py
+++ b/tests/companion/recall/test_store_open.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``RecallStore.open`` / ``open_recall_store`` factory behaviour."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tokenpak.companion.recall import (
+    RecallStore,
+    default_recall_db_path,
+    open_recall_store,
+)
+
+
+def test_open_creates_parent_directory(tmp_path: Path, require_fts5: None) -> None:
+    """Parent dir is created on first open if missing."""
+    nested = tmp_path / "deep" / "nested" / "recall.db"
+    assert not nested.parent.exists()
+    with RecallStore.open(nested) as store:
+        assert store.path == nested
+    assert nested.exists()
+
+
+def test_open_uses_default_when_path_is_none(tmp_path: Path, require_fts5: None) -> None:
+    """``RecallStore.open(None)`` resolves to ``default_recall_db_path()``."""
+    custom = tmp_path / "recall_default.db"
+    with patch.dict(os.environ, {"TOKENPAK_RECALL_DB": str(custom)}):
+        with RecallStore.open(None) as store:
+            assert store.path == custom
+    assert custom.exists()
+
+
+def test_default_path_respects_env_var(tmp_path: Path) -> None:
+    """The default path honours ``TOKENPAK_RECALL_DB``."""
+    target = tmp_path / "elsewhere.db"
+    with patch.dict(os.environ, {"TOKENPAK_RECALL_DB": str(target)}):
+        assert default_recall_db_path() == target
+
+
+def test_default_path_falls_back_to_companion_dir() -> None:
+    """Without the env var the default sits under ``~/.tokenpak/companion/``."""
+    env_without = {k: v for k, v in os.environ.items() if k != "TOKENPAK_RECALL_DB"}
+    with patch.dict(os.environ, env_without, clear=True):
+        path = default_recall_db_path()
+    assert path.name == "recall.db"
+    assert path.parent.name == "companion"
+
+
+def test_open_recall_store_returns_recallstore_instance(tmp_path: Path, require_fts5: None) -> None:
+    """The module-level wrapper returns a ``RecallStore``."""
+    db_path = tmp_path / "recall.db"
+    with open_recall_store(db_path) as store:
+        assert isinstance(store, RecallStore)
+
+
+def test_close_is_idempotent(tmp_path: Path, require_fts5: None) -> None:
+    """Closing twice does not raise."""
+    db_path = tmp_path / "recall.db"
+    store = RecallStore.open(db_path)
+    store.close()
+    store.close()  # must be a no-op
+
+
+def test_conn_property_exposes_underlying_connection(tmp_path: Path, require_fts5: None) -> None:
+    """``store.conn`` is the actual sqlite3 connection."""
+    import sqlite3
+
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        assert isinstance(store.conn, sqlite3.Connection)
+
+
+def test_pragmas_busy_timeout_applied(tmp_path: Path, require_fts5: None) -> None:
+    """``busy_timeout`` PRAGMA is set to 5000 ms."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        row = store.conn.execute("PRAGMA busy_timeout").fetchone()
+    assert row[0] == 5000
+
+
+def test_pragmas_synchronous_normal(tmp_path: Path, require_fts5: None) -> None:
+    """``synchronous`` PRAGMA is NORMAL (1) under WAL."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        row = store.conn.execute("PRAGMA synchronous").fetchone()
+    # 1 == NORMAL per sqlite3 docs.
+    assert row[0] == 1

--- a/tokenpak/companion/recall/__init__.py
+++ b/tokenpak/companion/recall/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Recall storage foundation (OSS Phase 1).
+
+This package owns the local-first SQLite schema and migration runner
+that the recall surface — both the OSS read paths and the Pro-tier
+resolver / scoring engine in a later phase — will read from and write
+to.
+
+PR-1 scope is the storage shape only: tables, the FTS5 virtual table,
+and the forward-only migration runner. No capture, no recall behavior,
+no ranking, no CLI. See ``schema.py`` for the DDL and ``migrations.py``
+for the runner contract.
+
+References:
+    - Standard 32 — MultiPak Pro Architecture, §5 / §6 / §9 / §13
+      (Decision #9 — recall storage foundation is OSS Phase 1).
+    - Standard 25 — Pro Tier Architecture, §1.1
+      (TIP capabilities must land in OSS before the Pro daemon can use them).
+"""
+
+from __future__ import annotations
+
+from tokenpak.companion.recall.schema import SCHEMA_VERSION
+from tokenpak.companion.recall.store import (
+    RecallStore,
+    default_recall_db_path,
+    open_recall_store,
+)
+
+__all__ = [
+    "RecallStore",
+    "SCHEMA_VERSION",
+    "default_recall_db_path",
+    "open_recall_store",
+]

--- a/tokenpak/companion/recall/migrations.py
+++ b/tokenpak/companion/recall/migrations.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Forward-only versioned migration runner for the recall store.
+
+Contract
+--------
+- Migrations are forward-only. There is no down/revert path; rolling back
+  is the user's git-history problem, not a runtime feature.
+- The runner is idempotent: re-running against an already-current database
+  is a no-op.
+- Each migration runs inside a transaction; a failure mid-migration leaves
+  the database at the previous version.
+- The ``schema_version`` table is the source of truth. A missing version
+  row is treated as version 0 (fresh database) and recovered automatically.
+
+Adding a future migration
+-------------------------
+Append a new ``Migration`` to ``MIGRATIONS`` with a version one greater
+than the prior entry. Do not edit a published migration once it has shipped.
+
+The PR-1 schema is the union of statements in
+``tokenpak.companion.recall.schema.ALL_DDL_V1``; later PRs will add
+new migrations (e.g. promotion-candidate counters, embedding column,
+write-side FTS triggers) as additional ``Migration`` entries.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import NamedTuple
+
+from tokenpak.companion.recall.schema import ALL_DDL_V1, SCHEMA_VERSION
+
+
+class Migration(NamedTuple):
+    """One forward-only schema migration.
+
+    ``statements`` is a tuple of SQL strings that are executed in order
+    inside a single transaction with the version bump.
+    """
+
+    version: int
+    name: str
+    statements: tuple[str, ...]
+
+
+MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        version=1,
+        name="initial_schema",
+        statements=ALL_DDL_V1,
+    ),
+)
+"""Ordered tuple of all known migrations. New entries APPEND; never edit
+or reorder a published migration."""
+
+
+# Internal: separated so tests can stub ``_now_iso8601`` deterministically.
+def _now_iso8601() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ensure_version_row(conn: sqlite3.Connection) -> int:
+    """Make sure ``schema_version`` has the singleton row; return current version.
+
+    A fresh database (no rows) is initialised at version 0 so the runner
+    can apply v1 through vN as normal.
+    """
+    # The table itself is created by every migration's first statement
+    # (the v1 list starts with ``CREATE TABLE IF NOT EXISTS schema_version``).
+    # But for a freshly-opened blank db we may need to create it here too,
+    # so that the version probe doesn't error before any migration runs.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            id           INTEGER PRIMARY KEY CHECK (id = 1),
+            version      INTEGER NOT NULL,
+            applied_at   TEXT    NOT NULL
+        )
+        """
+    )
+    row = conn.execute("SELECT version FROM schema_version WHERE id = 1").fetchone()
+    if row is None:
+        conn.execute(
+            "INSERT INTO schema_version (id, version, applied_at) VALUES (1, 0, ?)",
+            (_now_iso8601(),),
+        )
+        return 0
+    return int(row[0])
+
+
+def current_version(conn: sqlite3.Connection) -> int:
+    """Return the schema version currently applied to ``conn``.
+
+    Safe to call on a brand-new database — returns 0 and ensures the
+    ``schema_version`` row exists for future writers.
+    """
+    return _ensure_version_row(conn)
+
+
+def apply_migrations(conn: sqlite3.Connection) -> int:
+    """Apply any pending migrations and return the final schema version.
+
+    Idempotent — calling against an up-to-date database returns immediately
+    without writes. Each migration runs inside its own transaction; a
+    failure leaves the database at the previous version.
+    """
+    # Use deferred transactions; we explicitly BEGIN/COMMIT per migration.
+    conn.isolation_level = None  # autocommit so BEGIN is explicit
+
+    version = _ensure_version_row(conn)
+    last_known = MIGRATIONS[-1].version if MIGRATIONS else 0
+    if version > last_known:  # someone ran a newer build, then downgraded
+        return version
+    if version == last_known:
+        return version
+
+    for migration in MIGRATIONS:
+        if migration.version <= version:
+            continue
+        try:
+            conn.execute("BEGIN")
+            for stmt in migration.statements:
+                conn.execute(stmt)
+            conn.execute(
+                "UPDATE schema_version SET version = ?, applied_at = ? WHERE id = 1",
+                (migration.version, _now_iso8601()),
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            # SQLite raises if there's nothing to roll back, so be defensive.
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+        version = migration.version
+
+    return version
+
+
+__all__ = [
+    "Migration",
+    "MIGRATIONS",
+    "SCHEMA_VERSION",
+    "apply_migrations",
+    "current_version",
+]

--- a/tokenpak/companion/recall/schema.py
+++ b/tokenpak/companion/recall/schema.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DDL for the recall storage foundation.
+
+This module is intentionally pure data: no I/O, no connections, no logic.
+Migrations import these constants; the migration runner is the only writer.
+
+Schema shape (PR 1 — foundation only, no recall behavior):
+- ``schema_version`` — single-row pin for the migration runner.
+- ``paks``           — metadata index for Pak records (no full content).
+- ``paks_fts``       — FTS5 virtual table over title + summary (foundation only;
+                       PR 1 leaves the table empty — write triggers land later).
+- ``pak_anchors``    — anchor refs into source files / symbols / URLs.
+- ``pak_relations``  — supersession + dependency edges.
+
+Privacy: full Pak content lives outside this index. Only metadata, a
+short title, and a short summary may sit here. The FTS index is
+external-content-free for the same reason.
+
+References (architecture):
+    - MultiPak Pro Architecture standard, sections on the recall model,
+      context delivery levels, phasing, and Decision #9.
+    - Pro Tier Architecture standard, section 1.1: TIP capabilities must
+      land in the open-source surface before the Pro-tier daemon can
+      consume them.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SCHEMA_VERSION: Final[int] = 1
+"""Latest schema version applied by the current code."""
+
+
+SQL_CREATE_SCHEMA_VERSION: Final[str] = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    id           INTEGER PRIMARY KEY CHECK (id = 1),
+    version      INTEGER NOT NULL,
+    applied_at   TEXT    NOT NULL
+)
+""".strip()
+
+
+SQL_CREATE_PAKS: Final[str] = """
+CREATE TABLE IF NOT EXISTS paks (
+    pak_id           TEXT    PRIMARY KEY,
+    pak_type         TEXT    NOT NULL,
+    project          TEXT,
+    topic            TEXT,
+    source_type      TEXT    NOT NULL,
+    authority        TEXT    NOT NULL,
+    title            TEXT    NOT NULL,
+    summary          TEXT    NOT NULL DEFAULT '',
+    content_hash     TEXT    NOT NULL,
+    created_at       TEXT    NOT NULL,
+    updated_at       TEXT    NOT NULL,
+    superseded_by    TEXT REFERENCES paks(pak_id) ON DELETE SET NULL
+)
+""".strip()
+
+
+SQL_CREATE_PAKS_FTS: Final[str] = """
+CREATE VIRTUAL TABLE IF NOT EXISTS paks_fts USING fts5(
+    pak_id UNINDEXED,
+    title,
+    summary,
+    tokenize='unicode61 remove_diacritics 2'
+)
+""".strip()
+
+
+SQL_CREATE_PAK_ANCHORS: Final[str] = """
+CREATE TABLE IF NOT EXISTS pak_anchors (
+    pak_id        TEXT NOT NULL REFERENCES paks(pak_id) ON DELETE CASCADE,
+    anchor_id     TEXT NOT NULL,
+    source_path   TEXT NOT NULL,
+    kind          TEXT NOT NULL,
+    PRIMARY KEY (pak_id, anchor_id)
+)
+""".strip()
+
+
+SQL_CREATE_PAK_RELATIONS: Final[str] = """
+CREATE TABLE IF NOT EXISTS pak_relations (
+    pak_id          TEXT NOT NULL REFERENCES paks(pak_id) ON DELETE CASCADE,
+    related_pak_id  TEXT NOT NULL REFERENCES paks(pak_id) ON DELETE CASCADE,
+    relation_type   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    PRIMARY KEY (pak_id, related_pak_id, relation_type)
+)
+""".strip()
+
+
+SQL_CREATE_INDEXES: Final[tuple[str, ...]] = (
+    "CREATE INDEX IF NOT EXISTS idx_paks_project       ON paks(project)",
+    "CREATE INDEX IF NOT EXISTS idx_paks_topic         ON paks(topic)",
+    "CREATE INDEX IF NOT EXISTS idx_paks_pak_type      ON paks(pak_type)",
+    "CREATE INDEX IF NOT EXISTS idx_paks_updated       ON paks(updated_at)",
+    "CREATE INDEX IF NOT EXISTS idx_paks_content_hash  ON paks(content_hash)",
+    "CREATE INDEX IF NOT EXISTS idx_pak_anchors_source ON pak_anchors(source_path)",
+    "CREATE INDEX IF NOT EXISTS idx_relations_related  ON pak_relations(related_pak_id)",
+)
+
+
+ALL_DDL_V1: Final[tuple[str, ...]] = (
+    SQL_CREATE_SCHEMA_VERSION,
+    SQL_CREATE_PAKS,
+    SQL_CREATE_PAKS_FTS,
+    SQL_CREATE_PAK_ANCHORS,
+    SQL_CREATE_PAK_RELATIONS,
+    *SQL_CREATE_INDEXES,
+)
+"""All statements that make up the v1 schema, applied in order.
+
+Each statement is independently idempotent (``IF NOT EXISTS``), so a
+partial application is recoverable by re-running the same list.
+"""
+
+
+EXPECTED_TABLES_V1: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "paks",
+        "paks_fts",
+        "pak_anchors",
+        "pak_relations",
+    }
+)
+"""Tables (and the FTS5 virtual table) that must exist after v1 is applied."""
+
+
+EXPECTED_INDEXES_V1: Final[frozenset[str]] = frozenset(
+    {
+        "idx_paks_project",
+        "idx_paks_topic",
+        "idx_paks_pak_type",
+        "idx_paks_updated",
+        "idx_paks_content_hash",
+        "idx_pak_anchors_source",
+        "idx_relations_related",
+    }
+)
+"""Named indexes that must exist after v1 is applied."""

--- a/tokenpak/companion/recall/store.py
+++ b/tokenpak/companion/recall/store.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``RecallStore`` — opens (and lazily migrates) the recall storage database.
+
+PR-1 surface
+------------
+This module is intentionally minimal. It exposes:
+
+- ``RecallStore`` — a thin wrapper around an ``sqlite3.Connection`` that
+  knows how to open the file, apply PRAGMAs, run any pending migrations,
+  and close. The underlying connection is exposed as ``self.conn`` for
+  later PRs to attach read/write helpers without changing this surface.
+- ``open_recall_store(path)`` — convenience factory that resolves the
+  default DB location when ``path`` is ``None``.
+
+Default DB path resolution
+--------------------------
+1. ``TOKENPAK_RECALL_DB`` env var (matches the broader ``tokenpak.core.paths``
+   convention).
+2. ``~/.tokenpak/companion/recall.db`` (companion subsystem default,
+   matching ``journal.db`` placement).
+
+The parent directory is created on first open.
+
+Concurrency
+-----------
+WAL is enabled so concurrent readers don't block writers. A 5-second
+``busy_timeout`` covers transient lock contention. ``foreign_keys`` is
+on so cascade behaviour from the schema fires as expected.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from types import TracebackType
+from typing import Optional
+
+from tokenpak.companion.recall.migrations import apply_migrations, current_version
+from tokenpak.companion.recall.schema import SCHEMA_VERSION
+
+_DEFAULT_REL_PATH = ".tokenpak/companion/recall.db"
+_ENV_VAR = "TOKENPAK_RECALL_DB"
+
+
+def default_recall_db_path() -> Path:
+    """Resolve the default recall DB path, honouring the env override."""
+    if override := os.environ.get(_ENV_VAR):
+        return Path(override).expanduser()
+    return Path.home() / _DEFAULT_REL_PATH
+
+
+class RecallStore:
+    """Recall storage handle.
+
+    Open via :meth:`RecallStore.open` (or the module-level
+    :func:`open_recall_store`). The instance is a context manager so
+    callers can ``with RecallStore.open() as store: ...`` and have the
+    connection closed deterministically.
+    """
+
+    def __init__(self, conn: sqlite3.Connection, path: Path) -> None:
+        # Direct construction is allowed but ``open`` is the supported path.
+        self._conn = conn
+        self._path = path
+
+    @classmethod
+    def open(cls, path: Optional[Path] = None) -> "RecallStore":
+        """Open (and migrate if needed) the recall store at ``path``.
+
+        If ``path`` is ``None``, the default location is used.
+        """
+        resolved = path if path is not None else default_recall_db_path()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+
+        conn = sqlite3.connect(str(resolved))
+        try:
+            cls._apply_pragmas(conn)
+            apply_migrations(conn)
+        except Exception:
+            conn.close()
+            raise
+
+        return cls(conn=conn, path=resolved)
+
+    @staticmethod
+    def _apply_pragmas(conn: sqlite3.Connection) -> None:
+        # ``execute`` is fine — these are session-level pragmas, not statements
+        # that need to be inside a transaction.
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA synchronous = NORMAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        """The underlying SQLite connection.
+
+        Later PRs build their query/write helpers on top of this. PR 1
+        exposes the connection as the only public surface beyond open/close.
+        """
+        return self._conn
+
+    @property
+    def path(self) -> Path:
+        """The filesystem path the store was opened at."""
+        return self._path
+
+    @property
+    def schema_version(self) -> int:
+        """The schema version currently applied to the underlying DB."""
+        return current_version(self._conn)
+
+    def close(self) -> None:
+        """Close the underlying connection.
+
+        Safe to call multiple times.
+        """
+        try:
+            self._conn.close()
+        except sqlite3.ProgrammingError:
+            # Already closed — fine.
+            pass
+
+    # Context-manager sugar -------------------------------------------------
+
+    def __enter__(self) -> "RecallStore":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+
+def open_recall_store(path: Optional[Path] = None) -> RecallStore:
+    """Module-level convenience wrapper around :meth:`RecallStore.open`."""
+    return RecallStore.open(path)
+
+
+__all__ = [
+    "RecallStore",
+    "default_recall_db_path",
+    "open_recall_store",
+    "SCHEMA_VERSION",
+]


### PR DESCRIPTION
PR 1 of the Standard 32 §5 OSS Phase 1 recall stack.

## Scope

Storage shape only — no capture, no recall behaviour, no ranking, no CLI surface.
The §9 Class B amendment (already landed in the standard) moves this surface from
Phase 2 (Pro) to Phase 1 (OSS) per Standard 25 §1.1: TIP capabilities must land
in the open-source surface before the Pro daemon can consume them.

## What lands

Module `tokenpak/companion/recall/`:

| File            | Purpose                                                                   |
|-----------------|---------------------------------------------------------------------------|
| `schema.py`     | DDL constants (no I/O). Tables, indexes, and the FTS5 virtual table.      |
| `migrations.py` | Forward-only versioned migration runner. Idempotent, transactional.       |
| `store.py`      | `RecallStore` handle. Opens / migrates the DB and applies PRAGMAs.        |
| `__init__.py`   | Public exports: `RecallStore`, `open_recall_store`, `SCHEMA_VERSION`, ... |

Tables created at v1: `paks` (metadata only — no full content), `pak_anchors`,
`pak_relations`, `schema_version`, plus the `paks_fts` FTS5 virtual table
(inert in this PR — no triggers, no writer).

Default DB path: `~/.tokenpak/companion/recall.db`
(overridable via the `TOKENPAK_RECALL_DB` env var).

## Tests

`tests/companion/recall/` — 29 unit tests, all sub-second locally:

- Schema shape: table existence, index existence, `paks` columns, FK enforcement,
  WAL journal mode, per-statement idempotence.
- Migrations: fresh DB advances to latest, reopen is idempotent, a legacy DB
  missing the `schema_version` row is recovered, a failure mid-migration does
  not advance the version, a DB at a newer version than the running code is
  left alone.
- FTS5: extension detection (skip-clean if absent), table registration, MATCH
  returns inserted rows, `unicode61 remove_diacritics 2` tokenizer is live,
  empty index returns no rows.
- Store: parent dir is created, `path=None` resolves to the default, env var
  overrides default, module-level wrapper returns a `RecallStore`, `close()`
  is idempotent, `conn` exposes the underlying connection, `busy_timeout` is
  5000 ms, `synchronous` is NORMAL.

FTS5 tests skip cleanly with a clear reason if SQLite lacks FTS5.

## Out of scope (later PRs)

- Capture pipeline.
- Recall ranking / scoring engine.
- `/pak/*` loopback routes.
- `tokenpak pak inspect | export | import | recall | status | prune` CLI verbs.
- Embeddings.
- Encryption at rest.
- Local audit log.

## References

- Standard 32 §9 — phasing (Class B amendment already landed).
- Standard 32 §13 Decision #9 — recall storage foundation belongs in OSS Phase 1.
- Standard 25 §1.1 — TIP capabilities land in OSS before the Pro daemon uses them.

## Release / versioning

No release tag with this PR. Initiative-completion versioning waits for the
full Phase 1 OSS bundle.
