### PR TITLE
Repoint personal-username repo refs + CODEOWNERS to canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,37 +5,37 @@
 # review even when the promotion is otherwise green.
 
 # Default owner for everything
-*                                                  @kaywhy331
+*                                                  @tokenpak
 
 # Release-critical files
-/.github/workflows/release.yml                     @kaywhy331
-/pyproject.toml                                    @kaywhy331
-/CHANGELOG.md                                      @kaywhy331
-/tokenpak/__init__.py                              @kaywhy331
+/.github/workflows/release.yml                     @tokenpak
+/pyproject.toml                                    @tokenpak
+/CHANGELOG.md                                      @tokenpak
+/tokenpak/__init__.py                              @tokenpak
 
 # Public-surface guardrails
-/.github/CODEOWNERS                                @kaywhy331
-/.github/workflows/public-layout-check.yml         @kaywhy331
-/.github/workflows/identity-language-check.yml     @kaywhy331
-/.pre-commit-config.yaml                           @kaywhy331
-/.gitignore                                        @kaywhy331
+/.github/CODEOWNERS                                @tokenpak
+/.github/workflows/public-layout-check.yml         @tokenpak
+/.github/workflows/identity-language-check.yml     @tokenpak
+/.pre-commit-config.yaml                           @tokenpak
+/.gitignore                                        @tokenpak
 
 # Core proxy engine
-/tokenpak/proxy/                                   @kaywhy331
-/tokenpak/core/                                    @kaywhy331
+/tokenpak/proxy/                                   @tokenpak
+/tokenpak/core/                                    @tokenpak
 
 # Configuration and schemas
-/schemas/                                          @kaywhy331
-/tokenpak/config/                                  @kaywhy331
+/schemas/                                          @tokenpak
+/tokenpak/config/                                  @tokenpak
 
 # CI/CD
-/.github/workflows/                                @kaywhy331
+/.github/workflows/                                @tokenpak
 
 # Documentation surface
-/README.md                                         @kaywhy331
-/CONTRIBUTING.md                                   @kaywhy331
-/SECURITY.md                                       @kaywhy331
-/CODE_OF_CONDUCT.md                                @kaywhy331
-/LICENSE                                           @kaywhy331
-/LICENSE_COMMERCIAL.md                             @kaywhy331
-/docs/                                             @kaywhy331
+/README.md                                         @tokenpak
+/CONTRIBUTING.md                                   @tokenpak
+/SECURITY.md                                       @tokenpak
+/CODE_OF_CONDUCT.md                                @tokenpak
+/LICENSE                                           @tokenpak
+/LICENSE_COMMERCIAL.md                             @tokenpak
+/docs/                                             @tokenpak

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,7 @@ We aim to:
 ## Getting Help
 
 - Open a [GitHub Discussion](https://github.com/tokenpak/tokenpak/discussions)
-- Tag @kaywhy331 for blocking issues
+- Tag @tokenpak for blocking issues
 - Read the docs under `/docs`
 
 ---

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,14 +8,14 @@ Thank you for your interest in contributing! This guide covers how to get set up
 
 - Python 3.10, 3.11, 3.12, or 3.13
 - `git`
-- A GitHub account with fork access to `kaywhy331/tokenpak`
+- A GitHub account with fork access to `tokenpak/tokenpak`
 
 ---
 
 ## Local Setup
 
 ```bash
-git clone https://github.com/kaywhy331/tokenpak.git
+git clone https://github.com/tokenpak/tokenpak.git
 cd tokenpak
 pip install -e ".[dev]"
 ```
@@ -64,7 +64,7 @@ CI runs automatically on every push and pull request targeting `main` or `oss-la
 3. **Test Matrix** — `pytest` runs across Python 3.10, 3.11, 3.12, and 3.13 with `--cov-fail-under=70`
 4. **Coverage Upload** — Coverage report uploaded to Codecov from the Python 3.11 run
 
-CI badge: [![CI](https://github.com/kaywhy331/tokenpak/actions/workflows/ci.yml/badge.svg)](https://github.com/kaywhy331/tokenpak/actions)
+CI badge: [![CI](https://github.com/tokenpak/tokenpak/actions/workflows/ci.yml/badge.svg)](https://github.com/tokenpak/tokenpak/actions)
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -25,7 +25,7 @@ info:
 
   contact:
     name: TokenPak
-    url: https://github.com/kaywhy331/tokenpak
+    url: https://github.com/tokenpak/tokenpak
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1115,7 +1115,7 @@ EOF
 ### 1. Search existing issues
 
 Check if someone has already reported your problem:
-https://github.com/kaywhy331/tokenpak/issues
+https://github.com/tokenpak/tokenpak/issues
 
 ### 2. File a bug report
 
@@ -1145,7 +1145,7 @@ Include the following in your report:
 <paste sanitized config>
 ```
 
-File at: https://github.com/kaywhy331/tokenpak/issues/new
+File at: https://github.com/tokenpak/tokenpak/issues/new
 
 ### 3. Error codes reference
 
@@ -1170,5 +1170,5 @@ ss -ltnp | grep 8766
 
 ### 5. Community
 
-- **GitHub Discussions:** https://github.com/kaywhy331/tokenpak/discussions
+- **GitHub Discussions:** https://github.com/tokenpak/tokenpak/discussions
 - **Documentation:** See [Documentation Index](index.md) for the full documentation reference

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -252,7 +252,7 @@ import type {
 ## Links
 
 - [Full documentation](https://github.com/tokenpak/tokenpak/blob/main/README.md)
-- [TPK Protocol spec](https://github.com/kaywhy331/tokenpak)
+- [TPK Protocol spec](https://github.com/tokenpak/tokenpak)
 - [Python package (PyPI)](https://pypi.org/project/tokenpak/)
 - [Issue tracker](https://github.com/tokenpak/tokenpak/issues)
 


### PR DESCRIPTION
**Public-safety hygiene — surgical, scope-locked.** Removes a personal GitHub username exposed across public repo surface, repointing all references to the canonical `@tokenpak` owner. No functional change.

### Scope (username-only — deliberately NOT a staging sync)
- `.github/CODEOWNERS` — all 22 owner entries → `@tokenpak`
- Clone-URL / contributor-contact refs in `CONTRIBUTING.md`, `docs/contributing.md`, `docs/openapi.yaml`, `docs/troubleshooting.md`, `sdk/README.md`

### Verification
- `git grep kaywhy331` on the branch tree → **0 occurrences**
- Only handle in CODEOWNERS after change: `@tokenpak`
- Both commits authored + committed as `TokenPak <hello@tokenpak.ai>`
- Cherry-picked directly onto public `main` so no unrelated staging commits are dragged in