### PR TITLE
feat(proxy): opt-in response-egress capture intake (MultiPak Pro)

### DIFF
--- a/tests/proxy/test_capture_intake.py
+++ b/tests/proxy/test_capture_intake.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the opt-in response-egress capture intake (OSS side).
+
+Covers the structural invariants of `tokenpak/proxy/capture_intake.py`:
+
+* two-factor gate (operator flag AND per-request opt-in header),
+* read-only response-text extraction (Anthropic + OpenAI shapes),
+* daemon-shaped payload construction (the CaptureEvent wire contract),
+* loopback forward to a stand-in daemon (round-trip), and
+* fail-silent / inert-by-default behavior.
+
+No Pro code is imported — the OSS proxy constructs the documented JSON shape.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tokenpak.proxy import capture_intake as ci
+
+# ── Gate: two-factor (operator flag AND opt-in header) ──────────────────────
+
+class _Hdrs:
+    def __init__(self, mapping):
+        self._m = mapping
+
+    def get(self, k, default=None):
+        return self._m.get(k, default)
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(ci.ENABLE_ENV, raising=False)
+    assert ci.should_attempt(_Hdrs({ci.OPTIN_HEADER: "opt-in"})) is False
+
+
+def test_enabled_requires_header(monkeypatch):
+    monkeypatch.setenv(ci.ENABLE_ENV, "1")
+    assert ci.should_attempt(_Hdrs({})) is False
+    assert ci.should_attempt(_Hdrs({ci.OPTIN_HEADER: "nope"})) is False
+    assert ci.should_attempt(_Hdrs({ci.OPTIN_HEADER: "opt-in"})) is True
+    # case/space-insensitive on the value
+    assert ci.should_attempt(_Hdrs({ci.OPTIN_HEADER: "  Opt-In "})) is True
+
+
+def test_header_without_flag_is_inert(monkeypatch):
+    monkeypatch.setenv(ci.ENABLE_ENV, "0")
+    assert ci.should_attempt(_Hdrs({ci.OPTIN_HEADER: "opt-in"})) is False
+
+
+# ── extract_response_text: read-only, fail-soft ────────────────────────────
+
+def test_extract_anthropic_text():
+    body = json.dumps({
+        "content": [
+            {"type": "text", "text": "Hello "},
+            {"type": "tool_use", "name": "x"},
+            {"type": "text", "text": "world"},
+        ]
+    }).encode()
+    assert ci.extract_response_text(body, "claude-x") == "Hello world"
+
+
+def test_extract_openai_text():
+    body = json.dumps({"choices": [{"message": {"content": "hi there"}}]})
+    assert ci.extract_response_text(body) == "hi there"
+
+
+def test_extract_returns_none_on_garbage():
+    assert ci.extract_response_text(b"not json") is None
+    assert ci.extract_response_text(b"") is None
+    assert ci.extract_response_text(None) is None
+    assert ci.extract_response_text(json.dumps({"content": []})) is None
+    assert ci.extract_response_text(json.dumps({"foo": "bar"})) is None
+
+
+# ── build_capture_payload: the daemon wire contract ────────────────────────
+
+def test_payload_required_fields():
+    p = ci.build_capture_payload(
+        "some response", model="claude-x", session_id="sess-1", platform="anthropic",
+        captured_at_iso="2026-06-02T00:00:00+00:00",
+    )
+    # Required keys per CaptureEvent.from_dict
+    for k in ("source", "content", "captured_at", "platform"):
+        assert k in p
+    assert p["source"] == "llm_response"
+    assert p["content"] == "some response"
+    assert p["platform"] == "anthropic"
+    assert p["session_id"] == "sess-1"
+    assert p["metadata"]["via"] == "proxy-capture-intake"
+    assert p["metadata"]["model"] == "claude-x"
+    # must be JSON-serializable (it is sent over the wire)
+    json.dumps(p)
+
+
+def test_payload_omits_empty_session():
+    p = ci.build_capture_payload("x")
+    assert "session_id" not in p
+    assert p["platform"] == "proxy"
+
+
+# ── Stand-in daemon for loopback round-trip ────────────────────────────────
+
+class _StandInDaemon:
+    """Minimal HTTP server impersonating the Pro daemon's /pak/v1/promote."""
+
+    def __init__(self):
+        self.received: list[dict] = []
+        self.requests: list[dict] = []  # full metadata: path + headers + body
+        srv_self = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):  # silence
+                pass
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0") or "0")
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    body = json.loads(raw.decode("utf-8"))
+                except Exception:
+                    body = {"_unparseable": True}
+                srv_self.received.append(body)
+                srv_self.requests.append({
+                    "path": self.path,
+                    "headers": {k.lower(): v for k, v in self.headers.items()},
+                    "body": body,
+                })
+                payload = json.dumps({"promoted": True, "pak_id": "test-pak", "path": self.path}).encode()
+                self.send_response(201)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+        self.httpd = HTTPServer(("127.0.0.1", 0), H)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *a):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def active_daemon(monkeypatch, tmp_path):
+    """Spin up a stand-in daemon and point the probe at it."""
+    import tokenpak.licensing.daemon_probe as probe
+
+    with _StandInDaemon() as d:
+        info = tmp_path / "daemon.sock-info"
+        info.write_text(json.dumps({"port": d.port, "tip_version": "1.0", "started_at": 0}))
+        monkeypatch.setattr(probe, "detect_daemon_state", lambda *a, **k: "active")
+        monkeypatch.setattr(probe, "sock_info_path", lambda *a, **k: info)
+        yield d
+
+
+def test_forward_to_daemon_round_trip(active_daemon):
+    payload = ci.build_capture_payload("captured text", model="m", platform="anthropic")
+    result = ci.forward_to_daemon(payload)
+    assert result is not None
+    assert result["status"] == 201
+    assert result["body"]["promoted"] is True
+    assert len(active_daemon.received) == 1
+    got = active_daemon.received[0]
+    assert got["source"] == "llm_response"
+    assert got["content"] == "captured text"
+
+
+def test_forward_noop_when_daemon_unavailable(monkeypatch):
+    import tokenpak.licensing.daemon_probe as probe
+    monkeypatch.setattr(probe, "detect_daemon_state", lambda *a, **k: "unavailable")
+    assert ci.forward_to_daemon({"source": "llm_response", "content": "x"}) is None
+
+
+# ── _run_capture: gate → extract → build → forward ─────────────────────────
+
+def test_run_capture_end_to_end(monkeypatch, active_daemon):
+    monkeypatch.setenv(ci.ENABLE_ENV, "1")
+    body = json.dumps({"content": [{"type": "text", "text": "answer"}]}).encode()
+    result = ci._run_capture(_Hdrs({ci.OPTIN_HEADER: "opt-in"}), body, "claude-x")
+    assert result is not None and result["status"] == 201
+    assert active_daemon.received[0]["content"] == "answer"
+
+
+def test_no_license_channel_egress(monkeypatch, active_daemon):
+    """Privacy/egress invariant: captured content egresses ONLY to the daemon
+    capture channel (`/pak/v1/promote`) over loopback — never to a
+    license-validation endpoint — and the caller's auth/license headers are
+    NOT forwarded to the daemon.
+    """
+    monkeypatch.setenv(ci.ENABLE_ENV, "1")
+    body = json.dumps({"content": [{"type": "text", "text": "secret answer"}]}).encode()
+    hdrs = _Hdrs({
+        ci.OPTIN_HEADER: "opt-in",
+        "Authorization": "Bearer should-not-leak",
+        "X-TPK-Key": "should-not-leak",
+    })
+    result = ci._run_capture(hdrs, body, "claude-x")
+    assert result is not None and result["status"] == 201
+
+    # Exactly one egress, and it is the capture channel — not a license path.
+    assert len(active_daemon.requests) == 1
+    req = active_daemon.requests[0]
+    assert req["path"] == "/pak/v1/promote"
+    assert "license" not in req["path"]
+    assert req["path"] != "/v1/features"
+
+    # The caller's auth / license headers were NOT forwarded to the daemon.
+    assert "authorization" not in req["headers"]
+    assert "x-tpk-key" not in req["headers"]
+
+    # Positive control: the captured content reached the capture channel.
+    assert req["body"]["content"] == "secret answer"
+    assert req["body"]["source"] == "llm_response"
+
+
+def test_run_capture_inert_when_disabled(monkeypatch, active_daemon):
+    monkeypatch.delenv(ci.ENABLE_ENV, raising=False)
+    body = json.dumps({"content": [{"type": "text", "text": "answer"}]}).encode()
+    assert ci._run_capture(_Hdrs({ci.OPTIN_HEADER: "opt-in"}), body, "m") is None
+    assert active_daemon.received == []  # nothing forwarded → OSS captured nothing
+
+
+def test_run_capture_noop_without_text(monkeypatch, active_daemon):
+    monkeypatch.setenv(ci.ENABLE_ENV, "1")
+    assert ci._run_capture(_Hdrs({ci.OPTIN_HEADER: "opt-in"}), b"not json", "m") is None
+    assert active_daemon.received == []
+
+
+# ── maybe_forward_capture: non-blocking, fail-silent ───────────────────────
+
+def test_maybe_forward_inert_when_disabled(monkeypatch):
+    monkeypatch.delenv(ci.ENABLE_ENV, raising=False)
+    # Must not raise and must not spawn work.
+    assert ci.maybe_forward_capture(_Hdrs({ci.OPTIN_HEADER: "opt-in"}), b"{}", "m") is None
+
+
+def test_maybe_forward_spawns_and_forwards(monkeypatch, active_daemon):
+    monkeypatch.setenv(ci.ENABLE_ENV, "1")
+    body = json.dumps({"content": [{"type": "text", "text": "async answer"}]}).encode()
+    ci.maybe_forward_capture(_Hdrs({ci.OPTIN_HEADER: "opt-in"}), body, "m")
+    # Join the spawned capture thread deterministically.
+    for t in threading.enumerate():
+        if t.name == "tpk-capture-intake":
+            t.join(timeout=5)
+    assert len(active_daemon.received) == 1
+    assert active_daemon.received[0]["content"] == "async answer"

--- a/tokenpak/proxy/capture_intake.py
+++ b/tokenpak/proxy/capture_intake.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in response-egress capture intake (OSS side of MultiPak Pro capture).
+
+This is the OSS half of the MultiPak Pro response→Interaction-Pak path
+(the MultiPak Pro capture pipeline; OSS-contract-first — the OSS proxy never
+depends on the Pro daemon and always works without it). Its single job
+is to **forward** an opt-in-flagged model response to the loopback Pro daemon's
+``POST /pak/v1/promote`` endpoint. It does the absolute minimum so the
+"OSS never captures, never stores" invariant is *structural*, not just policy:
+
+* **OSS persists nothing.** This module reads the already-produced response,
+  builds a daemon-shaped payload, and POSTs it to the loopback daemon. There is
+  no local store, no DB write, no file write anywhere in this path.
+* **Opt-in is per-request and explicit.** A response is only forwarded when the
+  inbound request carried ``X-TokenPak-Capture: opt-in`` **and** the operator
+  has set ``TOKENPAK_PROXY_CAPTURE_INTAKE=1``. Absence of either → inert no-op.
+  There is no global "capture everything" switch.
+* **Pro-daemon-gated.** If no daemon is reachable (sock-info probe), the path is
+  a no-op. No daemon, no header, or disabled flag → nothing happens.
+* **Fail-silent, never blocks the client.** The proxy entrypoint
+  (:func:`maybe_forward_capture`) hands the work to a short-lived daemon thread
+  and returns immediately. The client already has its response by the time this
+  runs (the proxy writes the response to the client *before* the post-response
+  hook). Any error is swallowed — capture intake must never break a request.
+
+Wire contract (kept in sync with the Pro daemon's capture-event JSON shape; the
+OSS proxy intentionally does NOT import any Pro types — it constructs the
+documented JSON shape the daemon's promote endpoint accepts):
+
+    {
+      "source":      "llm_response",   # CaptureSource enum value
+      "content":     "<response text>",
+      "captured_at": "<ISO-8601 UTC>",
+      "platform":    "<provider/app>",
+      "session_id":  "<optional>",
+      "metadata":    {"model": "...", "via": "proxy-capture-intake"}
+    }
+
+Default is **OFF**. Public-default proxy behavior is unchanged when the flag is
+unset, which is the shipped default.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+# ── Opt-in surface ──────────────────────────────────────────────────────────
+OPTIN_HEADER = "X-TokenPak-Capture"
+OPTIN_VALUE = "opt-in"
+ENABLE_ENV = "TOKENPAK_PROXY_CAPTURE_INTAKE"
+
+# CaptureSource value for a model response observed at the proxy.
+_SOURCE_LLM_RESPONSE = "llm_response"
+# Loopback forward timeout. The daemon is local; if it can't answer a tiny POST
+# within this, treat it as unavailable. Keep small so a hung daemon cannot pin
+# the worker thread.
+_FORWARD_TIMEOUT_S = 2.0
+# Defensive ceiling on response text we will forward (protects the daemon and
+# avoids shipping pathological bodies over loopback). The capture pipeline
+# payloads are expected to be small.
+_MAX_CONTENT_CHARS = 256_000
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _enabled() -> bool:
+    """True when the operator explicitly enabled capture intake."""
+    return (os.environ.get(ENABLE_ENV, "") or "").strip().lower() in _TRUTHY
+
+
+def opt_in_requested(headers: Any) -> bool:
+    """True when the inbound request carried ``X-TokenPak-Capture: opt-in``.
+
+    ``headers`` is anything with a ``.get`` (``http.client.HTTPMessage`` or a
+    plain dict). Comparison is case- and whitespace-insensitive on the value.
+    """
+    try:
+        val = headers.get(OPTIN_HEADER)
+    except Exception:
+        return False
+    if not val:
+        return False
+    return str(val).strip().lower() == OPTIN_VALUE
+
+
+def should_attempt(headers: Any) -> bool:
+    """Two-factor gate: operator flag AND explicit per-request opt-in header."""
+    return _enabled() and opt_in_requested(headers)
+
+
+def extract_response_text(response_body: Any, model: str = "") -> Optional[str]:
+    """Best-effort extraction of assistant text from a buffered response body.
+
+    Read-only. Returns ``None`` (→ no-op upstream) on anything unparseable.
+    Supports the Anthropic Messages shape (``content`` = list of blocks) and the
+    OpenAI Chat Completions shape (``choices[0].message.content``). Never raises.
+    """
+    try:
+        if isinstance(response_body, (bytes, bytearray)):
+            raw = bytes(response_body).decode("utf-8", errors="replace")
+        elif isinstance(response_body, str):
+            raw = response_body
+        else:
+            return None
+        raw = raw.strip()
+        if not raw:
+            return None
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return None
+
+        # Anthropic Messages: {"content": [{"type": "text", "text": "..."}, ...]}
+        content = data.get("content")
+        if isinstance(content, list):
+            parts = [
+                blk.get("text", "")
+                for blk in content
+                if isinstance(blk, dict) and blk.get("type") == "text"
+            ]
+            text = "".join(p for p in parts if p)
+            if text.strip():
+                return text[:_MAX_CONTENT_CHARS]
+
+        # OpenAI Chat Completions: {"choices": [{"message": {"content": "..."}}]}
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            msg = choices[0].get("message") if isinstance(choices[0], dict) else None
+            if isinstance(msg, dict):
+                c = msg.get("content")
+                if isinstance(c, str) and c.strip():
+                    return c[:_MAX_CONTENT_CHARS]
+
+        return None
+    except Exception:
+        return None
+
+
+def build_capture_payload(
+    text: str,
+    *,
+    model: str = "",
+    session_id: Optional[str] = None,
+    platform: str = "proxy",
+    captured_at_iso: Optional[str] = None,
+) -> dict:
+    """Build the daemon-shaped ``CaptureEvent`` JSON payload (no Pro import)."""
+    if captured_at_iso is None:
+        captured_at_iso = datetime.now(timezone.utc).isoformat()
+    metadata = {"via": "proxy-capture-intake"}
+    if model:
+        metadata["model"] = model
+    payload: dict = {
+        "source": _SOURCE_LLM_RESPONSE,
+        "content": text,
+        "captured_at": captured_at_iso,
+        "platform": platform or "proxy",
+        "metadata": metadata,
+    }
+    if session_id:
+        payload["session_id"] = session_id
+    return payload
+
+
+def forward_to_daemon(payload: Mapping[str, Any], *, timeout: float = _FORWARD_TIMEOUT_S) -> Optional[dict]:
+    """POST ``payload`` to the loopback Pro daemon's ``/pak/v1/promote``.
+
+    Returns ``{"status": int, "body": dict}`` on a completed round-trip, or
+    ``None`` when no daemon is reachable / anything fails. Never raises.
+    OSS stores nothing — this only forwards.
+    """
+    try:
+        from tokenpak.licensing.daemon_probe import detect_daemon_state, sock_info_path
+    except Exception:
+        return None
+    try:
+        if detect_daemon_state() != "active":
+            return None
+        info = json.loads(sock_info_path().read_text(encoding="utf-8"))
+        port = int(info["port"])
+    except Exception:
+        return None
+
+    conn = None
+    try:
+        body = json.dumps(dict(payload)).encode("utf-8")
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+        # The daemon is loopback-only and requires no auth on /pak/v1/*; we do
+        # NOT forward the caller's auth headers (mirrors the existing
+        # _handle_pak_promote_forward defensive contract).
+        conn.request(
+            "POST",
+            "/pak/v1/promote",
+            body=body,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+        )
+        resp = conn.getresponse()
+        raw = resp.read()
+        parsed: dict = {}
+        if raw:
+            try:
+                parsed = json.loads(raw.decode("utf-8"))
+            except Exception:
+                parsed = {}
+        return {"status": resp.status, "body": parsed}
+    except Exception:
+        return None
+    finally:
+        try:
+            if conn is not None:
+                conn.close()
+        except Exception:
+            pass
+
+
+def _run_capture(
+    headers: Any,
+    response_body: Any,
+    model: str = "",
+    *,
+    session_id: Optional[str] = None,
+    platform: str = "proxy",
+) -> Optional[dict]:
+    """Synchronous worker: gate → extract → build → forward. Testable.
+
+    Returns the daemon round-trip result, or ``None`` for any no-op/short
+    circuit (disabled, no header, no text, no daemon). Never raises.
+    """
+    try:
+        if not should_attempt(headers):
+            return None
+        text = extract_response_text(response_body, model)
+        if not text:
+            return None
+        payload = build_capture_payload(
+            text, model=model, session_id=session_id, platform=platform
+        )
+        return forward_to_daemon(payload)
+    except Exception:
+        return None
+
+
+def maybe_forward_capture(
+    headers: Any,
+    response_body: Any,
+    model: str = "",
+    *,
+    session_id: Optional[str] = None,
+    platform: str = "proxy",
+) -> None:
+    """Proxy entrypoint — fire-and-forget, non-blocking, fail-silent.
+
+    Call from the proxy's **post-response** point (after the response has been
+    written to the client). Hands the work to a short-lived daemon thread and
+    returns immediately so the worker thread is never blocked on the daemon.
+    Does nothing (and never raises) unless capture intake is enabled AND the
+    request carried the opt-in header.
+    """
+    try:
+        if not should_attempt(headers):
+            return
+        t = threading.Thread(
+            target=_run_capture,
+            args=(headers, response_body, model),
+            kwargs={"session_id": session_id, "platform": platform},
+            name="tpk-capture-intake",
+            daemon=True,
+        )
+        t.start()
+    except Exception:
+        # Capture intake must never break a request — not even thread spawn.
+        try:
+            sys.stderr.write("tokenpak: capture-intake spawn failed (ignored)\n")
+        except Exception:
+            pass

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1806,6 +1806,22 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 except Exception:
                     pass  # telemetry must never break request handling
 
+                # ── Opt-in capture intake (MultiPak Pro capture pipeline) ───
+                # Forward an opt-in-flagged model response to the loopback Pro
+                # daemon for capture. Structurally safe: runs only AFTER the
+                # response was already written to the client (above); guarded to
+                # the non-streaming path where the full body is buffered;
+                # fire-and-forget (daemon thread); OSS stores nothing. Inert
+                # unless TOKENPAK_PROXY_CAPTURE_INTAKE=1 AND the request carried
+                # `X-TokenPak-Capture: opt-in`. Fully fail-silent — cannot break
+                # a request or touch the byte-preserved response.
+                try:
+                    if not is_streaming and "body_for_metrics" in dir():
+                        from tokenpak.proxy.capture_intake import maybe_forward_capture
+                        maybe_forward_capture(self.headers, body_for_metrics, model)
+                except Exception:
+                    pass  # capture intake must never break request handling
+
                 # Track per-request compression ratio for rolling average
                 if input_tokens > 0:
                     ratio = round(saved / input_tokens, 4)


### PR DESCRIPTION
Promotes the opt-in response-egress capture-intake slice (MultiPak Pro capture pipeline) from staging to the public mirror.

## What this adds
- `tokenpak/proxy/capture_intake.py` — a fail-silent, off-by-default helper that forwards an opt-in-flagged model response to the loopback Pro daemon's `POST /pak/v1/promote`. Two-factor gated (`TOKENPAK_PROXY_CAPTURE_INTAKE=1` **and** a per-request `X-TokenPak-Capture: opt-in` header) plus a daemon-presence probe. The OSS proxy forwards only and **stores nothing**.
- A single guarded, non-streaming, post-response call site in `tokenpak/proxy/server.py` that runs only after the response is written to the client and cannot touch byte-preserved response handling (fully wrapped in `try/except`, fire-and-forget on a daemon thread).
- `tests/proxy/test_capture_intake.py` — 16 tests: two-factor gate, Anthropic/OpenAI text extraction, loopback round-trip, and the inert-by-default / stores-nothing negative proofs.

## Safety
- **Off by default.** Inert unless both the env flag and the per-request header are present and a daemon is detected. No header / no daemon → no-op.
- **No automatic capture; the OSS proxy stores nothing** — it forwards only.
- Standard-library imports only; no behavior change to the default request path.

## Provenance
Contained promotion of the change merged to staging in tokenpak/tokenpak-staging#112 (staging `a1f7f09e21`). Scope is exactly the three files above (+550 lines); no other staging changes are included.
