### PR TITLE
release: v1.7.1 — surgical patch (fixes, hardening, CI/deps hygiene)

### DIFF
--- a/.changeset/p5c-release-gate-hardening.md
+++ b/.changeset/p5c-release-gate-hardening.md
@@ -1,0 +1,14 @@
+---
+---
+
+Release-gate: tag-source ancestry check.
+
+`release.yml` now validates, as the first step of the `build` job, that a pushed
+`v*` tag is reachable from `origin/main` before any artifact is built. On a tag that
+is not on `origin/main` the workflow fails fast (`::error::` + `exit 1`), preventing a
+wrong-source release from drifting onto PyPI. The check is skipped for `rehearsal-*`
+tags (excluded by the job-level `refs/tags/v*` guard) and for `workflow_dispatch`
+preflight runs (step-level `github.event_name == 'push'` guard).
+
+No version impact: CI workflow definition only — no public API, runtime, or packaged
+code changes. Enforces the staging → public promotion path before tagging.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,13 +4,19 @@ on:
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
+  # Nightly signal-bearing run. Timing-sensitive perf/SLA tests (needs_fast_host)
+  # are excluded from the always-on PR correctness matrix because shared runners
+  # are noisy; this scheduled run keeps them executing and reporting on a regular
+  # cadence so real regressions are still caught (just not as a per-PR merge flake).
+  schedule:
+    - cron: "37 7 * * *"
 
 # Cancel in-progress runs for the same PR/branch
 concurrency:
   group: benchmarks-${{ github.ref }}
   cancel-in-progress: true
 
-# The "Post comment on PR" step uses marocchino/sticky-pull-request-comment@v2
+# The "Post comment on PR" step uses marocchino/sticky-pull-request-comment@v3
 # which needs `pull-requests: write` to publish a benchmark summary back to
 # the PR. Without this, the step fails with "Resource not accessible by
 # integration" and tanks the whole job even though the actual benchmarks +
@@ -105,7 +111,7 @@ jobs:
 
       - name: Post comment on PR
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: tokenpak-benchmarks
           path: pr_comment.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,16 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run unit tests
+        # needs_fast_host is excluded here on purpose: these are timing-sensitive
+        # perf/SLA assertions (wall-clock latency/throughput) that flake on shared
+        # GitHub runners, which are noisy and have no guaranteed capacity. They
+        # remain signal-bearing and run in the dedicated "Performance Benchmarks"
+        # workflow (benchmarks.yml: per-PR + nightly schedule) — just not in this
+        # always-on correctness matrix, so a noisy-runner blip cannot red-flag
+        # unrelated PRs. Marker convention: tests/conftest.py.
         run: |
           python -m pytest tests/ -v --tb=short \
-            -m "not integration and not chaos and not slow" \
+            -m "not integration and not chaos and not slow and not needs_fast_host" \
             --junitxml=reports/test-results-py${{ matrix.python-version }}.xml \
             --cov=tokenpak \
             --cov-report=xml \
@@ -172,7 +179,7 @@ jobs:
           }
 
       - name: Upload coverage (Tier-1)
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.11'
         with:
           files: ./coverage.xml,./coverage-tier1.xml

--- a/.github/workflows/identity-language-check.yml
+++ b/.github/workflows/identity-language-check.yml
@@ -200,6 +200,15 @@ jobs:
               # Internal-execution senses ("agent fleet", "fleet worker",
               # "fleet runtime", "fleet governor", "fleet agents", "bot fleet")
               # are deliberately NOT masked and remain forbidden.
+              #
+              # Functional spend-guard fleet surface (analogous to the openclaw
+              # functional-symbol mask below): the spend guard scopes rolling
+              # caps across a multi-instance fleet via the `x-tokenpak-fleet`
+              # request header and per-fleet / fleet-level capability prose.
+              # These are non-renamable API/protocol identifiers plus the public
+              # multi-instance-fleet capability — NOT internal-execution
+              # language — so those specific functional forms are masked; the
+              # internal senses listed above remain forbidden.
               sed -E \
                 -e 's/tokenpak[[:space:]]+fleet/tokenpak __PUBLIC_FLEET_VERB__/g' \
                 -e 's/--fleet([^a-zA-Z]|$)/--__PUBLIC_FLEET_FLAG__\1/g' \
@@ -224,6 +233,12 @@ jobs:
                 -e 's/cli\.fleet/cli.__PUBLIC_FLEET_MODULE__/g' \
                 -e 's/configure fleet/configure __PUBLIC_FLEET_PHRASE__/g' \
                 -e 's/=fleet\b/=__PUBLIC_FLEET_KW__/g' \
+                -e 's/x-tokenpak-fleet/x-tokenpak-__FUNCTIONAL_FLEET_HDR__/g' \
+                -e 's/per-fleet/per-__FUNCTIONAL_FLEET_SCOPE__/g' \
+                -e 's/fleet-level/__FUNCTIONAL_FLEET_SCOPE__-level/g' \
+                -e 's/fleet([- ])protection/__FUNCTIONAL_FLEET_SCOPE__\1protection/g' \
+                -e 's/fleet caps/__FUNCTIONAL_FLEET_SCOPE__ caps/g' \
+                -e 's#session ?/ ?fleet ?/ ?agent#session/__FUNCTIONAL_FLEET_SCOPE__/agent#g' \
                 "$file"
             elif is_release_gate_impl_path "$file"; then
               # Tier 1 — release-gate implementation/test/workflow surface:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
           TOKENPAK_TEST_MODE: "1"
 
       - name: Upload integration coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.12'
         with:
           file: coverage-integration.xml
@@ -85,7 +85,7 @@ jobs:
           TOKENPAK_TEST_MODE: "1"
 
       - name: Upload chaos coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.12'
         with:
           file: coverage-chaos.xml
@@ -176,7 +176,7 @@ jobs:
             --cov-fail-under=80
 
       - name: Upload combined coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           file: coverage-combined.xml
           flags: combined

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -124,6 +124,11 @@ jobs:
     name: Release-gate snapshot validation
     needs: preflight
     runs-on: ubuntu-latest
+    env:
+      # Skip first-run RBAC admin bootstrap during snapshot introspection so the
+      # ephemeral admin password is never emitted into (public) CI logs.
+      # See REIPO-SNAPGEN-LOG-HYGIENE-01.
+      TOKENPAK_SNAPSHOT_GEN: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,11 @@ jobs:
     # Std 30 §7 + §13.3 (R7 + R11): snapshot checks before any build/release.
     name: Release-gate snapshot validation
     runs-on: ubuntu-latest
+    env:
+      # Skip first-run RBAC admin bootstrap during snapshot introspection so the
+      # ephemeral admin password is never emitted into (public) CI logs.
+      # See REIPO-SNAPGEN-LOG-HYGIENE-01.
+      TOKENPAK_SNAPSHOT_GEN: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -200,6 +205,23 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
+
+      # Tag-source ancestry validation: refuse to build a release from a v-tag
+      # that is not reachable from origin/main. The job-level `if` already
+      # restricts to refs/tags/v*, so rehearsal-* tags never reach here; the
+      # step-level `if` additionally skips workflow_dispatch preflight (allowed
+      # on any branch by contract). Enforces the staging -> public promotion path.
+      - name: Validate tag source on origin/main
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=200
+          if git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::notice::Tag verified on origin/main"
+          else
+            echo "::error::Tag ${{ github.ref }} (sha ${{ github.sha }}) is not reachable from origin/main; refusing release. Releases must promote through staging to public main before tagging."
+            exit 1
+          fi
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -283,13 +305,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
       - name: Download checksums artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: checksums
           path: .
@@ -367,7 +389,7 @@ jobs:
       id-token: write  # Required for Trusted Publisher (OIDC)
     steps:
       - name: Download dist artifact only
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [1.7.1] — 2026-06-03
+
+Surgical patch release: fixes, hardening, and public-safety/CI hygiene only. No new
+features, no default-behavior changes, no breaking changes. (The install-footprint
+extras split remains parked for a future minor — see the Unreleased section below.)
+
+### Fixed
+
+- **proxy:** evict upstream inflight keys when the in-flight counter reaches zero,
+  preventing an upstream RSS leak under sustained load.
+- **proxy:** consolidate `CLAUDE_CODE_HEADER_ALLOWLIST` to a single canonical definition.
+- **companion:** `check_budget` no longer presents its result as authoritative total spend.
+- **companion:** lazy-load sentence-transformers so the MCP server starts quickly
+  (cold-start fix); launch the MCP server with a safe Python path (`-P`).
+- **companion:** defensive guard for truncated provider streams.
+- **pakplan:** read Pak recall from `recall.db` instead of a stale `journal.db`.
+- **spend-guard:** attribution-clear rolling-cap `402` response body.
+- **cli:** banner shows the live installed package version instead of a hardcoded string.
+- **paths:** fail-loud subdir allowlist in `_paths.under()` (and allow the `dispatch/` subdir).
+- **telemetry:** skip the RBAC admin bootstrap during snapshot generation.
+
+### Changed
+
+- **docs:** audit and compliance CLI stubs reworded as Pro-tier features; corrected
+  protocol terminology to TIP per the glossary.
+
+### Dependencies
+
+- Bump `websockets` to `>=16.0`; bump CI actions `codecov-action` 4→6,
+  `download-artifact` 4→8, `sticky-pull-request-comment` 2→3.
+
+### Internal
+
+- Suppress the ephemeral RBAC admin password from release-gate snapshot-validation CI
+  logs; snapshot generation now sets `TOKENPAK_SNAPSHOT_GEN=1` to skip the first-run
+  admin bootstrap during introspection.
+- CI: quarantine runner-sensitive perf/SLA tests from the blocking matrix; refresh the
+  release-gate workflow-steps snapshot; validate the release tag is reachable from the
+  release branch before build; mask functional identifiers in the identity check.
+
+### Note — licensing
+
+- The `tokenpak activate` licensing integration that landed on `main` during the v1.7.0
+  line ships to PyPI for the first time in **1.7.1**; users on the published 1.7.0 wheel
+  do not have it.
+
 ## [v1.7.0] — 2026-05-25
 
 > Corrected 2026-05-29: the Beta-1 CLI surface below was originally listed

--- a/packages/tests/test_stream_translator_cov.py
+++ b/packages/tests/test_stream_translator_cov.py
@@ -1,5 +1,5 @@
 """
-Tests for tokenpak/agent/proxy/providers/stream_translator.py
+Tests for tokenpak/proxy/providers/stream_translator.py
 
 Coverage targets:
 - _parse_sse_line() — SSE line parsing
@@ -14,11 +14,7 @@ Coverage targets:
 import json
 import pytest
 
-# Import from the build location since source doesn't have it
-import sys
-sys.path.insert(0, "/home/cali/tokenpak/build/lib")
-
-from tokenpak.agent.proxy.providers.stream_translator import (
+from tokenpak.proxy.providers.stream_translator import (
     _parse_sse_line,
     _sse_line,
     _sse_done,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Core uses Python stdlib only
 # Optional for better token counting:
 # tiktoken>=0.5.0
-websockets>=12.0
+websockets>=16.0

--- a/scripts/release_gate/gen_api_snapshot.py
+++ b/scripts/release_gate/gen_api_snapshot.py
@@ -31,10 +31,16 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import os
 import pkgutil
 import sys
 import time
 from pathlib import Path
+
+# Mark this process as a snapshot-generation run before any tokenpak module
+# is imported, so library first-run side effects (e.g. RBAC admin bootstrap)
+# are skipped and cannot pollute deterministic snapshot output.
+os.environ.setdefault("TOKENPAK_SNAPSHOT_GEN", "1")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT = REPO_ROOT / "tokenpak" / "_snapshots" / "public-api.json"

--- a/scripts/release_gate/gen_telemetry_schema.py
+++ b/scripts/release_gate/gen_telemetry_schema.py
@@ -15,10 +15,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 import time
 from pathlib import Path
+
+# Mark this process as a snapshot-generation run before any tokenpak module
+# is imported, so library first-run side effects (e.g. RBAC admin bootstrap)
+# are skipped and cannot pollute deterministic snapshot output.
+os.environ.setdefault("TOKENPAK_SNAPSHOT_GEN", "1")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUT = REPO_ROOT / "tokenpak" / "_snapshots" / "telemetry-schema.json"

--- a/tests/benchmarks/test_compression_benchmarks.py
+++ b/tests/benchmarks/test_compression_benchmarks.py
@@ -27,6 +27,13 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+# These benchmarks assert wall-clock latency thresholds (median_ms <= baseline×k)
+# and therefore flake on shared/noisy CI runners. Classify as needs_fast_host so
+# the always-on correctness matrix (ci.yml) excludes them; they still run and
+# report in the dedicated Performance Benchmarks workflow (benchmarks.yml).
+# See tests/conftest.py for the env-dependency marker convention.
+pytestmark = pytest.mark.needs_fast_host
+
 # ---------------------------------------------------------------------------
 # Path setup (allow running from repo root or tests/ dir)
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_pakplan_recall_db_drift.py
+++ b/tests/cli/test_pakplan_recall_db_drift.py
@@ -1,0 +1,94 @@
+"""Regression coverage for the pakplan recall-store drift cleanup.
+
+The pakplan preview/report path historically read its Pak metadata from a
+stale ``journal.db`` and joined against the old ``pak_reasons`` / ``pak_risks``
+tables — names that predate the canonical recall store. The recall store now
+owns ``recall.db`` with ``pak_reason_codes`` and ``pak_risk_flags``.
+
+These tests pin the current names so the drift cannot silently return:
+
+1. ``_recall_db()`` resolves to ``recall.db`` (not ``journal.db``).
+2. ``_query_paks()`` reads reason/risk metadata from the canonical
+   ``pak_reason_codes`` / ``pak_risk_flags`` tables of a real recall store.
+3. The module source carries no stale ``journal.db`` / ``pak_reasons`` /
+   ``pak_risks`` literals (mirrors the packet's regression-acceptance grep).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tokenpak.cli.commands import pakplan
+from tokenpak.companion.recall.store import (
+    ReasonCodeEntry,
+    RecallStore,
+    RiskFlagEntry,
+)
+
+
+def _seed_recall_db(path: Path) -> None:
+    store = RecallStore.open(path)
+    try:
+        store.upsert_pak(
+            pak_id="vault://block/example",
+            pak_type="vault",
+            source_type="doc",
+            authority="test",
+            title="Example Pak",
+            content_hash="deadbeef",
+            summary="example summary",
+        )
+        store.set_pak_reason_codes(
+            "vault://block/example",
+            [ReasonCodeEntry("current_task", 0.9)],
+        )
+        store.set_pak_risk_flags(
+            "vault://block/example",
+            [RiskFlagEntry("mandatory_context_missing", "warn")],
+        )
+    finally:
+        store.close()
+
+
+def test_recall_db_resolves_to_recall_not_journal() -> None:
+    db = pakplan._recall_db()
+    assert db is not None
+    assert db.name == "recall.db"
+    assert "journal.db" not in str(db)
+
+
+def test_query_paks_reads_canonical_reason_and_risk_tables(tmp_path: Path) -> None:
+    db = tmp_path / "recall.db"
+    _seed_recall_db(db)
+
+    rows = pakplan._query_paks(db, limit=10)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["pak_id"] == "vault://block/example"
+    # Joined from pak_reason_codes / pak_risk_flags — not the old tables.
+    assert row["_reason_codes"] == ["current_task"]
+    assert row["_risk_flags"] == ["mandatory_context_missing"]
+
+
+def test_query_pak_by_id_uses_canonical_store(tmp_path: Path) -> None:
+    db = tmp_path / "recall.db"
+    _seed_recall_db(db)
+
+    row = pakplan._query_pak_by_id(db, "vault://block/example")
+
+    assert row is not None
+    assert row["_reason_codes"] == ["current_task"]
+    assert row["_risk_flags"] == ["mandatory_context_missing"]
+
+
+def test_source_has_no_stale_drift_literals() -> None:
+    src = Path(pakplan.__file__).read_text(encoding="utf-8")
+    # The recall db source and join tables must use the current names.
+    assert "journal.db" not in src
+    assert not re.search(r'"pak_reasons"', src)
+    assert not re.search(r'"pak_risks"', src)
+    assert '"pak_reason_codes"' in src
+    assert '"pak_risk_flags"' in src
+    assert '"recall.db"' in src

--- a/tests/companion/test_launcher.py
+++ b/tests/companion/test_launcher.py
@@ -84,7 +84,23 @@ def test_write_mcp_config_structure(tmp_path):
     server = mcp_data["mcpServers"]["tokenpak-companion"]
     assert server["type"] == "stdio"
     assert server["command"] == sys.executable
-    assert server["args"] == ["-m", "tokenpak.companion.mcp.server"]
+    assert server["args"] == ["-P", "-m", "tokenpak.companion.mcp.server"]
+
+
+def test_write_mcp_config_uses_safe_python_path(tmp_path):
+    """MCP server is launched with -P so a ``tokenpak`` entry in the launch
+    cwd cannot shadow the installed package (cwd-shadow regression guard)."""
+    cfg = CompanionConfig(journal_dir=tmp_path / "journal")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True)
+    with patch.object(type(cfg), "run_dir", new_callable=lambda: property(lambda self: run_dir)):
+        launcher._write_mcp_config(cfg)
+    server = json.loads((run_dir / "mcp.json").read_text())["mcpServers"][
+        "tokenpak-companion"
+    ]
+    assert "-P" in server["args"]
+    # -P must precede -m to take effect for the module launch.
+    assert server["args"].index("-P") < server["args"].index("-m")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/companion/test_vector_local_coldstart.py
+++ b/tests/companion/test_vector_local_coldstart.py
@@ -1,0 +1,125 @@
+"""Regression: ``tokenpak.vault.retrieval.vector_local`` must import cheaply,
+without pulling in the heavy ML stack (``sentence_transformers`` /
+``transformers`` / ``torch``).
+
+Background
+----------
+The companion MCP server's import chain (companion → proxy → router → vault
+retrieval) reaches this module. ``vector_local`` used to
+``import sentence_transformers`` at module-load time, which transitively pulls
+in ``transformers`` + ``torch`` — a ~13s cold import. That delay made the MCP
+server miss Claude Code's MCP-connect window, so Claude Code reported it as a
+failed setup ("⚠ N setup issues: MCP").
+
+The fix makes ``sentence_transformers`` lazy in ``vector_local``: availability
+is *detected* at import via ``importlib.util.find_spec`` (cheap, no torch), and
+the real backend is imported only when retrieval is invoked, through
+``_load_sentence_transformer()`` (the call ``_ensure_model`` makes). These tests
+lock that contract at the ``vector_local`` boundary.
+
+Scope note (Track A)
+--------------------
+These tests deliberately assert the contract at ``vector_local`` itself and do
+**not** import ``tokenpak.companion.mcp_server`` — that MCP-server substrate is
+tracked on a separate track and is not part of canonical staging. Proving the
+property at ``vector_local`` is both sufficient (it is the module that did the
+heavy import) and canonical-only.
+
+Each test runs in a fresh subprocess so ``sys.modules`` is clean (other tests
+in the suite may legitimately import torch). To avoid the repo-root cwd shadow
+that otherwise resolves ``tokenpak`` to a bare namespace package, the
+subprocess runs from a throwaway temporary directory (not via the ``-P`` flag,
+which is Python 3.11+ and would break the 3.10 CI leg, and unlike ``-P``/``-I``
+does not isolate the user-site editable install used in local dev).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+
+# The heavy, slow-to-import optional ML dependencies that must NOT be pulled in
+# as a side effect of importing vector_local.
+HEAVY_MODULES = ("sentence_transformers", "transformers", "torch")
+
+_SUBPROC_TIMEOUT = 120  # generous: a cold torch import (if it regressed) is ~13s
+
+
+def _run_py(code: str) -> subprocess.CompletedProcess:
+    """Run ``code`` in a fresh interpreter from a neutral working directory.
+
+    Running from a throwaway temp dir keeps the implicit ``''`` (cwd) entry that
+    ``python -c`` puts on ``sys.path`` pointed at an empty directory, so
+    ``tokenpak`` resolves to the *installed* package rather than the repo-root
+    source tree (the cwd shadow). This replaces the ``-P`` flag, which is only
+    available on Python 3.11+ (the CI matrix includes 3.10); it also avoids
+    ``-P``/``-I`` isolation, which would drop the user-site editable install
+    relied on in local dev.
+    """
+    with tempfile.TemporaryDirectory() as neutral_cwd:
+        return subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=neutral_cwd,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROC_TIMEOUT,
+        )
+
+
+def test_vector_local_import_does_not_load_heavy_ml_stack():
+    """Importing vector_local must not import sentence_transformers /
+    transformers / torch, yet must still detect backend availability."""
+    code = (
+        "import sys\n"
+        "import tokenpak.vault.retrieval.vector_local as vl\n"
+        f"loaded = [m for m in {HEAVY_MODULES!r} if m in sys.modules]\n"
+        "print('LOADED:' + ','.join(loaded))\n"
+        "print('AVAILABLE:' + str(vl._ST_AVAILABLE))\n"
+    )
+    proc = _run_py(code)
+    assert proc.returncode == 0, f"vector_local import raised:\n{proc.stderr}"
+    loaded_line = [
+        ln for ln in proc.stdout.splitlines() if ln.startswith("LOADED:")
+    ][-1]
+    loaded = [m for m in loaded_line[len("LOADED:"):].split(",") if m]
+    assert loaded == [], (
+        "importing tokenpak.vault.retrieval.vector_local pulled in heavy ML "
+        f"modules {loaded}; these must stay lazy so the companion MCP server "
+        "answers `initialize` promptly (see _load_sentence_transformer)."
+    )
+    # Availability detection must still reflect reality — without importing it.
+    expected = importlib.util.find_spec("sentence_transformers") is not None
+    assert f"AVAILABLE:{expected}" in proc.stdout, proc.stdout
+
+
+def test_vector_retrieval_loads_backend_on_demand():
+    """The other half of the contract: laziness is not 'never'. Invoking
+    ``_load_sentence_transformer()`` (the call ``_ensure_model`` makes) must
+    perform the real ``from sentence_transformers import SentenceTransformer``
+    and wire the class into the module global.
+
+    A lightweight fake ``sentence_transformers`` is injected so the import
+    *wiring* is exercised deterministically, without paying the real ~13s
+    ``torch``/``transformers`` cost (which would make timing flaky in CI). The
+    companion test above already proves the real backend is detected (and not
+    loaded) at import time.
+    """
+    code = (
+        "import sys, types, importlib.machinery\n"
+        "fake = types.ModuleType('sentence_transformers')\n"
+        "fake.__spec__ = importlib.machinery.ModuleSpec('sentence_transformers', loader=None)\n"
+        "class _FakeST:\n"
+        "    def __init__(self, *a, **k): pass\n"
+        "fake.SentenceTransformer = _FakeST\n"
+        "sys.modules['sentence_transformers'] = fake\n"
+        "import tokenpak.vault.retrieval.vector_local as vl\n"
+        "assert vl.SentenceTransformer is None, 'class bound before first use'\n"
+        "cls = vl._load_sentence_transformer()\n"
+        "assert cls is _FakeST, cls\n"
+        "assert vl.SentenceTransformer is _FakeST, 'module global not populated on demand'\n"
+        "print('OK')\n"
+    )
+    proc = _run_py(code)
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout, proc.stdout

--- a/tests/proxy/spend_guard/test_402_attribution_message.py
+++ b/tests/proxy/spend_guard/test_402_attribution_message.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Locks the attribution-clear shape of the rolling-cap 402 body.
+
+Regression guard: the legacy 402 wording ``(agent=worker-a, used=60.15, cap=60)``
+was misread as "worker-a spent $60.15" when the $60.15 was the FLEET aggregate
+and ``agent=worker-a`` was merely the triggering caller. These tests assert the
+dimension-aware wording + structured fields so an operator reads it correctly.
+"""
+from __future__ import annotations
+
+import json
+
+from tokenpak.proxy.spend_guard.block_response import (
+    ERR_ROLLING_CAP_BLOCKED,
+    build_rolling_cap_block,
+)
+from tokenpak.proxy.spend_guard.rolling_caps import CapBreach
+
+
+def _decode(breach: CapBreach) -> dict:
+    return json.loads(build_rolling_cap_block(breach).decode("utf-8"))["error"]
+
+
+def _fleet_breach() -> CapBreach:
+    return CapBreach(
+        cap_dimension="per_fleet_cost_usd",
+        agent_id="worker-a",
+        window_seconds=3600,
+        used=60.15,
+        cap=60.0,
+        projected_add=0.524,
+        retry_after_seconds=1800,
+    )
+
+
+def _agent_breach() -> CapBreach:
+    return CapBreach(
+        cap_dimension="per_agent_cost_usd",
+        agent_id="worker-a",
+        window_seconds=3600,
+        used=20.5,
+        cap=20.0,
+        projected_add=0.3,
+        retry_after_seconds=1800,
+    )
+
+
+def test_fleet_breach_does_not_imply_caller_is_spender():
+    err = _decode(_fleet_breach())
+    msg = err["message"]
+    # The misleading legacy pattern must be gone for fleet breaches.
+    assert "(agent=worker-a," not in msg
+    # Caller is named as the trigger, not the spender.
+    assert "triggered_by=worker-a" in msg
+    assert "NOT necessarily the biggest spender" in msg
+    # Aggregate is explicitly labelled fleet-wide.
+    assert "fleet_used" in msg
+    assert "SUM of all tagged agents" in msg
+
+
+def test_fleet_breach_structured_fields():
+    err = _decode(_fleet_breach())
+    assert err["type"] == ERR_ROLLING_CAP_BLOCKED
+    assert err["scope"] == "fleet"
+    assert err["triggered_by"] == "worker-a"
+    assert err["fleet_used"] == 60.15
+    assert err["fleet_cap"] == 60.0
+    assert err["window_seconds"] == 3600
+    # Legacy fields retained for backward-compat.
+    assert err["agent_id"] == "worker-a"
+    assert err["used"] == 60.15
+    assert err["cap"] == 60.0
+    assert err["projected_add"] == 0.524
+    assert err["bypass_directive"] == "[TIP: allow=once]"
+
+
+def test_agent_breach_keeps_spender_semantics():
+    err = _decode(_agent_breach())
+    assert err["scope"] == "agent"
+    assert err["triggered_by"] == "worker-a"
+    # For per-agent caps, the caller IS the spender — fleet_* are null.
+    assert err["fleet_used"] is None
+    assert err["fleet_cap"] is None
+    assert "this IS worker-a's rolling usage" in err["message"]
+
+
+def test_contributing_agents_included_only_when_present():
+    breach = _fleet_breach()
+    # Absent by default.
+    assert "contributing_agents" not in _decode(breach)
+    # Present when the breach carries it.
+    breach.contributing_agents = [{"agent": "worker-b", "cost_usd": 41.2}]
+    err = _decode(breach)
+    assert err["contributing_agents"] == [{"agent": "worker-b", "cost_usd": 41.2}]

--- a/tests/proxy/test_header_allowlist_canonicality.py
+++ b/tests/proxy/test_header_allowlist_canonicality.py
@@ -1,0 +1,48 @@
+"""Guard against re-introducing a dual definition of CLAUDE_CODE_HEADER_ALLOWLIST.
+
+Before this guard, `tokenpak.proxy.passthrough` held a 7-entry tuple and
+`tokenpak.proxy.headers` held the canonical 19-entry frozenset; the shim at
+`tokenpak.core.runtime.proxy` re-exported the wrong one, so any caller that
+imported from the shim silently lost x-stainless-* and x-app forwarding.
+"""
+
+from tokenpak.core.runtime.proxy import (
+    CLAUDE_CODE_HEADER_ALLOWLIST as SHIM_ALLOWLIST,
+)
+from tokenpak.proxy import CLAUDE_CODE_HEADER_ALLOWLIST as PKG_ALLOWLIST
+from tokenpak.proxy.headers import CLAUDE_CODE_HEADER_ALLOWLIST as CANONICAL
+
+
+def test_shim_reexports_canonical_object():
+    assert SHIM_ALLOWLIST is CANONICAL
+
+
+def test_package_export_is_canonical_object():
+    assert PKG_ALLOWLIST is CANONICAL
+
+
+def test_passthrough_no_longer_defines_allowlist():
+    from tokenpak.proxy import passthrough
+
+    assert not hasattr(passthrough, "CLAUDE_CODE_HEADER_ALLOWLIST")
+
+
+def test_allowlist_size_is_canonical_18():
+    assert len(CANONICAL) == 18
+
+
+def test_required_billing_routing_headers_present():
+    for h in (
+        "x-stainless-arch",
+        "x-stainless-os",
+        "x-stainless-runtime",
+        "x-stainless-runtime-version",
+        "x-stainless-package-version",
+        "x-stainless-lang",
+        "x-app",
+        "accept",
+        "content-type",
+        "x-claude-code-session-id",
+        "user-agent",
+    ):
+        assert h in CANONICAL, f"missing header in canonical allowlist: {h}"

--- a/tests/telemetry/operational/test_rbac_snapshot_ctx.py
+++ b/tests/telemetry/operational/test_rbac_snapshot_ctx.py
@@ -1,0 +1,38 @@
+"""Snapshot-context guard for RBAC admin bootstrap (snapgen log hygiene).
+
+When ``TOKENPAK_SNAPSHOT_GEN=1`` (set by the release-gate snapshot generators
+``gen_api_snapshot.py`` / ``gen_telemetry_schema.py``), the RBAC operational
+store must NOT bootstrap a default admin: snapshot generation only introspects
+schema and must not mutate the store or emit first-run side effects that would
+pollute deterministic snapshot output. With the env unset, the normal first-run
+admin bootstrap is preserved.
+"""
+from __future__ import annotations
+
+import pytest
+
+try:
+    from tokenpak.telemetry.operational.rbac_auth import RBACStore
+except ImportError:  # flask (telemetry optional extra) not installed in slim CI
+    pytest.skip("requires flask (telemetry optional extra)", allow_module_level=True)
+
+
+def _count_users(store: RBACStore) -> int:
+    with store._conn() as conn:
+        return conn.execute("SELECT COUNT(*) FROM tp_users").fetchone()[0]
+
+
+def test_no_bootstrap_under_snapshot_gen(tmp_path, monkeypatch):
+    """TOKENPAK_SNAPSHOT_GEN=1 -> no admin created, store left empty."""
+    monkeypatch.setenv("TOKENPAK_SNAPSHOT_GEN", "1")
+    monkeypatch.delenv("TOKENPAK_ADMIN_BOOTSTRAP", raising=False)
+    store = RBACStore(db_path=str(tmp_path / "rbac.db"))
+    assert _count_users(store) == 0
+
+
+def test_bootstrap_preserved_when_env_unset(tmp_path, monkeypatch):
+    """Env unset -> first-run bootstrap still creates the default admin."""
+    monkeypatch.delenv("TOKENPAK_SNAPSHOT_GEN", raising=False)
+    monkeypatch.delenv("TOKENPAK_ADMIN_BOOTSTRAP", raising=False)
+    store = RBACStore(db_path=str(tmp_path / "rbac.db"))
+    assert _count_users(store) >= 1

--- a/tests/test_companion_stream_truncation.py
+++ b/tests/test_companion_stream_truncation.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the companion defensive truncated-stream guard.
+
+Covers:
+  * unit — fake provider closes mid-chunk -> StreamTruncatedError with the
+    stable code, partial content, and a trace_id.
+  * unit — fake provider emits ``event: message_stop`` then EOF -> NO false
+    positive (clean passthrough, no error).
+  * unit — feature flag off (TPK_STREAM_GUARD=0) -> pure passthrough.
+  * integration — a monitor.db row is written for the truncation event and a
+    sibling journal.db is left untouched (plane discipline).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from tokenpak.companion import stream as stream_mod
+from tokenpak.companion.stream import (
+    STREAM_TRUNCATED_CODE,
+    StreamTruncatedError,
+    guarded_stream,
+    read_provider_errors,
+)
+
+# ---------------------------------------------------------------------------
+# Fake providers
+# ---------------------------------------------------------------------------
+
+
+def _provider_closes_mid_chunk() -> Iterator[bytes]:
+    """SSE-style provider that drops before sending ``message_stop``."""
+    yield b'event: message_start\ndata: {"type":"message_start","message":{}}\n\n'
+    yield b'event: content_block_start\ndata: {"type":"content_block_start"}\n\n'
+    yield b'event: content_block_delta\ndata: {"type":"content_block_'
+    # Stream ends here — truncated mid-chunk, no message_stop.
+    return
+
+
+def _provider_clean_complete() -> Iterator[bytes]:
+    """SSE-style provider that ends correctly with ``message_stop``."""
+    yield b'event: message_start\ndata: {"type":"message_start","message":{}}\n\n'
+    yield b'event: content_block_delta\ndata: {"type":"text","text":"hi"}\n\n'
+    yield b'event: content_block_stop\ndata: {"type":"content_block_stop"}\n\n'
+    yield b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+
+def _provider_raises_mid_chunk() -> Iterator[bytes]:
+    """Provider whose byte iterator raises mid-stream (connection drop)."""
+    yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+    raise ConnectionError("peer reset")
+
+
+@pytest.fixture(autouse=True)
+def _guard_on(monkeypatch):
+    """Default the guard ON for each test unless a test overrides it."""
+    monkeypatch.setenv("TPK_STREAM_GUARD", "1")
+
+
+@pytest.fixture()
+def monitor_db(tmp_path, monkeypatch) -> Path:
+    """Point the monitor DB resolver at an isolated temp file via TOKENPAK_DB."""
+    db = tmp_path / "monitor.db"
+    # Seed a minimal valid monitor.db so _paths recognises it (read path needs
+    # the `requests` table + >100 bytes), and so write-path resolution returns
+    # this file rather than the user's real ledger.
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE requests (id INTEGER PRIMARY KEY, timestamp TEXT, "
+        "model TEXT, padding TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO requests (timestamp, model, padding) VALUES (?, ?, ?)",
+        ("seed", "seed", "x" * 200),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("TOKENPAK_DB", str(db))
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Unit — truncation detected
+# ---------------------------------------------------------------------------
+
+
+def test_mid_chunk_close_raises_truncated_with_partial_and_trace(monitor_db):
+    received = []
+    with pytest.raises(StreamTruncatedError) as excinfo:
+        for chunk in guarded_stream(_provider_closes_mid_chunk(), db_path=str(monitor_db)):
+            received.append(chunk)
+
+    err = excinfo.value
+    # Stable code surfaced to caller.
+    assert err.code == STREAM_TRUNCATED_CODE
+    # Partial content preserved (bytes seen before the cut).
+    assert err.partial_content == b"".join(received)
+    assert b"content_block_" in err.partial_content
+    # Trace id present + stable across the error envelope.
+    assert err.trace_id
+    envelope = err.to_dict()["error"]
+    assert envelope["code"] == STREAM_TRUNCATED_CODE
+    assert envelope["trace_id"] == err.trace_id
+    assert "max_output_tokens" in envelope["remedy"]
+    assert envelope["partial_content"]  # partial text shown to the user
+    # Reason classifies it as missing message_stop (SSE stream, no terminal).
+    assert err.reason in {"message_stop_missing", "json_envelope_unterminated"}
+
+
+def test_connection_drop_mid_chunk_is_flagged(monitor_db):
+    with pytest.raises(StreamTruncatedError) as excinfo:
+        for _ in guarded_stream(_provider_raises_mid_chunk(), db_path=str(monitor_db)):
+            pass
+    assert excinfo.value.code == STREAM_TRUNCATED_CODE
+    assert "connection_dropped_mid_chunk" in excinfo.value.reason
+
+
+# ---------------------------------------------------------------------------
+# Unit — no false positive on a clean stream
+# ---------------------------------------------------------------------------
+
+
+def test_clean_message_stop_no_false_positive(monitor_db):
+    received = []
+    # Must NOT raise.
+    for chunk in guarded_stream(_provider_clean_complete(), db_path=str(monitor_db)):
+        received.append(chunk)
+    assert b"message_stop" in b"".join(received)
+    # No provider.error event written for a clean stream.
+    assert read_provider_errors(db_path=str(monitor_db)) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit — feature flag off => pure passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_guard_disabled_passes_through(monitor_db, monkeypatch):
+    monkeypatch.setenv("TPK_STREAM_GUARD", "0")
+    received = []
+    # Even a truncated stream must NOT raise when the guard is off.
+    for chunk in guarded_stream(_provider_closes_mid_chunk(), db_path=str(monitor_db)):
+        received.append(chunk)
+    assert received  # bytes still delivered
+    # No event written in passthrough mode.
+    assert read_provider_errors(db_path=str(monitor_db)) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration — monitor.db written, journal.db untouched (plane discipline)
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_db_row_written_journal_untouched(tmp_path, monkeypatch):
+    monkeypatch.setenv("TPK_STREAM_GUARD", "1")
+    monitor = tmp_path / "monitor.db"
+    journal = tmp_path / "journal.db"
+
+    # Seed monitor.db so the resolver accepts it.
+    conn = sqlite3.connect(str(monitor))
+    conn.execute("CREATE TABLE requests (id INTEGER PRIMARY KEY, padding TEXT)")
+    conn.execute("INSERT INTO requests (padding) VALUES (?)", ("x" * 200,))
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("TOKENPAK_DB", str(monitor))
+
+    assert not journal.exists()
+
+    trace_id = None
+    with pytest.raises(StreamTruncatedError) as excinfo:
+        for _ in guarded_stream(_provider_closes_mid_chunk(), db_path=str(monitor)):
+            pass
+    trace_id = excinfo.value.trace_id
+
+    # Wire-plane row landed in monitor.db.
+    rows = read_provider_errors(db_path=str(monitor))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["event"] == "provider.error"
+    assert row["kind"] == "stream_truncated"
+    assert row["severity"] == "warn"
+    assert row["trace_id"] == trace_id
+    assert row["bytes_received"] > 0
+    # Structural attrs only — no raw body column exists.
+    assert "reason" in row
+    assert all("content" not in k or k == "last_event_kind" for k in row.keys())
+
+    # Plane discipline: journal.db was never created/written.
+    assert not journal.exists()
+
+
+def test_self_check_passes(monkeypatch):
+    """The doctor self-check exercises the path and reports pass."""
+    monkeypatch.delenv("TPK_STREAM_GUARD", raising=False)
+    result = stream_mod.self_check()
+    assert result["passed"] is True
+    assert result["code"] == STREAM_TRUNCATED_CODE
+    assert result["event_written"] is True

--- a/tests/test_output_formatter.py
+++ b/tests/test_output_formatter.py
@@ -1,14 +1,13 @@
 
 import pytest
 
-pytest.importorskip("tokenpak.formatting.formatter", reason="module not available in current build")
+pytest.importorskip("tokenpak._formatting.formatter", reason="module not available in current build")
 import types
 
-from tokenpak.formatting import symbols as FS
-from tokenpak.formatting.formatter import OutputFormatter
-from tokenpak.formatting.modes import OutputMode, resolve_mode
-
 from tokenpak import cli
+from tokenpak._formatting import symbols as FS
+from tokenpak._formatting.formatter import OutputFormatter
+from tokenpak._formatting.modes import OutputMode, resolve_mode
 
 
 def test_symbols_are_semantic_set():
@@ -22,9 +21,12 @@ def test_symbols_are_semantic_set():
 
 
 def test_formatter_header_and_divider():
+    import tokenpak
+
     f = OutputFormatter("Status")
     out = f.header()
-    assert "TOKENPAK v0.3.1  |  Status" in out
+    # Banner must reflect the live package version, not a hardcoded string.
+    assert f"TOKENPAK v{tokenpak.__version__}  |  Status" in out
     assert "─" * 40 in out
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tokenpak._paths — Std 33 §2 resolution + §5 under() contract.
+
+Covers P-PATHS-01a (resolver + fail-loud subdir enum) and P-PATHS-01b
+(``dispatch`` subdir extension).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tokenpak import _paths
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Isolate HOME and clear the TOKENPAK_HOME override for each test."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv(_paths.ENV_VAR, raising=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Std 33 §2 resolution order
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_home_env_override(fake_home, monkeypatch):
+    override = fake_home / "sandbox-home"
+    monkeypatch.setenv(_paths.ENV_VAR, str(override))
+    assert _paths.resolved_home() == override
+    assert _paths.home() == override  # alias parity
+
+
+def test_resolved_home_canonical_when_present(fake_home):
+    (fake_home / _paths.CANONICAL_DIRNAME).mkdir()
+    assert _paths.resolved_home() == fake_home / _paths.CANONICAL_DIRNAME
+
+
+def test_resolved_home_legacy_only_when_canonical_absent(fake_home):
+    (fake_home / _paths.LEGACY_DIRNAME).mkdir()
+    # canonical absent + legacy present -> legacy
+    assert _paths.resolved_home() == fake_home / _paths.LEGACY_DIRNAME
+    assert _paths.is_legacy() is True
+
+
+def test_resolved_home_prefers_canonical_over_legacy(fake_home):
+    (fake_home / _paths.CANONICAL_DIRNAME).mkdir()
+    (fake_home / _paths.LEGACY_DIRNAME).mkdir()
+    assert _paths.resolved_home() == fake_home / _paths.CANONICAL_DIRNAME
+    assert _paths.is_legacy() is False
+
+
+def test_resolved_home_canonical_when_neither_and_does_not_create(fake_home):
+    canonical = fake_home / _paths.CANONICAL_DIRNAME
+    assert _paths.resolved_home() == canonical
+    assert not canonical.exists()  # read-only resolution
+
+
+# ---------------------------------------------------------------------------
+# ensure_home() — mode 0700, idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_home_creates_with_mode_0700(fake_home):
+    h = _paths.ensure_home()
+    assert h.exists()
+    assert (os.stat(h).st_mode & 0o777) == 0o700
+
+
+def test_ensure_home_idempotent(fake_home):
+    first = _paths.ensure_home()
+    second = _paths.ensure_home()
+    assert first == second
+    assert second.exists()
+
+
+# ---------------------------------------------------------------------------
+# Std 33 §5 under() — allowed subdirs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subdir", ["templates", "companion", "pro"])
+def test_under_allows_std33_subdirs(fake_home, subdir):
+    assert _paths.under(subdir) == _paths.resolved_home() / subdir
+
+
+def test_under_allows_adopted_subdir_paks(fake_home):
+    # paks/ is in active use (pak.py) though not yet in Std 33 §3 text.
+    assert _paths.under("paks") == _paths.resolved_home() / "paks"
+
+
+def test_under_allows_multi_segment_under_subdir(fake_home):
+    assert _paths.under("companion", "journal.db") == (
+        _paths.resolved_home() / "companion" / "journal.db"
+    )
+    assert _paths.under("pro", "state", "multipak") == (
+        _paths.resolved_home() / "pro" / "state" / "multipak"
+    )
+
+
+@pytest.mark.parametrize(
+    "fname",
+    ["config.json", "config.yaml", "license.json", "pricing.json", "alert_state.json"],
+)
+def test_under_allows_top_level_files(fake_home, fname):
+    # Std 33 §5 sanctions under("file") for top-level files.
+    assert _paths.under(fname) == _paths.resolved_home() / fname
+
+
+# ---------------------------------------------------------------------------
+# Std 33 §5 under() — fail-loud on unknown subdirs
+# ---------------------------------------------------------------------------
+
+
+def test_under_rejects_unknown_subdir(fake_home):
+    with pytest.raises(ValueError, match="unknown TokenPak home subdir"):
+        _paths.under("nonexistent")
+
+
+def test_under_rejects_typod_subdir(fake_home):
+    with pytest.raises(ValueError):
+        _paths.under("compaion")  # typo of "companion"
+
+
+def test_under_rejects_empty(fake_home):
+    with pytest.raises(ValueError):
+        _paths.under()
+
+
+def test_under_does_not_create_directory(fake_home):
+    p = _paths.under("companion")
+    assert not p.exists()  # pure-path helper
+
+
+# ---------------------------------------------------------------------------
+# dispatch/ subdir (Std 33 §3 amendment, approved 2026-05-20)
+# ---------------------------------------------------------------------------
+
+
+def test_under_allows_dispatch(fake_home):
+    """dispatch/ is a canonical layout subdir."""
+    assert _paths.under("dispatch") == _paths.resolved_home() / "dispatch"
+
+
+def test_under_allows_dispatch_multi_segment(fake_home):
+    assert _paths.under("dispatch", "runs.db") == (
+        _paths.resolved_home() / "dispatch" / "runs.db"
+    )

--- a/tests/test_perf_quarantine_markers.py
+++ b/tests/test_perf_quarantine_markers.py
@@ -1,0 +1,54 @@
+"""Guard: runner-sensitive perf/SLA tests stay classified as ``needs_fast_host``.
+
+Two test modules assert wall-clock performance and therefore flake on shared CI
+runners (noisy, no guaranteed capacity):
+
+* ``tests/benchmarks/test_compression_benchmarks.py`` — median-latency thresholds
+* ``tests/benchmarks/test_load_100rps.py`` — sustained-throughput SLA targets
+
+They are intentionally excluded from the always-on correctness matrix
+(``.github/workflows/ci.yml`` runs ``pytest -m "... and not needs_fast_host"``)
+and instead run + report in the dedicated "Performance Benchmarks" workflow
+(``.github/workflows/benchmarks.yml``: per-PR + nightly schedule).
+
+If the ``needs_fast_host`` marker is dropped from either module, those tests
+silently re-enter the blocking matrix and start flaking unrelated PRs again.
+This guard fails loudly so the quarantine stays intentional and documented.
+
+It is itself a fast, deterministic correctness check (no timing assertions), so
+it runs in the normal matrix and enforces the policy on every PR.
+"""
+
+import importlib
+
+import pytest
+
+# Modules whose timing-sensitive perf/SLA tests must stay quarantined.
+QUARANTINED_MODULES = [
+    "tests.benchmarks.test_compression_benchmarks",
+    "tests.benchmarks.test_load_100rps",
+]
+
+
+def _module_marker_names(module) -> set:
+    """Return the set of marker names declared in a module-level ``pytestmark``.
+
+    ``pytestmark`` may be a single mark or a list/tuple of marks; normalise both.
+    """
+    pm = getattr(module, "pytestmark", [])
+    if not isinstance(pm, (list, tuple)):
+        pm = [pm]
+    return {getattr(m, "name", None) for m in pm}
+
+
+@pytest.mark.parametrize("module_path", QUARANTINED_MODULES)
+def test_perf_sla_tests_are_quarantined(module_path):
+    module = importlib.import_module(module_path)
+    assert "needs_fast_host" in _module_marker_names(module), (
+        f"{module_path} must carry the module-level `needs_fast_host` marker so "
+        f"the always-on CI matrix (.github/workflows/ci.yml) excludes its "
+        f"timing-sensitive perf/SLA assertions. Removing it re-introduces "
+        f"shared-runner flakiness into unrelated PRs. Drop it only via a "
+        f"deliberate CI-policy change (see .github/workflows/benchmarks.yml and "
+        f"tests/conftest.py)."
+    )

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -2374,8 +2374,8 @@ def _build_stub_parsers(sub):
     instead of a traceback.
     """
     _STUBS = {
-        "audit": "Enterprise audit log management (not yet implemented)",
-        "compliance": "Generate compliance reports (not yet implemented)",
+        "audit": "Enterprise audit log management (available in TokenPak Pro)",
+        "compliance": "Generate compliance reports (available in TokenPak Pro)",
         "watch": "Live terminal savings dashboard (not yet implemented — use `tokenpak dashboard` instead)",
     }
 

--- a/tokenpak/_formatting/formatter.py
+++ b/tokenpak/_formatting/formatter.py
@@ -17,7 +17,9 @@ class OutputFormatter:
         self.color = supports_color()
 
     def header(self) -> str:
-        line1 = f"TOKENPAK v1.1.0  |  {self.section}"
+        from tokenpak import __version__
+
+        line1 = f"TOKENPAK v{__version__}  |  {self.section}"
         line2 = "─" * 40
         return "\n".join([line1, line2])
 

--- a/tokenpak/_paths.py
+++ b/tokenpak/_paths.py
@@ -42,6 +42,51 @@ CANONICAL_DIRNAME = ".tpk"
 LEGACY_DIRNAME = ".tokenpak"
 ENV_VAR = "TOKENPAK_HOME"
 
+# Canonical TokenPak home layout subdirectories. ``under()`` fail-loud rejects
+# any extension-less first segment that is not in this set (or _ADOPTED_SUBDIRS),
+# per the always-dynamic fail-loud principle: do not silently accept unknown
+# subdirs (a typo'd subdir would otherwise create junk state). New subdirs are
+# added here when the canonical layout is amended.
+_STD_33_SUBDIRS: frozenset[str] = frozenset(
+    {
+        "templates",
+        "companion",
+        "pro",
+        # dispatch/ — TokenPak Dispatch runtime state (runs.db, artifacts/,
+        # tmp/, overlays/). Added per the canonical layout amendment of
+        # 2026-05-20.
+        "dispatch",
+    }
+)
+
+# Subdirs in active use that are not (yet) enumerated in the canonical layout.
+# Tracked separately so the drift is visible and can be reconciled into the
+# canonical layout rather than silently blessed. ``paks/`` is written by
+# tokenpak/cli/commands/pak.py and predates the resolver's fail-loud contract.
+_ADOPTED_SUBDIRS: frozenset[str] = frozenset(
+    {
+        "paks",
+    }
+)
+
+
+def _known_subdirs() -> frozenset[str]:
+    """All subdir names ``under()`` will accept (canonical layout + adopted)."""
+    return _STD_33_SUBDIRS | _ADOPTED_SUBDIRS
+
+
+def _is_top_level_file(name: str) -> bool:
+    """True when the first segment names a top-level file (e.g. ``config.json``).
+
+    The resolver contract explicitly sanctions ``under("file")`` for top-level
+    files ("always ... call ``_paths.under(\"file\")``"). Every top-level file
+    carries an extension (``config.json``, ``license.json``, ``telemetry.db``
+    ...), so the presence of a ``.`` distinguishes a file target from a
+    (typo'd) subdir target.
+    """
+    return "." in name
+
+
 _MONITOR_DB_ENV = "TOKENPAK_DB"
 _MONITOR_DB_ENV_COMPAT = "TOKENPAK_MONITOR_DB"
 _MONITOR_TABLE = "requests"
@@ -114,8 +159,25 @@ def under(*parts: str) -> Path:
     Pure-path helper — does not create parents. Equivalent to
     ``home().joinpath(*parts)`` but spelled to encourage callsites to
     say what they want at the import site, not assemble strings.
+
+    Fail-loud per the resolver contract: the first segment must be either a
+    known layout subdir (``_STD_33_SUBDIRS`` / ``_ADOPTED_SUBDIRS``) or a
+    top-level file (a name containing an extension). An unknown
+    extension-less first segment raises ``ValueError`` rather than
+    silently resolving — this catches typo'd subdirs (``under("compaion")``)
+    and not-yet-enumerated subdirs before they create junk state.
     """
-    return home().joinpath(*parts)
+    if not parts:
+        raise ValueError("under() requires at least one path segment")
+    first = parts[0]
+    if first in _known_subdirs() or _is_top_level_file(first):
+        return home().joinpath(*parts)
+    raise ValueError(
+        f"unknown TokenPak home subdir {first!r}: allowed subdirs are "
+        f"{sorted(_known_subdirs())}, or a top-level file (name with an "
+        f"extension, e.g. 'config.json'). Add new subdirs to "
+        f"_STD_33_SUBDIRS per a canonical layout amendment."
+    )
 
 
 def is_legacy_active() -> bool:
@@ -125,6 +187,20 @@ def is_legacy_active() -> bool:
     ``tokenpak config migrate`` to move to ``~/.tpk/``" advisory.
     """
     return home() == legacy_home() and not has_canonical()
+
+
+# Resolver-contract API names: ``resolved_home`` / ``is_legacy`` are the names
+# the public path API uses. They alias the module's existing ``home`` /
+# ``is_legacy_active`` so both spellings resolve identically and no existing
+# callsite breaks.
+def resolved_home() -> Path:
+    """Alias for :func:`home`."""
+    return home()
+
+
+def is_legacy() -> bool:
+    """Alias for :func:`is_legacy_active`."""
+    return is_legacy_active()
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +301,8 @@ __all__ = [
     "LEGACY_DIRNAME",
     "ENV_VAR",
     "home",
+    "resolved_home",
+    "is_legacy",
     "legacy_home",
     "canonical_home",
     "has_legacy",

--- a/tokenpak/_snapshots/workflow-steps.json
+++ b/tokenpak/_snapshots/workflow-steps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-05-25T16:58:36Z",
+  "generated_at": "2026-06-02T19:15:59Z",
   "guarded_globs": [
     "release*.yml",
     "release-rehearsal.yml"
@@ -311,6 +311,12 @@
       "job": "build",
       "id": "",
       "name": "Upload dist artifact (wheels + sdist only)"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "build",
+      "id": "",
+      "name": "Validate tag source on origin/main"
     },
     {
       "workflow": "release.yml",

--- a/tokenpak/cli/commands/doctor.py
+++ b/tokenpak/cli/commands/doctor.py
@@ -1123,6 +1123,43 @@ def run_doctor(
     return 0
 
 
+def run_stream_check(output_json: bool = False) -> int:
+    """Exercise the companion truncated-stream guard. Returns exit code.
+
+    Drives the defensive stream reader over a fake provider that closes the
+    connection mid-chunk (no terminal ``message_stop``). Exits 0 when the
+    guard flags the truncation with the stable ``TPK_STREAM_TRUNCATED`` code
+    and writes the structured ``provider.error`` telemetry event.
+    """
+    from tokenpak.companion import stream as _stream
+
+    result = _stream.self_check()
+    passed = bool(result.get("passed"))
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return 0 if passed else 2
+
+    print("\nTOKENPAK  |  Doctor — stream guard")
+    print("──────────────────────────────\n")
+    if passed:
+        print(Colors.ok(
+            f"Stream guard        truncation flagged ({result.get('code')}); "
+            f"provider.error event written"
+        ))
+        print("\n──────────────────────────────")
+        print("0 errors, 0 warnings.")
+        return 0
+    print(Colors.fail(
+        "Stream guard        FAILED to flag truncated stream — "
+        f"flagged={result.get('flagged')} code={result.get('code')} "
+        f"event_written={result.get('event_written')}"
+    ))
+    print("\n──────────────────────────────")
+    print("1 error, 0 warnings.")
+    return 2
+
+
 try:
     import click
 
@@ -1142,6 +1179,10 @@ try:
         "--claude-code", "claude_code", is_flag=True,
         help="Run Claude Code integration checks (ENABLE_TOOL_SEARCH, mode, IDE detection)",
     )
+    @click.option(
+        "--stream", "stream", is_flag=True,
+        help="Exercise the truncated-stream guard via a fake provider that closes mid-chunk",
+    )
     def doctor_cmd(
         fix: bool,
         fleet: bool,
@@ -1149,6 +1190,7 @@ try:
         verbose: bool,
         output_json: bool,
         claude_code: bool,
+        stream: bool,
     ) -> None:
         """Run diagnostics on your TokenPak installation.
 
@@ -1172,7 +1214,9 @@ try:
           tokenpak doctor --fleet --fix     # check + fix all agents
           tokenpak doctor --fleet --deploy  # push latest doctor to all agents first
         """
-        if fleet:
+        if stream:
+            rc = run_stream_check(output_json=output_json)
+        elif fleet:
             rc = run_fleet_doctor(fix=fix, deploy=deploy)
         else:
             rc = run_doctor(fix=fix, output_json=output_json, verbose=verbose, claude_code=claude_code)

--- a/tokenpak/cli/commands/pakplan.py
+++ b/tokenpak/cli/commands/pakplan.py
@@ -222,14 +222,15 @@ def _recall_db() -> Optional[Path]:
     """Resolve the recall db path under the canonical TokenPak home."""
     from tokenpak import _paths
 
-    return _paths.under("companion", "journal.db")
+    return _paths.under("companion", "recall.db")
 
 
 def _query_paks(db: Path, *, limit: int) -> list[dict]:
     """Return up to ``limit`` Pak rows joined with their reasons + risks.
 
-    The exact table names follow the PR #184 foundation. We probe for
-    table presence to stay forward-compatible with future renames.
+    Reason/risk metadata lives in the recall store's ``pak_reason_codes``
+    and ``pak_risk_flags`` tables. We probe for the Pak table presence to
+    stay forward-compatible with future renames.
     """
     if not db.exists():
         return []
@@ -258,8 +259,8 @@ def _query_paks(db: Path, *, limit: int) -> list[dict]:
         out: list[dict] = []
         for r in rows:
             d = dict(r)
-            d["_reason_codes"] = _join_codes(conn, "pak_reasons", d.get("pak_id"))
-            d["_risk_flags"] = _join_codes(conn, "pak_risks", d.get("pak_id"))
+            d["_reason_codes"] = _join_codes(conn, "pak_reason_codes", d.get("pak_id"))
+            d["_risk_flags"] = _join_codes(conn, "pak_risk_flags", d.get("pak_id"))
             out.append(d)
         return out
     finally:

--- a/tokenpak/companion/launcher.py
+++ b/tokenpak/companion/launcher.py
@@ -200,7 +200,11 @@ def _write_mcp_config(config: CompanionConfig) -> str:
             "tokenpak-companion": {
                 "type": "stdio",
                 "command": sys.executable,
-                "args": ["-m", "tokenpak.companion.mcp.server"],
+                # -P keeps the launch directory off sys.path so a ``tokenpak``
+                # dir/symlink in the cwd can't shadow the installed package
+                # (which would resolve it as a namespace package and drop
+                # ``__version__``, crashing the server on import).
+                "args": ["-P", "-m", "tokenpak.companion.mcp.server"],
             }
         }
     }

--- a/tokenpak/companion/mcp/tools.py
+++ b/tokenpak/companion/mcp/tools.py
@@ -139,6 +139,20 @@ def _handle_check_budget(state: CompanionState, args: dict[str, Any]) -> str:
         })
     if status >= 400:
         return json.dumps(body)
+    # Honest-reporting (split-brain trust fix): the proxy only accounts for
+    # traffic actually routed through the TokenPak value plane. A client routed
+    # natively (e.g. provider-native caching, no TokenPak proxy in path) is NOT
+    # counted here — so a low/zero figure must never be read as authoritative
+    # total spend. Always attach an explicit scope note; never return a bare 0.
+    if isinstance(body, dict):
+        body = dict(body)
+        body["_tokenpak_scope"] = (
+            "Reflects ONLY traffic routed through the TokenPak value plane "
+            "(proxy/companion). Natively-routed client traffic is NOT counted "
+            "here; a low or zero figure does not mean low total spend. If this "
+            "client is not routed through TokenPak, treat TokenPak accounting "
+            "as unavailable for it."
+        )
     return json.dumps(body, indent=2)
 
 

--- a/tokenpak/companion/stream.py
+++ b/tokenpak/companion/stream.py
@@ -1,0 +1,557 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+tokenpak.companion.stream — Defensive Truncated-Stream Guard
+============================================================
+
+A defensive reader wrapped around a provider's streamed (SSE-style) response.
+It does NOT alter, retry, or rewrite the underlying bytes — it only *observes*
+the stream as it is consumed and, on detecting a truncated / unterminated
+stream, surfaces a clean, structured error to the calling client while
+preserving the partial content already received.
+
+Three truncation conditions are detected:
+
+  (a) JSON envelope opened but never closed
+      — a top-level ``{`` (or ``[``) was seen but the matching closer never
+        arrived before the stream ended.
+  (b) ``event: message_stop`` never received before EOF
+      — the canonical terminal SSE event for an Anthropic message stream was
+        never observed.
+  (c) provider connection dropped mid-chunk
+      — the byte iterator raised mid-stream (e.g. ``ConnectionError``,
+        ``IncompleteRead``) rather than ending cleanly.
+
+On detection the guard:
+
+  1. Emits a structured ``provider.error`` event (``kind=stream_truncated``,
+     ``severity=warn``) to the wire-plane ledger (``monitor.db``) with attrs
+     ``{bytes_received, last_event_kind, time_since_last_chunk_ms, trace_id}``.
+     NO raw provider body content is ever written.
+  2. Raises :class:`StreamTruncatedError` carrying the partial content, a
+     stable error code ``TPK_STREAM_TRUNCATED``, a remedy hint, and the
+     ``trace_id`` for replay.
+
+Plane discipline: this module writes ONLY to ``monitor.db`` (the wire plane).
+It never touches the companion journal (``journal.db``).
+
+Feature flag: behaviour is gated behind the ``TPK_STREAM_GUARD`` environment
+variable. Default is ON. Set ``TPK_STREAM_GUARD=0`` to pass the stream through
+unchanged (no detection, no events, no wrapped error) — a pure passthrough
+fallback identical to pre-guard behaviour.
+
+Usage::
+
+    from tokenpak.companion.stream import guarded_stream, StreamTruncatedError
+
+    try:
+        for chunk in guarded_stream(provider_byte_iter):
+            forward_to_client(chunk)
+    except StreamTruncatedError as err:
+        # err.partial_content holds bytes received so far
+        # err.code == "TPK_STREAM_TRUNCATED"
+        # err.trace_id for replay; err.remedy for the user-facing hint
+        surface_clean_error(err.to_dict())
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Environment flag controlling the guard. Default ON; "0" => passthrough.
+GUARD_ENV = "TPK_STREAM_GUARD"
+
+#: Stable, machine-parseable error code surfaced to the calling client.
+STREAM_TRUNCATED_CODE = "TPK_STREAM_TRUNCATED"
+
+#: User-facing remedy hint. No internal references.
+STREAM_TRUNCATED_REMEDY = "retry with smaller max_output_tokens or shorter prompt"
+
+#: TIP event name + classification for the emitted telemetry event.
+EVENT_NAME = "provider.error"
+EVENT_KIND = "stream_truncated"
+EVENT_SEVERITY = "warn"
+
+#: Canonical terminal SSE event line for an Anthropic message stream.
+_MESSAGE_STOP_MARKER = "message_stop"
+
+#: monitor.db table holding structured provider events (additive — the
+#: request ledger table ``requests`` is left untouched).
+_EVENTS_TABLE = "provider_events"
+
+
+def guard_enabled() -> bool:
+    """Return True when the stream guard is active.
+
+    ON by default; only the explicit string ``"0"`` disables it. Any other
+    value (including unset) keeps the guard on.
+    """
+    return os.environ.get(GUARD_ENV, "1").strip() != "0"
+
+
+# ---------------------------------------------------------------------------
+# Structured error surfaced to the caller
+# ---------------------------------------------------------------------------
+
+
+class StreamTruncatedError(Exception):
+    """Clean, structured error raised when a provider stream is truncated.
+
+    Carries the partial content received so far, a stable error code, a
+    remedy hint, and the trace_id for replay. The string form is safe to log
+    (it contains the code + trace_id but never raw provider body content).
+    """
+
+    code: str = STREAM_TRUNCATED_CODE
+
+    def __init__(
+        self,
+        *,
+        partial_content: bytes,
+        trace_id: str,
+        reason: str,
+        last_event_kind: str = "",
+        bytes_received: int = 0,
+        time_since_last_chunk_ms: int = 0,
+        remedy: str = STREAM_TRUNCATED_REMEDY,
+    ) -> None:
+        self.partial_content = partial_content
+        self.trace_id = trace_id
+        self.reason = reason
+        self.last_event_kind = last_event_kind
+        self.bytes_received = bytes_received
+        self.time_since_last_chunk_ms = time_since_last_chunk_ms
+        self.remedy = remedy
+        super().__init__(
+            f"{self.code}: provider stream truncated ({reason}); "
+            f"trace_id={trace_id}; remedy={remedy}"
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe error envelope for the calling client.
+
+        ``partial_content`` is decoded leniently to text so it can be shown to
+        the user. The byte form remains available on the exception instance.
+        """
+        return {
+            "error": {
+                "code": self.code,
+                "message": "Provider stream ended before completion.",
+                "reason": self.reason,
+                "remedy": self.remedy,
+                "trace_id": self.trace_id,
+                "partial_content": self.partial_content.decode("utf-8", "replace"),
+            }
+        }
+
+
+# ---------------------------------------------------------------------------
+# Stream-state tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StreamState:
+    """Mutable accounting carried while the guard consumes a stream."""
+
+    trace_id: str
+    buffer: bytearray = field(default_factory=bytearray)
+    bytes_received: int = 0
+    last_event_kind: str = ""
+    saw_message_stop: bool = False
+    json_depth: int = 0
+    json_opened: bool = False
+    in_string: bool = False
+    escaped: bool = False
+    last_chunk_at: float = field(default_factory=time.monotonic)
+    connection_dropped: bool = False
+    drop_detail: str = ""
+
+    def note_chunk(self, chunk: bytes) -> None:
+        """Update accounting from a freshly received chunk."""
+        self.last_chunk_at = time.monotonic()
+        self.bytes_received += len(chunk)
+        self.buffer.extend(chunk)
+        self._scan_json(chunk)
+        self._scan_events(chunk)
+
+    # ---- JSON envelope balance (condition a) -------------------------------
+
+    def _scan_json(self, chunk: bytes) -> None:
+        """Track top-level JSON brace/bracket balance, string-aware.
+
+        Detects whether a JSON envelope was opened. ``json_depth`` returning
+        to 0 after having opened means a balanced (closed) envelope; a
+        positive depth at EOF means an unterminated envelope.
+        """
+        for byte in chunk:
+            ch = chr(byte)
+            if self.in_string:
+                if self.escaped:
+                    self.escaped = False
+                elif ch == "\\":
+                    self.escaped = True
+                elif ch == '"':
+                    self.in_string = False
+                continue
+            if ch == '"':
+                self.in_string = True
+            elif ch in "{[":
+                self.json_depth += 1
+                self.json_opened = True
+            elif ch in "}]":
+                if self.json_depth > 0:
+                    self.json_depth -= 1
+
+    @property
+    def json_envelope_unterminated(self) -> bool:
+        """True when a JSON envelope was opened but never balanced/closed."""
+        return self.json_opened and (self.json_depth > 0 or self.in_string)
+
+    # ---- SSE event tracking (condition b) ----------------------------------
+
+    def _scan_events(self, chunk: bytes) -> None:
+        """Track the last SSE ``event:`` line and the terminal message_stop.
+
+        Decoded leniently; we only read structural ``event:`` markers, never
+        retain body content.
+        """
+        text = chunk.decode("utf-8", "ignore")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("event:"):
+                kind = stripped[len("event:"):].strip()
+                if kind:
+                    self.last_event_kind = kind
+                    if kind == _MESSAGE_STOP_MARKER:
+                        self.saw_message_stop = True
+
+    def time_since_last_chunk_ms(self) -> int:
+        return int((time.monotonic() - self.last_chunk_at) * 1000)
+
+
+def _looks_like_sse(buffer: bytes) -> bool:
+    """Heuristic: does this stream carry SSE ``event:`` framing at all?
+
+    The ``message_stop`` check (condition b) only applies to SSE-framed
+    streams. A non-SSE byte stream (e.g. a single JSON body) is judged purely
+    by the JSON-envelope balance check, avoiding false positives.
+    """
+    return b"event:" in buffer
+
+
+# ---------------------------------------------------------------------------
+# The guard itself
+# ---------------------------------------------------------------------------
+
+
+def guarded_stream(
+    source: Iterable[bytes],
+    *,
+    trace_id: Optional[str] = None,
+    db_path: Optional[str] = None,
+) -> Iterator[bytes]:
+    """Wrap *source* (an iterable of byte chunks) with truncation detection.
+
+    Yields each chunk unchanged as it is read (byte-for-byte passthrough). On
+    a clean end-of-stream the generator simply stops. On a detected
+    truncation it emits a ``provider.error`` event to ``monitor.db`` and
+    raises :class:`StreamTruncatedError` carrying the partial content.
+
+    When the guard is disabled (``TPK_STREAM_GUARD=0``) this is a pure
+    passthrough: chunks are yielded with no detection, no event, no wrapped
+    error.
+
+    Args:
+        source: Iterable yielding ``bytes`` chunks from the provider.
+        trace_id: Optional stable trace id; generated if omitted.
+        db_path: Optional explicit monitor.db path (testing/override).
+
+    Yields:
+        Each chunk of *source*, unmodified.
+
+    Raises:
+        StreamTruncatedError: when a truncated/unterminated stream is detected
+            (only when the guard is enabled).
+    """
+    if not guard_enabled():
+        yield from source
+        return
+
+    tid = trace_id or str(uuid.uuid4())
+    state = _StreamState(trace_id=tid)
+
+    iterator = iter(source)
+    while True:
+        try:
+            chunk = next(iterator)
+        except StopIteration:
+            break
+        except Exception as exc:  # condition (c): dropped mid-chunk
+            state.connection_dropped = True
+            state.drop_detail = type(exc).__name__
+            break
+        if not isinstance(chunk, (bytes, bytearray)):
+            chunk = bytes(str(chunk), "utf-8")
+        state.note_chunk(bytes(chunk))
+        yield bytes(chunk)
+
+    reason = _detect_truncation(state)
+    if reason is None:
+        return
+
+    _emit_provider_error(state, reason, db_path=db_path)
+    raise StreamTruncatedError(
+        partial_content=bytes(state.buffer),
+        trace_id=state.trace_id,
+        reason=reason,
+        last_event_kind=state.last_event_kind,
+        bytes_received=state.bytes_received,
+        time_since_last_chunk_ms=state.time_since_last_chunk_ms(),
+    )
+
+
+def _detect_truncation(state: _StreamState) -> Optional[str]:
+    """Return a short reason string if the stream was truncated, else None.
+
+    Order of precedence: connection drop (most authoritative) → unterminated
+    JSON envelope → missing message_stop on an SSE stream. An empty stream is
+    treated as a connection-dropped truncation (nothing useful arrived).
+    """
+    if state.connection_dropped:
+        return f"connection_dropped_mid_chunk:{state.drop_detail or 'unknown'}"
+    if state.bytes_received == 0:
+        return "empty_stream"
+    if state.json_envelope_unterminated:
+        return "json_envelope_unterminated"
+    if _looks_like_sse(bytes(state.buffer)) and not state.saw_message_stop:
+        return "message_stop_missing"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Telemetry — provider.error event into monitor.db (wire plane only)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_monitor_db(db_path: Optional[str]) -> Optional[str]:
+    """Resolve the monitor.db write path via _paths (or an explicit override)."""
+    if db_path:
+        return db_path
+    try:
+        from tokenpak import _paths
+
+        resolved = _paths.monitor_db(mode="write")
+        return str(resolved) if resolved else None
+    except Exception:
+        return None
+
+
+def _ensure_events_table(conn: sqlite3.Connection) -> None:
+    """Create the additive provider_events table if absent.
+
+    This is additive: it never alters the ``requests`` ledger schema and is
+    safe to call repeatedly.
+    """
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_EVENTS_TABLE} (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            event TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            trace_id TEXT,
+            bytes_received INTEGER DEFAULT 0,
+            last_event_kind TEXT DEFAULT '',
+            time_since_last_chunk_ms INTEGER DEFAULT 0,
+            reason TEXT DEFAULT ''
+        )
+        """
+    )
+    conn.execute(
+        f"CREATE INDEX IF NOT EXISTS idx_provider_events_ts "
+        f"ON {_EVENTS_TABLE}(timestamp)"
+    )
+
+
+def _emit_provider_error(
+    state: _StreamState,
+    reason: str,
+    *,
+    db_path: Optional[str] = None,
+) -> bool:
+    """Write a ``provider.error`` (kind=stream_truncated) row to monitor.db.
+
+    Returns True on a successful write, False if no DB could be resolved or the
+    write failed (telemetry is best-effort and never raises into the caller).
+
+    Only structural attrs are recorded — NEVER raw provider body content.
+    """
+    resolved = _resolve_monitor_db(db_path)
+    if not resolved:
+        return False
+    try:
+        conn = sqlite3.connect(str(resolved), timeout=5)
+        try:
+            _ensure_events_table(conn)
+            conn.execute(
+                f"""
+                INSERT INTO {_EVENTS_TABLE}
+                    (timestamp, event, kind, severity, trace_id,
+                     bytes_received, last_event_kind,
+                     time_since_last_chunk_ms, reason)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    datetime.now(timezone.utc).isoformat(),
+                    EVENT_NAME,
+                    EVENT_KIND,
+                    EVENT_SEVERITY,
+                    state.trace_id,
+                    int(state.bytes_received),
+                    state.last_event_kind,
+                    int(state.time_since_last_chunk_ms()),
+                    reason,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+    except Exception:
+        return False
+
+
+def read_provider_errors(
+    db_path: Optional[str] = None,
+    *,
+    kind: str = EVENT_KIND,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    """Read recent provider.error rows from monitor.db (for doctor/inspection).
+
+    Returns an empty list when the DB or table is absent.
+    """
+    resolved = _resolve_monitor_db(db_path)
+    if not resolved:
+        return []
+    try:
+        conn = sqlite3.connect(str(resolved), timeout=5)
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name=?",
+                (_EVENTS_TABLE,),
+            )
+            if cur.fetchone() is None:
+                return []
+            rows = conn.execute(
+                f"SELECT * FROM {_EVENTS_TABLE} WHERE kind=? "
+                f"ORDER BY id DESC LIMIT ?",
+                (kind, int(limit)),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Self-test exercised by ``tokenpak doctor --stream``
+# ---------------------------------------------------------------------------
+
+
+def self_check(db_path: Optional[str] = None) -> Dict[str, Any]:
+    """Exercise the truncation path with a FAKE provider closing mid-chunk.
+
+    Drives :func:`guarded_stream` over a fake SSE provider that emits a couple
+    of events and then ends WITHOUT ``event: message_stop`` (i.e. truncated).
+    Returns a result dict describing whether the guard flagged it.
+
+    The check uses an isolated temp monitor.db so it never pollutes the user's
+    real ledger, and is independent of the live ``TPK_STREAM_GUARD`` setting
+    (it forces the guard on for the duration of the check).
+    """
+    import tempfile
+
+    def _fake_truncating_provider() -> Iterator[bytes]:
+        yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+        yield b'event: content_block_delta\ndata: {"type":"content_block_'
+        # Connection drops here — no message_stop, mid-chunk.
+        return
+
+    prev = os.environ.get(GUARD_ENV)
+    os.environ[GUARD_ENV] = "1"
+    tmp = db_path
+    cleanup = False
+    if tmp is None:
+        fd, tmp = tempfile.mkstemp(prefix="tpk-stream-selfcheck-", suffix=".db")
+        os.close(fd)
+        cleanup = True
+
+    result: Dict[str, Any] = {
+        "check": "stream_guard",
+        "flagged": False,
+        "code": None,
+        "trace_id": None,
+        "event_written": False,
+        "reason": None,
+    }
+    try:
+        try:
+            for _ in guarded_stream(_fake_truncating_provider(), db_path=tmp):
+                pass
+        except StreamTruncatedError as err:
+            result["flagged"] = True
+            result["code"] = err.code
+            result["trace_id"] = err.trace_id
+            result["reason"] = err.reason
+            rows = read_provider_errors(db_path=tmp)
+            result["event_written"] = any(
+                r.get("trace_id") == err.trace_id for r in rows
+            )
+    finally:
+        if prev is None:
+            os.environ.pop(GUARD_ENV, None)
+        else:
+            os.environ[GUARD_ENV] = prev
+        if cleanup:
+            for suffix in ("", "-wal", "-shm"):
+                try:
+                    os.unlink(tmp + suffix)
+                except OSError:
+                    pass
+
+    result["passed"] = bool(
+        result["flagged"]
+        and result["code"] == STREAM_TRUNCATED_CODE
+        and result["event_written"]
+    )
+    return result
+
+
+__all__ = [
+    "GUARD_ENV",
+    "STREAM_TRUNCATED_CODE",
+    "STREAM_TRUNCATED_REMEDY",
+    "EVENT_NAME",
+    "EVENT_KIND",
+    "EVENT_SEVERITY",
+    "guard_enabled",
+    "guarded_stream",
+    "StreamTruncatedError",
+    "read_provider_errors",
+    "self_check",
+]

--- a/tokenpak/core/runtime/proxy.py
+++ b/tokenpak/core/runtime/proxy.py
@@ -3,12 +3,12 @@ tokenpak.core.runtime.proxy — compatibility shim
 
 The old monolithic proxy.py that lived here has been deleted as part of the
 TPK-CONSOLIDATION-B1 cleanup.  This shim re-exports canonical symbols from
-their new modular locations and provides inline implementations for CCG items
+their new modular locations and provides inline implementations for items
 that have not yet been extracted to the modular tree.
 
-CCG-04: CLAUDE_CODE_HEADER_ALLOWLIST, LEGACY_HEADER_ALLOWLIST, _classify_route
-CCG-06: _write_mutation_audit, _prune_mutation_audit
-CCG-07: _resolve_session_id
+CLAUDE_CODE_HEADER_ALLOWLIST, LEGACY_HEADER_ALLOWLIST, _classify_route
+_write_mutation_audit, _prune_mutation_audit
+_resolve_session_id
 """
 from __future__ import annotations
 
@@ -33,18 +33,18 @@ from tokenpak.proxy.server import ForwardProxyHandler  # noqa: F401
 from tokenpak.telemetry.monitoring.server import ThreadedHTTPServer  # noqa: F401
 
 # ---------------------------------------------------------------------------
-# can_compress — transparent mode must always return False (CCG-06 contract)
+# can_compress — transparent mode must always return False
 # ---------------------------------------------------------------------------
 
 def can_compress(risk_class: str, mode: str) -> bool:
     """Return whether compression is allowed. Transparent and safe modes always return False."""
-    if mode in ("strict", "transparent", "safe"):  # CCG-10: safe mode disables compression
+    if mode in ("strict", "transparent", "safe"):  # safe mode disables compression
         return False
     return _base_can_compress(risk_class, mode)
 
 
 # ---------------------------------------------------------------------------
-# _PROFILE_PRESETS — extend base with CCG-06 claude-code / transparent profiles
+# _PROFILE_PRESETS — extend base with claude-code / transparent profiles
 # ---------------------------------------------------------------------------
 _PROFILE_PRESETS: dict[str, dict[str, str]] = {
     **_BASE_PROFILE_PRESETS,
@@ -72,17 +72,17 @@ _PROFILE_PRESETS: dict[str, dict[str, str]] = {
 
 
 # ---------------------------------------------------------------------------
-# Monitor — subclass that adds CCG-02 schema additions (session_id +
+# Monitor — subclass that adds schema additions (session_id +
 # mutation_audit table) on top of the base modular Monitor._init_db.
 # ---------------------------------------------------------------------------
 class Monitor(_BaseMonitor):
-    """Monitor with CCG-02 schema additions (session_id column + mutation_audit table)
-    and CCG-07 session_id support in log()."""
+    """Monitor with schema additions (session_id column + mutation_audit table)
+    and session_id support in log()."""
 
     def _init_db(self):
         super()._init_db()
         conn = sqlite3.connect(str(self.db_path))
-        # CCG-02: session_id column on requests
+        # session_id column on requests
         try:
             conn.execute("ALTER TABLE requests ADD COLUMN session_id TEXT")
         except sqlite3.OperationalError:
@@ -90,7 +90,7 @@ class Monitor(_BaseMonitor):
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_requests_session ON requests(session_id)"
         )
-        # CCG-10: stable_hash and volatile_hash columns for safe-mode fingerprinting
+        # stable_hash and volatile_hash columns for safe-mode fingerprinting
         try:
             conn.execute("ALTER TABLE requests ADD COLUMN stable_hash TEXT")
         except sqlite3.OperationalError:
@@ -100,7 +100,7 @@ class Monitor(_BaseMonitor):
         except sqlite3.OperationalError:
             pass
         conn.commit()
-        # CCG-02: mutation_audit table
+        # mutation_audit table
         conn.execute("""
             CREATE TABLE IF NOT EXISTS mutation_audit (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -124,7 +124,7 @@ class Monitor(_BaseMonitor):
             " ON mutation_audit(timestamp)"
         )
         conn.commit()
-        # CCG-11: cache_invalidator_events table (log-only, Phase 2)
+        # cache_invalidator_events table (log-only, Phase 2)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS cache_invalidator_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -168,7 +168,7 @@ class Monitor(_BaseMonitor):
         stable_hash="",
         volatile_hash="",
     ):
-        """Log a request; extends parent with session_id (CCG-07) and fingerprints (CCG-10)."""
+        """Log a request; extends parent with session_id and fingerprints."""
         from datetime import datetime
         try:
             _conn = sqlite3.connect(str(self.db_path))
@@ -210,7 +210,7 @@ class Monitor(_BaseMonitor):
 
 
 # ---------------------------------------------------------------------------
-# CCG-06: mutation audit helpers
+# mutation audit helpers
 # ---------------------------------------------------------------------------
 
 def _prune_mutation_audit(conn: sqlite3.Connection, ttl_days: int) -> int:
@@ -233,7 +233,7 @@ def _write_mutation_audit(
     cache_risk: str,
     mode: str,
 ) -> None:
-    """CCG-06: Write one mutation_audit row per request."""
+    """Write one mutation_audit row per request."""
     pre_hash = hashlib.sha256(body_pre).hexdigest()
     post_hash = hashlib.sha256(body_post).hexdigest()
     rollback_possible = 1
@@ -262,7 +262,7 @@ def _write_mutation_audit(
 
 
 # ---------------------------------------------------------------------------
-# CCG-07: session id resolver
+# session id resolver
 # ---------------------------------------------------------------------------
 
 def _resolve_session_id(headers, model: str) -> str:
@@ -288,11 +288,13 @@ def _resolve_session_id(headers, model: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CCG-04: Per-route header allowlist — real implementation (re-exported from
-# tokenpak.proxy.passthrough where the HTTP path wiring also lives).
+# Per-route header allowlist — real implementation.
+# CLAUDE_CODE_HEADER_ALLOWLIST is canonical in tokenpak.proxy.headers (single
+# frozenset). LEGACY_HEADER_ALLOWLIST + _classify_route live in
+# tokenpak.proxy.passthrough alongside the HTTP-path wiring.
 # ---------------------------------------------------------------------------
+from tokenpak.proxy.headers import CLAUDE_CODE_HEADER_ALLOWLIST  # noqa: F401
 from tokenpak.proxy.passthrough import (  # noqa: F401
-    CLAUDE_CODE_HEADER_ALLOWLIST,
     LEGACY_HEADER_ALLOWLIST,
     _classify_route,
 )
@@ -301,7 +303,7 @@ from tokenpak.proxy.passthrough import (  # noqa: F401
 TOKENPAK_HEADER_ALLOWLIST = LEGACY_HEADER_ALLOWLIST  # noqa: F401
 
 # ---------------------------------------------------------------------------
-# SESSION — global request statistics dict.  The modular tree tracks per-
+# SESSION — global request statistics dict. The modular tree tracks per-
 # module state internally; this shim surfaces a single SESSION dict for
 # compatibility with tests and the /stats endpoint.
 # ---------------------------------------------------------------------------

--- a/tokenpak/core/state_manager.py
+++ b/tokenpak/core/state_manager.py
@@ -26,9 +26,12 @@ _SCHEMA_PATH = Path(__file__).parent / "state_schema.json"
 
 class StateManager:
     """
-    Manages compact JSON session state for TPK protocol.
+    Manages compact JSON session state for the TokenPak Integration Protocol (TIP).
 
-    Persists to: .tpk/state/session_<id>.state.json
+    Persists to: .tpk/state/session_<id>.state.json   (`.tpk/` is the brand-shortform
+    on-disk path, frozen by the 2026-05-06 terminology transition; do not rename.
+    The protocol layer is **TIP** — `TPK` is brand-shortform only, not an acronym.
+    See `08-naming-glossary.md` §TPK and §TIP.)
     Wire format: compact JSON (no whitespace), prefixed with STATE_JSON:
     """
 

--- a/tokenpak/proxy/passthrough.py
+++ b/tokenpak/proxy/passthrough.py
@@ -34,12 +34,13 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Set, Tuple
 
 # ---------------------------------------------------------------------------
-# CCG-04: Per-route HTTP header forwarding allowlists
+# Per-route HTTP header forwarding allowlists
 # ---------------------------------------------------------------------------
 # These mirror the WS-path allowlist tuple onto the HTTP path as a per-route
-# allowlist.  LEGACY_HEADER_ALLOWLIST must never gain new entries — legacy
+# allowlist. LEGACY_HEADER_ALLOWLIST must never gain new entries — legacy
 # traffic must produce exactly the same forwarded headers as today (bit-for-bit).
-# CLAUDE_CODE_HEADER_ALLOWLIST extends it with Claude Code-specific headers.
+# CLAUDE_CODE_HEADER_ALLOWLIST lives in tokenpak.proxy.headers (canonical
+# frozenset); do not redeclare it here.
 
 LEGACY_HEADER_ALLOWLIST: tuple = (
     "x-api-key",
@@ -48,23 +49,13 @@ LEGACY_HEADER_ALLOWLIST: tuple = (
     "anthropic-beta",
 )
 
-CLAUDE_CODE_HEADER_ALLOWLIST: tuple = (
-    "x-api-key",
-    "authorization",
-    "anthropic-version",
-    "anthropic-beta",
-    "anthropic-dangerous-direct-browser-access",
-    "x-claude-code-session-id",
-    "user-agent",
-)
-
 
 def _classify_route(path: str, headers) -> str:
     """Classify an incoming HTTP request as 'claude-code' or 'tokenpak'.
 
     Inspects headers only — no DB access, no network round-trips.
     Claude Code wins when both X-Claude-Code-Session-Id and X-TokenPak-Session
-    are present (matching CCG-03's resolver priority order).
+    are present (matching the resolver priority order).
 
     Returns:
         "claude-code"  if X-Claude-Code-Session-Id is present (case-insensitive)

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -160,11 +160,24 @@ def _get_upstream_semaphore(
 def _upstream_inflight_delta(
     provider: str, delta: int, session_key: Optional[str] = None
 ) -> int:
-    """Adjust and return the in-flight counter for (provider, session)."""
+    """Adjust and return the in-flight counter for (provider, session).
+
+    When a release (delta < 0) drives the counter to zero, the key is evicted
+    from both _upstream_inflight and _upstream_semaphores. session_key falls
+    back to the per-connection client "ip:port", so without eviction every
+    distinct key mints a permanent entry in both dicts that is never reclaimed
+    — they accumulate even with zero active connections, which is the RSS heap
+    leak. Entries are recreated lazily on the next request for the same key.
+    """
     key = (provider or "_unknown", session_key or "_shared")
     with _upstream_sem_lock:
-        _upstream_inflight[key] = max(0, _upstream_inflight.get(key, 0) + delta)
-        return _upstream_inflight[key]
+        count = max(0, _upstream_inflight.get(key, 0) + delta)
+        if delta < 0 and count == 0:
+            _upstream_inflight.pop(key, None)
+            _upstream_semaphores.pop(key, None)
+        else:
+            _upstream_inflight[key] = count
+        return count
 
 
 def get_upstream_inflight_snapshot() -> Dict[str, int]:

--- a/tokenpak/proxy/spend_guard/block_response.py
+++ b/tokenpak/proxy/spend_guard/block_response.py
@@ -153,22 +153,54 @@ def build_rolling_cap_block(breach) -> bytes:
     `breach` is a :class:`rolling_caps.CapBreach` dataclass instance.
     Returns the structured 402 body bytes; the caller wraps the HTTP
     status and headers.
+
+    Attribution clarity: for **per_fleet** breaches, ``agent_id`` is the
+    *triggering caller* (the request that tripped the cap), and ``used`` is the
+    **fleet-wide aggregate** across all tagged callers in the window — NOT the
+    triggering caller's own spend. The legacy ``(agent=X, used=$)`` wording was
+    routinely misread as "caller X spent $" and cost diagnostic time. The
+    message + body below are dimension-aware so an operator reads it correctly
+    once: ``triggered_by`` always names the caller; ``fleet_used``/``fleet_cap``
+    carry the aggregate for fleet-wide breaches. Legacy fields (``agent_id``,
+    ``used``, ``cap``, ``projected_add``) are retained unchanged for backward
+    compatibility.
     """
+    is_fleet = str(breach.cap_dimension).startswith("per_fleet")
+    scope = "fleet" if is_fleet else "agent"
+    if is_fleet:
+        attribution = (
+            f"triggered_by={breach.agent_id} (this caller tripped the cap; it is "
+            f"NOT necessarily the biggest spender). fleet_used={breach.used:.4g}, "
+            f"fleet_cap={breach.cap:.4g}, would_add={breach.projected_add:.4g}, "
+            f"window={breach.window_seconds}s. fleet_used is the SUM of all tagged "
+            f"agents in the window, not {breach.agent_id} alone."
+        )
+    else:
+        attribution = (
+            f"agent={breach.agent_id} used={breach.used:.4g} of its own cap="
+            f"{breach.cap:.4g} (this IS {breach.agent_id}'s rolling usage), "
+            f"would_add={breach.projected_add:.4g}, window={breach.window_seconds}s."
+        )
+    message = (
+        f"TIP Spend Guard rolling cap exceeded: {breach.cap_dimension} [{scope}]. "
+        f"{attribution} "
+        "Reply 'yes' or prepend '[TIP: allow=once]' to bypass; "
+        "wait ~30 min for usage to age out, or operator may raise "
+        "the cap in spend_guard.rolling_caps."
+    )
     payload = {
         "error": {
             "type": ERR_ROLLING_CAP_BLOCKED,
-            "message": (
-                "TIP Spend Guard rolling cap exceeded: "
-                f"{breach.cap_dimension} (agent={breach.agent_id}, "
-                f"window={breach.window_seconds}s, used={breach.used:.4g}, "
-                f"cap={breach.cap:.4g}, would_add={breach.projected_add:.4g}). "
-                "Reply 'yes' or prepend '[TIP: allow=once]' to bypass; "
-                "wait ~30 min for usage to age out, or operator may raise "
-                "the cap in spend_guard.rolling_caps."
-            ),
+            "message": message,
+            # --- attribution-clear fields ---
+            "scope": scope,                       # "fleet" | "agent"
+            "triggered_by": breach.agent_id,      # the caller that tripped the cap
+            "fleet_used": breach.used if is_fleet else None,
+            "fleet_cap": breach.cap if is_fleet else None,
+            "window_seconds": breach.window_seconds,
+            # --- backward-compatible legacy fields (DO NOT remove) ---
             "cap_dimension": breach.cap_dimension,
             "agent_id": breach.agent_id,
-            "window_seconds": breach.window_seconds,
             "used": breach.used,
             "cap": breach.cap,
             "projected_add": breach.projected_add,
@@ -176,4 +208,9 @@ def build_rolling_cap_block(breach) -> bytes:
             "bypass_directive": "[TIP: allow=once]",
         }
     }
+    # Optional per-agent breakdown — included only when the breach carries it
+    # (top-N by spend in the window). Full population is a separate slice.
+    contributing = getattr(breach, "contributing_agents", None)
+    if contributing:
+        payload["error"]["contributing_agents"] = contributing
     return json.dumps(payload, separators=(",", ":")).encode("utf-8")

--- a/tokenpak/telemetry/operational/rbac_auth.py
+++ b/tokenpak/telemetry/operational/rbac_auth.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 SESSION_TTL_HOURS = 24
 API_KEY_PREFIX = "tp_"
 ADMIN_BOOTSTRAP_ENV = "TOKENPAK_ADMIN_BOOTSTRAP"  # set to "1" to force re-bootstrap
+SNAPSHOT_GEN_ENV = "TOKENPAK_SNAPSHOT_GEN"  # set to "1" by release-gate snapshot generators
 
 # ---------------------------------------------------------------------------
 # Schema
@@ -171,6 +172,13 @@ class RBACStore:
 
     def _maybe_bootstrap_admin(self):
         """Create default admin on first run if no users exist."""
+        # Skip first-run admin bootstrap during release-gate snapshot
+        # generation (gen_api_snapshot / gen_telemetry_schema set
+        # TOKENPAK_SNAPSHOT_GEN=1): introspecting the RBAC schema must not
+        # create a user, mutate the store, or emit bootstrap side effects
+        # that would pollute deterministic snapshot output.
+        if os.environ.get(SNAPSHOT_GEN_ENV) == "1":
+            return
         with self._conn() as conn:
             count = conn.execute("SELECT COUNT(*) FROM tp_users").fetchone()[0]
             force = os.environ.get(ADMIN_BOOTSTRAP_ENV) == "1"

--- a/tokenpak/vault/retrieval/vector_local.py
+++ b/tokenpak/vault/retrieval/vector_local.py
@@ -4,6 +4,7 @@ Gracefully degrades if sentence-transformers is not installed.
 """
 from __future__ import annotations
 
+import importlib.util
 import logging
 import warnings
 from pathlib import Path
@@ -13,13 +14,47 @@ from .base import RetrievalQuery, RetrievalResult, Retriever, RetrieverType
 
 logger = logging.getLogger(__name__)
 
-# Optional dependency checks
+# Optional dependency availability.
+#
+# ``sentence_transformers`` transitively pulls in ``transformers`` + ``torch``,
+# a ~13s cold import. Importing it at module-load time made every consumer of
+# the retrieval/proxy/companion import chain pay that cost up front; in
+# particular it pushed the companion MCP server's startup past Claude Code's
+# MCP-connect window, so the server never answered ``initialize`` in time and
+# Claude Code reported it as a failed setup.
+#
+# We therefore only *detect* availability here — ``find_spec`` locates the
+# package without executing it (cheap, no torch load) — and defer the actual
+# import to ``_load_sentence_transformer()``, which runs lazily inside
+# ``_ensure_model`` the first time vector/semantic retrieval is invoked.
 try:
-    from sentence_transformers import SentenceTransformer
-    _ST_AVAILABLE = True
-except ImportError:
+    _ST_AVAILABLE = importlib.util.find_spec("sentence_transformers") is not None
+except (ImportError, ValueError):  # pragma: no cover - defensive
     _ST_AVAILABLE = False
-    SentenceTransformer = None  # type: ignore[misc,assignment]
+
+# Populated lazily by ``_load_sentence_transformer()``. Kept at module scope
+# (rather than a local) so existing call sites and tests that reference
+# ``vector_local.SentenceTransformer`` keep working.
+SentenceTransformer = None  # type: ignore[misc,assignment]
+
+
+def _load_sentence_transformer():
+    """Import and return the ``SentenceTransformer`` class on demand.
+
+    Returns ``None`` if the backend is not installed. The heavy
+    ``sentence_transformers`` / ``transformers`` / ``torch`` import happens
+    here — not at module load — so importing this module stays cheap for
+    fast-start consumers such as the companion MCP server.
+    """
+    global SentenceTransformer
+    if SentenceTransformer is not None:
+        return SentenceTransformer
+    try:
+        from sentence_transformers import SentenceTransformer as _ST
+    except ImportError:
+        return None
+    SentenceTransformer = _ST
+    return _ST
 
 try:
     import numpy as np
@@ -102,8 +137,16 @@ class LocalVectorRetriever(Retriever):
         if not self._available:
             return False
         if self._model is None:
+            model_cls = _load_sentence_transformer()
+            if model_cls is None:
+                logger.warning(
+                    "sentence-transformers unavailable at model-load time; "
+                    "LocalVectorRetriever disabled."
+                )
+                self._available = False
+                return False
             try:
-                self._model = SentenceTransformer(self._model_name)
+                self._model = model_cls(self._model_name)
             except Exception as e:
                 logger.warning("Failed to load sentence-transformers model %r: %s", self._model_name, e)
                 self._available = False


### PR DESCRIPTION
Surgical patch release over v1.7.0 — fixes, hardening, and CI/dependency hygiene only.

- No new features
- No default-behavior changes
- No breaking changes (the install-footprint extras split remains parked under `[Unreleased]` for a future minor)

See `CHANGELOG.md` → `[1.7.1]` for the full list. Highlights: proxy upstream inflight-key eviction (RSS-leak fix) + Claude Code header-allowlist consolidation; companion MCP cold-start lazy-load, safe Python path, truncated-stream guard, honest `check_budget` scope; pakplan `recall.db` read-path fix; spend-guard `402` attribution body; CLI live-version banner; paths fail-loud subdir allowlist; telemetry snapshot-bootstrap skip; dependency + CI action bumps.

Opened to run full CI before promotion. **Not for merge until CI is green.**
