### PR TITLE
docs(examples): use generic clone path in quick-start

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ Use them to understand compression, caching, metrics, and proxy cost behavior.
 ## Quick start
 
 ```bash
-cd /home/trix/Projects/tokenpak
+cd /path/to/tokenpak
 python -m venv .venv
 source .venv/bin/activate
 pip install -e .


### PR DESCRIPTION
The examples quick-start hard-coded a machine-specific absolute path. Replace it with a generic `/path/to/tokenpak` placeholder so the copy-paste workflow is portable for all users.

Scope: `examples/README.md` only, one line (+1/−1). No behavior change.