### PR TITLE
docs: add NOTICE and align README identity

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+TokenPak
+Copyright 2026 TokenPak
+
+This product is licensed under the Apache License, Version 2.0 (the
+"License"). You may not use this product except in compliance with the
+License. The full license text is in the LICENSE file in this
+repository, and is also available at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+----------------------------------------------------------------------
+Third-party components
+----------------------------------------------------------------------
+TokenPak depends on third-party Python packages declared in its
+packaging metadata (pyproject.toml). Those packages are obtained from
+their canonical distributions and remain under their own licenses;
+their original copyright and permission notices are retained by their
+respective projects and are not relicensed by TokenPak. No third-party
+source requiring additional NOTICE propagation is vendored into this
+repository. Should any such component be added, its required
+attributions will be aggregated in this file.
+
+----------------------------------------------------------------------
+Trademarks
+----------------------------------------------------------------------
+"TokenPak", the TokenPak logo, slogans, product identity, and domains
+are trademarks / brand assets of TokenPak and are NOT licensed under
+Apache-2.0 (Apache-2.0 Section 6 grants no trademark rights). All
+rights in them are reserved.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# TokenPak — Cut your LLM token spend with deterministic context compression, zero config
+# TokenPak — Cut your LLM token spend — zero config
 
 [![PyPI version](https://img.shields.io/pypi/v/tokenpak.svg)](https://pypi.org/project/tokenpak/)
 [![Python 3.10+](https://img.shields.io/pypi/pyversions/tokenpak.svg)](https://pypi.org/project/tokenpak/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-green.svg)](LICENSE)
 <!-- CI badge: pending repo transfer to tokenpak/tokenpak — add after transfer is confirmed -->
 
-TokenPak is a local proxy that compresses your LLM context before it hits the API — fewer tokens, lower cost, no code changes, no cloud, no credentials stored.
+> **The open logistics layer for AI context.**
+
+TokenPak starts as a local proxy that **packs AI requests** before they ship — reducing wasted context and giving teams receipts for what changed. Fewer tokens, lower cost. No code changes, no cloud, no credentials stored.
 
 ---
 


### PR DESCRIPTION
Brings the two remaining public-trust artifacts to the public repo, matching the versions already on the staging mirror.

## Changes

- **`NOTICE`** (new) — Apache-2.0 §4(d) attribution file (copyright + `LICENSE` pointer, third-party-attribution statement, trademark note). The repo shipped `LICENSE` without the companion `NOTICE`.
- **`README.md` hero** — restores the product's canonical identity: removes the retired "deterministic context compression" framing from the title, adds the category line ("the open logistics layer for AI context"), and leads with "packs AI requests before they ship … receipts for what changed."

## Scope

Exactly two files: `NOTICE` (new) and the `README.md` hero region (title + tagline + lead paragraph). No badge, status, or other content changed.

`SECURITY.md` is intentionally unchanged. The security contact remains as-is pending a separate mail-route confirmation.
