### PR TITLE
fix: skeleton capability probe + restore /health, /stats response builders

### DIFF
--- a/tests/proxy/test_stats_builders.py
+++ b/tests/proxy/test_stats_builders.py
@@ -1,0 +1,93 @@
+"""Regression: /health + /stats response builders must exist and be exercisable.
+
+`routes.py` lazily imports `build_health_response`/`build_stats_response` from
+`tokenpak.proxy.stats`; both defs were dropped in an earlier change, so hitting
+GET /health or GET /stats raised ImportError. These tests fail with ImportError
+against the broken tree and pass once the builders are restored.
+"""
+
+import json
+
+from tokenpak.proxy.stats import build_health_response, build_stats_response
+
+
+def test_build_health_response_returns_json_serialisable_dict():
+    resp = build_health_response(
+        session={"requests": 3, "canon_hits": 1},
+        compilation_mode="balanced",
+        vault_info={"available": True, "blocks": 12, "path": "/tmp/vault"},
+        router_info={"backends": 2},
+        router_enabled=True,
+        capsule_available=True,
+        canon_available=True,
+        skeleton_enabled=False,
+        shadow_enabled=False,
+        budget_total_tokens=100000,
+        tool_registry_stats={"tools": 5},
+        tool_registry_available=True,
+        term_resolver_enabled=False,
+        term_resolver_available=False,
+        term_resolver_top_k=8,
+        term_resolver_max_bytes=2048,
+        query_expansion_enabled=False,
+        upstream_timeout=60,
+        provider_circuits={"anthropic": {"open": False, "failures": 0}},
+        request_latencies=[10, 20, 30, 40],
+    )
+    assert resp["status"] == "ok"
+    assert resp["router"] == {"enabled": True, "backends": 2}
+    assert resp["circuit_breakers"]["anthropic"] == {"open": False, "failures": 0}
+    assert resp["stats"]["requests"] == 3
+    assert resp["latency"]["samples"] == 4
+    json.dumps(resp)  # must be JSON-serialisable
+
+
+def test_build_health_response_handles_empty_latencies():
+    resp = build_health_response(
+        session={},
+        compilation_mode="balanced",
+        vault_info={"available": False, "blocks": 0, "path": ""},
+        router_info={},
+        router_enabled=False,
+        capsule_available=False,
+        canon_available=False,
+        skeleton_enabled=False,
+        shadow_enabled=False,
+        budget_total_tokens=0,
+        tool_registry_stats={},
+        tool_registry_available=False,
+        term_resolver_enabled=False,
+        term_resolver_available=False,
+        term_resolver_top_k=0,
+        term_resolver_max_bytes=0,
+        query_expansion_enabled=False,
+        upstream_timeout=0,
+        provider_circuits={},
+        request_latencies=[],
+    )
+    assert resp["latency"] == {"p50_latency_ms": 0, "p99_latency_ms": 0, "samples": 0}
+    json.dumps(resp)
+
+
+def test_build_stats_response_returns_json_serialisable_dict():
+    resp = build_stats_response(
+        session={"requests": 7, "canon_hits": 2, "canon_tokens_saved": 99},
+        compilation_mode="aggressive",
+        vault_info={"available": True, "blocks": 4, "last_timing_ms": {}},
+        router_enabled=True,
+        capsule_available=False,
+        compression_timeouts=1,
+        max_compression_time_ms=500,
+        canon_available=True,
+        skeleton_enabled=True,
+        shadow_enabled=False,
+        budget_total_tokens=50000,
+        monitor_today={"requests": 7},
+        monitor_by_model={"claude": 7},
+        monitor_recent=[{"id": 1}],
+    )
+    assert resp["session"]["requests"] == 7
+    assert resp["canon"]["tokens_saved"] == 99
+    assert resp["today"] == {"requests": 7}
+    assert resp["recent"] == [{"id": 1}]
+    json.dumps(resp)

--- a/tests/test_skeleton_phantom_capability.py
+++ b/tests/test_skeleton_phantom_capability.py
@@ -1,0 +1,123 @@
+"""Regression tests for the skeleton phantom-capability truth patch.
+
+Context: the "code skeleton" feature is wired into config, profiles, the proxy
+injection path, and the doctor/status capability surface, and historically
+claimed "70-90% reduction on code" — but the core extractor module
+(``tokenpak.skeleton_extractor``) does not exist, so at runtime the feature is
+a silent no-op. The truth patch makes the capability surface report from a real
+import probe (not the intent flag), emits a diagnostic when the extractor is
+missing, and removes the unbacked savings claim.
+
+These tests fail against the pre-patch phantom state (feature reported
+active/available while the extractor is absent) and pass after it.
+
+When the real extractor is implemented, the ``pytest.skip`` guards below
+deactivate the "absent" assertions, and a follow-up change replaces them with
+their post-implementation inverse.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def _extractor_present() -> bool:
+    try:
+        from tokenpak.skeleton_extractor import extract_skeleton  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    _extractor_present(),
+    reason="skeleton extractor present (implemented); absence-invariant tests N/A",
+)
+
+
+def test_skeleton_available_probe_false_when_extractor_absent():
+    """The capability probe must reflect real importability, not a config flag."""
+    from tokenpak.proxy.config import skeleton_available
+
+    assert skeleton_available() is False
+
+
+def test_skeleton_not_reported_active_despite_enabled_flag(monkeypatch):
+    """Core anti-phantom invariant: enabled intent must NOT report 'active'
+    when the extractor cannot be imported."""
+    import tokenpak.proxy.config as cfg
+
+    # Even with the intent flag forced on (its default is True), skeleton must
+    # not be reported active because the extractor is absent.
+    monkeypatch.setattr(cfg, "SKELETON_ENABLED", True, raising=False)
+    assert cfg.skeleton_active() is False
+
+
+def test_skeletonize_block_is_noop_and_emits_diagnostic(monkeypatch, caplog):
+    """A missing extractor must (a) leave the block byte-identical and
+    (b) emit a diagnostic signal — never a silent swallow."""
+    import tokenpak.proxy.config as cfg
+    import tokenpak.vault.chunk_shaping as cs
+
+    monkeypatch.setattr(cfg, "SKELETON_ENABLED", True, raising=False)
+    # Reset the one-shot diagnostic latch for a deterministic assertion.
+    monkeypatch.setattr(cs, "_SKELETON_EXTRACTOR_MISSING", False, raising=False)
+
+    code = "def foo(x):\n    return x + 1\n"
+    with caplog.at_level(logging.WARNING, logger="tokenpak.skeleton"):
+        out = cs._skeletonize_block(code, ".py")
+
+    # (a) no-op / no corruption
+    assert out == code
+    # (b) diagnostic observable via status field ...
+    status = cs.skeleton_runtime_status()
+    assert status["enabled"] is True
+    assert status["available"] is False
+    assert status["extractor_missing_observed"] is True
+    # ... and via a log line
+    assert any("extractor unavailable" in r.message for r in caplog.records)
+
+
+def test_non_skeleton_injection_path_byte_identical(monkeypatch):
+    """Acceptance #4: the non-skeleton injection path (feature disabled) is
+    byte-identical — the truth patch must not change it."""
+    import tokenpak.proxy.config as cfg
+    import tokenpak.vault.chunk_shaping as cs
+
+    monkeypatch.setattr(cfg, "SKELETON_ENABLED", False, raising=False)
+    blocks = "Some prose.\n\n```python\ndef foo(x):\n    return x + 1\n```\n"
+    assert cs._inject_skeleton_into_blocks(blocks) == blocks
+
+
+def test_extractor_missing_preserves_code_body(monkeypatch):
+    """With skeleton enabled but the extractor absent, the code body must be
+    preserved (no skeletonization / no corruption).
+
+    NOTE: the enabled fence-rewrite path normalizes block whitespace (adds a
+    trailing newline before the closing fence) independently of this patch — a
+    pre-existing cosmetic quirk left for the real extractor work. This test
+    asserts content survival, not byte-equality, to avoid coupling to that quirk.
+    """
+    import tokenpak.proxy.config as cfg
+    import tokenpak.vault.chunk_shaping as cs
+
+    monkeypatch.setattr(cfg, "SKELETON_ENABLED", True, raising=False)
+    blocks = "Some prose.\n\n```python\ndef foo(x):\n    return x + 1\n```\n"
+    out = cs._inject_skeleton_into_blocks(blocks)
+    assert "def foo(x):" in out
+    assert "return x + 1" in out
+
+
+def test_no_unbacked_savings_percentage_in_injection_source():
+    """No live code may assert a skeleton savings percentage that isn't backed
+    by a passing benchmark test (the removed '70-90% reduction' claim)."""
+    import tokenpak.proxy.vault_bridge as vb
+
+    src = Path(vb.__file__).read_text(encoding="utf-8")
+    assert "70-90% reduction" not in src
+    assert "70-90%" not in src

--- a/tokenpak/proxy/config.py
+++ b/tokenpak/proxy/config.py
@@ -136,6 +136,37 @@ BUDGET_TOTAL_TOKENS: int = _cfg("budget.total_tokens", 12000, "TOKENPAK_BUDGET_T
 CHAT_FOOTER_ENABLED: bool = _cfg("features.chat_footer", False, "TOKENPAK_CHAT_FOOTER", bool)
 HTTP100_KEEPALIVE_ENABLED: bool = _cfg("features.http100_keepalive", False, "TOKENPAK_HTTP100_KEEPALIVE", bool)
 
+
+# ---------------------------------------------------------------------------
+# Skeleton capability probe
+#
+# SKELETON_ENABLED above is an *intent* flag only. The skeleton feature is
+# functional solely when the extractor module (tokenpak.skeleton_extractor)
+# can actually be imported. That module is optional and may be absent — in
+# which case chunk_shaping falls back to a no-op. The capability surface
+# (doctor / status / health) must therefore report from a *real probe*, not
+# from the intent flag; otherwise the feature reports "active" while doing
+# nothing. Report via skeleton_active(), not SKELETON_ENABLED.
+# ---------------------------------------------------------------------------
+def skeleton_available() -> bool:
+    """Real capability probe: True iff the skeleton extractor is importable."""
+    try:
+        from tokenpak.skeleton_extractor import extract_skeleton  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def skeleton_active() -> bool:
+    """True iff skeleton is enabled (intent) AND available (capability).
+
+    The only state in which skeleton extraction actually runs, and the value
+    the capability surface (doctor / status / health) must report.
+    """
+    return bool(SKELETON_ENABLED) and skeleton_available()
+
+
 # ---------------------------------------------------------------------------
 # TIP Spend Guard (proxy-side pre-send circuit breaker)
 # ---------------------------------------------------------------------------

--- a/tokenpak/proxy/routes.py
+++ b/tokenpak/proxy/routes.py
@@ -184,11 +184,11 @@ class ProxyRoutesMixin:
             QUERY_EXPANSION_ENABLED,
             ROUTER_ENABLED,
             SHADOW_ENABLED,
-            SKELETON_ENABLED,
             TERM_RESOLVER_ENABLED,
             TERM_RESOLVER_MAX_BYTES,
             TERM_RESOLVER_TOP_K,
             UPSTREAM_TIMEOUT,
+            skeleton_active,
         )
         from tokenpak.proxy.fallback import _provider_circuits
         from tokenpak.proxy.request_pipeline import (
@@ -220,7 +220,9 @@ class ProxyRoutesMixin:
             router_enabled=ROUTER_ENABLED,
             capsule_available=CAPSULE_BUILDER is not None,
             canon_available=CANON_AVAILABLE,
-            skeleton_enabled=SKELETON_ENABLED,
+            # Report from the real capability probe, not the intent flag:
+            # skeleton is "active" only if enabled AND the extractor imports.
+            skeleton_enabled=skeleton_active(),
             shadow_enabled=SHADOW_ENABLED,
             budget_total_tokens=BUDGET_TOTAL_TOKENS,
             tool_registry_stats=(
@@ -257,7 +259,7 @@ class ProxyRoutesMixin:
             MAX_COMPRESSION_TIME_MS,
             ROUTER_ENABLED,
             SHADOW_ENABLED,
-            SKELETON_ENABLED,
+            skeleton_active,
         )
         from tokenpak.proxy.stats import build_stats_response
 
@@ -275,7 +277,7 @@ class ProxyRoutesMixin:
                 compression_timeouts=SESSION.get("compression_timeouts", 0),
                 max_compression_time_ms=MAX_COMPRESSION_TIME_MS,
                 canon_available=CANON_AVAILABLE,
-                skeleton_enabled=SKELETON_ENABLED,
+                skeleton_enabled=skeleton_active(),
                 shadow_enabled=SHADOW_ENABLED,
                 budget_total_tokens=BUDGET_TOTAL_TOKENS,
                 monitor_today=MONITOR.get_stats(),

--- a/tokenpak/proxy/stats.py
+++ b/tokenpak/proxy/stats.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 
 class StatsCollector:
@@ -238,6 +238,173 @@ def reset_stats_collector() -> None:
         # Update module-level STATS as well
         import sys
         sys.modules[__name__].STATS = _SINGLETON
+
+
+def build_health_response(
+    *,
+    session: dict,
+    compilation_mode: str,
+    vault_info: dict,
+    router_info: dict,
+    router_enabled: bool,
+    capsule_available: bool,
+    canon_available: bool,
+    skeleton_enabled: bool,
+    shadow_enabled: bool,
+    budget_total_tokens: int,
+    tool_registry_stats: dict,
+    tool_registry_available: bool,
+    term_resolver_enabled: bool,
+    term_resolver_available: bool,
+    term_resolver_top_k: int,
+    term_resolver_max_bytes: int,
+    query_expansion_enabled: bool,
+    upstream_timeout: int,
+    provider_circuits: dict,
+    request_latencies: list,
+) -> dict:
+    """
+    Assemble the /health endpoint response dict.
+
+    All inputs are passed explicitly so this function is pure and testable.
+
+    Args:
+        session: Session-level counters dict.
+        compilation_mode: Active compilation mode string.
+        vault_info: Dict with ``available``, ``blocks``, ``path`` keys.
+        router_info: Dict returned by the router health helper.
+        router_enabled: Whether request routing is enabled.
+        capsule_available: Whether the capsule builder is initialised.
+        canon_available: Whether canon resolution is active.
+        skeleton_enabled: Whether skeleton mode is active.
+        shadow_enabled: Whether shadow reader is active.
+        budget_total_tokens: Configured token budget ceiling.
+        tool_registry_stats: Stats dict from ToolSchemaRegistry (may be empty).
+        tool_registry_available: Whether the tool registry is available.
+        term_resolver_enabled: Whether term resolver middleware is active.
+        term_resolver_available: Whether a TermResolver instance exists.
+        term_resolver_top_k: Configured top-k for term resolution.
+        term_resolver_max_bytes: Configured max bytes per term card.
+        query_expansion_enabled: Whether BM25 query expansion is active.
+        upstream_timeout: Upstream timeout in seconds.
+        provider_circuits: Dict of circuit-breaker state per provider.
+        request_latencies: Sorted list of recent request latency values (ms).
+
+    Returns:
+        JSON-serialisable dict suitable for ``self._send_json()``.
+    """
+    lats = sorted(request_latencies)
+    latency_info = {
+        "p50_latency_ms": lats[int(len(lats) * 0.50)] if lats else 0,
+        "p99_latency_ms": lats[int(len(lats) * 0.99)] if lats else 0,
+        "samples": len(lats),
+    }
+
+    return {
+        "status": "ok",
+        "compilation_mode": compilation_mode,
+        "vault_index": vault_info,
+        "router": {"enabled": router_enabled, **router_info},
+        "capsule_available": capsule_available,
+        "canon": {
+            "enabled": canon_available,
+            "session_hits": session.get("canon_hits", 0),
+        },
+        "skeleton": {"enabled": skeleton_enabled},
+        "shadow_reader": {"enabled": shadow_enabled},
+        "budget": {"enabled": True, "total_tokens": budget_total_tokens},
+        "tool_schema_registry": {
+            "enabled": tool_registry_available,
+            **(tool_registry_stats if tool_registry_available else {}),
+        },
+        "term_resolver": {
+            "enabled": term_resolver_enabled,
+            "available": term_resolver_available,
+            "top_k": term_resolver_top_k,
+            "max_bytes_per_card": term_resolver_max_bytes,
+        },
+        "query_expansion": {"enabled": query_expansion_enabled},
+        "cache_poison_removal": {"enabled": True},
+        "upstream_timeout_seconds": upstream_timeout,
+        "circuit_breakers": {
+            p: {"open": cb["open"], "failures": cb["failures"]}
+            for p, cb in provider_circuits.items()
+        },
+        "stats": {
+            "requests": session.get("requests", 0),
+            "input_tokens": session.get("input_tokens", 0),
+            "sent_input_tokens": session.get("sent_input_tokens", 0),
+            "saved_tokens": session.get("saved_tokens", 0),
+            "errors": session.get("errors", 0),
+            "cache_hits": session.get("cache_hits", 0),
+            "cache_misses": session.get("cache_misses", 0),
+            "cost": session.get("cost", 0),
+        },
+        "latency": latency_info,
+    }
+
+
+def build_stats_response(
+    *,
+    session: dict,
+    compilation_mode: str,
+    vault_info: dict,
+    router_enabled: bool,
+    capsule_available: bool,
+    compression_timeouts: int,
+    max_compression_time_ms: int,
+    canon_available: bool,
+    skeleton_enabled: bool,
+    shadow_enabled: bool,
+    budget_total_tokens: int,
+    monitor_today: Any,
+    monitor_by_model: Any,
+    monitor_recent: Any,
+) -> dict:
+    """
+    Assemble the /stats endpoint response dict.
+
+    All inputs are passed explicitly so this function is pure and testable.
+
+    Args:
+        session: Full session-level counters dict.
+        compilation_mode: Active compilation mode string.
+        vault_info: Dict with ``available``, ``blocks``, ``last_timing_ms`` keys.
+        router_enabled: Whether request routing is enabled.
+        capsule_available: Whether the capsule builder is initialised.
+        compression_timeouts: Count of compression timeouts this session.
+        max_compression_time_ms: Configured compression timeout ceiling (ms).
+        canon_available: Whether canon resolution is active.
+        skeleton_enabled: Whether skeleton mode is active.
+        shadow_enabled: Whether shadow reader is active.
+        budget_total_tokens: Configured token budget ceiling.
+        monitor_today: Today's stats from the Monitor instance.
+        monitor_by_model: Per-model stats from the Monitor instance.
+        monitor_recent: Recent request list from the Monitor instance.
+
+    Returns:
+        JSON-serialisable dict suitable for ``self._send_json()``.
+    """
+    return {
+        "session": session,
+        "compilation_mode": compilation_mode,
+        "vault_index": vault_info,
+        "router": {"enabled": router_enabled},
+        "capsule_available": capsule_available,
+        "compression_timeouts": compression_timeouts,
+        "max_compression_time_ms": max_compression_time_ms,
+        "canon": {
+            "enabled": canon_available,
+            "session_hits": session.get("canon_hits", 0),
+            "tokens_saved": session.get("canon_tokens_saved", 0),
+        },
+        "skeleton": {"enabled": skeleton_enabled},
+        "shadow_reader": {"enabled": shadow_enabled},
+        "budget": {"enabled": True, "total_tokens": budget_total_tokens},
+        "today": monitor_today,
+        "by_model": monitor_by_model,
+        "recent": monitor_recent,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tokenpak/proxy/vault_bridge.py
+++ b/tokenpak/proxy/vault_bridge.py
@@ -655,7 +655,9 @@ def inject_vault_context(
     if not combined_injection:
         return body_bytes, 0, []
 
-    # Apply skeleton extraction to code blocks in injection text (70-90% reduction on code)
+    # Apply skeleton extraction to code blocks in injection text (code-body
+    # elision when the extractor is available). No fixed savings percentage is
+    # asserted here — any such claim must be backed by a committed benchmark.
     _t4 = time.perf_counter()
     if SKELETON_ENABLED:
         combined_injection = _inject_skeleton_into_blocks(combined_injection)

--- a/tokenpak/vault/chunk_shaping.py
+++ b/tokenpak/vault/chunk_shaping.py
@@ -24,8 +24,41 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any, Dict, List, Tuple
+
+_log = logging.getLogger("tokenpak.skeleton")
+
+# Diagnostic state: flipped True the first time skeleton extraction is requested
+# (SKELETON_ENABLED) but the extractor module cannot be imported. A missing
+# extractor must NOT be swallowed silently — it is surfaced here and via
+# skeleton_runtime_status() so doctor/status/tests can observe the no-op.
+_SKELETON_EXTRACTOR_MISSING = False
+
+
+def _mark_skeleton_extractor_missing(exc: object = None) -> None:
+    """Record + log (once) that skeleton was enabled but the extractor is absent."""
+    global _SKELETON_EXTRACTOR_MISSING
+    if not _SKELETON_EXTRACTOR_MISSING:
+        _SKELETON_EXTRACTOR_MISSING = True
+        _log.warning(
+            "skeleton enabled but extractor unavailable "
+            "(tokenpak.skeleton_extractor.extract_skeleton not importable) — "
+            "code injection is a no-op; reporting skeleton as inactive (%s)",
+            exc,
+        )
+
+
+def skeleton_runtime_status() -> Dict[str, Any]:
+    """Diagnostic snapshot of skeleton runtime state (testable status field)."""
+    from tokenpak.proxy.config import SKELETON_ENABLED, skeleton_available
+
+    return {
+        "enabled": bool(SKELETON_ENABLED),
+        "available": skeleton_available(),
+        "extractor_missing_observed": _SKELETON_EXTRACTOR_MISSING,
+    }
 
 # ---------------------------------------------------------------------------
 # Shape Registry
@@ -400,7 +433,11 @@ def _skeletonize_block(content: str, file_ext: str) -> str:
         from tokenpak.skeleton_extractor import extract_skeleton
 
         return extract_skeleton(content, lang)
-    except Exception:
+    except Exception as exc:
+        # Fail-safe: return the block unchanged (no corruption), but emit a
+        # diagnostic signal so a missing/broken extractor is never swallowed
+        # silently and the feature is not reported as active.
+        _mark_skeleton_extractor_missing(exc)
         return content
 
 


### PR DESCRIPTION
Promotes two staging-verified fixes to the public OSS tree. Both ride the governed staging→public path; this PR opens the public CI gate.

## 1. Skeleton capability probe (not the intent flag)
The code-skeleton feature was wired into config, the proxy injection path, and the doctor/status/health capability surface, and asserted a fixed savings figure — but the extractor module is optional and may be absent, in which case injection silently no-ops while the surface still reported the feature active.
- `skeleton_available()` / `skeleton_active()` capability probes (real import check, not the enable flag)
- `/health` + `/stats` report from the probe
- diagnostic signal when enabled-but-unavailable instead of a silent swallow
- dropped the unbacked savings-percentage claim (must be benchmark-backed)
- regression tests covering probe, diagnostic, no-op, and claim removal
- the extractor implementation itself is intentionally out of scope

## 2. Restore `/health` + `/stats` response builders
`routes.py` lazily imports and calls `build_health_response` (`/health`) and `build_stats_response` (`/stats`) from `proxy.stats`, but both builder functions had been dropped from the tree — so exercising either route raised `ImportError`.
- restore both builders (signatures match the call sites); add `Any` to the typing import
- regression smoke test that fails pre-fix (ImportError) and passes after, asserting JSON-serializable output

## Scope / safety
- 7 files, +462/−7; no version bump, no tag, no release, no runtime change.
- Targeted tests green locally; both changes already passed the full staging CI.
- No behavior change to the non-skeleton injection path.