### PR TITLE
chore(packaging): prune top-level tests/ from sdist via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+# Packaging hygiene: keep the OSS sdist from shipping the top-level dev
+# `tests/` tree. Those files are not part of the public API surface and
+# may carry development-only references. The wheel already excludes
+# tests/ via [tool.setuptools.packages.find] (include = ["tokenpak*"]);
+# this prune brings the sdist in line with that intent
+# ([tool.pytest.ini_options] markers note "excluded from OSS sdist").
+prune tests


### PR DESCRIPTION
Brings the OSS source distribution in line with the wheel. The wheel already excludes the top-level development `tests/` tree via `[tool.setuptools.packages.find]`, and the test markers document those files as "excluded from OSS sdist". This adds a `MANIFEST.in` with `prune tests` so the sdist matches that documented intent.

Single new file (`MANIFEST.in`); no code or public API change.

**Held** — draft for maintainer review; do not merge without sign-off.