### PR TITLE
fix(proxy): evict upstream inflight keys to stop RSS leak (P1-PROXY-RSS-LEAK-RCA-FIX)

### DIFF
--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -160,11 +160,24 @@ def _get_upstream_semaphore(
 def _upstream_inflight_delta(
     provider: str, delta: int, session_key: Optional[str] = None
 ) -> int:
-    """Adjust and return the in-flight counter for (provider, session)."""
+    """Adjust and return the in-flight counter for (provider, session).
+
+    When a release (delta < 0) drives the counter to zero, the key is evicted
+    from both _upstream_inflight and _upstream_semaphores. session_key falls
+    back to the per-connection client "ip:port", so without eviction every
+    distinct key mints a permanent entry in both dicts that is never reclaimed
+    — they accumulate even with zero active connections, which is the RSS heap
+    leak. Entries are recreated lazily on the next request for the same key.
+    """
     key = (provider or "_unknown", session_key or "_shared")
     with _upstream_sem_lock:
-        _upstream_inflight[key] = max(0, _upstream_inflight.get(key, 0) + delta)
-        return _upstream_inflight[key]
+        count = max(0, _upstream_inflight.get(key, 0) + delta)
+        if delta < 0 and count == 0:
+            _upstream_inflight.pop(key, None)
+            _upstream_semaphores.pop(key, None)
+        else:
+            _upstream_inflight[key] = count
+        return count
 
 
 def get_upstream_inflight_snapshot() -> Dict[str, int]:


### PR DESCRIPTION
## Summary
Fixes the `tokenpak-proxy` RSS heap leak (~180–270 MB/h, memguard tripping at 2.8–3.2 GB with zero active connections).

**Root cause (RCA pinned by Sue, TokenPak fleet, 2026-06-01):** the module-level `_upstream_semaphores` and `_upstream_inflight` dicts in `tokenpak/proxy/server.py` are keyed by `(provider, session_key)`, where `session_key` falls back to the ephemeral per-connection client `ip:port`. Entries were created on first use but never removed (no `pop`/`del`/`clear`/TTL anywhere), so every new client TCP connection minted a permanent entry in both dicts — memory retained even at zero active connections.

**Fix:** evict both keys in `_upstream_inflight_delta` when a release (`delta < 0`) drives the in-flight count to zero. Entries are recreated lazily on the next request for the same key. No hardcoded cap; the optional LRU cap is unnecessary because eviction-on-zero already bounds both dicts to the set of currently in-flight keys.

## Scope
- `tokenpak/proxy/server.py` only — matches `expected_files_changed`. No drift.

## Test evidence
- **import-clean:** `import tokenpak.proxy.server` → OK (loaded from editable workbench install).
- **Smoke (200-request replay, touched path):** 200 distinct ephemeral `ip:port` keys cycled through acquire → +1 → release → −1.
  - `_upstream_inflight` entries after: **0**
  - `_upstream_semaphores` entries after: **0**
  - RSS delta: **0 KB** (no monotonic growth in the touched path)
  - Sanity: a key still in-flight is NOT evicted (eviction is release-only) — passes.
- **Regression:** `pytest tests/test_proxy_endpoints.py` → **37 passed**.
- **ruff** `tokenpak/proxy/server.py` → clean.

`tests: none-justified` per packet (runtime RSS-retention fix; no unit-test surface). Smoke harness: `/tmp/rss_leak_smoke.py`.

## Standards
Std 02 (code — ruff clean), Std 21 §10 (commit identity `TokenPak <hello@tokenpak.ai>`), Std 30 §9, Std 41 (canonical status).

## Out of scope / flags for review
- **Soak split (downstream gate):** multi-hour flat-RSS soak + memguard relaxation is a separate observation gate on the pr69 runtime (per rescoped acceptance 2026-06-01). This PR lands at fix + smoke.
- **Live pr69 tracemalloc confirmation + deploy** remain coupled to `p1-pr69-deploy-path-repair-2026-05-31`; not executed here (workbench host unreachable over SSH this cycle; `live_api_allowed: false`).
- **Pre-existing boundary leaks:** repo-wide public/internal boundary check reports 86 leaks, **none in `tokenpak/proxy/server.py`** and none in this diff — tracked separately by `p1-public-boundary-leak-scrub-pre-cutover-2026-06-01`.

Draft for Suki review. Trix does not merge.
