### PR TITLE
[DO NOT MERGE pending maintainer approval] README: pricing + savings trust hygiene (surgical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,13 @@ shared secret to require `Authorization: Bearer <token>` on remote requests
 - **A/B testing and replay/debug** — compare compression configs, replay past requests
 - **50 built-in compression recipes** — YAML, customizable
 
-80%+ of operations cost zero tokens. See [docs/quickstart.md](docs/quickstart.md) and [docs/api-tpk-v1.md](docs/api-tpk-v1.md) to get started.
+Repeated context is reused from cache instead of re-sent on every call. See [docs/quickstart.md](docs/quickstart.md) and [docs/api-tpk-v1.md](docs/api-tpk-v1.md) to get started.
 
 ---
 
-## Pricing
+## Open source & editions
 
-| | Free | Pro | Team |
-|--|:--:|:--:|:--:|
-| Context compression | ✅ | ✅ | ✅ |
-| Client integration (all 9) | ✅ | ✅ | ✅ |
-| Model routing | ✅ | ✅ | ✅ |
-| Cost tracking | ✅ | ✅ | ✅ |
-| Vault indexing + search | ✅ | ✅ | ✅ |
-| CLI + proxy | ✅ | ✅ | ✅ |
-| Advanced compression recipes | — | ✅ | ✅ |
-| Budget enforcement + alerts | — | ✅ | ✅ |
-| Priority support | — | ✅ | ✅ |
-| Multi-agent coordination | — | — | ✅ |
-| Shared vault (team) | — | — | ✅ |
-| RBAC + audit logs | — | — | ✅ |
-| **Price** | **Free** | **$99/mo** | **$299/mo** |
-
-See [tokenpak.ai/pricing](https://tokenpak.ai/pricing) for full tier details and enterprise options.
+TokenPak's core is Apache-2.0 open source; TokenPak Pro and hosted services are proprietary. Commercial packaging is not published yet.
 
 ---
 


### PR DESCRIPTION
## Summary

Surgical README trust-hygiene fix. **README only, 4 insertions / 20 deletions.** Two hunks:

1. **Remove the unpublished pricing table.** Drops the `$99/mo` / `$299/mo` Free/Pro/Team table and the dead `tokenpak.ai/pricing` link (returns HTTP 404). Commercial packaging is not published, so the table and link overclaim. Replaced with an honest commercial-status note:
   > TokenPak's core is Apache-2.0 open source; TokenPak Pro and hosted services are proprietary. Commercial packaging is not published yet.
2. **Remove the naked savings number.** Replaces `80%+ of operations cost zero tokens` with non-numeric, receipt-safe wording:
   > Repeated context is reused from cache instead of re-sent on every call.

No quantified savings claim is introduced (no `30–50%`, no `90%+`) — there is no published benchmark figure to cite.

## Explicitly preserved

- ✅ The `## License` and `### Trademark` sections are **unchanged**.
- ✅ Everything else on `main` is unchanged — this is a narrow, surgical diff, **not** a wholesale README replacement.

## Scope / guarantees

- `git diff --name-only` = `README.md` only.
- 4 insertions / 20 deletions.

## Merge gate

🚫 **Do not merge yet** — awaiting explicit maintainer approval. Merge via the project's governed path (local squash + fast-forward push that preserves the canonical commit identity); please do **not** use the web "Merge" button or `--squash` (both rewrite author/committer identity).