### PR TITLE
feat(companion/recall): OSS write API + FTS triggers

### DIFF
--- a/tests/companion/recall/test_fts_triggers.py
+++ b/tests/companion/recall/test_fts_triggers.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FTS5 shadow-table triggers introduced in migration v2.
+
+The triggers maintain ``paks_fts`` in lockstep with ``paks``. These tests
+fire the triggers via both the ``RecallStore.upsert_pak`` write path and
+direct SQL on the ``paks`` table to prove the contract is at the schema
+layer, not at the API layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import RecallStore
+
+
+def _fts_pak_ids(store: RecallStore) -> list[str]:
+    rows = store.conn.execute("SELECT pak_id FROM paks_fts").fetchall()
+    return sorted(r[0] for r in rows)
+
+
+def _match(store: RecallStore, term: str) -> list[str]:
+    rows = store.conn.execute(
+        "SELECT pak_id FROM paks_fts WHERE paks_fts MATCH ?", (term,)
+    ).fetchall()
+    return sorted(r[0] for r in rows)
+
+
+def _full_row() -> dict[str, str]:
+    return {
+        "pak_id": "vault://block/credential",
+        "pak_type": "vault",
+        "source_type": "doc",
+        "authority": "llm_generated",
+        "title": "router-not-vault credential architecture",
+        "content_hash": "ab" * 16,
+        "summary": "Single refresh-owner pattern across providers.",
+        "project": "tokenpak",
+        "topic": "creds",
+    }
+
+
+# ----- Trigger expectations on the schema -----------------------------------
+
+def test_v2_triggers_are_registered(tmp_path: Path, require_fts5: None) -> None:
+    """The three v2 triggers are present on a freshly-opened store."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        names = {
+            r[0]
+            for r in store.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            ).fetchall()
+        }
+    assert {"paks_ai_fts", "paks_au_fts", "paks_ad_fts"}.issubset(names)
+
+
+# ----- Insert path (via upsert_pak) ----------------------------------------
+
+def test_upsert_pak_populates_fts(tmp_path: Path, require_fts5: None) -> None:
+    """``upsert_pak`` inserts a paks row → FTS row appears via the trigger."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_full_row())
+        ids = _fts_pak_ids(store)
+        hits = _match(store, "credential")
+    assert ids == ["vault://block/credential"]
+    assert hits == ["vault://block/credential"]
+
+
+# ----- Insert path (via raw SQL) -------------------------------------------
+
+def test_raw_insert_into_paks_populates_fts(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A direct ``INSERT INTO paks`` also fires the AFTER INSERT trigger."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.conn.execute(
+            "INSERT INTO paks ("
+            "pak_id, pak_type, source_type, authority, "
+            "title, summary, content_hash, created_at, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "vault://block/raw",
+                "vault",
+                "doc",
+                "llm_generated",
+                "raw insert with token",
+                "raw summary",
+                "11" * 16,
+                "2026-05-11T00:00:00Z",
+                "2026-05-11T00:00:00Z",
+            ),
+        )
+        store.conn.commit()
+        ids = _fts_pak_ids(store)
+        hits = _match(store, "token")
+    assert ids == ["vault://block/raw"]
+    assert hits == ["vault://block/raw"]
+
+
+# ----- Update path ---------------------------------------------------------
+
+def test_upsert_body_change_updates_fts_content(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Updating title/summary via ``upsert_pak`` rewrites the FTS row."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_full_row())
+        revised = _full_row()
+        revised["content_hash"] = "cd" * 16
+        revised["title"] = "router-not-vault — revised"
+        revised["summary"] = "completely different summary mentioning rotation"
+        store.upsert_pak(**revised)
+        ids = _fts_pak_ids(store)
+        old_hits = _match(store, "Single")
+        new_hits = _match(store, "rotation")
+    assert ids == ["vault://block/credential"]
+    # The original summary mentioned "Single"; after replacement it should not.
+    assert old_hits == []
+    assert new_hits == ["vault://block/credential"]
+
+
+def test_raw_update_of_title_only_rewrites_fts(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A direct ``UPDATE paks SET title=?`` fires the column-filtered trigger."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_full_row())
+        store.conn.execute(
+            "UPDATE paks SET title = ? WHERE pak_id = ?",
+            ("new heading only", "vault://block/credential"),
+        )
+        store.conn.commit()
+        hits_new = _match(store, "heading")
+        # ``router`` would still match the new title's "router…heading"
+        # phrasing if FTS hadn't been rewritten, but the original token
+        # ``architecture`` would not — use the more distinctive token.
+        hits_old = _match(store, "architecture")
+    assert hits_new == ["vault://block/credential"]
+    assert hits_old == []
+
+
+def test_unrelated_column_update_does_not_rewrite_fts(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Updating only ``project`` must not delete the FTS row.
+
+    The ``AFTER UPDATE OF title, summary`` filter means an unrelated
+    update is silent for the FTS shadow. The row is still searchable.
+    """
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_full_row())
+        store.conn.execute(
+            "UPDATE paks SET project = ? WHERE pak_id = ?",
+            ("different-project", "vault://block/credential"),
+        )
+        store.conn.commit()
+        hits = _match(store, "credential")
+    assert hits == ["vault://block/credential"]
+
+
+# ----- Delete path ---------------------------------------------------------
+
+def test_delete_from_paks_removes_fts_row(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """``DELETE FROM paks WHERE pak_id = ?`` fires the AFTER DELETE trigger."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_full_row())
+        assert _fts_pak_ids(store) == ["vault://block/credential"]
+        store.conn.execute(
+            "DELETE FROM paks WHERE pak_id = ?",
+            ("vault://block/credential",),
+        )
+        store.conn.commit()
+        ids = _fts_pak_ids(store)
+        hits = _match(store, "credential")
+    assert ids == []
+    assert hits == []
+
+
+# ----- Multi-row sanity ----------------------------------------------------
+
+def test_match_isolates_rows(tmp_path: Path, require_fts5: None) -> None:
+    """FTS rows are independent; deleting one row leaves siblings searchable."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        a = _full_row()
+        b = _full_row()
+        b["pak_id"] = "vault://block/other"
+        b["title"] = "unrelated cache topic"
+        b["summary"] = "different content"
+        b["content_hash"] = "ef" * 16
+        store.upsert_pak(**a)
+        store.upsert_pak(**b)
+
+        store.conn.execute(
+            "DELETE FROM paks WHERE pak_id = ?", ("vault://block/credential",)
+        )
+        store.conn.commit()
+        ids = _fts_pak_ids(store)
+        hits = _match(store, "cache")
+    assert ids == ["vault://block/other"]
+    assert hits == ["vault://block/other"]

--- a/tests/companion/recall/test_idempotency.py
+++ b/tests/companion/recall/test_idempotency.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``RecallStore.upsert_pak`` — idempotency and body-conflict behaviour."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import RecallStore
+
+_PID = "vault://block/idempotent"
+
+
+def _row() -> dict[str, str]:
+    return {
+        "pak_id": _PID,
+        "pak_type": "vault",
+        "source_type": "doc",
+        "authority": "llm_generated",
+        "title": "idempotency under content equality",
+        "content_hash": "aa" * 16,
+        "summary": "first summary",
+        "project": "tokenpak",
+        "topic": "recall",
+    }
+
+
+def test_upsert_same_content_hash_is_idempotent_count(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Calling twice with identical content_hash yields exactly one row."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(now="2026-05-11T10:00:00Z", **_row())
+        result = store.upsert_pak(now="2026-05-11T11:00:00Z", **_row())
+        n = store.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert n == 1
+    assert result.inserted is False
+    assert result.body_changed is False
+
+
+def test_upsert_same_content_hash_preserves_created_at_bumps_updated_at(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A second upsert keeps ``created_at`` and bumps ``updated_at``."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(now="2026-05-11T10:00:00Z", **_row())
+        store.upsert_pak(now="2026-05-11T11:00:00Z", **_row())
+        created, updated = store.conn.execute(
+            "SELECT created_at, updated_at FROM paks WHERE pak_id = ?",
+            (_PID,),
+        ).fetchone()
+    assert created == "2026-05-11T10:00:00Z"
+    assert updated == "2026-05-11T11:00:00Z"
+
+
+def test_upsert_idempotency_holds_across_reopen(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Re-opening the store keeps the single-row invariant."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as first:
+        first.upsert_pak(**_row())
+    with RecallStore.open(db_path) as second:
+        second.upsert_pak(**_row())
+        n = second.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert n == 1
+
+
+def test_upsert_body_changed_replaces_metadata_and_warns(
+    tmp_path: Path, require_fts5: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A differing content_hash for the same pak_id replaces metadata + warns."""
+    db_path = tmp_path / "recall.db"
+    initial = _row()
+    new = _row()
+    new["content_hash"] = "bb" * 16
+    new["title"] = "router-not-vault — revised"
+    new["summary"] = "second summary"
+
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(now="2026-05-11T10:00:00Z", **initial)
+        with caplog.at_level(logging.WARNING, logger="tokenpak.companion.recall.store"):
+            result = store.upsert_pak(now="2026-05-11T11:00:00Z", **new)
+
+        n = store.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+        title, summary, content_hash, created, updated = store.conn.execute(
+            "SELECT title, summary, content_hash, created_at, updated_at "
+            "FROM paks WHERE pak_id = ?",
+            (_PID,),
+        ).fetchone()
+
+    assert n == 1
+    assert result.inserted is False
+    assert result.body_changed is True
+    assert title == "router-not-vault — revised"
+    assert summary == "second summary"
+    assert content_hash == "bb" * 16
+    assert created == "2026-05-11T10:00:00Z"
+    assert updated == "2026-05-11T11:00:00Z"
+
+    # Warn-level log must mention the pak_id; the digest is short-rendered.
+    warn_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warn_records, "expected at least one WARNING record"
+    joined = "\n".join(r.getMessage() for r in warn_records)
+    assert _PID in joined
+    assert "content_hash changed" in joined
+
+
+def test_upsert_idempotent_call_does_not_emit_warning(
+    tmp_path: Path, require_fts5: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A no-change re-upsert is silent at WARNING level."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**_row())
+        with caplog.at_level(logging.WARNING, logger="tokenpak.companion.recall.store"):
+            store.upsert_pak(**_row())
+    warn_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warn_records == []
+
+
+def test_upsert_body_change_optional_fields_can_be_cleared(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Replacement allows clearing previously-set optional fields to NULL."""
+    db_path = tmp_path / "recall.db"
+    initial = _row()
+    cleared = _row()
+    cleared["content_hash"] = "cc" * 16
+    cleared["project"] = None
+    cleared["topic"] = None
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**initial)
+        store.upsert_pak(**cleared)
+        project, topic = store.conn.execute(
+            "SELECT project, topic FROM paks WHERE pak_id = ?", (_PID,)
+        ).fetchone()
+    assert project is None
+    assert topic is None

--- a/tests/companion/recall/test_migrations.py
+++ b/tests/companion/recall/test_migrations.py
@@ -123,9 +123,10 @@ def test_failure_inside_migration_does_not_advance_version(
         after = current_version(conn)
     finally:
         conn.close()
-    # The bad migration should NOT have advanced the version past v1.
+    # All clean migrations apply first, then v99 errors; the version is
+    # left at the latest clean migration (``SCHEMA_VERSION``), not past it.
     assert before == 0
-    assert after == SCHEMA_VERSION  # v1 applied before v99 errored
+    assert after == SCHEMA_VERSION
     assert after < 99
 
 
@@ -142,3 +143,70 @@ def test_db_at_newer_version_than_code_is_left_alone(tmp_path: Path, require_fts
     # Re-open with the current (older) code — must not regress.
     with RecallStore.open(db_path) as store:
         assert store.schema_version == 999
+
+
+# ----- v1 → v2 upgrade coverage --------------------------------------------
+
+def test_v2_applies_on_top_of_v1_only(tmp_path: Path, require_fts5: None) -> None:
+    """A DB seeded at v1 advances to v2 without re-running v1's DDL."""
+    db_path = tmp_path / "recall.db"
+
+    # Hand-roll a v1 database by applying only the first migration.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        only_v1 = MIGRATIONS[0]
+        conn.execute("BEGIN")
+        for stmt in only_v1.statements:
+            conn.execute(stmt)
+        # Persist the v1 schema_version row by hand so the runner doesn't
+        # start from 0 the next time around.
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version (id, version, applied_at) "
+            "VALUES (1, 1, ?)",
+            ("2026-05-11T00:00:00Z",),
+        )
+        conn.execute("COMMIT")
+        # Smoke-check the v1 state has no v2 triggers yet.
+        trig_before = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+    assert "paks_ai_fts" not in trig_before
+
+    # Now open via RecallStore: the runner should apply v2 only.
+    with RecallStore.open(db_path) as store:
+        assert store.schema_version == SCHEMA_VERSION  # i.e. 2
+        trig_after = {
+            r[0]
+            for r in store.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            ).fetchall()
+        }
+    assert {"paks_ai_fts", "paks_au_fts", "paks_ad_fts"}.issubset(trig_after)
+
+
+def test_v2_is_idempotent_on_already_v2_db(tmp_path: Path, require_fts5: None) -> None:
+    """Re-opening a v2 DB does not re-run v2 (and does not error)."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as first:
+        assert first.schema_version == SCHEMA_VERSION
+    with RecallStore.open(db_path) as second:
+        assert second.schema_version == SCHEMA_VERSION
+        trig = {
+            r[0]
+            for r in second.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            ).fetchall()
+        }
+    assert {"paks_ai_fts", "paks_au_fts", "paks_ad_fts"}.issubset(trig)
+
+
+def test_schema_version_constant_is_v2() -> None:
+    """``SCHEMA_VERSION`` should track the v2 migration head."""
+    assert SCHEMA_VERSION == 2
+    assert MIGRATIONS[-1].version == 2
+    assert MIGRATIONS[-1].name == "paks_fts_triggers"

--- a/tests/companion/recall/test_upsert.py
+++ b/tests/companion/recall/test_upsert.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``RecallStore.upsert_pak`` — happy path and validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.recall import RecallStore
+from tokenpak.companion.recall.store import UpsertResult
+
+_BASE_ROW = {
+    "pak_id": "vault://block/auth-pattern",
+    "pak_type": "vault",
+    "source_type": "doc",
+    "authority": "llm_generated",
+    "title": "router-not-vault credential architecture",
+    "content_hash": "0123456789abcdef" * 4,
+    "summary": "Single-refresh-owner invariant across providers.",
+    "project": "tokenpak",
+    "topic": "creds",
+}
+
+
+def test_upsert_inserts_new_row(tmp_path: Path, require_fts5: None) -> None:
+    """A first call inserts a row and reports ``inserted=True``."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        result = store.upsert_pak(**_BASE_ROW)
+        row = store.conn.execute(
+            "SELECT pak_id, pak_type, project, topic, source_type, authority, "
+            "title, summary, content_hash, superseded_by "
+            "FROM paks WHERE pak_id = ?",
+            (_BASE_ROW["pak_id"],),
+        ).fetchone()
+
+    assert isinstance(result, UpsertResult)
+    assert result.inserted is True
+    assert result.body_changed is False
+    assert result.pak_id == _BASE_ROW["pak_id"]
+
+    assert row == (
+        _BASE_ROW["pak_id"],
+        _BASE_ROW["pak_type"],
+        _BASE_ROW["project"],
+        _BASE_ROW["topic"],
+        _BASE_ROW["source_type"],
+        _BASE_ROW["authority"],
+        _BASE_ROW["title"],
+        _BASE_ROW["summary"],
+        _BASE_ROW["content_hash"],
+        None,  # superseded_by — left NULL when not provided
+    )
+
+
+def test_upsert_sets_timestamps(tmp_path: Path, require_fts5: None) -> None:
+    """``created_at`` and ``updated_at`` are both populated on first insert."""
+    db_path = tmp_path / "recall.db"
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(now="2026-05-11T12:00:00Z", **_BASE_ROW)
+        row = store.conn.execute(
+            "SELECT created_at, updated_at FROM paks WHERE pak_id = ?",
+            (_BASE_ROW["pak_id"],),
+        ).fetchone()
+    assert row == ("2026-05-11T12:00:00Z", "2026-05-11T12:00:00Z")
+
+
+def test_upsert_default_summary_is_empty_string(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """``summary`` defaults to ``""`` and is stored as such."""
+    db_path = tmp_path / "recall.db"
+    fields = {k: v for k, v in _BASE_ROW.items() if k != "summary"}
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**fields)
+        s = store.conn.execute(
+            "SELECT summary FROM paks WHERE pak_id = ?",
+            (_BASE_ROW["pak_id"],),
+        ).fetchone()
+    assert s == ("",)
+
+
+def test_upsert_two_distinct_paks(tmp_path: Path, require_fts5: None) -> None:
+    """Two distinct pak_ids yield two rows."""
+    db_path = tmp_path / "recall.db"
+    other = dict(_BASE_ROW)
+    other["pak_id"] = "vault://block/other"
+    other["title"] = "other heading"
+    other["content_hash"] = "feedfacecafebabe" * 4
+    with RecallStore.open(db_path) as store:
+        r1 = store.upsert_pak(**_BASE_ROW)
+        r2 = store.upsert_pak(**other)
+        n = store.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert r1.inserted is True
+    assert r2.inserted is True
+    assert n == 2
+
+
+def test_upsert_optional_fields_stored_as_null(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """``project`` / ``topic`` / ``superseded_by`` default to NULL when omitted."""
+    db_path = tmp_path / "recall.db"
+    minimal = {
+        "pak_id": "vault://block/minimal",
+        "pak_type": "vault",
+        "source_type": "doc",
+        "authority": "llm_generated",
+        "title": "minimal",
+        "content_hash": "00" * 16,
+    }
+    with RecallStore.open(db_path) as store:
+        store.upsert_pak(**minimal)
+        row = store.conn.execute(
+            "SELECT project, topic, superseded_by FROM paks WHERE pak_id = ?",
+            (minimal["pak_id"],),
+        ).fetchone()
+    assert row == (None, None, None)
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "pak_id",
+        "pak_type",
+        "source_type",
+        "authority",
+        "title",
+        "content_hash",
+    ],
+)
+def test_upsert_missing_required_field_raises(
+    tmp_path: Path, require_fts5: None, missing: str
+) -> None:
+    """An empty / whitespace required field raises ``ValueError``."""
+    db_path = tmp_path / "recall.db"
+    bad = dict(_BASE_ROW)
+    bad[missing] = "   "
+    with RecallStore.open(db_path) as store:
+        with pytest.raises(ValueError) as exc:
+            store.upsert_pak(**bad)
+    assert missing in str(exc.value)
+
+
+def test_upsert_failed_validation_does_not_insert(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A validation failure must not leave a row behind."""
+    db_path = tmp_path / "recall.db"
+    bad = dict(_BASE_ROW)
+    bad["title"] = ""
+    with RecallStore.open(db_path) as store:
+        with pytest.raises(ValueError):
+            store.upsert_pak(**bad)
+        n = store.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert n == 0
+
+
+def test_upsert_unknown_superseded_by_raises_integrity(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A foreign-key violation on ``superseded_by`` surfaces as IntegrityError."""
+    import sqlite3
+
+    db_path = tmp_path / "recall.db"
+    bad = dict(_BASE_ROW)
+    bad["superseded_by"] = "vault://block/does-not-exist"
+    with RecallStore.open(db_path) as store:
+        with pytest.raises(sqlite3.IntegrityError):
+            store.upsert_pak(**bad)
+        n = store.conn.execute("SELECT COUNT(*) FROM paks").fetchone()[0]
+    assert n == 0

--- a/tokenpak/companion/recall/migrations.py
+++ b/tokenpak/companion/recall/migrations.py
@@ -29,7 +29,11 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import NamedTuple
 
-from tokenpak.companion.recall.schema import ALL_DDL_V1, SCHEMA_VERSION
+from tokenpak.companion.recall.schema import (
+    ALL_DDL_V1,
+    ALL_DDL_V2_TRIGGERS,
+    SCHEMA_VERSION,
+)
 
 
 class Migration(NamedTuple):
@@ -49,6 +53,11 @@ MIGRATIONS: tuple[Migration, ...] = (
         version=1,
         name="initial_schema",
         statements=ALL_DDL_V1,
+    ),
+    Migration(
+        version=2,
+        name="paks_fts_triggers",
+        statements=ALL_DDL_V2_TRIGGERS,
     ),
 )
 """Ordered tuple of all known migrations. New entries APPEND; never edit

--- a/tokenpak/companion/recall/schema.py
+++ b/tokenpak/companion/recall/schema.py
@@ -4,11 +4,14 @@
 This module is intentionally pure data: no I/O, no connections, no logic.
 Migrations import these constants; the migration runner is the only writer.
 
-Schema shape (PR 1 — foundation only, no recall behavior):
+Schema shape:
 - ``schema_version`` — single-row pin for the migration runner.
 - ``paks``           — metadata index for Pak records (no full content).
-- ``paks_fts``       — FTS5 virtual table over title + summary (foundation only;
-                       PR 1 leaves the table empty — write triggers land later).
+- ``paks_fts``       — FTS5 virtual table over title + summary.
+- ``paks_fts`` triggers (v2) — ``AFTER INSERT|UPDATE|DELETE`` on ``paks``
+                       keep the FTS shadow in lockstep with the metadata
+                       row. The triggers are the only write-side contract
+                       between ``paks`` and ``paks_fts``.
 - ``pak_anchors``    — anchor refs into source files / symbols / URLs.
 - ``pak_relations``  — supersession + dependency edges.
 
@@ -28,7 +31,7 @@ from __future__ import annotations
 
 from typing import Final
 
-SCHEMA_VERSION: Final[int] = 1
+SCHEMA_VERSION: Final[int] = 2
 """Latest schema version applied by the current code."""
 
 
@@ -141,3 +144,60 @@ EXPECTED_INDEXES_V1: Final[frozenset[str]] = frozenset(
     }
 )
 """Named indexes that must exist after v1 is applied."""
+
+
+# v2 — FTS shadow triggers ----------------------------------------------------
+#
+# The v2 migration adds three ``AFTER`` triggers on ``paks`` that keep the
+# ``paks_fts`` shadow table consistent with the metadata row. Only ``title``
+# and ``summary`` are mirrored — those are the only FTS columns.
+#
+# The ``UPDATE`` trigger is filtered to ``OF title, summary`` so cosmetic
+# updates (``updated_at`` alone, or unrelated columns like ``project``)
+# don't rewrite the FTS row needlessly.
+
+SQL_CREATE_PAKS_AI_FTS_TRIGGER: Final[str] = """
+CREATE TRIGGER IF NOT EXISTS paks_ai_fts
+AFTER INSERT ON paks BEGIN
+    INSERT INTO paks_fts (pak_id, title, summary)
+    VALUES (NEW.pak_id, NEW.title, COALESCE(NEW.summary, ''));
+END
+""".strip()
+
+
+SQL_CREATE_PAKS_AU_FTS_TRIGGER: Final[str] = """
+CREATE TRIGGER IF NOT EXISTS paks_au_fts
+AFTER UPDATE OF title, summary ON paks BEGIN
+    DELETE FROM paks_fts WHERE pak_id = OLD.pak_id;
+    INSERT INTO paks_fts (pak_id, title, summary)
+    VALUES (NEW.pak_id, NEW.title, COALESCE(NEW.summary, ''));
+END
+""".strip()
+
+
+SQL_CREATE_PAKS_AD_FTS_TRIGGER: Final[str] = """
+CREATE TRIGGER IF NOT EXISTS paks_ad_fts
+AFTER DELETE ON paks BEGIN
+    DELETE FROM paks_fts WHERE pak_id = OLD.pak_id;
+END
+""".strip()
+
+
+ALL_DDL_V2_TRIGGERS: Final[tuple[str, ...]] = (
+    SQL_CREATE_PAKS_AI_FTS_TRIGGER,
+    SQL_CREATE_PAKS_AU_FTS_TRIGGER,
+    SQL_CREATE_PAKS_AD_FTS_TRIGGER,
+)
+"""Statements introduced by the v2 migration (FTS shadow triggers).
+
+Each statement uses ``IF NOT EXISTS`` so re-application is safe."""
+
+
+EXPECTED_TRIGGERS_V2: Final[frozenset[str]] = frozenset(
+    {
+        "paks_ai_fts",
+        "paks_au_fts",
+        "paks_ad_fts",
+    }
+)
+"""Named triggers that must exist after v2 is applied."""

--- a/tokenpak/companion/recall/store.py
+++ b/tokenpak/companion/recall/store.py
@@ -1,16 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """``RecallStore`` — opens (and lazily migrates) the recall storage database.
 
-PR-1 surface
-------------
-This module is intentionally minimal. It exposes:
+Surface
+-------
+The module exposes:
 
 - ``RecallStore`` — a thin wrapper around an ``sqlite3.Connection`` that
   knows how to open the file, apply PRAGMAs, run any pending migrations,
   and close. The underlying connection is exposed as ``self.conn`` for
-  later PRs to attach read/write helpers without changing this surface.
+  later code to attach further helpers without changing this surface.
+- ``RecallStore.upsert_pak(...)`` — metadata-only write path. Inserts a
+  new row keyed on ``pak_id`` or replaces the existing row's metadata
+  in place. The v2 FTS triggers keep ``paks_fts`` consistent.
 - ``open_recall_store(path)`` — convenience factory that resolves the
   default DB location when ``path`` is ``None``.
+- ``UpsertResult`` — NamedTuple describing the outcome of an upsert.
+
+This module does *not* expose any read / query / recall surface; that
+is deferred to a later phase.
 
 Default DB path resolution
 --------------------------
@@ -30,17 +37,53 @@ on so cascade behaviour from the schema fires as expected.
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from tokenpak.companion.recall.migrations import apply_migrations, current_version
 from tokenpak.companion.recall.schema import SCHEMA_VERSION
 
 _DEFAULT_REL_PATH = ".tokenpak/companion/recall.db"
 _ENV_VAR = "TOKENPAK_RECALL_DB"
+
+_log = logging.getLogger(__name__)
+
+
+# Required (non-empty, non-whitespace) fields on ``upsert_pak``.
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "pak_id",
+    "pak_type",
+    "source_type",
+    "authority",
+    "title",
+    "content_hash",
+)
+
+
+class UpsertResult(NamedTuple):
+    """The outcome of a single :meth:`RecallStore.upsert_pak` call.
+
+    Attributes:
+        pak_id: The stable identity the row was written under.
+        inserted: ``True`` if the row was newly created; ``False`` if an
+            existing row was updated in place.
+        body_changed: ``True`` iff an existing row's ``content_hash``
+            differed from the incoming value. Always ``False`` when
+            ``inserted`` is ``True``.
+    """
+
+    pak_id: str
+    inserted: bool
+    body_changed: bool
+
+
+def _utc_now_iso8601() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def default_recall_db_path() -> Path:
@@ -111,6 +154,163 @@ class RecallStore:
         """The schema version currently applied to the underlying DB."""
         return current_version(self._conn)
 
+    # Metadata write surface ------------------------------------------------
+
+    def upsert_pak(
+        self,
+        *,
+        pak_id: str,
+        pak_type: str,
+        source_type: str,
+        authority: str,
+        title: str,
+        content_hash: str,
+        summary: str = "",
+        project: Optional[str] = None,
+        topic: Optional[str] = None,
+        superseded_by: Optional[str] = None,
+        now: Optional[str] = None,
+    ) -> UpsertResult:
+        """Insert or update a single Pak metadata row.
+
+        The write is keyed on ``pak_id`` — that is the stable external
+        identity callers use to address a Pak. Behaviour:
+
+        - **No existing row** → INSERT. ``created_at`` and ``updated_at``
+          are both set to ``now`` (or the current UTC time if ``now``
+          is omitted).
+        - **Existing row, identical ``content_hash``** → metadata-only
+          UPDATE. ``created_at`` is preserved; ``updated_at`` is bumped.
+        - **Existing row, different ``content_hash``** → UPDATE that
+          replaces metadata and bumps ``content_hash`` / ``updated_at``.
+          A warning is emitted (``logging.WARNING``) because the source
+          object changed under the same identity; downstream audit /
+          versioning lands in a later PR.
+
+        Required (non-empty) fields are listed in ``_REQUIRED_FIELDS``;
+        ``ValueError`` is raised if any are missing or all-whitespace.
+
+        The FTS5 shadow is kept consistent by the v2 triggers — callers
+        do not write to ``paks_fts`` directly.
+
+        Parameters:
+            pak_id: Stable Pak identity (e.g. ``vault://block/foo``).
+            pak_type: Kind of Pak (e.g. ``vault``, ``code``).
+            source_type: Source classification (e.g. ``code``, ``doc``).
+            authority: Authority label for the source.
+            title: Short heading; indexed in FTS.
+            content_hash: Hex digest of the underlying body bytes.
+            summary: Short summary; indexed in FTS. Defaults to ``""``.
+            project: Optional project tag.
+            topic: Optional topic tag.
+            superseded_by: Optional ``pak_id`` of a superseding row.
+            now: Optional ISO-8601 UTC string for deterministic testing.
+
+        Returns:
+            :class:`UpsertResult` describing what happened.
+
+        Raises:
+            ValueError: One of the required fields was missing /
+                empty / whitespace-only.
+            sqlite3.IntegrityError: A FK constraint failed (e.g. an
+                unknown ``superseded_by``).
+        """
+        # Validation -------------------------------------------------------
+        values = {
+            "pak_id": pak_id,
+            "pak_type": pak_type,
+            "source_type": source_type,
+            "authority": authority,
+            "title": title,
+            "content_hash": content_hash,
+        }
+        for name in _REQUIRED_FIELDS:
+            v = values[name]
+            if v is None or not isinstance(v, str) or not v.strip():
+                raise ValueError(
+                    f"upsert_pak: required field {name!r} must be a non-empty string"
+                )
+        if summary is None:
+            summary = ""
+
+        ts = now if now is not None else _utc_now_iso8601()
+        conn = self._conn
+
+        # Transaction ------------------------------------------------------
+        # ``apply_migrations`` leaves the connection in autocommit mode
+        # (``isolation_level=None``); make BEGIN explicit so the lookup +
+        # write happen atomically and the FTS triggers fire as one unit.
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT content_hash FROM paks WHERE pak_id = ?",
+                (pak_id,),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO paks ("
+                    "pak_id, pak_type, project, topic, source_type, authority, "
+                    "title, summary, content_hash, created_at, updated_at, superseded_by"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        pak_id,
+                        pak_type,
+                        project,
+                        topic,
+                        source_type,
+                        authority,
+                        title,
+                        summary,
+                        content_hash,
+                        ts,
+                        ts,
+                        superseded_by,
+                    ),
+                )
+                inserted = True
+                body_changed = False
+            else:
+                old_hash = row[0]
+                body_changed = old_hash != content_hash
+                conn.execute(
+                    "UPDATE paks SET "
+                    "pak_type = ?, project = ?, topic = ?, source_type = ?, "
+                    "authority = ?, title = ?, summary = ?, content_hash = ?, "
+                    "updated_at = ?, superseded_by = ? "
+                    "WHERE pak_id = ?",
+                    (
+                        pak_type,
+                        project,
+                        topic,
+                        source_type,
+                        authority,
+                        title,
+                        summary,
+                        content_hash,
+                        ts,
+                        superseded_by,
+                        pak_id,
+                    ),
+                )
+                inserted = False
+                if body_changed:
+                    _log.warning(
+                        "recall.upsert_pak: content_hash changed for pak_id=%s "
+                        "(old=%s new=%s); replacing metadata in place.",
+                        pak_id,
+                        _short_hash(old_hash),
+                        _short_hash(content_hash),
+                    )
+            conn.execute("COMMIT")
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            raise
+
+        return UpsertResult(pak_id=pak_id, inserted=inserted, body_changed=body_changed)
+
     def close(self) -> None:
         """Close the underlying connection.
 
@@ -141,8 +341,15 @@ def open_recall_store(path: Optional[Path] = None) -> RecallStore:
     return RecallStore.open(path)
 
 
+def _short_hash(value: object) -> str:
+    """Render a hash for log lines without leaking the whole digest."""
+    s = "" if value is None else str(value)
+    return s[:12] + ("…" if len(s) > 12 else "")
+
+
 __all__ = [
     "RecallStore",
+    "UpsertResult",
     "default_recall_db_path",
     "open_recall_store",
     "SCHEMA_VERSION",


### PR DESCRIPTION
## Summary

OSS-Phase-1 storage-foundation write half for the local-first context-continuity feature set. Builds on the schema landed in #15-equivalent (`9a3f549be8`) by adding the metadata write API + FTS5 shadow triggers.

## Changes

- **`RecallStore.upsert_pak(...)`** — caller-driven metadata-only write path keyed on `pak_id`. Three branches: INSERT on no-existing-row, metadata-only UPDATE on identical `content_hash` (preserves `created_at`, bumps `updated_at`), or UPDATE-with-`WARNING`-log when `content_hash` differs under the same identity (the source object changed; downstream versioning lands later). Returns `UpsertResult(pak_id, inserted, body_changed)`.
- **Migration v2** — three `AFTER` triggers on `paks` keep `paks_fts` in lockstep:
  - `paks_ai_fts` (`AFTER INSERT`) — populate FTS row
  - `paks_au_fts` (`AFTER UPDATE OF title, summary`) — DELETE + INSERT (canonical FTS5 shadow pattern); column-filtered so cosmetic updates don't churn the index
  - `paks_ad_fts` (`AFTER DELETE`) — drop FTS row
  - Schema version 1 → 2. Forward-only and idempotent (`IF NOT EXISTS`).
- **Validation** — required fields (`pak_id`, `pak_type`, `source_type`, `authority`, `title`, `content_hash`) raise `ValueError` on missing / empty / whitespace-only, **before** the transaction opens, so a validation failure leaves no row behind.
- **Atomicity** — `BEGIN IMMEDIATE` makes lookup + write atomic and ensures the FTS triggers fire as one unit.

## Scope (deliberately narrow)

This PR does **not** introduce any of:

- recall / query / search API
- ranking / scoring
- capture pipeline / event listener / orchestrator
- `tokenpak pak recall|status|prune` CLI verbs
- `/pak/*` HTTP routes
- `tokenpak pak inspect|export|import` CLI verbs
- embedding column / encryption / audit log / sensitive-block-list
- cloud / sync / team behavior

CLI surface unchanged (`generate-cli-docs.py` zero-diff).

## Verification

- `pytest tests/companion/recall/ -q` → **59 passed** (27.10 s)
- `ruff check tokenpak/companion/recall/ tests/companion/recall/` → clean
- `python3 scripts/generate-cli-docs.py` → zero diff vs tracked tree
- Identity-language scan on diff → clean
- Public-layout / no-Pro-leakage scan on diff → clean

30 new tests:

- `tests/companion/recall/test_upsert.py` — 8 (happy path, defaults, validation matrix, FK violation)
- `tests/companion/recall/test_idempotency.py` — 6 (count invariance, timestamp behavior, persistence across reopen, body-change `WARNING`, optional-fields cleared)
- `tests/companion/recall/test_fts_triggers.py` — 8 (trigger registration, insert + update + delete via both API and raw SQL, column-filter, multi-row isolation)
- `tests/companion/recall/test_migrations.py` — 4 added (v1→v2 upgrade, v2 idempotency, `SCHEMA_VERSION == 2` invariant)

## Commit

`feat(companion/recall): OSS write API + FTS triggers` (squashed)

Author + committer: TokenPak (hello@tokenpak.ai).
