### PR TITLE
ci(release): full-tree public-leak scan gating build and publish

### DIFF
--- a/.github/workflows/identity-language-check.yml
+++ b/.github/workflows/identity-language-check.yml
@@ -27,8 +27,12 @@ jobs:
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           # Only files added or modified in this PR; binary files skipped.
+          # scripts/release_gate/check_release_leaks.py is excluded for the same
+          # reason this workflow and public-layout-check.yml are: it is the
+          # full-tree sibling scanner and intentionally contains the
+          # forbidden-pattern register + path-scoped allowlist literals.
           git diff --name-only --diff-filter=AM "$base" "$head" \
-            | grep -vE "^(packages/tests/|tests/|sdk/dist/|\.github/workflows/identity-language-check\.yml|\.github/workflows/public-layout-check\.yml|\.pre-commit-config\.yaml)" \
+            | grep -vE "^(packages/tests/|tests/|sdk/dist/|scripts/release_gate/check_release_leaks\.py|\.github/workflows/identity-language-check\.yml|\.github/workflows/public-layout-check\.yml|\.pre-commit-config\.yaml)" \
             | grep -E '\.(md|py|yml|yaml|json|toml|sh|js|ts|tsx)$' \
             > changed-files.txt || true
           echo "Changed files (filtered):"

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -147,9 +147,29 @@ jobs:
       - name: taxonomy-check (Std 30 §5 R5)
         run: make taxonomy-check
 
+  leak-scan:
+    # Full-tree public-leak gate (rehearsal mirror of release.yml). Keeps the
+    # weekly dry-run faithful to "every gate in the production release pipeline":
+    # scans the built sdist + wheel for internal identity / workflow language
+    # before artifacts are built.
+    name: Public-leak scan (full shipped tree)
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build sdist + wheel for scanning
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Scan shipped artifact for public-leak patterns
+        run: python scripts/release_gate/check_release_leaks.py --dist dist/
+
   build-artifacts:
     name: Build sdist + wheel + sdist purity (R9)
-    needs: [install-shape-matrix, release-gate-snapshots]
+    needs: [install-shape-matrix, release-gate-snapshots, leak-scan]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,39 @@ jobs:
         run: make taxonomy-check
 
   # ─────────────────────────────────────────────────────────────────────
+  # Step 1b: Full-tree public-leak gate (runs before build, gates build/publish)
+  # ─────────────────────────────────────────────────────────────────────
+  #
+  # Scans the ENTIRE shipped artifact (built sdist + wheel) for internal
+  # identity / workflow language, using the same forbidden-pattern register and
+  # path-scoped allowlists as the per-PR delta gate
+  # (.github/workflows/identity-language-check.yml). The delta gate only
+  # re-checks files changed in a PR, so a reference in a file that no later PR
+  # touches is never re-scanned and can ship. This job closes that blind spot.
+  #
+  # It runs on BOTH manual preflight (workflow_dispatch) and tag pushes, and the
+  # build job below `needs:` it — so any leak fails before a distribution is
+  # built or published.
+  leak-scan:
+    name: Public-leak scan (full shipped tree)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist + wheel for scanning
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Scan shipped artifact for public-leak patterns
+        run: python scripts/release_gate/check_release_leaks.py --dist dist/
+
+  # ─────────────────────────────────────────────────────────────────────
   # Step 2: Build distribution artifacts
   # ─────────────────────────────────────────────────────────────────────
   #
@@ -206,7 +239,7 @@ jobs:
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
-    needs: [test, release-gate-snapshots]
+    needs: [test, release-gate-snapshots, leak-scan]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ clean-all: clean  ## Remove everything including venv
 # ── Release-Gate Trust Contract (Std 30, ratified 2026-05-09) ────────────────
 .PHONY: api-snapshot api-snapshot-check api-snapshot-diff workflow-steps-snapshot \
         workflow-steps-check telemetry-snapshot telemetry-check taxonomy-check \
-        deps-audit migration-multihop release-gate-snapshots release-gate-check
+        deps-audit migration-multihop release-gate-snapshots release-gate-check \
+        release-leak-check
 
 api-snapshot:  ## Std 30 §7 (R7) — regenerate tokenpak/_snapshots/public-api.json
 	$(PYTHON) scripts/release_gate/gen_api_snapshot.py
@@ -156,3 +157,8 @@ release-gate-snapshots: api-snapshot workflow-steps-snapshot telemetry-snapshot 
 
 release-gate-check: api-snapshot-check workflow-steps-check telemetry-check taxonomy-check  ## Validate ALL release-gate snapshots
 	@echo "✅  All release-gate checks passed"
+
+release-leak-check:  ## Full-tree public-leak scan of the built sdist + wheel (release gate)
+	$(PYTHON) -m pip install --quiet build
+	$(PYTHON) -m build
+	$(PYTHON) scripts/release_gate/check_release_leaks.py --dist dist/

--- a/scripts/release_gate/check_release_leaks.py
+++ b/scripts/release_gate/check_release_leaks.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Full-tree public-leak release gate.
+
+Scans the *shipped* TokenPak artifact tree — the contents of the built sdist
+and wheel, or any directory tree — for internal identity / workflow language,
+using the SAME forbidden-pattern register and path-scoped allowlists as the
+per-PR delta gate (``.github/workflows/identity-language-check.yml``).
+
+Why this exists
+---------------
+The delta gate only re-checks files **changed in a pull request**
+(``git diff`` against base). A reference introduced in a file that no later
+PR touches is never re-scanned, so it survives forever and can ship in the
+published wheel. This gate closes that gap: it scans the **entire shipped
+artifact** on every release preflight (manual ``workflow_dispatch``) and on
+every release tag build, *before* the distribution is built and published.
+
+Scope of the pattern register
+------------------------------
+This gate intentionally mirrors the delta gate's register and allowlists
+exactly (agent identities, private home paths, internal task-ID prefixes,
+internal standard-number references, and the ``openclaw`` / ``fleet``
+path-scoped public-surface allowlists). That is the proven, soaked set and it
+directly covers the internal-development-reference class of leak.
+
+It does NOT (yet) implement the broader personal-identifier or credential-shape
+categories of the public-safe-defaults policy; extending the register to those
+is a deliberate, separately-tracked follow-up.
+
+Scope of the scanned tree
+-------------------------
+To stay consistent with the delta gate, this scanner applies the same
+non-public-surface exclusions: top-level ``tests/`` / ``packages/tests/`` (dev
+surfaces) and build-generated manifests (``RECORD`` / ``SOURCES.txt`` / … —
+auto-emitted path listings). The in-package ``tokenpak/tests/`` subpackage IS
+scanned (it ships in the wheel). The effective scope is therefore the shipped
+package source + docs + package metadata.
+
+SYNC OBLIGATION
+---------------
+The pattern register and the allowlist path-functions below MUST stay
+semantically in sync with ``.github/workflows/identity-language-check.yml``.
+A follow-up should extract a single shared engine so the two cannot drift.
+
+Usage
+-----
+    # Scan a built distribution directory (CI default):
+    python -m build
+    python scripts/release_gate/check_release_leaks.py --dist dist/
+
+    # Scan a directory tree directly (local / fixtures):
+    python scripts/release_gate/check_release_leaks.py --tree tokenpak/
+
+Exit status: ``0`` if no unallowlisted match is found, ``1`` otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+
+# ──────────────────────────────────────────────────────────────────────────
+# Forbidden-pattern register (verbatim from identity-language-check.yml).
+# Each entry is a POSIX-ERE-compatible regex understood by Python ``re``.
+# ──────────────────────────────────────────────────────────────────────────
+FLEET = r"\bfleet\b"
+OPENCLAW = r"\bopenclaw\b"
+CLAUDE_PROJECTS = r"\.claude/projects"
+
+PATTERNS: list[str] = [
+    r"\bSue\b",
+    r"\bCali\b",
+    r"\bTrix\b",
+    r"\bSuki\b",
+    r"\bAya\b",
+    r"\bDee\b",
+    r"\bReiPo\b",
+    OPENCLAW,
+    FLEET,
+    r"TSR-[0-9]",
+    r"TPS-[0-9]",
+    r"CCI-[0-9]",
+    r"MTC-[0-9]",
+    r"OAS-[0-9]",
+    r"TIP7-[0-9]",
+    r"TRIX-MTC",
+    r"WS-[0-9]",
+    r"CCG-[0-9]",
+    r"CCP-[0-9]",
+    r"VDS-[0-9]",
+    r"FIN-[0-9]",
+    r"TSG-[0-9]",
+    r"TIP-[0-9][0-9]",
+    CLAUDE_PROJECTS,
+    r"/home/sue/",
+    r"trixxie168",
+    r"\bStd 2[0-9]\b",
+    r"\bStd 3[0-9]\b",
+    r"Suki: auto-commit",
+]
+
+# ──────────────────────────────────────────────────────────────────────────
+# Path-scoped allowlists (verbatim from identity-language-check.yml).
+# Paths are repository-relative (POSIX separators), e.g. "tokenpak/sdk/openclaw.py".
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def is_release_gate_impl_path(path: str) -> bool:
+    """Release-gate implementation surfaces — mask Std 21 / Std 30 references only.
+
+    These human-authored files legitimately implement the release-gate
+    standards and reference them by number. All other patterns remain enforced.
+    """
+    if path in (
+        ".github/workflows/release.yml",
+        ".github/workflows/release-rehearsal.yml",
+        "Makefile",
+    ):
+        return True
+    return path.startswith("scripts/release_gate/")
+
+
+def is_release_gate_snapshot_path(path: str) -> bool:
+    """Generated-artifact snapshot surface — mask Std 21/30 + openclaw + fleet.
+
+    ``tokenpak/_snapshots/*`` capture real generated symbol names
+    (``tokenpak.creds.providers.openclaw``, ``tokenpak.cli.fleet`` …) and
+    release-gate metadata; those are legitimate. Agent names / task IDs /
+    private paths remain enforced even here.
+    """
+    return path.startswith("tokenpak/_snapshots/")
+
+
+def is_openclaw_public_path(path: str) -> bool:
+    """OpenClaw provider/SDK/integration subsystem — ``openclaw`` is the
+    legitimate, non-renamable public provider/module name in these files."""
+    if path.startswith("tokenpak/integrations/openclaw/"):
+        return True
+    if path.startswith("tokenpak/services/routing_service/"):
+        return True
+    return path in (
+        "tokenpak/sdk/openclaw.py",
+        "tokenpak/sdk/registry.py",
+        "tokenpak/sdk/__init__.py",
+        "tokenpak/creds/providers/openclaw.py",
+        "tokenpak/creds/providers/__init__.py",
+        "tokenpak/creds/router.py",
+        "tokenpak/creds/doctor.py",
+        "tokenpak/proxy/route_policy.py",
+        "tokenpak/tests/test_sdk_openclaw.py",
+    )
+
+
+def is_fleet_public_path(path: str) -> bool:
+    """Public ``tokenpak fleet`` feature + functional spend-guard fleet surface —
+    every ``fleet`` here is the user-facing multi-instance-proxy capability."""
+    if path.startswith("tokenpak/integrations/openclaw/"):
+        return True
+    return path in (
+        "tokenpak/cli/fleet.py",
+        "tokenpak/cli/commands/dashboard.py",
+        "tokenpak/tests/test_fleet.py",
+        "scripts/install-completions.sh",
+        "tokenpak/proxy/spend_guard/rolling_caps.py",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Masking (verbatim semantics from identity-language-check.yml
+# ``content_for_pattern``). Masks substitute legitimate public-surface forms
+# so the forbidden-pattern grep does not match them. Substitutions never add
+# or remove newlines, so line numbers are preserved.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _mask_snapshot(text: str) -> str:
+    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
+    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
+    text = re.sub(r"\bopenclaw\b", "__GEN_SYM_OPENCLAW__", text)
+    text = re.sub(r"\bfleet\b", "__GEN_SYM_FLEET__", text)
+    return text
+
+
+def _mask_relgate_impl(text: str) -> str:
+    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
+    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
+    return text
+
+
+def _mask_openclaw_functional(text: str) -> str:
+    text = re.sub(r"tokenpak\.sdk\.openclaw", "tokenpak.sdk.__FUNC_OC_MODULE__", text)
+    text = re.sub(
+        r"tokenpak\.creds\.providers\.openclaw",
+        "tokenpak.creds.providers.__FUNC_OC_MODULE__",
+        text,
+    )
+    text = re.sub(r"x-openclaw-session", "x-__FUNC_OC_HEADER__-session", text)
+    text = re.sub(r"x-openclaw-workspace", "x-__FUNC_OC_HEADER__-workspace", text)
+    text = re.sub(r'"openclaw"', '"__FUNC_OC_LITERAL__"', text)
+    text = re.sub(r"openclaw:main", "__FUNC_OC_CALLER__:main", text)
+    text = re.sub(r"openclaw\.json", "__FUNC_OC_CONFIG__.json", text)
+    return text
+
+
+def _mask_fleet_functional(text: str) -> str:
+    text = re.sub(r"tokenpak\s+fleet", "tokenpak __PUBLIC_FLEET_VERB__", text)
+    text = re.sub(r"--fleet([^a-zA-Z]|$)", r"--__PUBLIC_FLEET_FLAG__\1", text)
+    text = re.sub(r"fleet\.yaml", "__PUBLIC_FLEET_CONFIG__.yaml", text)
+    text = re.sub(
+        r"fleet\s+(config|configuration|command|management|rollup|status)",
+        r"__PUBLIC_FLEET_PHRASE__ \1",
+        text,
+    )
+    text = re.sub(r"fleet-telemetry", "__PUBLIC_FLEET_PHRASE__-telemetry", text)
+    text = re.sub(r"fleet-wide", "__PUBLIC_FLEET_PHRASE__-wide", text)
+    text = re.sub(r"multi-instance\s+fleet", "multi-instance __PUBLIC_TMUX_MODE__", text)
+    text = re.sub(r"multi-instance-fleet", "multi-instance-__PUBLIC_TMUX_MODE__", text)
+    text = re.sub(r'"fleet"', '"__PUBLIC_FLEET_LITERAL__"', text)
+    text = re.sub(r"fleet=", "__PUBLIC_FLEET_KW__=", text)
+    text = re.sub(r"if fleet:", "if __PUBLIC_FLEET_PARAM__:", text)
+    text = re.sub(r"fleet: bool", "__PUBLIC_FLEET_PARAM__: bool", text)
+    text = re.sub(r"a fleet of", "a __PUBLIC_FLEET_PHRASE__ of", text)
+    text = re.sub(r"proxy fleet", "proxy __PUBLIC_FLEET_PHRASE__", text)
+    text = re.sub(r"fleet manifest", "__PUBLIC_FLEET_PHRASE__ manifest", text)
+    text = re.sub(r"fleet automation", "__PUBLIC_FLEET_PHRASE__ automation", text)
+    text = re.sub(r"Current fleet", "Current __PUBLIC_FLEET_PHRASE__", text)
+    text = re.sub(r"fleet init", "__PUBLIC_FLEET_PHRASE__ init", text)
+    text = re.sub(r"agents in fleet", "agents in __PUBLIC_FLEET_PHRASE__", text)
+    text = re.sub(r"configured in fleet", "configured in __PUBLIC_FLEET_PHRASE__", text)
+    text = re.sub(r"cli\.fleet", "cli.__PUBLIC_FLEET_MODULE__", text)
+    text = re.sub(r"configure fleet", "configure __PUBLIC_FLEET_PHRASE__", text)
+    text = re.sub(r"=fleet\b", "=__PUBLIC_FLEET_KW__", text)
+    text = re.sub(r"x-tokenpak-fleet", "x-tokenpak-__FUNC_FLEET_HDR__", text)
+    text = re.sub(r"per-fleet", "per-__FUNC_FLEET_SCOPE__", text)
+    text = re.sub(r"fleet-level", "__FUNC_FLEET_SCOPE__-level", text)
+    text = re.sub(r"fleet([- ])protection", r"__FUNC_FLEET_SCOPE__\1protection", text)
+    text = re.sub(r"fleet caps", "__FUNC_FLEET_SCOPE__ caps", text)
+    text = re.sub(r"session ?/ ?fleet ?/ ?agent", "session/__FUNC_FLEET_SCOPE__/agent", text)
+    return text
+
+
+def mask_content(pattern: str, path: str, text: str) -> str:
+    """Return ``text`` with the legitimate public-surface forms masked for this
+    (pattern, path) pair. Dispatch order mirrors the delta gate exactly."""
+    if is_release_gate_snapshot_path(path):
+        return _mask_snapshot(text)
+    if pattern == FLEET and is_fleet_public_path(path):
+        return re.sub(r"\bfleet\b", "__PUBLIC_FLEET_FEATURE__", text)
+    if pattern == FLEET:
+        return _mask_fleet_functional(text)
+    if is_release_gate_impl_path(path):
+        return _mask_relgate_impl(text)
+    if pattern == OPENCLAW and is_openclaw_public_path(path):
+        return re.sub(r"\bopenclaw\b", "__INTEGRATION_OPENCLAW__", text)
+    if pattern == OPENCLAW:
+        return _mask_openclaw_functional(text)
+    if pattern == CLAUDE_PROJECTS:
+        return re.sub(r"~/\.claude/projects", "~/__FUNC_CLAUDE_TRANSCRIPT_DIR__", text)
+    return text
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# File collection
+# ──────────────────────────────────────────────────────────────────────────
+# Binary / non-text extensions are skipped (cannot carry readable leaks and
+# break utf-8 decoding).
+_BINARY_EXT = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".ico",
+    ".svg",
+    ".webp",
+    ".pdf",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".eot",
+    ".otf",
+    ".pyc",
+    ".pyo",
+    ".so",
+    ".dylib",
+    ".dll",
+    ".o",
+    ".a",
+    ".zip",
+    ".gz",
+    ".tar",
+    ".whl",
+    ".bz2",
+    ".xz",
+    ".7z",
+    ".db",
+    ".sqlite",
+    ".sqlite3",
+    ".wal",
+    ".bin",
+    ".mo",
+}
+_SKIP_DIRS = {".git", "__pycache__", ".mypy_cache", ".ruff_cache", ".pytest_cache"}
+
+# Path prefixes that are NOT a public-language-bound surface. These mirror the
+# delta gate's changed-files exclusions (identity-language-check.yml) so the two
+# gates apply the same scope. ``tests/`` (top-level) and ``packages/tests/`` are
+# dev surfaces; the in-package ``tokenpak/tests/`` subpackage is NOT excluded
+# here (it ships in the wheel and IS scanned, with its own path-scoped
+# allowlist entries). ``sdk/dist/`` is generated SDK output.
+_EXCLUDE_PREFIXES = ("tests/", "packages/tests/", "sdk/dist/")
+
+# Build-generated manifest files: auto-emitted path / hash / dependency
+# listings, not authored content. They necessarily enumerate legitimate file
+# paths (``tokenpak/sdk/openclaw.py`` …) and would false-positive forever.
+_MANIFEST_BASENAMES = {
+    "RECORD",
+    "SOURCES.txt",
+    "top_level.txt",
+    "entry_points.txt",
+    "WHEEL",
+    "dependency_links.txt",
+    "requires.txt",
+    "not-zip-safe",
+    "zip-safe",
+}
+
+
+def _is_excluded(relpath: str) -> bool:
+    if relpath.startswith(_EXCLUDE_PREFIXES):
+        return True
+    if ".egg-info/" in relpath:
+        return True
+    base = relpath.rsplit("/", 1)[-1]
+    if base in _MANIFEST_BASENAMES:
+        return True
+    return False
+
+
+@dataclass
+class ScanFile:
+    relpath: str  # repository-relative, POSIX separators
+    abspath: str
+
+
+def _looks_binary(abspath: str) -> bool:
+    ext = os.path.splitext(abspath)[1].lower()
+    if ext in _BINARY_EXT:
+        return True
+    try:
+        with open(abspath, "rb") as fh:
+            chunk = fh.read(4096)
+        if b"\x00" in chunk:
+            return True
+        chunk.decode("utf-8")
+    except (UnicodeDecodeError, OSError):
+        return True
+    return False
+
+
+def collect_tree(root: str, prefix_strip: str = "") -> list[ScanFile]:
+    """Walk ``root`` and return text files as repo-relative ScanFile entries.
+
+    ``prefix_strip`` is removed from the front of each relative path so that
+    e.g. an sdist's ``tokenpak-1.2.3/`` top directory maps to repo-relative
+    paths the allowlist functions understand.
+    """
+    out: list[ScanFile] = []
+    root = os.path.abspath(root)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            abspath = os.path.join(dirpath, name)
+            rel = os.path.relpath(abspath, root).replace(os.sep, "/")
+            if prefix_strip and rel.startswith(prefix_strip):
+                rel = rel[len(prefix_strip) :]
+            if _is_excluded(rel):
+                continue
+            if _looks_binary(abspath):
+                continue
+            out.append(ScanFile(relpath=rel, abspath=abspath))
+    return out
+
+
+def collect_dist(dist_dir: str, workdir: str) -> list[ScanFile]:
+    """Extract every sdist (*.tar.gz) and wheel (*.whl) in ``dist_dir`` into
+    ``workdir`` and return their text files as repo-relative ScanFile entries.
+
+    sdist members are ``name-version/<repo path>`` → the top directory is
+    stripped. wheel members are already repo-relative for the package
+    (``tokenpak/...``) plus a ``*.dist-info/`` metadata dir.
+    """
+    files: list[ScanFile] = []
+    sdists = [f for f in os.listdir(dist_dir) if f.endswith(".tar.gz")]
+    wheels = [f for f in os.listdir(dist_dir) if f.endswith(".whl")]
+    if not sdists and not wheels:
+        raise SystemExit(f"error: no sdist (*.tar.gz) or wheel (*.whl) found in {dist_dir!r}")
+
+    for i, sd in enumerate(sorted(sdists)):
+        dest = os.path.join(workdir, f"sdist_{i}")
+        os.makedirs(dest, exist_ok=True)
+        with tarfile.open(os.path.join(dist_dir, sd)) as tf:
+            _safe_extract_tar(tf, dest)
+        # sdist root dir is "<name>-<version>/"
+        roots = [d for d in os.listdir(dest) if os.path.isdir(os.path.join(dest, d))]
+        for r in roots:
+            files += collect_tree(os.path.join(dest, r))
+
+    for i, wh in enumerate(sorted(wheels)):
+        dest = os.path.join(workdir, f"wheel_{i}")
+        os.makedirs(dest, exist_ok=True)
+        with zipfile.ZipFile(os.path.join(dist_dir, wh)) as zf:
+            zf.extractall(dest)
+        files += collect_tree(dest)
+
+    return files
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, dest: str) -> None:
+    dest_abs = os.path.abspath(dest)
+    for member in tf.getmembers():
+        target = os.path.abspath(os.path.join(dest, member.name))
+        if not (target == dest_abs or target.startswith(dest_abs + os.sep)):
+            raise SystemExit(f"error: unsafe path in archive: {member.name!r}")
+    tf.extractall(dest)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Scan
+# ──────────────────────────────────────────────────────────────────────────
+@dataclass
+class Finding:
+    path: str
+    line: int
+    pattern: str
+    text: str
+
+
+def scan_files(files: list[ScanFile]) -> list[Finding]:
+    compiled = [(p, re.compile(p)) for p in PATTERNS]
+    findings: list[Finding] = []
+    for sf in files:
+        try:
+            with open(sf.abspath, encoding="utf-8") as fh:
+                content = fh.read()
+        except (UnicodeDecodeError, OSError):
+            continue
+        orig_lines = content.split("\n")
+        for pat, rx in compiled:
+            masked = mask_content(pat, sf.relpath, content)
+            for idx, mline in enumerate(masked.split("\n")):
+                if rx.search(mline):
+                    findings.append(
+                        Finding(
+                            path=sf.relpath,
+                            line=idx + 1,
+                            pattern=pat,
+                            text=orig_lines[idx] if idx < len(orig_lines) else "",
+                        )
+                    )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--dist",
+        metavar="DIR",
+        help="directory containing built sdist (*.tar.gz) and/or wheel (*.whl)",
+    )
+    src.add_argument(
+        "--tree",
+        metavar="DIR",
+        help="directory tree to scan (repo-relative paths computed from DIR)",
+    )
+    args = ap.parse_args(argv)
+
+    with tempfile.TemporaryDirectory() as workdir:
+        if args.dist:
+            files = collect_dist(args.dist, workdir)
+            source_desc = f"distribution artifacts in {args.dist}"
+        else:
+            files = collect_tree(args.tree)
+            source_desc = f"tree {args.tree}"
+
+        findings = scan_files(files)
+
+    if findings:
+        # GitHub-annotation lines + human summary.
+        seen = set()
+        for f in findings:
+            key = (f.path, f.line, f.pattern)
+            if key in seen:
+                continue
+            seen.add(key)
+            print(
+                f"::error file={f.path},line={f.line}::"
+                f"Forbidden pattern '{f.pattern}' in shipped file."
+            )
+            print(f"  {f.path}:{f.line}: {f.text.strip()}")
+        print()
+        print(
+            f"FAIL: {len(seen)} forbidden-pattern match(es) in {source_desc}.\n"
+            "These ship to users. See CONTRIBUTING.md → Public language rules.\n"
+            "If a match is a legitimate public surface, add a path-scoped "
+            "allowlist entry (and keep it in sync with the delta gate)."
+        )
+        return 1
+
+    print(f"OK: scanned {len(files)} shipped file(s) in {source_desc}; no leaks found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release_gate/test_release_leak_scan.py
+++ b/tests/release_gate/test_release_leak_scan.py
@@ -1,0 +1,194 @@
+"""Regression tests for the full-tree public-leak release gate.
+
+Exercises scripts/release_gate/check_release_leaks.py end-to-end via its CLI:
+
+  * an untouched file carrying an internal reference FAILS the gate
+    (the blind spot the per-PR delta gate cannot catch);
+  * legitimate public ``openclaw`` / ``fleet`` surfaces at their allowlisted
+    paths PASS;
+  * a clean shipped tree PASSES;
+  * the ``--dist`` mode extracts an sdist, strips the version prefix, and still
+    applies the path-scoped allowlist correctly.
+
+These fixtures intentionally contain the forbidden strings. They live under
+``tests/`` (excluded from the delta gate and never shipped in the wheel/sdist),
+so they cannot trip either gate themselves.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNER = REPO_ROOT / "scripts" / "release_gate" / "check_release_leaks.py"
+
+
+def _write(root: Path, relpath: str, content: str) -> None:
+    p = root / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _run_tree(tree: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCANNER), "--tree", str(tree)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_dist(dist: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCANNER), "--dist", str(dist)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_scanner_exists():
+    assert SCANNER.is_file(), f"scanner missing at {SCANNER}"
+
+
+def test_clean_tree_passes(tmp_path):
+    _write(tmp_path, "tokenpak/proxy/server.py", "def serve():\n    return 'ok'\n")
+    _write(tmp_path, "README.md", "# TokenPak\n\nCut LLM costs.\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"clean tree should pass:\n{res.stdout}\n{res.stderr}"
+
+
+def test_untouched_private_path_leak_fails(tmp_path):
+    # An untouched file with a private home path — the exact class the delta
+    # gate misses when no PR touches the file.
+    _write(tmp_path, "tokenpak/proxy/cache.py", 'CACHE_DIR = "/home/sue/.cache"\n')
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "private-path leak must fail the gate"
+    assert "tokenpak/proxy/cache.py" in res.stdout
+
+
+def test_agent_name_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/notes.py", "# last reviewed by Sue\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "agent-name leak must fail the gate"
+    assert "tokenpak/core/notes.py" in res.stdout
+
+
+def test_internal_task_id_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/x.py", "# tracked in TSR-1234\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "internal task-ID leak must fail the gate"
+
+
+def test_allowlisted_openclaw_path_passes(tmp_path):
+    # `openclaw` is the legitimate, non-renamable provider/module name in the
+    # OpenClaw integration subsystem.
+    _write(
+        tmp_path,
+        "tokenpak/integrations/openclaw/provider.py",
+        'NAME = "openclaw"\n\n\ndef connect_openclaw():\n    return NAME\n',
+    )
+    _write(
+        tmp_path,
+        "tokenpak/sdk/openclaw.py",
+        '"""OpenClaw SDK surface."""\nMODULE = "tokenpak.sdk.openclaw"\n',
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"allowlisted openclaw must pass:\n{res.stdout}"
+
+
+def test_allowlisted_fleet_path_passes(tmp_path):
+    # `fleet` is the user-facing multi-instance-proxy CLI feature here.
+    _write(
+        tmp_path,
+        "tokenpak/cli/fleet.py",
+        'def fleet():\n    """Manage the tokenpak fleet."""\n    return True\n',
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"allowlisted fleet must pass:\n{res.stdout}"
+
+
+def test_bare_openclaw_outside_allowlist_fails(tmp_path):
+    # Same token, NON-allowlisted path -> still caught. Proves the allowlist is
+    # path-scoped, not a blanket exemption.
+    _write(tmp_path, "tokenpak/proxy/misc.py", "# the openclaw agent fleet\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "bare openclaw outside allowlist must fail"
+
+
+def test_bare_fleet_outside_allowlist_fails(tmp_path):
+    _write(tmp_path, "tokenpak/proxy/runtime.py", "# the agent fleet worker loop\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "internal-sense fleet outside allowlist must fail"
+
+
+def test_top_level_tests_dir_excluded(tmp_path):
+    # Mirrors the delta gate: top-level tests/ is a dev surface, not scanned.
+    _write(tmp_path, "tests/test_thing.py", "# authored by Sue, see TSR-01\n")
+    _write(tmp_path, "tokenpak/proxy/server.py", "OK = True\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"top-level tests/ must be excluded:\n{res.stdout}"
+
+
+def test_in_package_tests_subpackage_is_scanned(tmp_path):
+    # tokenpak/tests/ ships in the wheel and IS scanned (NOT excluded), except
+    # at its specific allowlisted paths.
+    _write(tmp_path, "tokenpak/tests/test_misc.py", "# the openclaw agent fleet\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "in-package tokenpak/tests/ must be scanned"
+    assert "tokenpak/tests/test_misc.py" in res.stdout
+
+
+def test_build_manifests_excluded(tmp_path):
+    # Auto-generated path listings enumerate legitimate file paths and must not
+    # false-positive.
+    _write(
+        tmp_path,
+        "tokenpak.egg-info/SOURCES.txt",
+        "tokenpak/sdk/openclaw.py\ntokenpak/cli/fleet.py\n",
+    )
+    _write(
+        tmp_path,
+        "tokenpak-9.9.9.dist-info/RECORD",
+        "tokenpak/sdk/openclaw.py,sha256=abc,100\n",
+    )
+    _write(tmp_path, "tokenpak/proxy/server.py", "OK = True\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"build manifests must be excluded:\n{res.stdout}"
+
+
+def _make_sdist(dist_dir: Path, files: dict[str, str], name: str = "tokenpak-9.9.9"):
+    """Write a minimal sdist tarball whose members are <name>/<repo-path>."""
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    tar_path = dist_dir / f"{name}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        for relpath, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=f"{name}/{relpath}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return tar_path
+
+
+def test_dist_mode_strips_prefix_and_detects_leak(tmp_path):
+    dist = tmp_path / "dist"
+    _make_sdist(dist, {"tokenpak/proxy/cache.py": 'D = "/home/sue/x"\n'})
+    res = _run_dist(dist)
+    assert res.returncode == 1, "sdist leak must be detected"
+    # path reported repo-relative (version prefix stripped)
+    assert "tokenpak/proxy/cache.py" in res.stdout
+
+
+def test_dist_mode_allowlist_applies_after_prefix_strip(tmp_path):
+    dist = tmp_path / "dist"
+    _make_sdist(
+        dist,
+        {
+            "tokenpak/integrations/openclaw/provider.py": 'N = "openclaw"\n',
+            "README.md": "# TokenPak\n",
+        },
+    )
+    res = _run_dist(dist)
+    assert res.returncode == 0, f"allowlist must apply to sdist paths:\n{res.stdout}"

--- a/tokenpak/_snapshots/workflow-steps.json
+++ b/tokenpak/_snapshots/workflow-steps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-02T19:15:59Z",
+  "generated_at": "2026-06-07T21:07:28Z",
   "guarded_globs": [
     "release*.yml",
     "release-rehearsal.yml"
@@ -149,6 +149,54 @@
       "job": "install-shape-matrix",
       "id": "pytest",
       "name": "Pytest with --continue-on-collection-errors (Std 30 \u00a74 R4)"
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Build sdist + wheel for scanning"
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Build sdist + wheel for scanning"
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Scan shipped artifact for public-leak patterns"
+    },
+    {
+      "workflow": "release-rehearsal.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Scan shipped artifact for public-leak patterns"
     },
     {
       "workflow": "release-rehearsal.yml",
@@ -323,6 +371,30 @@
       "job": "build",
       "id": "",
       "name": "Verify package"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Build sdist + wheel for scanning"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Scan shipped artifact for public-leak patterns"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "leak-scan",
+      "id": "",
+      "name": "Set up Python 3.12"
     },
     {
       "workflow": "release.yml",


### PR DESCRIPTION
## What

Adds a release gate that scans the **entire shipped artifact** (built sdist + wheel) for internal identity / workflow language before a distribution is built or published. It reuses the same forbidden-pattern register and path-scoped allowlists as the existing per-PR identity-language check, but applies them to the whole shipped tree rather than just a PR's changed files.

## Why

The per-PR check (`identity-language-check.yml`) only re-scans files **changed in a pull request**. A reference in a file that no later PR touches is never re-checked and can ship in the published wheel. This gate closes that blind spot.

## How it gates

- New `leak-scan` job in `release.yml` runs on **manual preflight** (`workflow_dispatch`) and on **release tag pushes**. The `build` job `needs:` it, so any match fails **before** build/publish.
- A mirror job is added to `release-rehearsal.yml` so the weekly dry-run stays faithful to the production pipeline.
- `make release-leak-check` for local runs.

## Scanner

`scripts/release_gate/check_release_leaks.py`:
- `--dist DIR` — scans built sdist + wheel contents (CI default; the exact files that ship).
- `--tree DIR` — scans a directory tree (local / tests).
- Path-scoped allowlists preserved for the public OpenClaw provider/SDK/integration surfaces and the public `fleet` CLI feature.
- Mirrors the per-PR check's non-public-surface exclusions (top-level `tests/`, build manifests such as `RECORD` / `SOURCES.txt`). The in-package `tokenpak/tests/` subpackage IS scanned.

## Tests

`tests/release_gate/test_release_leak_scan.py` (14 cases): an untouched file with an internal reference fails the gate; legitimate allowlisted `openclaw` / `fleet` paths pass; a clean tree passes; `--dist` extraction + sdist prefix-stripping verified; top-level `tests/` + build manifests are excluded while `tokenpak/tests/` is scanned.

## Verification (local)

- `--dist` scan of the freshly built sdist + wheel: **clean** (2087 files).
- Seeded-leak fixtures fail as expected (exit 1).
- `ruff check` + `ruff format --check` clean; `workflow-steps` snapshot regenerated and consistent; taxonomy check passes.

No package runtime behavior change; no version bump.
