### PR TITLE
fix: cross-platform portability and packaging corrections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${TOKENPAK_PORT}/health', timeout=5)" || exit 1
 
 # Start proxy — reads port from TOKENPAK_PORT env var
-CMD ["python", "-m", "tokenpak.cli", "proxy"]
+CMD ["python", "-m", "tokenpak.cli", "serve"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=61.0",
+    # >=64 for modern PEP 660 editable installs (editable_wheel backend).
+    "setuptools>=64",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -164,6 +165,10 @@ serve = [
     "starlette>=0.36.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",
+    # Optional WebSocket proxy endpoint (tokenpak/proxy/websocket.py). The
+    # import is guarded (try/except ImportError) and the WS server is simply
+    # disabled when absent, so this is serve-only, not a core dependency.
+    "websockets>=12.0",
 ]
 telemetry = [
     "pydantic>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-# Core uses Python stdlib only
-# Optional for better token counting:
-# tiktoken>=0.5.0
-websockets>=16.0
+# Dependencies are declared canonically in pyproject.toml.
+#
+#   pip install tokenpak            # slim core
+#   pip install "tokenpak[serve]"   # proxy + WebSocket server (websockets, fastapi, ...)
+#   pip install "tokenpak[full]"    # all optional feature extras
+#
+# This file is intentionally minimal — do not duplicate pinned versions here;
+# add or change dependencies in pyproject.toml instead.

--- a/tokenpak/companion/launcher.py
+++ b/tokenpak/companion/launcher.py
@@ -306,14 +306,16 @@ def _write_settings(config: CompanionConfig) -> str:
     # vault checkout or any operator-state directory, and every session
     # trips the sandbox. Only adds dirs that actually exist on this host
     # — no phantom paths. Operators who need additional candidate dirs
-    # beyond ``~/vault`` can list them (colon-separated; absolute paths
-    # or names relative to ``$HOME``) in the
-    # ``TOKENPAK_COMPANION_EXTRA_DIRS`` environment variable.
+    # beyond ``~/vault`` can list them (absolute paths or names relative to
+    # ``$HOME``) in the ``TOKENPAK_COMPANION_EXTRA_DIRS`` environment variable.
+    # Entries are separated by the platform path separator (``:`` on POSIX,
+    # ``;`` on Windows), matching the convention used by ``$PATH``.
     add_dirs = permissions.setdefault("additionalDirectories", [])
     candidates: list[Path] = [Path.home() / "vault"]
     extra = os.environ.get("TOKENPAK_COMPANION_EXTRA_DIRS", "")
-    for entry in (s.strip() for s in extra.split(":") if s.strip()):
-        candidates.append(Path(entry) if entry.startswith("/") else Path.home() / entry)
+    for entry in (s.strip() for s in extra.split(os.pathsep) if s.strip()):
+        path = Path(entry)
+        candidates.append(path if path.is_absolute() else Path.home() / entry)
     for candidate in candidates:
         if candidate.is_dir():
             candidate_str = str(candidate)

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -3082,7 +3082,12 @@ def main() -> None:
         ps.compilation_mode = os.environ.get("TOKENPAK_MODE", ps.compilation_mode)
         print(f"[tokenpak] config reloaded: mode={ps.compilation_mode}", flush=True)
 
-    signal.signal(signal.SIGHUP, _handle_sighup)
+    # SIGHUP-based hot-reload is POSIX-only; skip on platforms that lack it
+    # (e.g. Windows has no signal.SIGHUP attribute).
+    try:
+        signal.signal(signal.SIGHUP, _handle_sighup)
+    except (OSError, ValueError, AttributeError):
+        pass
 
     try:
         ps.start(blocking=True)


### PR DESCRIPTION
## Cross-platform portability and packaging corrections

Isolated, single-commit fix focused on Windows/POSIX portability and packaging hygiene. No version, release, tag, or publish movement.

### Portability (Windows/POSIX)
- **`proxy/server.py`**: guard the `signal.signal(SIGHUP, ...)` install with `try/except (OSError, ValueError, AttributeError)` — `SIGHUP` does not exist on Windows. Mirrors the existing safe pattern in the embedding adapter. The hot-reload handler is now skipped instead of crashing startup.
- **`companion/launcher.py`**: split `TOKENPAK_COMPANION_EXTRA_DIRS` on `os.pathsep` (`:` on POSIX, `;` on Windows) instead of a literal `:`, and detect absolute entries with `Path.is_absolute()` rather than a leading-`/` check, so the env var works on Windows.

### Packaging
- **`pyproject.toml`**: declare `websockets>=12.0` in the `[serve]` extra. It is imported only by the optional WebSocket proxy endpoint behind a guarded `try/except ImportError`, so it is serve-only, not a core dependency.
- **`pyproject.toml`**: bump the build-system `setuptools` floor `61.0 -> 64` for modern PEP 660 editable installs.
- **`requirements.txt`**: drop the stale "core uses stdlib only" note and the duplicate `websockets` pin; point to `pyproject.toml` as the canonical dependency source.
- **`Dockerfile`**: `CMD` now invokes the registered `serve` verb instead of `proxy`, which is not a CLI subcommand.

### Verification
- 5 files changed, +28/−27 net packaging/portability only.
- Targeted test suite (companion launcher + proxy) green against this base.
