### PR TITLE
fix(update): tolerate PEP 668 externally-managed environments

### DIFF
--- a/tests/test_update_pep668.py
+++ b/tests/test_update_pep668.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PEP 668-tolerant ``tokenpak update`` package upgrade.
+
+``_pip_upgrade_tokenpak`` must retry into the user site with
+``--break-system-packages`` when a plain ``pip install`` is refused on an
+externally-managed interpreter (PEP 668), and must defer to ``pipx upgrade``
+when running inside a pipx-managed venv. All cases keep CI offline — no real
+pip invocation happens (``subprocess.run`` is always mocked).
+"""
+
+import subprocess
+
+from tokenpak import _cli_core
+
+PEP668_STDERR = (
+    "error: externally-managed-environment\n\n"
+    "× This environment is externally managed\n"
+    "╰─> To install Python packages system-wide, try apt install ...\n"
+)
+
+
+class _FakeProc:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_pep668_retries_with_break_system_packages(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "--break-system-packages" in cmd:
+            return _FakeProc(0)
+        return _FakeProc(1, stderr=PEP668_STDERR)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok, method, detail = _cli_core._pip_upgrade_tokenpak(verbose=False)
+
+    assert ok is True
+    assert method == "pip-bsp"
+    assert len(calls) == 2
+    # First attempt is plain; only the retry carries --break-system-packages.
+    assert "--break-system-packages" not in calls[0]
+    assert "--break-system-packages" in calls[1]
+    # Always targets the running interpreter and the tokenpak package.
+    assert calls[1][:3] == [_cli_core.sys.executable, "-m", "pip"]
+    assert calls[1][-1] == "tokenpak"
+
+
+def test_clean_success_no_retry(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeProc(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok, method, detail = _cli_core._pip_upgrade_tokenpak(verbose=False)
+
+    assert ok is True
+    assert method == "pip"
+    assert len(calls) == 1
+    assert "--break-system-packages" not in calls[0]
+
+
+def test_pipx_install_defers_without_calling_pip(monkeypatch):
+    monkeypatch.setattr(_cli_core.sys, "prefix", "/home/u/.local/pipx/venvs/tokenpak")
+
+    def fail_run(cmd, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("pip must not run for a pipx-managed install")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    ok, method, detail = _cli_core._pip_upgrade_tokenpak(verbose=False)
+
+    assert ok is False
+    assert method == "pipx"
+
+
+def test_non_pep668_failure_surfaces_detail(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeProc(1, stderr="ERROR: Could not find a version that satisfies ...")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok, method, detail = _cli_core._pip_upgrade_tokenpak(verbose=False)
+
+    assert ok is False
+    assert method == "pip"
+    assert "Could not find a version" in detail
+
+
+def test_user_install_detection(monkeypatch, tmp_path):
+    import site
+
+    import tokenpak as _tp
+
+    monkeypatch.setattr(site, "getuserbase", lambda: str(tmp_path / ".local"))
+    monkeypatch.setattr(
+        _tp, "__file__", str(tmp_path / ".local" / "lib" / "tokenpak" / "__init__.py")
+    )
+    assert _cli_core._tokenpak_is_user_install() is True
+
+    monkeypatch.setattr(
+        _tp, "__file__", "/usr/lib/python3/dist-packages/tokenpak/__init__.py"
+    )
+    assert _cli_core._tokenpak_is_user_install() is False

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -3971,6 +3971,69 @@ def cmd_version(args):
         print(f"\n  Lock file not found at {_LOCK_FILE}")
 
 
+def _tokenpak_is_user_install() -> bool:
+    """True when the running tokenpak package lives in the per-user site (``~/.local``)."""
+    try:
+        import site
+
+        import tokenpak as _tp
+
+        base = (site.getuserbase() or "").replace(os.sep, "/")
+        loc = (os.path.dirname(os.path.abspath(_tp.__file__)) or "").replace(os.sep, "/")
+        return bool(base) and loc.startswith(base)
+    except Exception:
+        return False
+
+
+def _pip_upgrade_tokenpak(verbose: bool = True) -> Tuple[bool, str, str]:
+    """Upgrade the running ``tokenpak`` package, tolerant of PEP 668.
+
+    Installs into whichever interpreter is currently executing (``sys.executable``).
+    On an externally-managed interpreter (e.g. a distro system Python — PEP 668) a
+    plain ``pip install`` is refused; we retry into the per-user site with
+    ``--break-system-packages``, which writes only to the user site (``~/.local``)
+    and never touches system/distro-managed packages. pipx-managed installs are
+    detected and reported so the caller can advise ``pipx upgrade`` instead of
+    running pip inside the pipx venv.
+
+    Returns ``(ok, method, detail)`` where ``method`` is ``pip`` / ``pip-bsp`` /
+    ``pipx`` and ``detail`` carries trimmed stderr on failure.
+    """
+    import subprocess as _sp
+
+    # pipx-managed: running pip inside the pipx venv is the wrong tool.
+    if "/pipx/venvs/" in (sys.prefix or "").replace(os.sep, "/"):
+        return False, "pipx", ""
+
+    in_venv = sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    # Match where the package currently lives so we upgrade it in place.
+    scope = [] if in_venv else (["--user"] if _tokenpak_is_user_install() else [])
+
+    def _run(extra):
+        return _sp.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade", *extra, "tokenpak"],
+            capture_output=True,
+            text=True,
+        )
+
+    result = _run(scope)
+    if result.returncode == 0:
+        return True, "pip", ""
+
+    blob = ((result.stderr or "") + (result.stdout or "")).lower()
+    if "externally-managed-environment" in blob or "externally managed" in blob:
+        if verbose:
+            print(
+                "  ⚠ Externally-managed environment (PEP 668); retrying into the "
+                "user site with --break-system-packages (writes only to ~/.local)…"
+            )
+        result = _run(scope + ["--break-system-packages"])
+        if result.returncode == 0:
+            return True, "pip-bsp", ""
+
+    return False, "pip", (result.stderr or result.stdout or "")[:400]
+
+
 def cmd_update(args):
     """Update TokenPak proxy and CLI to latest."""
     import subprocess as _sp
@@ -4018,6 +4081,10 @@ def cmd_update(args):
 
     if dry_run:
         print("\nWould run: pip install --upgrade tokenpak")
+        print(
+            "  (retries into the user site with --break-system-packages on "
+            "externally-managed / PEP 668 environments)"
+        )
         print("Would restart proxy if running.")
         return
 
@@ -4026,15 +4093,24 @@ def cmd_update(args):
     proxy_running = "error" not in proxy_info
 
     print("\nUpdating TokenPak...")
-    result = _sp.run(
-        [sys.executable, "-m", "pip", "install", "--upgrade", "tokenpak"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        print("  ✓ tokenpak updated")
+    ok, method, detail = _pip_upgrade_tokenpak()
+    if ok:
+        if method == "pip-bsp":
+            print("  ✓ tokenpak updated (user site, --break-system-packages)")
+        else:
+            print("  ✓ tokenpak updated")
+    elif method == "pipx":
+        print("  ✗ tokenpak is managed by pipx — upgrade with:\n      pipx upgrade tokenpak")
+        return
     else:
-        print(f"  ✗ pip install failed:\n{result.stderr[:400]}")
+        print(f"  ✗ pip install failed:\n{detail}")
+        print(
+            "\n  Manual upgrade options:\n"
+            "    • inside a virtualenv:  pip install --upgrade tokenpak\n"
+            f"    • user site (PEP 668):  {sys.executable} -m pip install "
+            "--user --upgrade --break-system-packages tokenpak\n"
+            "    • pipx install:         pipx upgrade tokenpak"
+        )
         return
 
     # Restart proxy if it was running


### PR DESCRIPTION
## Tolerate PEP 668 externally-managed environments in `tokenpak update`

`tokenpak update` shelled out to a bare `pip install --upgrade tokenpak`, which is **refused on externally-managed interpreters** (PEP 668 — e.g. a distro system Python). The command printed the error and gave up without upgrading.

### Changes
- **`tokenpak/_cli_core.py`** — add `_pip_upgrade_tokenpak()`:
  - upgrades the running interpreter in place (`sys.executable -m pip install --upgrade tokenpak`);
  - on a PEP 668 `externally-managed-environment` refusal, retries into the per-user site with `--break-system-packages` (writes only to `~/.local`, never system/distro-managed packages);
  - detects pipx-managed installs and advises `pipx upgrade tokenpak` rather than running pip inside the pipx venv;
  - on other failures, surfaces the trimmed error plus explicit manual-upgrade options.
  - `cmd_update` now routes through this helper and reports the method used; the `--dry-run` text notes the PEP 668 retry behavior.
- **`tests/test_update_pep668.py`** — offline, fully-mocked tests covering the plain-pip path, the PEP 668 retry into `--break-system-packages`, the pipx detection path, the failure path, and the user-install detection.

### Verification
- 2 files changed, +191/−8. No version/release/packaging/PyPI files touched. No network in tests (subprocess mocked).
- Focused `tests/test_update_pep668.py` passes.
