### PR TITLE
feat(pak): /pak/v1/list cursor pagination + OSS-safe inspect fallback

### DIFF
--- a/tests/companion/recall/test_read_helpers.py
+++ b/tests/companion/recall/test_read_helpers.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``RecallStore.list_paks`` and ``RecallStore.get_pak`` — read coverage.
+
+Storage-level tests for the OSS read surface introduced alongside the
+``/pak/v1/list`` endpoint. The HTTP layer has its own coverage; this
+module verifies the SQL-level behaviour the endpoint depends on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tokenpak.companion.recall import (
+    LIST_LIMIT_DEFAULT,
+    LIST_LIMIT_MAX,
+    PakListFilters,
+    PakRow,
+    RecallStore,
+)
+
+
+def _seed(store: RecallStore, *rows: dict[str, Any]) -> None:
+    """Insert each row via ``upsert_pak``; ``now`` controls ordering."""
+    for r in rows:
+        store.upsert_pak(**r)
+
+
+def _row(
+    pak_id: str,
+    *,
+    now: str,
+    pak_type: str = "vault",
+    project: str | None = "alpha",
+    source_type: str = "doc",
+    authority: str = "llm_generated",
+    title: str | None = None,
+    content_hash: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "pak_id": pak_id,
+        "pak_type": pak_type,
+        "source_type": source_type,
+        "authority": authority,
+        "title": title or f"title-{pak_id}",
+        "content_hash": content_hash or (pak_id * 4)[:32],
+        "project": project,
+        "now": now,
+    }
+
+
+# ---------------------------------------------------------------------------
+# list_paks — empty / basic / ordering
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty_store(tmp_path: Path, require_fts5: None) -> None:
+    """Listing an empty store yields zero items, no cursor, not truncated."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        result = store.list_paks()
+
+    assert result.items == []
+    assert result.next_cursor is None
+    assert result.truncated is False
+    assert result.limit == LIST_LIMIT_DEFAULT
+
+
+def test_list_returns_rows_newest_first(tmp_path: Path, require_fts5: None) -> None:
+    """Rows are ordered by ``updated_at DESC, pak_id DESC``."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z"),
+            _row("b", now="2026-05-11T10:02:00Z"),
+            _row("c", now="2026-05-11T10:01:00Z"),
+        )
+        result = store.list_paks()
+
+    assert [r.pak_id for r in result.items] == ["b", "c", "a"]
+    assert all(isinstance(r, PakRow) for r in result.items)
+    assert result.truncated is False
+    assert result.next_cursor is None
+
+
+def test_list_tiebreak_by_pak_id_desc(tmp_path: Path, require_fts5: None) -> None:
+    """Within the same ``updated_at`` rows tiebreak by ``pak_id DESC``."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a1", now="2026-05-11T10:00:00Z"),
+            _row("a2", now="2026-05-11T10:00:00Z"),
+            _row("a3", now="2026-05-11T10:00:00Z"),
+        )
+        result = store.list_paks()
+
+    assert [r.pak_id for r in result.items] == ["a3", "a2", "a1"]
+
+
+# ---------------------------------------------------------------------------
+# list_paks — filters
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_pak_type_byte_literal(tmp_path: Path, require_fts5: None) -> None:
+    """``pak_type`` filter is byte-literal — no alias / casefold."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z", pak_type="vault"),
+            _row("b", now="2026-05-11T10:01:00Z", pak_type="interaction"),
+            _row("c", now="2026-05-11T10:02:00Z", pak_type="vault"),
+            _row("d", now="2026-05-11T10:03:00Z", pak_type="decision"),
+        )
+
+        only_vault = store.list_paks(PakListFilters(pak_type="vault"))
+        only_interaction = store.list_paks(PakListFilters(pak_type="interaction"))
+        # Alias check — the legacy "project" name is NOT translated to "vault"
+        # by this layer. The filter matches literally; zero rows have that value.
+        alias_attempt = store.list_paks(PakListFilters(pak_type="project"))
+        # Casefold check — "VAULT" does not match "vault" byte-literally.
+        casefold_attempt = store.list_paks(PakListFilters(pak_type="VAULT"))
+
+    assert [r.pak_id for r in only_vault.items] == ["c", "a"]
+    assert [r.pak_id for r in only_interaction.items] == ["b"]
+    assert alias_attempt.items == []
+    assert casefold_attempt.items == []
+
+
+def test_filter_by_project_byte_literal(tmp_path: Path, require_fts5: None) -> None:
+    """``project`` filter is byte-literal too."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z", project="alpha"),
+            _row("b", now="2026-05-11T10:01:00Z", project="beta"),
+            _row("c", now="2026-05-11T10:02:00Z", project="alpha"),
+            _row("d", now="2026-05-11T10:03:00Z", project=None),
+        )
+
+        only_alpha = store.list_paks(PakListFilters(project="alpha"))
+        only_beta = store.list_paks(PakListFilters(project="beta"))
+
+    assert [r.pak_id for r in only_alpha.items] == ["c", "a"]
+    assert [r.pak_id for r in only_beta.items] == ["b"]
+
+
+def test_filters_compose_with_and(tmp_path: Path, require_fts5: None) -> None:
+    """Multiple filters compose with logical AND."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z", pak_type="vault", project="alpha"),
+            _row("b", now="2026-05-11T10:01:00Z", pak_type="vault", project="beta"),
+            _row("c", now="2026-05-11T10:02:00Z", pak_type="interaction", project="alpha"),
+        )
+        result = store.list_paks(PakListFilters(pak_type="vault", project="alpha"))
+
+    assert [r.pak_id for r in result.items] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# list_paks — limit, cap, truncation
+# ---------------------------------------------------------------------------
+
+
+def test_default_limit_is_default(tmp_path: Path, require_fts5: None) -> None:
+    """The default ``PakListFilters`` reports the default limit in the result."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        result = store.list_paks()
+    assert result.limit == LIST_LIMIT_DEFAULT
+
+
+def test_limit_clamps_to_max(tmp_path: Path, require_fts5: None) -> None:
+    """A caller asking for more than the max is silently clamped."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        result = store.list_paks(PakListFilters(limit=999_999))
+    assert result.limit == LIST_LIMIT_MAX
+    # Defensive: the cap is 100 today; if that changes, this assertion shows it.
+    assert result.limit == 100
+
+
+def test_non_positive_limit_falls_back_to_default(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Zero or negative limits at the API edge default; the HTTP layer rejects."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        result_zero = store.list_paks(PakListFilters(limit=0))
+        result_neg = store.list_paks(PakListFilters(limit=-5))
+    assert result_zero.limit == LIST_LIMIT_DEFAULT
+    assert result_neg.limit == LIST_LIMIT_DEFAULT
+
+
+def test_truncation_flag_and_cursor(tmp_path: Path, require_fts5: None) -> None:
+    """When more rows match than the page returns, truncated=True + cursor set."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z"),
+            _row("b", now="2026-05-11T10:01:00Z"),
+            _row("c", now="2026-05-11T10:02:00Z"),
+            _row("d", now="2026-05-11T10:03:00Z"),
+        )
+        page1 = store.list_paks(PakListFilters(limit=2))
+
+    assert [r.pak_id for r in page1.items] == ["d", "c"]
+    assert page1.truncated is True
+    assert page1.next_cursor is not None
+    assert page1.limit == 2
+
+
+def test_cursor_resumes_at_next_row(tmp_path: Path, require_fts5: None) -> None:
+    """Passing back ``next_cursor`` yields the rows the previous page did not."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(
+            store,
+            _row("a", now="2026-05-11T10:00:00Z"),
+            _row("b", now="2026-05-11T10:01:00Z"),
+            _row("c", now="2026-05-11T10:02:00Z"),
+            _row("d", now="2026-05-11T10:03:00Z"),
+        )
+        page1 = store.list_paks(PakListFilters(limit=2))
+        page2 = store.list_paks(PakListFilters(limit=2, cursor=page1.next_cursor))
+
+    assert [r.pak_id for r in page1.items] == ["d", "c"]
+    assert [r.pak_id for r in page2.items] == ["b", "a"]
+    assert page2.truncated is False
+    assert page2.next_cursor is None
+
+
+def test_invalid_cursor_raises_value_error(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """A malformed cursor surfaces as ``ValueError`` — the HTTP layer maps to 400."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        with pytest.raises(ValueError):
+            store.list_paks(PakListFilters(cursor="not-a-real-cursor!!!"))
+
+
+# ---------------------------------------------------------------------------
+# get_pak
+# ---------------------------------------------------------------------------
+
+
+def test_get_pak_hit(tmp_path: Path, require_fts5: None) -> None:
+    """``get_pak`` returns a fully-populated :class:`PakRow` on hit."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        _seed(store, _row("a", now="2026-05-11T10:00:00Z", project="alpha"))
+        row = store.get_pak("a")
+
+    assert row is not None
+    assert isinstance(row, PakRow)
+    assert row.pak_id == "a"
+    assert row.project == "alpha"
+    assert row.pak_type == "vault"
+
+
+def test_get_pak_miss(tmp_path: Path, require_fts5: None) -> None:
+    """``get_pak`` returns ``None`` when the row does not exist."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        assert store.get_pak("never-inserted") is None
+
+
+def test_get_pak_empty_inputs_are_misses(
+    tmp_path: Path, require_fts5: None
+) -> None:
+    """Empty / whitespace ``pak_id`` short-circuits to ``None`` without a SELECT."""
+    with RecallStore.open(tmp_path / "recall.db") as store:
+        assert store.get_pak("") is None
+        assert store.get_pak("   ") is None

--- a/tests/proxy/conftest.py
+++ b/tests/proxy/conftest.py
@@ -15,12 +15,41 @@ from __future__ import annotations
 
 import json
 import socket
+import sqlite3
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Generator
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# FTS5 availability — shared with the /pak/v1/list HTTP coverage which opens
+# RecallStore (FTS5 virtual table is created at open time).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def fts5_available() -> bool:
+    """``True`` iff the linked SQLite build has FTS5 compiled in."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+    return True
+
+
+@pytest.fixture
+def require_fts5(fts5_available: bool) -> None:
+    """Skip a /pak/v1/list test that needs FTS5 when it isn't compiled in."""
+    if not fts5_available:
+        pytest.skip(
+            "FTS5 extension not compiled into this SQLite build; "
+            "skipping /pak/v1/list HTTP coverage that opens RecallStore."
+        )
 
 # ---------------------------------------------------------------------------
 # Paths to canned fixture responses

--- a/tests/proxy/test_pak_endpoints.py
+++ b/tests/proxy/test_pak_endpoints.py
@@ -252,13 +252,37 @@ def test_inspect_empty_pak_id_returns_400():
     assert h.response_status() == 400
 
 
-def test_inspect_non_vault_returns_501_not_implemented():
+def test_inspect_non_vault_unknown_returns_404_oss_safe(tmp_path, monkeypatch):
+    """Non-vault inspect with no matching recall row → 404, OSS-safe wording.
+
+    Per PR 3 decision 2: ``pro_daemon_required`` 501 is removed entirely
+    from the OSS inspect surface. A non-vault ``pak_id`` that has no
+    metadata row in the recall store yields the same 404 contract as
+    any other read miss. No Pro / daemon / license wording leaks from
+    this path.
+    """
+    from tokenpak.companion.recall import RecallStore
+    from tokenpak.proxy import app_endpoints
+
+    store_path = tmp_path / "recall.db"
+    with RecallStore.open(store_path):
+        pass  # empty store
+    monkeypatch.setattr(
+        app_endpoints,
+        "_open_recall_store_default",
+        lambda: RecallStore.open(store_path),
+    )
+
     h = _get("/pak/v1/inspect/journal:s1:42")
-    assert h.response_status() == 501
+    assert h.response_status() == 404
     body = h.response_json()
-    assert body["error"] == "not_implemented"
-    assert body["reason"] == "pro_daemon_required"
-    assert body["daemon_state"] == "unavailable"
+    assert body["error"] == "pak_not_found"
+    # OSS-safe — no Pro / daemon / license wording leaks here.
+    blob = json.dumps(body).lower()
+    assert "pro_daemon_required" not in blob
+    assert "pro daemon" not in blob
+    assert "tokenpak-paid" not in blob
+    assert "license" not in blob
 
 
 def test_inspect_vault_returns_404_when_block_not_indexed():
@@ -311,6 +335,282 @@ def test_inspect_vault_returns_pak_when_indexed(tmp_path):
 def test_inspect_unknown_endpoint_returns_404():
     h = _get("/pak/v1/inspectoid/x")
     assert h.response_status() == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /pak/v1/list — PR 3 OSS list surface
+# ---------------------------------------------------------------------------
+#
+# Decisions from PR 3 review (2026-05-11):
+#   1. Response envelope: {items, next_cursor, limit, truncated} (always).
+#   2. No ``pro_daemon_required`` 501 anywhere on the OSS list path.
+#   3. Filter key is byte-literal ``?pak_type=...`` (no alias expansion).
+#   4. Default + cap = 100; surplus triggers ``truncated=true`` + cursor.
+#
+# These tests inject a tmp ``RecallStore`` via the
+# ``_open_recall_store_default`` shim so the suite never depends on the
+# user's real recall.db.
+
+
+def _patch_recall_store(monkeypatch, tmp_path, seed_rows: list[dict] | None = None):
+    """Replace the default recall-store opener with one pointing at a
+    freshly-seeded tmp DB. Returns the resolved DB path for follow-up
+    assertions.
+    """
+    from tokenpak.companion.recall import RecallStore
+    from tokenpak.proxy import app_endpoints
+
+    store_path = tmp_path / "recall.db"
+    with RecallStore.open(store_path) as store:
+        for r in (seed_rows or []):
+            store.upsert_pak(**r)
+
+    monkeypatch.setattr(
+        app_endpoints,
+        "_open_recall_store_default",
+        lambda: RecallStore.open(store_path),
+    )
+    return store_path
+
+
+def _list_seed_row(
+    pak_id: str,
+    *,
+    now: str,
+    pak_type: str = "vault",
+    project: str | None = "alpha",
+    source_type: str = "doc",
+    authority: str = "llm_generated",
+) -> dict:
+    return {
+        "pak_id": pak_id,
+        "pak_type": pak_type,
+        "source_type": source_type,
+        "authority": authority,
+        "title": f"title-{pak_id}",
+        "content_hash": (pak_id * 4)[:32],
+        "project": project,
+        "now": now,
+    }
+
+
+def test_list_envelope_shape_on_empty_store(tmp_path, monkeypatch, require_fts5):
+    """Decision 1 — even an empty store returns the cursor-pagination envelope.
+
+    No bare array, no missing keys; ``next_cursor`` is ``null`` and
+    ``truncated`` is ``false``.
+    """
+    _patch_recall_store(monkeypatch, tmp_path)
+    h = _get("/pak/v1/list")
+    assert h.response_status() == 200
+    body = h.response_json()
+    assert set(body.keys()) == {"items", "next_cursor", "limit", "truncated"}
+    assert body["items"] == []
+    assert body["next_cursor"] is None
+    assert body["truncated"] is False
+    assert body["limit"] == 100  # decision 4 default
+
+
+def test_list_envelope_shape_with_rows(tmp_path, monkeypatch, require_fts5):
+    """Decision 1 — non-empty page still uses the envelope, never a bare array."""
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[
+            _list_seed_row("a", now="2026-05-11T10:00:00Z"),
+            _list_seed_row("b", now="2026-05-11T10:01:00Z"),
+        ],
+    )
+    h = _get("/pak/v1/list")
+    body = h.response_json()
+    assert h.response_status() == 200
+    assert isinstance(body["items"], list)
+    assert [r["pak_id"] for r in body["items"]] == ["b", "a"]
+    # Each item carries the metadata schema, not body bytes.
+    first = body["items"][0]
+    assert {
+        "pak_id",
+        "pak_type",
+        "project",
+        "topic",
+        "source_type",
+        "authority",
+        "title",
+        "summary",
+        "content_hash",
+        "created_at",
+        "updated_at",
+        "superseded_by",
+    } <= set(first.keys())
+    assert body["next_cursor"] is None
+    assert body["truncated"] is False
+
+
+def test_list_default_and_cap_at_100(tmp_path, monkeypatch, require_fts5):
+    """Decision 4 — default limit is 100; asking for more is clamped to 100."""
+    rows = [
+        _list_seed_row(f"r{i:03d}", now=f"2026-05-11T10:{i // 60:02d}:{i % 60:02d}Z")
+        for i in range(105)
+    ]
+    _patch_recall_store(monkeypatch, tmp_path, seed_rows=rows)
+
+    # No limit → default 100.
+    h = _get("/pak/v1/list")
+    body = h.response_json()
+    assert body["limit"] == 100
+    assert len(body["items"]) == 100
+    assert body["truncated"] is True
+    assert body["next_cursor"] is not None
+
+    # Explicit cap-exceeding limit → silently clamped, no error.
+    h2 = _get("/pak/v1/list?limit=500")
+    body2 = h2.response_json()
+    assert body2["limit"] == 100
+    assert len(body2["items"]) == 100
+    assert body2["truncated"] is True
+
+
+def test_list_smaller_limit_truncates_when_more_remain(
+    tmp_path, monkeypatch, require_fts5
+):
+    """Decision 4 — sub-cap limit still surfaces truncated + cursor when more rows match."""
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[
+            _list_seed_row("a", now="2026-05-11T10:00:00Z"),
+            _list_seed_row("b", now="2026-05-11T10:01:00Z"),
+            _list_seed_row("c", now="2026-05-11T10:02:00Z"),
+        ],
+    )
+    h = _get("/pak/v1/list?limit=2")
+    body = h.response_json()
+    assert body["limit"] == 2
+    assert [r["pak_id"] for r in body["items"]] == ["c", "b"]
+    assert body["truncated"] is True
+    assert body["next_cursor"] is not None
+
+
+def test_list_cursor_round_trip_completes_page(
+    tmp_path, monkeypatch, require_fts5
+):
+    """Decision 1 + 4 — feeding ``next_cursor`` back yields the remainder."""
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[
+            _list_seed_row("a", now="2026-05-11T10:00:00Z"),
+            _list_seed_row("b", now="2026-05-11T10:01:00Z"),
+            _list_seed_row("c", now="2026-05-11T10:02:00Z"),
+            _list_seed_row("d", now="2026-05-11T10:03:00Z"),
+        ],
+    )
+    page1 = _get("/pak/v1/list?limit=2").response_json()
+    cursor = page1["next_cursor"]
+    assert cursor
+
+    # URL-encode the cursor (urlsafe-b64 has no special chars, but be defensive).
+    from urllib.parse import quote
+
+    page2 = _get(f"/pak/v1/list?limit=2&cursor={quote(cursor)}").response_json()
+    assert [r["pak_id"] for r in page2["items"]] == ["b", "a"]
+    assert page2["truncated"] is False
+    assert page2["next_cursor"] is None
+
+
+def test_list_pak_type_filter_byte_literal(tmp_path, monkeypatch, require_fts5):
+    """Decision 3 — ``?pak_type=`` matches exactly, no alias / casefold expansion."""
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[
+            _list_seed_row("a", now="2026-05-11T10:00:00Z", pak_type="vault"),
+            _list_seed_row("b", now="2026-05-11T10:01:00Z", pak_type="interaction"),
+            _list_seed_row("c", now="2026-05-11T10:02:00Z", pak_type="vault"),
+        ],
+    )
+
+    only_vault = _get("/pak/v1/list?pak_type=vault").response_json()
+    assert [r["pak_id"] for r in only_vault["items"]] == ["c", "a"]
+
+    only_inter = _get("/pak/v1/list?pak_type=interaction").response_json()
+    assert [r["pak_id"] for r in only_inter["items"]] == ["b"]
+
+    # ``project`` value MUST NOT alias-expand to ``vault`` at this layer.
+    alias_miss = _get("/pak/v1/list?pak_type=project").response_json()
+    assert alias_miss["items"] == []
+
+    # Casefold is not honored — PR 3 byte-literal contract.
+    casefold_miss = _get("/pak/v1/list?pak_type=VAULT").response_json()
+    assert casefold_miss["items"] == []
+
+
+def test_list_project_filter_byte_literal(tmp_path, monkeypatch, require_fts5):
+    """``?project=`` is also byte-literal in PR 3."""
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[
+            _list_seed_row("a", now="2026-05-11T10:00:00Z", project="alpha"),
+            _list_seed_row("b", now="2026-05-11T10:01:00Z", project="beta"),
+            _list_seed_row("c", now="2026-05-11T10:02:00Z", project="alpha"),
+        ],
+    )
+    only_alpha = _get("/pak/v1/list?project=alpha").response_json()
+    assert [r["pak_id"] for r in only_alpha["items"]] == ["c", "a"]
+
+
+def test_list_invalid_limit_returns_400(tmp_path, monkeypatch, require_fts5):
+    """Non-integer ``limit`` → 400 invalid_request, not a 500 / silent fallback."""
+    _patch_recall_store(monkeypatch, tmp_path)
+    h = _get("/pak/v1/list?limit=not-an-int")
+    assert h.response_status() == 400
+    body = h.response_json()
+    assert body["error"] == "invalid_request"
+
+
+def test_list_zero_limit_returns_400(tmp_path, monkeypatch, require_fts5):
+    """``limit=0`` is rejected at the HTTP layer (storage clamps; HTTP refuses)."""
+    _patch_recall_store(monkeypatch, tmp_path)
+    h = _get("/pak/v1/list?limit=0")
+    assert h.response_status() == 400
+
+
+def test_list_invalid_cursor_returns_400(tmp_path, monkeypatch, require_fts5):
+    """A bogus cursor surfaces as 400 invalid_request (mapped from store ValueError)."""
+    _patch_recall_store(monkeypatch, tmp_path)
+    h = _get("/pak/v1/list?cursor=not-a-cursor!!!")
+    assert h.response_status() == 400
+    assert h.response_json()["error"] == "invalid_request"
+
+
+def test_list_rejects_non_localhost(tmp_path, monkeypatch, require_fts5):
+    """Auth gate matches every other /pak/v1/* surface."""
+    _patch_recall_store(monkeypatch, tmp_path)
+    h = _get("/pak/v1/list", client_ip="10.0.0.1")
+    assert h.response_status() == 401
+
+
+def test_list_no_pro_wording_anywhere(tmp_path, monkeypatch, require_fts5):
+    """Decision 2 scope-guard — no Pro / daemon / license wording leaks
+    from the OSS list response, regardless of empty / non-empty / cursor state.
+    """
+    _patch_recall_store(
+        monkeypatch,
+        tmp_path,
+        seed_rows=[_list_seed_row("a", now="2026-05-11T10:00:00Z")],
+    )
+    blob = json.dumps(_get("/pak/v1/list").response_json()).lower()
+    for forbidden in (
+        "pro_daemon_required",
+        "pro daemon",
+        "tokenpak-paid",
+        "license",
+        "cloud",
+        "sync",
+        "pricing",
+    ):
+        assert forbidden not in blob, f"OSS leak: {forbidden!r} appeared in /pak/v1/list response"
 
 
 # ---------------------------------------------------------------------------

--- a/tokenpak/companion/recall/__init__.py
+++ b/tokenpak/companion/recall/__init__.py
@@ -22,12 +22,22 @@ from __future__ import annotations
 
 from tokenpak.companion.recall.schema import SCHEMA_VERSION
 from tokenpak.companion.recall.store import (
+    LIST_LIMIT_DEFAULT,
+    LIST_LIMIT_MAX,
+    PakListFilters,
+    PakListResult,
+    PakRow,
     RecallStore,
     default_recall_db_path,
     open_recall_store,
 )
 
 __all__ = [
+    "LIST_LIMIT_DEFAULT",
+    "LIST_LIMIT_MAX",
+    "PakListFilters",
+    "PakListResult",
+    "PakRow",
     "RecallStore",
     "SCHEMA_VERSION",
     "default_recall_db_path",

--- a/tokenpak/companion/recall/store.py
+++ b/tokenpak/companion/recall/store.py
@@ -12,12 +12,18 @@ The module exposes:
 - ``RecallStore.upsert_pak(...)`` — metadata-only write path. Inserts a
   new row keyed on ``pak_id`` or replaces the existing row's metadata
   in place. The v2 FTS triggers keep ``paks_fts`` consistent.
+- ``RecallStore.list_paks(filters)`` — metadata-only read path. Returns
+  a paginated :class:`PakListResult` ordered newest-first. Caps page
+  size at ``LIST_LIMIT_MAX``; supports keyset pagination via opaque
+  cursor tokens.
+- ``RecallStore.get_pak(pak_id)`` — single-row metadata fetch, or ``None``.
 - ``open_recall_store(path)`` — convenience factory that resolves the
   default DB location when ``path`` is ``None``.
-- ``UpsertResult`` — NamedTuple describing the outcome of an upsert.
+- ``UpsertResult`` / ``PakRow`` / ``PakListFilters`` / ``PakListResult``
+  — NamedTuple records describing inputs / outputs.
 
-This module does *not* expose any read / query / recall surface; that
-is deferred to a later phase.
+This module does *not* expose any ranking, scoring, or full-text
+search surface; those are deferred to a later phase.
 
 Default DB path resolution
 --------------------------
@@ -37,13 +43,14 @@ on so cascade behaviour from the schema fires as expected.
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 from tokenpak.companion.recall.migrations import apply_migrations, current_version
 from tokenpak.companion.recall.schema import SCHEMA_VERSION
@@ -63,6 +70,84 @@ _REQUIRED_FIELDS: tuple[str, ...] = (
     "title",
     "content_hash",
 )
+
+
+# Pagination bounds for ``list_paks``. The default and the maximum are the
+# same: callers asking for more than ``LIST_LIMIT_MAX`` rows are silently
+# clamped, and callers passing nothing get the same page size.
+LIST_LIMIT_DEFAULT: int = 100
+LIST_LIMIT_MAX: int = 100
+
+
+# Column order used by ``list_paks`` and ``get_pak`` — kept aligned with
+# the :class:`PakRow` field order so the rowset can be splat into the
+# NamedTuple constructor positionally.
+_PAK_COLUMNS: str = (
+    "pak_id, pak_type, project, topic, source_type, authority, "
+    "title, summary, content_hash, created_at, updated_at, superseded_by"
+)
+
+
+class PakRow(NamedTuple):
+    """A single ``paks`` row, as read by :meth:`RecallStore.list_paks` /
+    :meth:`RecallStore.get_pak`.
+
+    Field order matches :data:`_PAK_COLUMNS` so a positional unpack of
+    the SQLite row builds the record without translation. ``project``,
+    ``topic``, and ``superseded_by`` are nullable in the schema; the
+    rest are required.
+    """
+
+    pak_id: str
+    pak_type: str
+    project: Optional[str]
+    topic: Optional[str]
+    source_type: str
+    authority: str
+    title: str
+    summary: str
+    content_hash: str
+    created_at: str
+    updated_at: str
+    superseded_by: Optional[str]
+
+
+class PakListFilters(NamedTuple):
+    """Inputs to :meth:`RecallStore.list_paks`.
+
+    Attributes:
+        project: When set, restrict rows to ``project = <value>``. Byte-literal
+            match — no alias expansion.
+        pak_type: When set, restrict rows to ``pak_type = <value>``. Byte-literal
+            match — no alias expansion.
+        limit: Requested page size. Clamped to ``[1, LIST_LIMIT_MAX]``.
+        cursor: Opaque pagination cursor returned by a previous call. ``None``
+            on the first page.
+    """
+
+    project: Optional[str] = None
+    pak_type: Optional[str] = None
+    limit: int = LIST_LIMIT_DEFAULT
+    cursor: Optional[str] = None
+
+
+class PakListResult(NamedTuple):
+    """Outputs from :meth:`RecallStore.list_paks`.
+
+    Attributes:
+        items: The rows on this page, newest-first.
+        next_cursor: Opaque cursor to pass to the next call, or ``None``
+            when no more rows match the filters.
+        limit: The effective page size used (after clamping).
+        truncated: ``True`` if more rows match the filters than this page
+            returned. Always implies ``next_cursor`` is not ``None`` when
+            ``items`` is non-empty.
+    """
+
+    items: list[PakRow]
+    next_cursor: Optional[str]
+    limit: int
+    truncated: bool
 
 
 class UpsertResult(NamedTuple):
@@ -311,6 +396,104 @@ class RecallStore:
 
         return UpsertResult(pak_id=pak_id, inserted=inserted, body_changed=body_changed)
 
+    # Metadata read surface -------------------------------------------------
+
+    def list_paks(self, filters: Optional[PakListFilters] = None) -> PakListResult:
+        """Return a paginated page of ``paks`` rows, newest-first.
+
+        Page ordering is ``(updated_at DESC, pak_id DESC)`` — the latter is
+        the tiebreak when two rows share an ``updated_at``. Pagination is
+        keyset-based: the cursor encodes the last row's ``(updated_at, pak_id)``
+        tuple so the next page can resume without offsets (which scale poorly
+        and skip rows under concurrent writes).
+
+        Filters compose with ``AND``. ``project`` and ``pak_type`` are
+        byte-literal — the schema column value must equal the filter
+        verbatim. No alias / casefold / normalisation is applied.
+
+        Parameters:
+            filters: A :class:`PakListFilters` record. If ``None``, defaults
+                are used (no filters, full page).
+
+        Returns:
+            :class:`PakListResult`. ``items`` is a possibly-empty list of
+            :class:`PakRow`. ``truncated`` is ``True`` iff more rows match
+            than fit on this page; in that case ``next_cursor`` is the
+            cursor to use to fetch the next page. The ``limit`` field
+            reports the effective limit after clamping.
+
+        Raises:
+            ValueError: ``filters.cursor`` is set and not a valid opaque
+                cursor.
+        """
+        f = filters if filters is not None else PakListFilters()
+
+        # Clamp limit to [1, LIST_LIMIT_MAX]. Non-positive values fall back
+        # to the default rather than rejecting — defensive.
+        raw_limit = f.limit if isinstance(f.limit, int) and f.limit > 0 else LIST_LIMIT_DEFAULT
+        limit = min(raw_limit, LIST_LIMIT_MAX)
+
+        where_clauses: list[str] = []
+        params: list[Any] = []
+        if f.project is not None:
+            where_clauses.append("project = ?")
+            params.append(f.project)
+        if f.pak_type is not None:
+            where_clauses.append("pak_type = ?")
+            params.append(f.pak_type)
+        if f.cursor:
+            cur_ts, cur_id = _decode_cursor(f.cursor)
+            # Keyset for ORDER BY updated_at DESC, pak_id DESC: the next page
+            # starts strictly after (cur_ts, cur_id) in that DESC ordering —
+            # i.e. (updated_at, pak_id) is less than the cursor's tuple.
+            where_clauses.append(
+                "(updated_at < ? OR (updated_at = ? AND pak_id < ?))"
+            )
+            params.extend([cur_ts, cur_ts, cur_id])
+
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        sql = (
+            f"SELECT {_PAK_COLUMNS} FROM paks "
+            f"{where_sql} "
+            "ORDER BY updated_at DESC, pak_id DESC "
+            "LIMIT ?"
+        )
+        # Fetch one more than the limit so we can detect truncation without
+        # a separate COUNT query.
+        params.append(limit + 1)
+        rows = self._conn.execute(sql, params).fetchall()
+        truncated = len(rows) > limit
+        if truncated:
+            rows = rows[:limit]
+        items: list[PakRow] = [PakRow(*row) for row in rows]
+        next_cursor: Optional[str] = None
+        if truncated and items:
+            last = items[-1]
+            next_cursor = _encode_cursor(last.updated_at, last.pak_id)
+        return PakListResult(
+            items=items,
+            next_cursor=next_cursor,
+            limit=limit,
+            truncated=truncated,
+        )
+
+    def get_pak(self, pak_id: str) -> Optional[PakRow]:
+        """Return the ``paks`` row for ``pak_id``, or ``None`` if absent.
+
+        Whitespace-only or empty ``pak_id`` returns ``None`` rather than
+        running the SELECT — the schema rejects empty primary keys at
+        write time, so a lookup on one is unambiguously a miss.
+        """
+        if not pak_id or not pak_id.strip():
+            return None
+        row = self._conn.execute(
+            f"SELECT {_PAK_COLUMNS} FROM paks WHERE pak_id = ?",
+            (pak_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return PakRow(*row)
+
     def close(self) -> None:
         """Close the underlying connection.
 
@@ -347,7 +530,45 @@ def _short_hash(value: object) -> str:
     return s[:12] + ("…" if len(s) > 12 else "")
 
 
+# Cursor encode/decode --------------------------------------------------------
+#
+# The cursor is an opaque token to the caller: the only contract is that
+# passing a cursor returned by a previous call yields the rows that would
+# have come on the next page. The encoding chosen here is base64 of
+# ``"<updated_at>|<pak_id>"`` — short, URL-safe, and easy to decode in
+# tests without exposing the schema-level keyset detail.
+
+_CURSOR_SEP = "|"
+
+
+def _encode_cursor(updated_at: str, pak_id: str) -> str:
+    raw = f"{updated_at}{_CURSOR_SEP}{pak_id}".encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> tuple[str, str]:
+    if not isinstance(cursor, str) or not cursor:
+        raise ValueError("invalid cursor: empty or non-string")
+    # Re-pad — ``urlsafe_b64encode`` may have produced a token without
+    # trailing ``=`` after the ``rstrip`` step above.
+    pad = (-len(cursor)) % 4
+    padded = cursor + ("=" * pad)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError(f"invalid cursor: {exc!r}") from exc
+    parts = raw.split(_CURSOR_SEP, 1)
+    if len(parts) != 2:
+        raise ValueError("invalid cursor: missing separator")
+    return parts[0], parts[1]
+
+
 __all__ = [
+    "LIST_LIMIT_DEFAULT",
+    "LIST_LIMIT_MAX",
+    "PakListFilters",
+    "PakListResult",
+    "PakRow",
     "RecallStore",
     "UpsertResult",
     "default_recall_db_path",

--- a/tokenpak/proxy/app_endpoints.py
+++ b/tokenpak/proxy/app_endpoints.py
@@ -29,8 +29,16 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import parse_qs, urlparse
+
+from tokenpak.companion.recall import (
+    LIST_LIMIT_DEFAULT,
+    PakListFilters,
+)
+
+if TYPE_CHECKING:  # noqa: F401 — types only used in string-quoted hints
+    from tokenpak.companion.recall import PakRow, RecallStore
 
 # ---------------------------------------------------------------------------
 # Auth
@@ -86,9 +94,9 @@ def try_handle_get(handler: Any) -> bool:
     - ``/tpk/v1/*`` — the OSS app API (vault, budget, journal, capsules,
       models). This is the canonical proxy-owned read surface per glossary
       ``api-tpk-v1``.
-    - ``/pak/v1/*`` — the MultiPak Pro daemon protocol surface (Std 25 §2.1,
-      Std 32 §1.3). Stubs return ``not_implemented`` when the Pro daemon is
-      absent; ``status`` always works.
+    - ``/pak/v1/*`` — the MultiPak Pro daemon protocol surface. Stubs return
+      ``not_implemented`` when the Pro daemon is absent; ``status`` always
+      works.
     """
     parsed = urlparse(handler.path)
     path = parsed.path
@@ -794,7 +802,7 @@ def _handle_tokens_estimate(handler: Any, body: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# /pak/v1/* — MultiPak Pro daemon protocol surface (Std 25 §2.1, Std 32 §1.3)
+# /pak/v1/* — MultiPak Pro daemon protocol surface
 # ---------------------------------------------------------------------------
 #
 # The /pak/v1/* namespace is distinct from /tpk/v1/* by design:
@@ -807,7 +815,7 @@ def _handle_tokens_estimate(handler: Any, body: dict[str, Any]) -> None:
 #                /pak/v1/status always works (diagnostic surface).
 #
 # Phase 1 OSS ships read-only Vault Pak inspection via the adapter; everything
-# else is a 501 stub gated on daemon presence per Std 25 §3.4 fallback contract.
+# else is a 501 stub gated on daemon presence per the daemon fallback contract.
 
 
 def _try_handle_pak_get(handler: Any, path: str, parsed: Any) -> bool:
@@ -826,6 +834,8 @@ def _try_handle_pak_get(handler: Any, path: str, parsed: Any) -> bool:
         )
         return True
 
+    qs = parse_qs(parsed.query or "")
+
     # ── /pak/v1/status ──────────────────────────────────────────────────
     # Diagnostic surface — works regardless of daemon presence. Mirrors the
     # `tokenpak pak status` CLI.
@@ -833,9 +843,18 @@ def _try_handle_pak_get(handler: Any, path: str, parsed: Any) -> bool:
         _handle_pak_status(handler)
         return True
 
+    # ── /pak/v1/list ─────────────────────────────────────────────────────
+    # Paginated listing of recall-store Pak metadata rows. OSS read path.
+    # Supports filter-by-project and filter-by-pak_type (both byte-literal),
+    # cursor-based pagination, and a hard cap of LIST_LIMIT_MAX rows/page.
+    if path == "/pak/v1/list":
+        _handle_pak_list(handler, qs)
+        return True
+
     # ── /pak/v1/inspect/<pak-id> ────────────────────────────────────────
     # Read-only Pak inspection. Vault Paks (pak_id starts with "vault:")
-    # are served via the OSS adapter; other subtypes require the daemon.
+    # are served via the OSS adapter; other ``pak_id`` values fall back to a
+    # recall-store metadata lookup and return 404 if unknown.
     # ``#`` is URL-significant (fragment delimiter) and is mandatory in
     # vault block IDs — clients MUST percent-encode as ``%23``; the handler
     # decodes via :func:`urllib.parse.unquote` to recover the canonical id.
@@ -862,17 +881,17 @@ def _try_handle_pak_post(handler: Any, path: str) -> bool:
         return True
 
     # ── POST /pak/v1/promote ────────────────────────────────────────────
-    # Pro-gated capture pipeline (Std 32 §4). When the Pro daemon is
-    # reachable, forward the request body to the daemon's loopback port
-    # and proxy the response back. When the daemon is absent or
-    # unreachable, return the standardized 501 ``pro_daemon_required``.
+    # Pro-gated capture pipeline. When the Pro daemon is reachable, forward
+    # the request body to the daemon's loopback port and proxy the response
+    # back. When the daemon is absent or unreachable, return the standardized
+    # 501 ``pro_daemon_required``.
     if path == "/pak/v1/promote":
         _handle_pak_promote_forward(handler)
         return True
 
     # ── POST /pak/v1/recall ─────────────────────────────────────────────
-    # Pro-only per Std 32 §1.3 row 8. Always 501 in OSS; the daemon owns
-    # ranking, hydration, and packaging.
+    # Pro-only. Always 501 in OSS; the daemon owns ranking, hydration, and
+    # packaging.
     if path == "/pak/v1/recall":
         _send_pak_not_implemented(
             handler,
@@ -893,8 +912,8 @@ def _try_handle_pak_post(handler: Any, path: str) -> bool:
 def _handle_pak_promote_forward(handler: Any) -> None:
     """Forward POST /pak/v1/promote to the Pro daemon's loopback port.
 
-    Std 32 §4 capture pipeline lives in the closed-source daemon. The
-    OSS proxy's job here is to:
+    The capture pipeline lives in the closed-source daemon. The OSS proxy's
+    job here is to:
 
     1. Probe daemon presence via ``daemon_probe.detect_daemon_state``.
     2. If absent → return 501 ``pro_daemon_required``.
@@ -905,9 +924,9 @@ def _handle_pak_promote_forward(handler: Any) -> None:
     Defensive details:
 
     - The auth headers from the caller are NOT forwarded to the daemon.
-      The daemon is loopback-only by construction (Std 25 §2.1), so
-      it requires no auth on /pak/v1/*; passing the OSS caller's auth
-      headers through would leak them into the daemon's logs needlessly.
+      The daemon is loopback-only by construction, so it requires no auth
+      on /pak/v1/*; passing the OSS caller's auth headers through would
+      leak them into the daemon's logs needlessly.
     - Short timeout (5s). The daemon is local; if it's not responding
       within that, we treat it as TOCTOU race (probe said active,
       daemon stopped between probe and forward) and return 503.
@@ -1013,9 +1032,10 @@ def _send_pak_not_implemented(
 
     The shape is stable across all Pro-gated endpoints so clients can
     treat ``error == "not_implemented"`` + ``reason`` as the canonical
-    "daemon absent" signal. ``daemon_state`` mirrors Std 25 §3.4 telemetry
-    so callers can disambiguate "Pro never installed" from "Pro present
-    but version-incompatible" once Phase 2 ships.
+    "daemon absent" signal. ``daemon_state`` mirrors the daemon
+    fallback-contract telemetry so callers can disambiguate "Pro never
+    installed" from "Pro present but version-incompatible" once Phase 2
+    ships.
     """
     from tokenpak.licensing.daemon_probe import detect_daemon_state
 
@@ -1032,6 +1052,146 @@ def _send_pak_not_implemented(
     )
 
 
+def _handle_pak_list(handler: Any, qs: dict[str, list[str]]) -> None:
+    """GET /pak/v1/list — paginated metadata listing from the recall store.
+
+    Query parameters (all optional):
+        project     — filter rows by exact ``project`` value (byte-literal).
+        pak_type    — filter rows by exact ``pak_type`` value (byte-literal).
+        limit       — page size; clamped to ``[1, LIST_LIMIT_MAX]`` (default
+                      ``LIST_LIMIT_DEFAULT``). Invalid integers yield 400.
+        cursor      — opaque token returned by a previous response; resumes
+                      after the row it identifies. Invalid cursors yield 400.
+
+    Response shape (always — including the empty page):
+
+        {
+          "items":       [<pak metadata dict>, ...],
+          "next_cursor": "<token>" | null,
+          "limit":       <int, the effective limit>,
+          "truncated":   true | false
+        }
+
+    ``items`` is metadata only: no body bytes, no anchors, no full text.
+    ``next_cursor`` is non-null whenever more rows match the filters than
+    fit on this page (i.e. ``truncated`` is true). When ``truncated`` is
+    false, ``next_cursor`` is always null.
+    """
+    # Parse + clamp limit ------------------------------------------------------
+    limit_raw = (qs.get("limit", [""]) or [""])[0]
+    if limit_raw == "":
+        limit_arg = LIST_LIMIT_DEFAULT
+    else:
+        try:
+            limit_arg = int(limit_raw)
+        except ValueError:
+            _send_error(
+                handler,
+                400,
+                "invalid_request",
+                f"limit must be an integer (got {limit_raw!r})",
+            )
+            return
+        if limit_arg < 1:
+            _send_error(
+                handler,
+                400,
+                "invalid_request",
+                "limit must be >= 1",
+            )
+            return
+
+    project = (qs.get("project", [None]) or [None])[0]
+    pak_type = (qs.get("pak_type", [None]) or [None])[0]
+    cursor = (qs.get("cursor", [None]) or [None])[0]
+
+    filters = PakListFilters(
+        project=project,
+        pak_type=pak_type,
+        limit=limit_arg,
+        cursor=cursor,
+    )
+
+    try:
+        store = _open_recall_store_default()
+    except Exception as exc:
+        _send_error(
+            handler,
+            500,
+            "internal_error",
+            f"recall store unavailable: {exc}",
+        )
+        return
+
+    try:
+        try:
+            result = store.list_paks(filters)
+        except ValueError as exc:
+            # Invalid cursor surface — keep client-facing wording neutral.
+            _send_error(handler, 400, "invalid_request", str(exc))
+            return
+    finally:
+        store.close()
+
+    _send_json(
+        handler,
+        200,
+        {
+            "items": [_pak_row_to_dict(r) for r in result.items],
+            "next_cursor": result.next_cursor,
+            "limit": result.limit,
+            "truncated": result.truncated,
+        },
+    )
+
+
+def _pak_row_to_dict(row: "PakRow") -> dict[str, Any]:
+    """Serialise a :class:`PakRow` into the wire-shape dict.
+
+    Field set is exactly the ``paks`` schema columns — no derived fields,
+    no body bytes, no anchor refs. Nullable columns surface as ``null``
+    via the standard JSON encoder.
+    """
+    return {
+        "pak_id": row.pak_id,
+        "pak_type": row.pak_type,
+        "project": row.project,
+        "topic": row.topic,
+        "source_type": row.source_type,
+        "authority": row.authority,
+        "title": row.title,
+        "summary": row.summary,
+        "content_hash": row.content_hash,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+        "superseded_by": row.superseded_by,
+    }
+
+
+def _open_recall_store_default() -> "RecallStore":
+    """Open the recall store at its default location.
+
+    Wrapped so test code can monkey-patch this single function rather
+    than reach into ``tokenpak.companion.recall`` directly.
+    """
+    from tokenpak.companion.recall import open_recall_store
+
+    return open_recall_store()
+
+
+def _recall_get_pak(pak_id: str) -> Optional["PakRow"]:
+    """Convenience: open store, fetch one row, close store.
+
+    Used by ``_handle_pak_inspect`` non-vault fallback. Lifted out so
+    tests can patch the open path independently from the inspect logic.
+    """
+    store = _open_recall_store_default()
+    try:
+        return store.get_pak(pak_id)
+    finally:
+        store.close()
+
+
 def _handle_pak_status(handler: Any) -> None:
     """GET /pak/v1/status — diagnostic snapshot.
 
@@ -1039,7 +1199,7 @@ def _handle_pak_status(handler: Any) -> None:
     a configured Pak store. Provides the four signals a CLI / dashboard
     needs to render Pro readiness:
 
-    - ``daemon_state`` — Std 25 §3.4 fallback-contract value.
+    - ``daemon_state`` — fallback-contract value emitted by the probe.
     - ``multipak_enabled`` — config flag (``pro.multipak.enabled``).
     - ``pak_store_present`` — does ``~/.tokenpak/pro/state/multipak/``
       exist on disk?
@@ -1082,9 +1242,17 @@ def _handle_pak_status(handler: Any) -> None:
 def _handle_pak_inspect(handler: Any, pak_id: str) -> None:
     """GET /pak/v1/inspect/<pak-id> — return a Pak's serialized form.
 
-    Vault Paks (``pak_id`` starts with ``vault:``) are served by the OSS
-    Vault Pak adapter — no daemon needed. Other subtypes require the
-    daemon (Phase 2+) and return 501.
+    Resolution order:
+
+    1. If ``pak_id`` starts with ``vault:`` the OSS Vault Pak adapter
+       serves it from the vault index. Returns 404 if the underlying
+       block isn't indexed.
+    2. Otherwise the OSS recall store is consulted for a metadata row.
+       Returns 200 with the row's metadata if present, 404 if not.
+
+    No surface beyond this lookup is exposed by the OSS endpoint — the
+    body bytes of a Pak are not part of the metadata index by design
+    (the index is content-hash-keyed, not content-bearing).
     """
     if not pak_id:
         _send_error(handler, 400, "invalid_request", "pak_id required")
@@ -1131,26 +1299,40 @@ def _handle_pak_inspect(handler: Any, pak_id: str) -> None:
             )
             return
 
-    # Non-Vault subtypes: daemon required.
-    _send_pak_not_implemented(
-        handler,
-        reason="pro_daemon_required",
-        detail=(
-            f"Inspecting Pak {pak_id!r} requires the Pro daemon "
-            "(non-Vault subtypes are encrypted at rest)."
-        ),
-    )
+    # Non-vault id — consult the OSS recall metadata store. A hit returns
+    # the metadata row; a miss returns 404. No further fallback in OSS.
+    try:
+        row = _recall_get_pak(pak_id)
+    except Exception as exc:
+        _send_error(
+            handler,
+            500,
+            "internal_error",
+            f"recall lookup failed: {exc}",
+        )
+        return
+
+    if row is None:
+        _send_error(
+            handler,
+            404,
+            "pak_not_found",
+            f"no Pak with pak_id {pak_id!r}",
+        )
+        return
+
+    _send_json(handler, 200, _pak_row_to_dict(row))
 
 
 def _read_multipak_enabled() -> bool:
     """Read ``pro.multipak.enabled`` from ``~/.tokenpak/config.yaml``.
 
-    Default ``False`` per Std 32 §13.1 Decision #6 (opt-in until 1-week
-    soak post-bootstrap). Resilient to missing/malformed config — never
-    raises; failures degrade to ``False``.
+    Default ``False`` (opt-in until the 1-week soak post-bootstrap
+    completes). Resilient to missing/malformed config — never raises;
+    failures degrade to ``False``.
 
     Lookup order:
-    1. ``pro.multipak.enabled`` (Std 25 §2.1 Pro-config layout)
+    1. ``pro.multipak.enabled`` (canonical Pro-config layout).
     2. ``multipak.enabled`` (legacy/unscoped fallback — accepted but not
        canonical; configs should migrate).
     """


### PR DESCRIPTION
## PR 3 — Phase 1 OSS list/inspect surface

Adds `GET /pak/v1/list` with cursor pagination, rewires `GET /pak/v1/inspect/<pak-id>` non-vault path to an OSS-safe 404, and ships full storage + HTTP coverage.

### Decisions codified (2026-05-11 review)

| # | Decision | Where |
|---|---|---|
| 1 | List response is a stable object (`{items, next_cursor, limit, truncated}`) — never a bare array | `app_endpoints.py::_handle_pak_list`, tests `test_list_envelope_shape_*` |
| 2 | `pro_daemon_required` 501 removed entirely from OSS inspect fallback; non-vault unknown → plain 404 `pak_not_found` | `app_endpoints.py::_handle_pak_inspect`, test `test_inspect_non_vault_unknown_returns_404_oss_safe` |
| 3 | Filter key is byte-literal `?pak_type=...` (no alias / casefold expansion at this layer) | `store.py::list_paks`, `app_endpoints.py::_handle_pak_list`, test `test_list_pak_type_filter_byte_literal` |
| 4 | Default limit and hard cap = 100. Surplus → `truncated: true` + `next_cursor` | `LIST_LIMIT_DEFAULT` / `LIST_LIMIT_MAX` in `store.py`, tests `test_list_default_and_cap_at_100` / `test_list_smaller_limit_truncates_when_more_remain` |

### Scope guardrails (held)

- No version bump.
- No Pro implementation leakage; `/pak/v1/promote` and `/pak/v1/recall` 501 paths untouched.
- No `cloud`/`sync`/`pricing`/`license` wording — enforced by `test_list_no_pro_wording_anywhere`.
- TIP-1.1 docs-contracts alignment unchanged.

### Storage layer (`tokenpak/companion/recall/store.py`)

- `RecallStore.list_paks(PakListFilters)` → `PakListResult`, ordered `updated_at DESC, pak_id DESC` with keyset pagination.
- Opaque cursor = base64(`updated_at|pak_id`); decode raises `ValueError` on malformed input → mapped to HTTP 400.
- `RecallStore.get_pak(pak_id)` for single-row metadata lookup; whitespace-only ids short-circuit to `None`.
- `LIST_LIMIT_DEFAULT = LIST_LIMIT_MAX = 100` exported.

### HTTP layer (`tokenpak/proxy/app_endpoints.py`)

- New `_handle_pak_list`; 400 on non-integer / non-positive limit and malformed cursor; 401 for non-loopback callers.
- `_open_recall_store_default` test seam — HTTP tests inject a tmp store without reaching into the package internals.
- Inspect non-vault path now does a recall metadata lookup → 200 with metadata row or 404 `pak_not_found`. No Pro wording.

### Test coverage

- `tests/companion/recall/test_read_helpers.py` — 15 storage cases (envelope, ordering, tiebreak, filters, clamp, truncation, cursor round-trip, invalid cursor, `get_pak` hit/miss/empty).
- `tests/proxy/test_pak_endpoints.py` — 12 new HTTP cases for `/pak/v1/list` + rewritten inspect-fallback test. `require_fts5` fixture lifted into `tests/proxy/conftest.py`.

### Local run

```
pytest tests/companion/recall tests/proxy/test_pak_endpoints.py \
       tests/tip/test_multipak_contracts.py tests/tip/test_vault_pak_adapter.py \
       tests/cli/test_pak_command.py tests/companion/test_pak_aware_journal.py
# 245 passed
```

### Refs

- Std 25 §2.1, §3.4 (Pro daemon protocol surface + fallback contract).
- Std 32 §1.3, §5, §9, §13.1 Decision #9 (recall storage foundation = Phase 1 OSS).

