### PR TITLE
feat(companion): memory-source ingestion (bring your own knowledge base)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to TokenPak are documented in this file.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [1.8.0] — 2026-06-06
+
+Minor release: companion **memory-source ingestion** — point the companion at
+your own Markdown notes ("bring your own knowledge base"). Additive only: no
+changes to existing behavior, no breaking changes.
+
+### Added
+
+- **companion:** memory-source ingest library API — `ingest_from_dir()` and
+  `ingest_sources()` in `tokenpak.companion.memory.lesson_ingest` ingest lessons
+  from arbitrary directories of Markdown notes (scanned recursively),
+  independent of the built-in memory schema. `ingest_sources()` returns a
+  per-source status report whose `reason` distinguishes *no source configured*
+  from *missing* / *not-a-directory* / *present but no matching files* / *ok*.
+- **companion:** `TOKENPAK_COMPANION_MEMORY_DIRS` configuration — an
+  OS-path-separator- or comma-separated list of extra memory directories,
+  parsed into `CompanionConfig.memory_dirs` (`~` expanded; empty entries
+  dropped; fail-open, never raises).
+- **companion (MCP):** the `session_info` tool now reports the configured
+  `memory_dirs` and surfaces a hint when no memory source is set, so an empty
+  ingest is self-explaining.
+
+### Tests & docs
+
+- `tests/test_companion_memory_source.py` — coverage for the env-var parser,
+  `ingest_from_dir`, and the `ingest_sources` status contract.
+- Companion guide: a "Memory sources — bring your own knowledge base" section
+  documenting the env var, the library API, and the MCP surface.
+
+### Internal
+
+- Regenerated the public-API snapshot. Beyond the companion additions above,
+  this is a ratchet correction that absorbs already-public `tokenpak.proxy`
+  symbols the committed snapshot had drifted from — no new public API in this
+  release other than the companion additions.
+
 ## [1.7.1] — 2026-06-03
 
 Surgical patch release: fixes, hardening, and public-safety/CI hygiene only. No new

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-04T03:44:13Z",
-  "package_version": "1.7.1",
+  "generated_at": "2026-06-07T03:35:28Z",
+  "package_version": "1.8.0",
   "symbols": [
     {
       "module": "tokenpak",
@@ -1949,11 +1949,23 @@
     },
     {
       "module": "tokenpak.companion.memory.lesson_ingest",
+      "name": "MARKDOWN_SUFFIXES"
+    },
+    {
+      "module": "tokenpak.companion.memory.lesson_ingest",
       "name": "extract_lessons"
     },
     {
       "module": "tokenpak.companion.memory.lesson_ingest",
+      "name": "ingest_from_dir"
+    },
+    {
+      "module": "tokenpak.companion.memory.lesson_ingest",
       "name": "ingest_from_vault"
+    },
+    {
+      "module": "tokenpak.companion.memory.lesson_ingest",
+      "name": "ingest_sources"
     },
     {
       "module": "tokenpak.companion.memory.session_capsules",
@@ -7948,6 +7960,42 @@
       "name": "get_capsule_request_hook"
     },
     {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "ENABLE_ENV"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "OPTIN_HEADER"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "OPTIN_VALUE"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "build_capture_payload"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "extract_response_text"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "forward_to_daemon"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "maybe_forward_capture"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "opt_in_requested"
+    },
+    {
+      "module": "tokenpak.proxy.capture_intake",
+      "name": "should_attempt"
+    },
+    {
       "module": "tokenpak.proxy.circuit_breaker",
       "name": "CircuitBreaker"
     },
@@ -9786,10 +9834,6 @@
     {
       "module": "tokenpak.proxy.server_extra.websocket_proxy",
       "name": "WebSocketConnectionStats"
-    },
-    {
-      "module": "tokenpak.proxy.server_extra.websocket_proxy",
-      "name": "WebSocketServerProtocol"
     },
     {
       "module": "tokenpak.proxy.server_extra.websocket_proxy",
@@ -16874,10 +16918,6 @@
     {
       "module": "tokenpak.vault.retrieval.vector_local",
       "name": "SentenceTransformer"
-    },
-    {
-      "module": "tokenpak.vault.retrieval.vector_local",
-      "name": "faiss"
     },
     {
       "module": "tokenpak.vault.scoring",

--- a/tokenpak/companion/GUIDE.md
+++ b/tokenpak/companion/GUIDE.md
@@ -57,6 +57,51 @@ TOKENPAK_COMPANION_HOOKS=0 tokenpak claude
 
 ---
 
+## Memory sources — bring your own knowledge base
+
+The companion can surface lessons from your own Markdown notes, not just its
+built-in memory schema. Any folder of `.md` / `.markdown` files works (scanned
+recursively) — no special directory layout is required.
+
+**Tell the companion where your notes live** with the
+`TOKENPAK_COMPANION_MEMORY_DIRS` environment variable. It accepts an
+OS-path-separator- or comma-separated list; `~` is expanded; missing or empty
+entries are dropped (never fatal):
+
+```bash
+export TOKENPAK_COMPANION_MEMORY_DIRS=~/notes:~/work/journal
+```
+
+The configured directories are parsed into `CompanionConfig.memory_dirs` and
+reported by the `session_info` MCP tool, which also surfaces a hint when no
+memory source is set — so an empty result is self-explaining.
+
+**Ingest with the library API.** `ingest_from_dir` ingests a single directory;
+`ingest_sources` orchestrates every configured source and returns a per-source
+status report:
+
+```python
+from tokenpak.companion.config import CompanionConfig
+from tokenpak.companion.memory.decision_memory import DecisionMemoryDB
+from tokenpak.companion.memory.lesson_ingest import ingest_from_dir, ingest_sources
+
+db = DecisionMemoryDB()
+
+# Ingest a single directory of notes
+n = ingest_from_dir("~/notes", db)
+
+# Or ingest every directory from TOKENPAK_COMPANION_MEMORY_DIRS, with status
+cfg = CompanionConfig.from_env()
+report = ingest_sources(db, memory_dirs=cfg.memory_dirs)
+# -> {"total": int, "sources": [{"path", "kind", "ingested", "reason"}, ...]}
+```
+
+Lessons are extracted from the `## Lessons Learned` / `## Notes` /
+task-summary sections of each file. Missing or unreadable files are skipped,
+never fatal.
+
+---
+
 ## MCP Tools Reference
 
 When the companion is active, Claude Code gains seven MCP tools served by

--- a/tokenpak/companion/config.py
+++ b/tokenpak/companion/config.py
@@ -15,6 +15,11 @@ TOKENPAK_COMPANION_HOOKS        Enable hook pipeline (default: 1)
 TOKENPAK_COMPANION_MCP          Enable MCP server (default: 1)
 TOKENPAK_COMPANION_SHOW_COST    Show cost estimates in TUI (default: 1)
 TOKENPAK_COMPANION_PRUNE_THRESHOLD  Token count above which pruning is suggested (default: 50000)
+TOKENPAK_COMPANION_MEMORY_DIRS  Extra memory/knowledge directories to ingest lessons
+                                from (default: none).  OS-pathsep- or comma-separated
+                                list of directories holding your own Markdown notes —
+                                "bring your own knowledge base", no vault schema
+                                required.  ``~`` is expanded; empty entries dropped.
 TOKENPAK_COMPANION_BARE         Strip Claude Code native context (default: 0)
                                 Disables CLAUDE.md, auto memory, prompt history,
                                 system prompt injection, settings/hooks overlay,
@@ -49,6 +54,12 @@ class CompanionConfig:
     prune_threshold: int = 50_000
     bare: bool = False
 
+    # Generic "bring your own knowledge base" memory sources.  These are
+    # directories of the user's own Markdown notes the companion ingests
+    # lessons from — distinct from the vault schema and from
+    # ``additionalDirectories`` filesystem-access grants (EXTRA_DIRS).
+    memory_dirs: list[Path] = field(default_factory=list)
+
     # Session-scoped (set at launch, immutable after)
     session_id: str = ""
     project_dir: str = ""
@@ -82,6 +93,7 @@ class CompanionConfig:
                 os.environ.get("TOKENPAK_COMPANION_PRUNE_THRESHOLD", "50000")
             ),
             bare=_bool("TOKENPAK_COMPANION_BARE", False),
+            memory_dirs=_path_list("TOKENPAK_COMPANION_MEMORY_DIRS"),
         )
 
     def profile_overrides(self) -> None:
@@ -113,3 +125,25 @@ def _float(key: str, default: float) -> float:
         return float(val)
     except ValueError:
         return default
+
+
+def _path_list(key: str) -> list[Path]:
+    """Parse an env var holding a list of directories.
+
+    Accepts both the OS path separator (``:`` on POSIX, ``;`` on Windows) and
+    commas, so ``~/notes:~/work/journal`` and ``~/notes,~/work/journal`` both
+    work.  ``~`` is expanded; surrounding whitespace and empty entries are
+    dropped.  Returns ``[]`` when the var is unset or contains only empties —
+    never raises, preserving the companion's fail-open posture.
+    """
+    val = os.environ.get(key)
+    if not val:
+        return []
+    # Normalize the OS path separator to a comma, then split on commas.
+    raw = val.replace(os.pathsep, ",")
+    out: list[Path] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if part:
+            out.append(Path(os.path.expanduser(part)))
+    return out

--- a/tokenpak/companion/mcp/tools.py
+++ b/tokenpak/companion/mcp/tools.py
@@ -276,8 +276,18 @@ def _handle_session_info(state: CompanionState, args: dict[str, Any]) -> str:
             "budget_daily_usd": state.config.budget_daily_usd,
             "hooks_enabled": state.config.hooks_enabled,
             "prune_threshold": state.config.prune_threshold,
+            "memory_dirs": [str(p) for p in getattr(state.config, "memory_dirs", [])],
         },
     }
+    # Make "no lessons" self-explaining: report whether a memory source is
+    # configured at all (TOKENPAK_COMPANION_MEMORY_DIRS / vault), so a
+    # fresh user knows why ingestion may be empty and how to point it at notes.
+    if not local["config"]["memory_dirs"]:
+        local["config"]["memory_source_hint"] = (
+            "no memory dirs configured — set TOKENPAK_COMPANION_MEMORY_DIRS to "
+            "directories of your own Markdown notes, then ingest them with the "
+            "companion memory-source API (ingest_from_dir / ingest_sources)"
+        )
     status, proxy_info = _proxy_get("/tpk/v1/session/info")
     if status == 200:
         local["proxy"] = proxy_info

--- a/tokenpak/companion/memory/lesson_ingest.py
+++ b/tokenpak/companion/memory/lesson_ingest.py
@@ -126,12 +126,138 @@ def extract_lessons(filepath: str) -> List[Dict[str, Any]]:
     return lessons
 
 
+MARKDOWN_SUFFIXES = ('.md', '.markdown')
+
+
+def _record_lessons(lessons: List[Dict[str, Any]], db: DecisionMemoryDB, source: str) -> int:
+    """Write a list of extracted lessons to the DB. Returns count written.
+
+    Uses the same deterministic ``query`` key shape as :func:`ingest_from_vault`
+    (``lesson_<timestamp>_<task_id>``) so callers that later dedupe by query
+    hash can do so.  NOTE: ``DecisionMemoryDB.record`` currently always inserts
+    (it does not upsert on the query hash), so re-running ingestion re-inserts —
+    this matches the existing vault-path behavior and is intentionally not
+    changed here (out of scope for this change).
+    """
+    count = 0
+    for lesson in lessons:
+        query = f"lesson_{lesson['timestamp']}_{lesson.get('task_id', 'general')}"
+        db.record(
+            query=query,
+            decision=lesson['lesson'],
+            confidence=lesson['confidence'],
+            notes=f"source: {source}, section: {lesson['section']}",
+        )
+        count += 1
+    return count
+
+
+def ingest_from_dir(directory: str, db: DecisionMemoryDB) -> int:
+    """
+    Recursively ingest lessons from any directory of Markdown notes.
+
+    This is the generic "bring your own knowledge base" path: it does NOT
+    require the vault ``03_AGENT_PACKS/<agent>/memory/`` schema.  Every
+    ``.md`` / ``.markdown`` file under ``directory`` (at any depth) is parsed
+    with the same :func:`extract_lessons` parser used for vault logs.
+
+    Missing, unreadable, or empty directories return ``0`` without raising,
+    preserving the companion's fail-open posture.  Use :func:`ingest_sources`
+    for a structured per-source status report.
+
+    Args:
+        directory: path to a directory holding the user's Markdown notes
+        db: DecisionMemoryDB instance to write to
+
+    Returns:
+        Total count of lessons ingested
+    """
+    directory = os.path.expanduser(directory)
+    if not os.path.isdir(directory):
+        return 0
+
+    total_ingested = 0
+    for root, _dirs, files in os.walk(directory):
+        for filename in sorted(files):
+            if filename.lower().endswith(MARKDOWN_SUFFIXES):
+                filepath = os.path.join(root, filename)
+                try:
+                    lessons = extract_lessons(filepath)
+                except (OSError, UnicodeDecodeError):
+                    # Skip files we cannot read; never abort the whole walk.
+                    continue
+                rel = os.path.relpath(filepath, directory)
+                total_ingested += _record_lessons(lessons, db, source=rel)
+    return total_ingested
+
+
+def ingest_sources(
+    db: DecisionMemoryDB,
+    vault_dir: str | None = None,
+    memory_dirs: "list | None" = None,
+) -> Dict[str, Any]:
+    """
+    Ingest from all configured memory sources and report per-source status.
+
+    Orchestrates both ingestion paths so a fresh user gets a self-explaining
+    result instead of a bare ``0``:
+
+    - ``vault_dir`` (optional): vault-schema ingestion via
+      :func:`ingest_from_vault` (backwards-compatible default).
+    - ``memory_dirs`` (optional): generic per-directory ingestion via
+      :func:`ingest_from_dir` ("bring your own knowledge base").
+
+    Each source carries a ``reason`` classification so callers (status/doctor)
+    can distinguish *no source configured* from *configured but
+    missing/unreadable* from *present but no matching files*.
+
+    Returns:
+        ``{"total": int, "sources": [{"path", "kind", "ingested", "reason"}]}``
+    """
+    sources: List[Dict[str, Any]] = []
+    total = 0
+
+    if vault_dir:
+        vp = os.path.expanduser(vault_dir)
+        packs = os.path.join(vp, '03_AGENT_PACKS')
+        if not os.path.isdir(packs):
+            sources.append({"path": vault_dir, "kind": "vault",
+                            "ingested": 0, "reason": "missing-or-not-vault-schema"})
+        else:
+            n = ingest_from_vault(vault_dir, db)
+            sources.append({"path": vault_dir, "kind": "vault", "ingested": n,
+                            "reason": "ok" if n else "present-but-no-matching-files"})
+            total += n
+
+    for d in (memory_dirs or []):
+        ds = str(d)
+        dp = os.path.expanduser(ds)
+        if not os.path.exists(dp):
+            sources.append({"path": ds, "kind": "memory-dir", "ingested": 0,
+                            "reason": "missing"})
+        elif not os.path.isdir(dp):
+            sources.append({"path": ds, "kind": "memory-dir", "ingested": 0,
+                            "reason": "not-a-directory"})
+        else:
+            n = ingest_from_dir(ds, db)
+            sources.append({"path": ds, "kind": "memory-dir", "ingested": n,
+                            "reason": "ok" if n else "present-but-no-matching-files"})
+            total += n
+
+    if not sources:
+        sources.append({"path": None, "kind": None, "ingested": 0,
+                        "reason": "no-source-configured"})
+
+    return {"total": total, "sources": sources}
+
+
 def ingest_from_vault(vault_dir: str, db: DecisionMemoryDB) -> int:
     """
     Walk vault daily logs and ingest all lessons into the DecisionMemoryDB.
 
-    Scans all files matching <vault_dir>/agents/*/memory/YYYY-MM-DD.md
-    and extracts lessons, populating the database.
+    Scans all files matching ``<vault_dir>/03_AGENT_PACKS/<agent>/memory/YYYY-MM-DD.md``
+    and extracts lessons, populating the database.  This is the vault-schema
+    path; for arbitrary user note directories use :func:`ingest_from_dir`.
 
     Args:
         vault_dir: path to vault root directory

--- a/tokenpak/tests/test_companion_memory_source.py
+++ b/tokenpak/tests/test_companion_memory_source.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for configurable generic memory-source ingestion.
+
+Covers the "bring your own knowledge base" path added so a fresh (solo) user
+can point the companion at any Markdown notes directory — without the vault
+``03_AGENT_PACKS/<agent>/memory/`` schema.
+
+Maps to the feature acceptance criteria:
+  AC#1 vault-schema default path still works (regression guard)
+  AC#2 custom memory dir ingests
+  AC#3 Markdown supported (.md / .markdown)
+  AC#4 missing / empty dirs fail gracefully (no crash) with distinct reasons
+  AC#5 status surfaces configured source(s) — see test_status_reports_sources
+  AC#6 from_env parses TOKENPAK_COMPANION_MEMORY_DIRS (pathsep/comma/~/empties)
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.config import CompanionConfig, _path_list
+from tokenpak.companion.memory.decision_memory import DecisionMemoryDB
+from tokenpak.companion.memory.lesson_ingest import (
+    ingest_from_dir,
+    ingest_from_vault,
+    ingest_sources,
+)
+
+
+@pytest.fixture
+def db():
+    """A throwaway on-disk DecisionMemoryDB (SQLite needs a real path)."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+    try:
+        yield DecisionMemoryDB(path)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------- #
+# AC#6 — from_env parsing of TOKENPAK_COMPANION_MEMORY_DIRS
+# --------------------------------------------------------------------------- #
+
+
+class TestFromEnvMemoryDirs:
+    def test_default_empty(self, monkeypatch):
+        monkeypatch.delenv("TOKENPAK_COMPANION_MEMORY_DIRS", raising=False)
+        cfg = CompanionConfig.from_env()
+        assert cfg.memory_dirs == []
+
+    def test_pathsep_form(self, monkeypatch):
+        monkeypatch.setenv(
+            "TOKENPAK_COMPANION_MEMORY_DIRS",
+            os.pathsep.join(["/tmp/a", "/tmp/b"]),
+        )
+        cfg = CompanionConfig.from_env()
+        assert cfg.memory_dirs == [Path("/tmp/a"), Path("/tmp/b")]
+
+    def test_comma_form(self, monkeypatch):
+        monkeypatch.setenv("TOKENPAK_COMPANION_MEMORY_DIRS", "/tmp/a,/tmp/b")
+        cfg = CompanionConfig.from_env()
+        assert cfg.memory_dirs == [Path("/tmp/a"), Path("/tmp/b")]
+
+    def test_tilde_expansion_and_empties(self, monkeypatch):
+        monkeypatch.setenv(
+            "TOKENPAK_COMPANION_MEMORY_DIRS", "~/notes,, ,~/work/journal,"
+        )
+        cfg = CompanionConfig.from_env()
+        home = os.path.expanduser("~")
+        assert cfg.memory_dirs == [
+            Path(home) / "notes",
+            Path(home) / "work" / "journal",
+        ]
+
+    def test_path_list_unset_is_empty(self, monkeypatch):
+        monkeypatch.delenv("TOKENPAK_COMPANION_MEMORY_DIRS", raising=False)
+        assert _path_list("TOKENPAK_COMPANION_MEMORY_DIRS") == []
+
+
+# --------------------------------------------------------------------------- #
+# AC#1 — vault-schema default path still works (regression guard)
+# --------------------------------------------------------------------------- #
+
+
+def test_vault_schema_still_works(db):
+    with tempfile.TemporaryDirectory() as tmp:
+        mem = Path(tmp) / "03_AGENT_PACKS" / "TestAgent" / "memory"
+        mem.mkdir(parents=True)
+        (mem / "2026-03-27.md").write_text(
+            "# Daily Log\n\n## Lessons Learned\n- Lesson A\n- Lesson B\n"
+        )
+        assert ingest_from_vault(tmp, db) == 2
+        assert db.count() == 2
+
+
+# --------------------------------------------------------------------------- #
+# AC#2 / AC#3 — custom memory dir ingests Markdown (.md and .markdown)
+# --------------------------------------------------------------------------- #
+
+
+def test_custom_memory_dir_ingests(db):
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "notes.md").write_text(
+            "# My Notes\n\n## Lessons Learned\n- Keep a changelog\n- Write tests first\n"
+        )
+        # nested + .markdown extension also picked up
+        sub = Path(tmp) / "sub"
+        sub.mkdir()
+        (sub / "more.markdown").write_text(
+            "## Lessons Learned\n- Back up before migrations\n"
+        )
+        assert ingest_from_dir(tmp, db) == 3
+        assert db.count() == 3
+
+
+def test_non_markdown_ignored(db):
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / "keep.md").write_text("## Lessons Learned\n- Real lesson\n")
+        (Path(tmp) / "skip.txt").write_text("## Lessons Learned\n- ignored\n")
+        (Path(tmp) / "skip.json").write_text('{"lesson": "ignored"}')
+        assert ingest_from_dir(tmp, db) == 1
+
+
+# --------------------------------------------------------------------------- #
+# AC#4 — missing / empty directories fail gracefully (no crash)
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_dir_no_crash(db):
+    assert ingest_from_dir("/nonexistent/path/xyz", db) == 0
+
+
+def test_empty_dir_no_crash(db):
+    with tempfile.TemporaryDirectory() as tmp:
+        assert ingest_from_dir(tmp, db) == 0
+
+
+# --------------------------------------------------------------------------- #
+# ingest_sources orchestrator — structured per-source reasons (AC#4/#5 support)
+# --------------------------------------------------------------------------- #
+
+
+class TestIngestSources:
+    def test_no_source_configured(self, db):
+        res = ingest_sources(db)
+        assert res["total"] == 0
+        assert res["sources"][0]["reason"] == "no-source-configured"
+
+    def test_missing_memory_dir_reason(self, db):
+        res = ingest_sources(db, memory_dirs=["/nope/missing"])
+        assert res["total"] == 0
+        assert res["sources"][0]["reason"] == "missing"
+
+    def test_empty_memory_dir_reason(self, db):
+        with tempfile.TemporaryDirectory() as tmp:
+            res = ingest_sources(db, memory_dirs=[tmp])
+            assert res["sources"][0]["reason"] == "present-but-no-matching-files"
+
+    def test_mixed_vault_and_memory_dirs(self, db):
+        with tempfile.TemporaryDirectory() as vault, \
+             tempfile.TemporaryDirectory() as notes:
+            mem = Path(vault) / "03_AGENT_PACKS" / "A" / "memory"
+            mem.mkdir(parents=True)
+            (mem / "2026-03-27.md").write_text("## Lessons Learned\n- vault lesson\n")
+            (Path(notes) / "n.md").write_text("## Lessons Learned\n- byo lesson\n")
+            res = ingest_sources(db, vault_dir=vault, memory_dirs=[notes])
+            assert res["total"] == 2
+            kinds = {s["kind"] for s in res["sources"]}
+            assert kinds == {"vault", "memory-dir"}
+            assert all(s["reason"] == "ok" for s in res["sources"])
+
+    def test_rerun_matches_vault_path_behavior(self, db):
+        """Generic path has the SAME re-run semantics as the vault path.
+
+        ``DecisionMemoryDB.record`` always inserts (no upsert on the query
+        hash), so both ``ingest_from_dir`` and ``ingest_from_vault`` re-insert
+        on a second run.  This test documents that parity — the generic path
+        does not introduce a new behavior, and changing the DB to dedupe is
+        out of scope for this change.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "n.md").write_text(
+                "## Lessons Learned\n- one\n- two\n"
+            )
+            assert ingest_from_dir(tmp, db) == 2
+            first = db.count()
+            assert ingest_from_dir(tmp, db) == 2
+            assert db.count() == first + 2  # re-insert, same as vault path
+
+
+def test_status_reports_sources(monkeypatch):
+    """AC#5: ``session_info`` surfaces configured memory sources + a hint.
+
+    The MCP ``session_info`` tool only *reports* ``memory_dirs`` (and, when none
+    are set, a hint on how to configure them) — it never ingests. This guards
+    that the hint points at the shipped surface (the env var + the library API)
+    and NOT at the deliberately deferred ``tokenpak companion ingest`` CLI verb.
+    """
+    import json
+
+    from tokenpak.companion.mcp import tools as mcp_tools
+
+    # Exercise only the local-config surface; never touch a real proxy.
+    monkeypatch.setattr(
+        mcp_tools, "_proxy_get",
+        lambda *a, **k: (0, {"detail": "proxy down (test)"}),
+    )
+
+    # No memory dirs configured -> a self-explaining hint is reported.
+    cfg_empty = CompanionConfig.from_env()
+    cfg_empty.memory_dirs = []
+    out = json.loads(mcp_tools._handle_session_info(
+        mcp_tools.CompanionState(config=cfg_empty), {}))
+    assert out["config"]["memory_dirs"] == []
+    hint = out["config"]["memory_source_hint"]
+    assert "TOKENPAK_COMPANION_MEMORY_DIRS" in hint
+    assert ("ingest_from_dir" in hint) or ("ingest_sources" in hint)
+    # Must NOT advertise the deferred CLI flag / verb.
+    assert "--memory-dir" not in hint
+    assert "companion ingest" not in hint
+
+    # Memory dirs configured -> reported, and no "configure me" hint.
+    cfg_set = CompanionConfig.from_env()
+    cfg_set.memory_dirs = [Path("/tmp/notes"), Path("/tmp/journal")]
+    out2 = json.loads(mcp_tools._handle_session_info(
+        mcp_tools.CompanionState(config=cfg_set), {}))
+    assert out2["config"]["memory_dirs"] == ["/tmp/notes", "/tmp/journal"]
+    assert "memory_source_hint" not in out2["config"]


### PR DESCRIPTION
## Summary

Adds companion **memory-source ingestion** — point the companion at your own
directories of Markdown notes ("bring your own knowledge base"), independent of
the built-in memory schema. **Additive only**: no changes to existing behavior,
no breaking changes.

Shipped as a **library API + configuration + MCP visibility** (no new CLI verb):

- **Library API** (`tokenpak.companion.memory.lesson_ingest`):
  - `ingest_from_dir(directory, db)` — recursively ingest one directory of notes.
  - `ingest_sources(db, vault_dir=None, memory_dirs=None)` — orchestrate all
    configured sources and return a per-source status report (`reason`:
    `no-source-configured` / `missing` / `not-a-directory` /
    `present-but-no-matching-files` / `ok`).
  - Fail-open: missing or unreadable paths never raise.
- **Config**: `TOKENPAK_COMPANION_MEMORY_DIRS` (OS-path-separator- or
  comma-separated; `~` expanded; empty entries dropped) parsed into
  `CompanionConfig.memory_dirs`.
- **MCP**: the `session_info` tool reports the configured `memory_dirs` and a
  hint when none are set, so an empty ingest is self-explaining.

## Tests & docs

- `tests/test_companion_memory_source.py` (16 tests): env-var parser,
  `ingest_from_dir`, the `ingest_sources` status contract, and the
  `session_info` surface.
- Companion guide: a "Memory sources — bring your own knowledge base" section
  documenting the env var, the library API, and the MCP surface.

## Public-API snapshot

Regenerated `tokenpak/_snapshots/public-api.json`. Beyond the three new
companion symbols (`ingest_from_dir`, `ingest_sources`, `MARKDOWN_SUFFIXES`),
this is a **ratchet correction** that absorbs already-public
`tokenpak.proxy.capture_intake` symbols the committed snapshot had drifted
from — **not** a new feature. `make api-snapshot-check` passes locally.

## Notes

- Version bumped to **1.8.0**.
- No CLI verb in this PR.
