### PR TITLE
fix(companion/codex): migrate lifecycle-hooks feature flag to current Codex name

### DIFF
--- a/tests/companion/test_codex_hooks.py
+++ b/tests/companion/test_codex_hooks.py
@@ -407,3 +407,48 @@ def test_post_tool_use_hook_hardcap_emits_additional_context(tmp_path):
     spec = payload["hookSpecificOutput"]
     assert spec["hookEventName"] == "PostToolUse"
     assert "hard cap" in spec["additionalContext"].lower()
+
+
+# ──────────────────────────────────────────────────────────────
+# ensure_hooks_feature_enabled — invokes the current Codex feature flag.
+#
+# Codex renamed the lifecycle-hooks feature flag to ``hooks``; the older
+# name is no longer a recognized feature, so enabling it is a silent
+# no-op that leaves hooks inactive. These tests pin the flag the
+# companion passes to ``codex features enable``.
+# ──────────────────────────────────────────────────────────────
+
+
+def test_ensure_hooks_feature_enabled_uses_current_flag(monkeypatch):
+    captured_cmd: "list[str]" = []
+
+    class _Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, *args, **kwargs):
+        captured_cmd.extend(cmd)
+        return _Completed()
+
+    monkeypatch.setattr(codex_hooks.subprocess, "run", fake_run)
+    # Avoid touching the real ~/.codex/config.toml during the warning-suppress step.
+    monkeypatch.setattr(codex_hooks, "_suppress_unstable_warning", lambda: None)
+
+    assert codex_hooks.ensure_hooks_feature_enabled() is True
+    assert captured_cmd[:4] == ["codex", "features", "enable", "hooks"]
+    assert "codex_hooks" not in captured_cmd
+
+
+def test_ensure_hooks_feature_enabled_returns_false_on_nonzero(monkeypatch):
+    class _Completed:
+        returncode = 1
+        stdout = ""
+        stderr = "unknown feature"
+
+    monkeypatch.setattr(
+        codex_hooks.subprocess, "run", lambda *a, **k: _Completed()
+    )
+    monkeypatch.setattr(codex_hooks, "_suppress_unstable_warning", lambda: None)
+
+    assert codex_hooks.ensure_hooks_feature_enabled() is False

--- a/tokenpak/companion/codex/doctor.py
+++ b/tokenpak/companion/codex/doctor.py
@@ -50,12 +50,12 @@ def check_hooks_feature() -> "tuple[bool, str]":
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return False, f"codex features list failed: {exc}"
     for line in result.stdout.splitlines():
-        # Format: "codex_hooks     under development  true"
+        # Format: "hooks     under development  true"
         parts = line.split()
-        if parts and parts[0] == "codex_hooks":
+        if parts and parts[0] == "hooks":
             state = parts[-1].lower()
-            return state == "true", f"codex_hooks={state}"
-    return False, "codex_hooks feature not found in `codex features list`"
+            return state == "true", f"hooks={state}"
+    return False, "hooks feature not found in `codex features list`"
 
 
 def check_mcp_registered() -> "tuple[bool, str]":
@@ -211,7 +211,7 @@ def _parse_initialize_reply(stdout: str) -> "tuple[bool, str]":
 
 CHECKS: list["tuple[str, CheckFn]"] = [
     ("codex binary", check_codex_binary),
-    ("codex_hooks feature", check_hooks_feature),
+    ("hooks feature", check_hooks_feature),
     ("MCP registration", check_mcp_registered),
     ("hooks.json schema", check_hooks_json),
     ("AGENTS.md", check_agents_md),

--- a/tokenpak/companion/codex/hooks.py
+++ b/tokenpak/companion/codex/hooks.py
@@ -12,7 +12,7 @@ deferred to L5 — see L1 audit delta hooks #10):
 - **PostToolUse** → token-out journal
 - **Stop** → session closeout, journal summary, cost recording
 
-Hooks must be enabled via the ``codex_hooks`` feature flag.
+Hooks must be enabled via the ``hooks`` feature flag.
 
 The event set is held in :data:`_TOKENPAK_HOOK_EVENTS` — a declarative
 module-level table keyed by Codex event name. Adding a new event means
@@ -197,7 +197,7 @@ def _merge_hooks(existing: dict, new: dict) -> dict:
 
 
 def ensure_hooks_feature_enabled() -> bool:
-    """Enable the ``codex_hooks`` feature via ``codex features enable``.
+    """Enable the ``hooks`` feature via ``codex features enable``.
 
     Uses the Codex-native command rather than hand-writing config.toml,
     so we inherit any future config-schema changes for free. Idempotent.
@@ -208,7 +208,7 @@ def ensure_hooks_feature_enabled() -> bool:
     """
     try:
         result = subprocess.run(
-            ["codex", "features", "enable", "codex_hooks"],
+            ["codex", "features", "enable", "hooks"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -218,7 +218,7 @@ def ensure_hooks_feature_enabled() -> bool:
         return False
     if result.returncode != 0:
         print(
-            f"tokenpak: failed to enable codex_hooks feature: {result.stderr.strip()}",
+            f"tokenpak: failed to enable hooks feature: {result.stderr.strip()}",
             file=sys.stderr,
         )
         return False

--- a/tokenpak/companion/codex/launcher.py
+++ b/tokenpak/companion/codex/launcher.py
@@ -55,7 +55,7 @@ def main(args: list[str] | None = None) -> int:
             print(f"tokenpak: hooks installed ({hooks_path})", file=sys.stderr)
         else:
             print(
-                "tokenpak: codex_hooks feature could not be enabled",
+                "tokenpak: hooks feature could not be enabled",
                 file=sys.stderr,
             )
 


### PR DESCRIPTION
## Migrate the Codex lifecycle-hooks feature flag to its current name

The Codex CLI renamed its lifecycle-hooks feature flag to `hooks`. The companion still invoked the previous flag name in `codex features enable`, which the current Codex CLI no longer recognizes as a feature — the enable call writes a dead config key and silently no-ops, leaving hooks **inactive**.

### Changes
- **`companion/codex/hooks.py`** — `ensure_hooks_feature_enabled()` now runs `codex features enable hooks` (was the old flag name), with matching docstring/error-message updates.
- **`companion/codex/launcher.py`** — update the "feature could not be enabled" message to the new flag name.
- **`companion/codex/doctor.py`** — the diagnostic's `check_hooks_feature()` now parses `codex features list` for the `hooks` row and labels the check `hooks feature`, so `tokenpak codex doctor` reports the renamed flag truthfully (otherwise it would false-negative a now-active feature). Scope is strictly the flag-name rename — the check keeps its existing `(bool, str)` contract; no other diagnostic behavior changes.
- **`tests/companion/test_codex_hooks.py`** — pin the exact flag the companion passes to `codex features enable`, plus the non-zero failure path.

### Verification
- 4 files changed, +55/−10. No version/release/packaging/PyPI files touched.
- Focused codex-hooks tests pass; `companion/codex/doctor.py` imports cleanly with the renamed check registered.
