### PR TITLE
docs(dispatch): mark v0.1-alpha as unreleased preview across public CLI surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,13 @@ This release ships no runtime, CLI, or public-API behavior change. It is a packa
 
 ## [Unreleased] — install footprint extras split
 
+### Added
+
+- TokenPak Dispatch (v0.1-alpha, **preview**) — scoped, station-based,
+  resumable work packages with a Decision Inbox and delivery receipts.
+  Available on the main branch only; **not yet included in a released
+  `pip install tokenpak` package**. See `tokenpak dispatch --help`.
+
 ### Breaking — install footprint: heavy extras are now opt-in
 
 **Background:** `pip install tokenpak` previously pulled ~5 GB of CUDA/ML wheels (torch, nvidia/\*, transformers, sentence-transformers, scipy, tree-sitter-languages, pandas, litellm, llmlingua) as hard runtime dependencies. This made first-run installs impractical on machines without CUDA or a fast connection.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -511,7 +511,7 @@ Live request explorer
 
 ### `tokenpak dispatch`
 
-TokenPak Dispatch — scoped, station-based, resumable, gated work packages with a Decision Inbox and delivery receipts (OSS, v0.1-alpha; CLI-first).
+TokenPak Dispatch — scoped, station-based, resumable, gated work packages with a Decision Inbox and delivery receipts (OSS, v0.1-alpha preview — not yet in a released pip package; available on the project main branch; CLI-first).
 
 **Subcommands:**
 

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -242,7 +242,7 @@ _COMMAND_GROUPS = {
         ("fleet", "Fleet status"),
         ("aggregate", "Aggregate ledger"),
         ("requests", "Live request explorer"),
-        ("dispatch", "Workflow control: run, decide, deliver"),
+        ("dispatch", "Workflow control (v0.1-alpha preview): run, decide, deliver"),
     ],
     "Companion": [
         ("claude", "Launch with Claude Code"),

--- a/tokenpak/cli/commands/dispatch_cmd.py
+++ b/tokenpak/cli/commands/dispatch_cmd.py
@@ -62,7 +62,8 @@ def build_dispatch_parser(sub: Any) -> None:
         description=(
             "TokenPak Dispatch — scoped, station-based, resumable, gated work "
             "packages with a Decision Inbox and delivery receipts (OSS, "
-            "v0.1-alpha; CLI-first)."
+            "v0.1-alpha preview — not yet in a released pip package; available "
+            "on the project main branch; CLI-first)."
         ),
     )
     dsub = p.add_subparsers(dest="dispatch_action", required=False)


### PR DESCRIPTION
## Why
`tokenpak dispatch` (v0.1-alpha) exists only on the `main` branch — no released pip package includes it yet. The command index, command description, cli-reference, and changelog implied it was an available released command. A user who runs `pip install tokenpak` then `tokenpak dispatch …` hits an unknown-command error.

## What (string/doc only, no behaviour change)
- command index label → `Workflow control (v0.1-alpha preview)`
- command description → `v0.1-alpha preview — not yet in a released pip package; available on the project main branch`
- regenerated `docs/cli-reference.md` from source (drift-clean)
- added a preview entry under CHANGELOG `[Unreleased]`

Closes the over-claim that the dispatch CLI ships in `pip install tokenpak`. 4 files, +11/-3. Identity-clean. Public promotion of the corresponding staging truth-fix.