### PR TITLE
test(cost-budget): pin clock so month/week window tests are date-stable

### DIFF
--- a/tests/test_cost_budget_cli.py
+++ b/tests/test_cost_budget_cli.py
@@ -16,6 +16,23 @@ import pytest
 # Helpers to wire the module to a temp DB
 # ---------------------------------------------------------------------------
 
+# A fixed reference "today" used by the date-relative fixtures below. It is
+# pinned to a mid-month, mid-week date so that "today" and "yesterday" always
+# fall in the same calendar month AND the same rolling 7-day window, regardless
+# of the real wall-clock date the suite runs on. Without this, the fixture's
+# "yesterday" row crosses the month boundary on the 1st of any month and the
+# "month" window query drops it (the failure mode this guard prevents).
+_FROZEN_TODAY = date(2026, 6, 15)
+
+
+class _FrozenDate(date):
+    """date subclass whose today() returns the fixed reference date."""
+
+    @classmethod
+    def today(cls):
+        return _FROZEN_TODAY
+
+
 @pytest.fixture
 def temp_db(tmp_path):
     """Create a temp monitor.db with schema + sample rows."""
@@ -42,8 +59,8 @@ def temp_db(tmp_path):
             cache_creation_tokens INTEGER
         )
     """)
-    today = date.today().isoformat()
-    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    today = _FROZEN_TODAY.isoformat()
+    yesterday = (_FROZEN_TODAY - timedelta(days=1)).isoformat()
     rows = [
         (f"{today}T10:00:00", "claude-sonnet-4-6", "chat", 1000, 100, 0.003, 300, 200, "https://api.anthropic.com/v1/messages", "hybrid", 900, 100, 200, None, 500, 50),
         (f"{today}T11:00:00", "claude-haiku-4-5",  "chat",  500,  50, 0.001, 200, 200, "https://api.anthropic.com/v1/messages", "hybrid", 400,  50, 100, None, 200, 20),
@@ -66,7 +83,8 @@ def cost_mod(temp_db):
 
     import tokenpak.cli.commands.cost as cost
     importlib.reload(cost)
-    with patch.object(cost, "_MONITOR_DB", temp_db):
+    with patch.object(cost, "_MONITOR_DB", temp_db), \
+         patch.object(cost, "date", _FrozenDate):
         yield cost
 
 
@@ -79,7 +97,8 @@ def budget_mod(temp_db, tmp_path):
     importlib.reload(budget)
     cfg_path = tmp_path / "budget_config.yaml"
     with patch.object(budget, "_MONITOR_DB", temp_db), \
-         patch.object(budget, "_BUDGET_CONFIG", cfg_path):
+         patch.object(budget, "_BUDGET_CONFIG", cfg_path), \
+         patch.object(budget, "date", _FrozenDate):
         yield budget, cfg_path
 
 


### PR DESCRIPTION
## What

Pins the clock for the cost/budget CLI window tests so they are deterministic regardless of the calendar date the suite runs on.

## Why

`TestQuerySummary::test_month_includes_all_rows` (and the other window tests) build sample rows relative to the real `date.today()` — 3 rows dated *today* + 1 dated *yesterday*. On the **1st of any month**, the *yesterday* row falls into the previous calendar month, so `query_summary("month")` — which filters `strftime('%Y-%m', timestamp) = <current month>` — drops it, and the test fails with `assert 3 == 4`.

This is a latent, date-fragile assertion that only breaks on the 1st of the month (it passed every other day), making CI unreliable once a month.

## Fix (test-only)

- Pin a fixed mid-month reference date (`2026-06-15`) for the date-relative fixtures, so *today* and *yesterday* always share the same calendar month **and** the same rolling 7-day window.
- Freeze the `date.today()` seen by `cost.py` and `budget.py` (via a `date` subclass patched into each module's fixture) so the product's window queries align with the fixture rows.

No product behavior change. Touches only `tests/test_cost_budget_cli.py`.

## Test evidence
- `tests/test_cost_budget_cli.py`: **50 passed** (previously 1 failed on the 1st-of-month boundary).
- `ruff check tokenpak/ tests/ --select=E,F,W,I --ignore=E501,E701,E702,E402,E741,F841`: clean.
