### PR TITLE
fix(spend-guard): never persist credential headers to disk

### DIFF
--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -964,9 +964,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     if _sg_outcome.body is not None:
                         body = _sg_outcome.body
                     if _sg_outcome.headers:
-                        # Merge replayed headers (but don't drop incoming
-                        # auth — the replay headers ARE the original auth).
-                        for _hk, _hv in _sg_outcome.headers.items():
+                        # Re-apply only the held request's NON-credential
+                        # headers (content-type, api-version, etc.). Credential
+                        # headers are never persisted to disk; the held
+                        # request replays with the live approving request's own
+                        # auth, already on self.headers — so we must not let a
+                        # stale/absent stored value clobber it.
+                        try:
+                            from tokenpak.proxy.spend_guard.pending import (
+                                redact_headers as _sg_redact,
+                            )
+                            _replay_hdrs = _sg_redact(_sg_outcome.headers)
+                        except Exception:
+                            _replay_hdrs = {}
+                        for _hk, _hv in _replay_hdrs.items():
                             try:
                                 self.headers[_hk] = _hv  # type: ignore[index]
                             except Exception:

--- a/tokenpak/proxy/spend_guard/pending.py
+++ b/tokenpak/proxy/spend_guard/pending.py
@@ -27,17 +27,58 @@ from typing import Optional
 
 from .contracts import PendingRequest
 
+# Credential-bearing request headers are NEVER persisted to spend_guard.db.
+# The held request is replayed with the live approving request's own auth
+# (the proxy re-applies it — see proxy/server.py replay-merge), so dropping
+# these from storage is safe and keeps raw credentials off disk, matching
+# the proxy's "zero disk writes" passthrough contract for credentials.
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",
+    "proxy-authorization",
+    "x-api-key",
+    "api-key",
+    "openai-api-key",
+    "anthropic-api-key",
+    "x-goog-api-key",
+    "cookie",
+    "set-cookie",
+})
+
+
+def redact_headers(headers: dict) -> dict:
+    """Return a copy of ``headers`` with credential-bearing headers removed.
+
+    Case-insensitive on the header name. Used at store time (so creds never
+    reach disk) and defensively at replay time.
+    """
+    if not headers:
+        return {}
+    return {
+        k: v for k, v in headers.items()
+        if str(k).lower() not in _SENSITIVE_HEADERS
+    }
+
 
 def _db_path(audit_db_path: str) -> Path:
-    """Expand and ensure parent dir exists."""
+    """Expand and ensure parent dir exists (owner-only)."""
     p = Path(os.path.expanduser(audit_db_path))
     p.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(p.parent, 0o700)
+    except OSError:
+        pass
     return p
 
 
 def _connect(path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(path), timeout=5.0)
     conn.row_factory = sqlite3.Row
+    # The db holds request metadata — keep it owner-only (0600), like
+    # credentials.toml. Best-effort; never fail a connect over perms.
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
     return conn
 
 
@@ -68,7 +109,39 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_pending_hash ON pending_requests(request_hash, status)"
     )
+    # One-time migration: redact credential headers from any rows written by
+    # an older build that persisted raw headers (raw credential-on-disk
+    # exposure). Gated by PRAGMA user_version so it runs exactly once per db;
+    # no rows are deleted, so held requests stay replayable.
+    if conn.execute("PRAGMA user_version").fetchone()[0] < 1:
+        _redact_existing_rows(conn)
+        conn.execute("PRAGMA user_version = 1")
     conn.commit()
+
+
+def _redact_existing_rows(conn: sqlite3.Connection) -> None:
+    """Rewrite ``raw_request_headers`` in place, dropping credential headers.
+
+    No rows are deleted — held requests stay replayable (replay uses the live
+    approving request's auth, not the persisted copy).
+    """
+    rows = conn.execute(
+        "SELECT pending_id, raw_request_headers FROM pending_requests"
+    ).fetchall()
+    for row in rows:
+        try:
+            hdrs = json.loads(row["raw_request_headers"] or "{}")
+        except (ValueError, TypeError):
+            hdrs = {}
+        if not isinstance(hdrs, dict):
+            hdrs = {}
+        redacted = redact_headers(hdrs)
+        if redacted != hdrs:
+            conn.execute(
+                "UPDATE pending_requests SET raw_request_headers = ? "
+                "WHERE pending_id = ?",
+                (json.dumps(redacted, default=str), row["pending_id"]),
+            )
 
 
 def hash_request(body: bytes, model: str) -> str:
@@ -114,7 +187,9 @@ class PendingStore:
         expires_at = now + ttl_seconds
         request_hash = hash_request(body, model)
         blob = gzip.compress(body, compresslevel=3)
-        headers_json = json.dumps(headers, default=str)
+        # Credential headers never touch disk — replay re-applies live auth.
+        safe_headers = redact_headers(headers)
+        headers_json = json.dumps(safe_headers, default=str)
 
         conn = _connect(self.path)
         try:
@@ -149,7 +224,7 @@ class PendingStore:
             projected_tokens=projected_tokens,
             projected_cost_usd=projected_cost_usd,
             raw_request_blob=body,           # uncompressed for caller convenience
-            raw_request_headers=headers,
+            raw_request_headers=safe_headers,
             target_url=target_url,
             status="pending",
         )

--- a/tokenpak/tests/test_spend_guard_pending.py
+++ b/tokenpak/tests/test_spend_guard_pending.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import os
+import stat
 import time
+from pathlib import Path
 
 import pytest
 
@@ -120,10 +123,90 @@ class TestAntiLoop:
         assert hash_request(b, "modelA") != hash_request(b, "modelB")
 
 
-class TestHeadersRoundTrip:
-    def test_headers_preserved(self, store):
-        hdrs = {"X-Api-Key": "abc123", "Content-Type": "application/json",
-                "X-Custom": "value with spaces"}
+class TestHeaderRedaction:
+    """Credential headers must never be persisted to disk.
+
+    The held request is replayed with the live approving request's own auth,
+    so dropping credential headers from storage is safe.
+    """
+
+    def test_non_credential_headers_preserved(self, store):
+        hdrs = {"Content-Type": "application/json", "X-Custom": "value with spaces",
+                "anthropic-version": "2023-06-01"}
         p = _store_one(store, headers=hdrs)
         out = store.consume(p.pending_id)
         assert out.raw_request_headers == hdrs
+
+    def test_credential_headers_dropped_on_store(self, store):
+        hdrs = {"Authorization": "Bearer CRED-SENTINEL-A", "x-api-key": "CRED-SENTINEL-B",
+                "Cookie": "session=abc", "Content-Type": "application/json"}
+        p = _store_one(store, headers=hdrs)
+        # Returned object is already redacted.
+        assert p.raw_request_headers == {"Content-Type": "application/json"}
+
+    def test_consume_yields_redacted_headers(self, store):
+        p = _store_one(store, headers={"authorization": "Bearer x", "x-foo": "1"})
+        out = store.consume(p.pending_id)
+        assert "authorization" not in out.raw_request_headers
+        assert out.raw_request_headers == {"x-foo": "1"}
+
+    def test_raw_secret_absent_from_db_bytes(self, store):
+        # The literal secret must not appear anywhere in the db file.
+        _store_one(store, headers={"Authorization": "Bearer LEAK-SENTINEL-AAAA1111",
+                                   "x-api-key": "LEAK-SENTINEL-BBBB2222"})
+        raw = Path(store.path).read_bytes()
+        assert b"LEAK-SENTINEL-AAAA1111" not in raw
+        assert b"LEAK-SENTINEL-BBBB2222" not in raw
+
+
+class TestDbPermissions:
+    def test_db_file_is_owner_only(self, store):
+        _store_one(store)
+        mode = stat.S_IMODE(os.stat(store.path).st_mode)
+        assert mode == 0o600
+
+
+class TestRedactionMigration:
+    def test_existing_raw_rows_redacted_on_open(self, tmp_path):
+        # Simulate an OLD db that persisted raw creds, then open it with the
+        # current code and confirm the one-time migration redacts in place
+        # without deleting the row.
+        import json as _json
+        import sqlite3
+        dbp = tmp_path / "spend_guard.db"
+        conn = sqlite3.connect(str(dbp))
+        conn.execute(
+            """CREATE TABLE pending_requests (
+                   pending_id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+                   created_at REAL NOT NULL, expires_at REAL NOT NULL,
+                   request_hash TEXT NOT NULL, provider TEXT NOT NULL DEFAULT '',
+                   model TEXT NOT NULL DEFAULT '',
+                   projected_tokens INTEGER NOT NULL DEFAULT 0,
+                   projected_cost_usd REAL NOT NULL DEFAULT 0.0,
+                   raw_request_blob BLOB NOT NULL,
+                   raw_request_headers TEXT NOT NULL DEFAULT '{}',
+                   target_url TEXT NOT NULL DEFAULT '',
+                   status TEXT NOT NULL DEFAULT 'pending')"""
+        )
+        raw = _json.dumps({"Authorization": "Bearer OLD-LEAK-SENTINEL",
+                           "Content-Type": "application/json"})
+        conn.execute(
+            "INSERT INTO pending_requests (pending_id, session_id, created_at, "
+            "expires_at, request_hash, raw_request_blob, raw_request_headers, status) "
+            "VALUES ('tpg_old', 'sess-old', 0, 9e18, 'h', X'00', ?, 'pending')",
+            (raw,),
+        )
+        conn.commit()
+        conn.close()
+        # Any connecting method triggers _ensure_schema → the one-time migration.
+        s = PendingStore(str(dbp))
+        assert s.get_by_session("no-such-session") is None
+        # Verify in-place: row preserved (not deleted), headers redacted.
+        conn2 = sqlite3.connect(str(dbp))
+        row = conn2.execute(
+            "SELECT raw_request_headers FROM pending_requests WHERE pending_id='tpg_old'"
+        ).fetchone()
+        conn2.close()
+        assert row is not None  # row preserved, not deleted
+        assert _json.loads(row[0]) == {"Content-Type": "application/json"}
+        assert b"OLD-LEAK-SENTINEL" not in Path(dbp).read_bytes()

--- a/tokenpak/tests/test_spend_guard_replay.py
+++ b/tokenpak/tests/test_spend_guard_replay.py
@@ -54,14 +54,18 @@ class TestPositiveIntentReplay:
         assert out.body == original  # byte-identical
         assert out.audit_event == "replay"
 
-    def test_replay_returns_original_headers(self, store):
+    def test_replay_returns_redacted_headers(self, store):
+        # Credential headers are dropped at store time; replay carries only
+        # non-credential headers. Auth is re-applied from the live approving
+        # request by the proxy (server.py replay-merge), not from storage.
         hdrs = {"X-Api-Key": "key123", "anthropic-version": "2023-06-01"}
         p = _make_pending(store, headers=hdrs)
         out = resolve_pending(
             store=store, pending=p, intent=Intent.POSITIVE, tip=None,
             cfg=SpendGuardConfig(), builders=_BUILDERS,
         )
-        assert out.headers == hdrs
+        assert out.headers == {"anthropic-version": "2023-06-01"}
+        assert "X-Api-Key" not in out.headers
 
     def test_replay_includes_target_url(self, store):
         p = _make_pending(store, target_url="https://example.com/v1/messages")


### PR DESCRIPTION
Promotes the spend-guard credential-redaction fix (staging-validated) to public.

**Change:** adds `redact_headers()` in `tokenpak/proxy/spend_guard/pending.py` and applies it on the proxy replay-merge (`tokenpak/proxy/server.py`) so the replay path re-applies only non-credential headers; the held request replays with the live approving request's own auth rather than any stored value.

**Scope:** 4 files — `pending.py` (+81), `server.py` (single 17-line replay-merge hunk), `test_spend_guard_pending.py`, `test_spend_guard_replay.py`. No unrelated changes.

**Tests:** `pytest test_spend_guard_pending.py test_spend_guard_replay.py` → 29 passed locally.

Security-positive: prevents credential headers from being resurfaced via the replay path.