### PR TITLE
fix(release-gate): regenerate public-API snapshot in the canonical environment

### DIFF
--- a/.changeset/api-snapshot-reconcile.md
+++ b/.changeset/api-snapshot-reconcile.md
@@ -26,10 +26,7 @@ Compatibility preserved:
   `from tokenpak.proxy.passthrough import CLAUDE_CODE_HEADER_ALLOWLIST`
   continues to work unchanged.
 
-removes-public-symbol: tokenpak.proxy.server_extra.websocket_proxy.WebSocketServerProtocol
-
-- Upstream-driven: `websockets` 16 removed `websockets.server.WebSocketServerProtocol`.
-  This module's optional re-export already degrades to `None` when the upstream
-  symbol is unavailable, so the snapshot now reflects that reality. This is an
-  upstream/third-party compatibility surface, not a TokenPak-owned API removal,
-  and there is no behavior change beyond what the upstream library dictates.
+The snapshot is regenerated in the canonical release environment (the union of
+non-agent-framework extras) so that optional and third-party-conditional symbols
+(e.g. `websocket_proxy.WebSocketServerProtocol`, `vector_local.faiss`) are
+captured consistently with the release-gate check. No public symbol is removed.

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-04T01:44:48Z",
+  "generated_at": "2026-06-04T03:44:13Z",
   "package_version": "1.7.1",
   "symbols": [
     {
@@ -9789,6 +9789,10 @@
     },
     {
       "module": "tokenpak.proxy.server_extra.websocket_proxy",
+      "name": "WebSocketServerProtocol"
+    },
+    {
+      "module": "tokenpak.proxy.server_extra.websocket_proxy",
       "name": "compress_chunk"
     },
     {
@@ -16870,6 +16874,10 @@
     {
       "module": "tokenpak.vault.retrieval.vector_local",
       "name": "SentenceTransformer"
+    },
+    {
+      "module": "tokenpak.vault.retrieval.vector_local",
+      "name": "faiss"
     },
     {
       "module": "tokenpak.vault.scoring",


### PR DESCRIPTION
Regenerates `tokenpak/_snapshots/public-api.json` in the **canonical release environment** so the checked-in snapshot matches the release-gate `api-snapshot-check`.

**Why:** the previous v1.7.1 snapshot was generated in a non-canonical local environment that had `websockets` installed. The snapshot generator filters third-party re-exports by `__module__`, so `websocket_proxy.WebSocketServerProtocol` (a conditional re-export) was dropped locally but is **present** in the canonical env (where `websockets` is not a dependency and the optional import falls back to `None`). Same for the lazily-imported `vector_local.faiss`. The release-gate validation installs the union of non-agent-framework extras, so it captured both symbols and flagged the local snapshot as drifted.

**This PR:**
- Regenerates the snapshot in the canonical env (`.[dev,full,serve,telemetry,tokens,otel]` + `python-multipart`) → adds back `WebSocketServerProtocol` and `faiss` (net +2 symbols).
- Drops the incorrect `removes-public-symbol` declaration — **no public symbol is actually removed.**
- Keeps the `CLAUDE_CODE_HEADER_ALLOWLIST` back-compat alias and the retargeted canonicality guard from the prior reconcile.

Verified: `api-snapshot-check` passes in the canonical env.
