### PR TITLE
chore(release): 1.6.0 prep — version + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [v1.6.0] — 2026-05-16
+
+### Added
+
+- `tokenpak tip` (validate / inspect / conformance / doctor / scaffold-adapter)
+- `tokenpak features` + `tokenpak features explain <feature>`
+- `tokenpak pakplan preview / explain / report`
+- `tokenpak home` (path / init / validate / explain / migrate)
+- `tokenpak pak create` and `tokenpak pak import` (OSS Beta 1)
+- `tokenpak doctor --conformance` flag (regression recovery from v1.3.7)
+- `BETA_ONBOARDING.md` + `KNOWN_LIMITATIONS.md`
+- `tokenpak._paths` canonical home-resolver covering the `~/.tpk/` boundary
+- OSS `tokenpak activate` consults the Pro daemon's `/v1/features` endpoint
+  with a 2-second timeout and five fail-closed states (daemon-unreachable,
+  daemon-timeout, key-not-found, key-expired, key-revoked)
+- Release-gate trust contract Phases 4r/5/6 — public-API, telemetry-schema,
+  and workflow-steps snapshot ratchets enforced by CI on every PR
+
+### Changed
+
+- `tokenpak plan` output is dynamically derived from the live pricing
+  index; the previous "TBD" placeholder is gone
+- `tokenpak activate` rejects empty / too-short / non-printable /
+  placeholder keys before any daemon round-trip
+- `tokenpak pak status` no longer triggers a heavy vault index load; the
+  status path returns in under 2 seconds on populated vaults
+- Wheel ships `tokenpak/tip/schemas/*.json` (was missing pre-1.6.0)
+- Wheel ships `tokenpak/_snapshots/*.json` (release-gate snapshot ratchets)
+
+### Fixed
+
+- `pak status` no longer hangs on hosts with populated vault directories
+- `doctor` surfaces the home-boundary advisory before other checks so a
+  half-migrated host produces a single clear diagnostic rather than a
+  cascade of secondary failures
+
 ## [v1.5.6] — 2026-05-11
 
 ### Repository

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.5.6"
+__version__ = "1.6.0"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"


### PR DESCRIPTION
## Summary

Prep-only changes for the v1.6.0 MINOR release. Bumps `tokenpak/__init__.py:__version__` from 1.5.6 to 1.6.0 and adds the v1.6.0 section to `CHANGELOG.md`.

No tag is cut by merging this PR. The tag + Release TokenPak workflow trigger + PyPI publish are gated on the explicit release command.

## Scope

- **Why MINOR?** Significant additive surface (new tip / features / pakplan / home / pak / doctor verb families, BETA_ONBOARDING + KNOWN_LIMITATIONS docs, the `_paths` canonical home-resolver covering the `~/.tpk/` home-boundary, OSS `activate` ↔ Pro-daemon `/v1/features` integration with five fail-closed states, and release-gate trust contract Phases 4r/5/6) with no breaking changes. Legacy `~/.tokenpak/` continues to work. `pak import` is a placeholder-to-OSS promotion, not a real-user break.
- **Migration risk:** low. The only state migration is `~/.tokenpak/` → `~/.tpk/`, opt-in via `tokenpak home migrate`, fully reversible (legacy preserved).
- **Release-gate counter:** `counter=1, consecutive_clean=2` going into this release. One more clean publish floors the counter at 0 (trusted).

## Test plan

- [ ] CI green on this PR (all checks)
- [ ] No public-language regressions surfaced by `Identity & language check`
- [ ] `Release-gate snapshot validation` passes (snapshots already aligned in the prior commit `990c145ee5`)
- [ ] After merge: `workflow_dispatch` preflight run of `Release TokenPak` against this commit before tag push (per the v1.5.4 release-path hardening — the preflight is the safety net against the v1.5.3-class failure mode)