### PR TITLE
feat(telemetry): honest platform-origin attribution + coverage metric

### DIFF
--- a/tests/test_d5_monitor_feed_normalization.py
+++ b/tests/test_d5_monitor_feed_normalization.py
@@ -144,3 +144,96 @@ def test_readers_delegate_to_canonical_resolver(tmp_path, monkeypatch):
     canon = os.path.realpath(str(_paths.monitor_db(mode="read")))
     assert os.path.realpath(_get_db_path()) == canon
     assert os.path.realpath(str(_get_monitor_db_path())) == canon
+
+
+# --------------------------------------------------------------------------
+# AT-C — honest platform-origin attribution (attribution_source)
+# --------------------------------------------------------------------------
+
+def _attr_rows(db_path):
+    try:
+        _monitor_mod._DB_WRITE_QUEUE.join()
+    except Exception:
+        pass
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT attribution_source FROM requests ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def test_schema_has_attribution_source_column(tmp_path):
+    db = tmp_path / "monitor.db"
+    Monitor(str(db))
+    cols = [r[1] for r in sqlite3.connect(str(db)).execute("PRAGMA table_info(requests)")]
+    assert "attribution_source" in cols
+
+
+def test_log_persists_known_attribution_source(tmp_path):
+    db = tmp_path / "monitor.db"
+    m = Monitor(str(db))
+    m.log(
+        model="claude-opus-4-8", input_tokens=10, output_tokens=2, cost=0.0,
+        latency_ms=5, status_code=200, endpoint="http://x",
+        attribution_source="openclaw_active_session_file",
+    )
+    rows = _attr_rows(db)
+    assert rows and rows[-1][0] == "openclaw_active_session_file"
+
+
+def test_attribution_source_empty_sentinel_when_unknown(tmp_path):
+    db = tmp_path / "monitor.db"
+    m = Monitor(str(db))
+    m.log(
+        model="claude-haiku-4-5", input_tokens=1, output_tokens=1, cost=0.0,
+        latency_ms=1, status_code=200, endpoint="http://y",
+    )
+    rows = _attr_rows(db)
+    # '' sentinel (never NULL, never fabricated) so 'non-empty == known origin'
+    assert rows and rows[-1][0] == ""
+
+
+def test_path_c_mapping_unknown_origin_is_empty_not_fabricated():
+    """Wiring rule: extractor None -> '' (honest unknown); openclaw -> a
+    non-empty, evidence-graded source, NEVER the proxy's own name."""
+    from tokenpak.services.routing_service.platform_bridge import _openclaw_extract
+
+    origin = _openclaw_extract({"User-Agent": "claude-code/2.1.0"}, b"")
+    mapped = (origin.attribution_source if origin is not None else "") or ""
+    assert mapped == ""
+
+    oc = _openclaw_extract({"User-Agent": "openclaw/2026.4.28-1"}, b"")
+    assert oc is not None
+    mapped_oc = (oc.attribution_source if oc is not None else "") or ""
+    assert mapped_oc != ""
+    assert "tokenpak" not in mapped_oc.lower()
+
+
+# --------------------------------------------------------------------------
+# AT-D — attribution coverage metric (% known origin)
+# --------------------------------------------------------------------------
+
+def test_attribution_coverage_metric(tmp_path):
+    """Coverage = % of requests rows with a non-empty (known) origin."""
+    from tokenpak.cli.commands.doctor import attribution_coverage
+
+    db = tmp_path / "monitor.db"
+    m = Monitor(str(db))
+    for src in ("openclaw_active_session_file", "anonymous_user_agent_only",
+                "openclaw_active_session_file"):
+        m.log(model="claude-opus-4-8", input_tokens=1, output_tokens=1, cost=0.0,
+              latency_ms=1, status_code=200, endpoint="http://x",
+              attribution_source=src)
+    m.log(model="claude-opus-4-8", input_tokens=1, output_tokens=1, cost=0.0,
+          latency_ms=1, status_code=200, endpoint="http://y")  # unknown -> ''
+    _drain(db)
+    known, total, pct = attribution_coverage(str(db))
+    assert (known, total) == (3, 4)
+    assert pct == pytest.approx(75.0)
+
+
+def test_attribution_coverage_graceful_when_absent(tmp_path):
+    from tokenpak.cli.commands.doctor import attribution_coverage
+    assert attribution_coverage(str(tmp_path / "missing.db")) == (0, 0, None)

--- a/tokenpak/cli/commands/doctor.py
+++ b/tokenpak/cli/commands/doctor.py
@@ -296,6 +296,37 @@ def verify_integration_target(key: str, proxy_url: str) -> tuple[bool, str]:
         return (False, f"verify raised: {exc}")
 
 
+def attribution_coverage(db_path) -> "tuple[int, int, float | None]":
+    """Return ``(known, total, pct)`` attribution coverage over the requests
+    ledger — the share of rows whose origin is genuinely known (non-empty
+    ``attribution_source``). Internal gate measure only; NOT a public number.
+    Degrades to ``(0, 0, None)`` when the db / table / column is absent."""
+    import sqlite3 as _sq
+
+    try:
+        conn = _sq.connect(str(db_path), timeout=2.0)
+    except Exception:
+        return (0, 0, None)
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(requests)")]
+        if "attribution_source" not in cols:
+            return (0, 0, None)
+        total = conn.execute("SELECT COUNT(*) FROM requests").fetchone()[0] or 0
+        known = conn.execute(
+            "SELECT COUNT(*) FROM requests "
+            "WHERE attribution_source IS NOT NULL AND attribution_source != ''"
+        ).fetchone()[0] or 0
+        pct = (100.0 * known / total) if total else None
+        return (known, total, pct)
+    except Exception:
+        return (0, 0, None)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def run_doctor(
     fix: bool = False,
     output_json: bool = False,
@@ -441,6 +472,24 @@ def run_doctor(
             f"{requests_total} reqs, {latency_str}",
             detail=f"compilation_mode={mode} requests={requests_total} p95={p95} p99={p99} outlier={outlier}",
         )
+
+        # Attribution coverage — % of ledger rows with a genuinely known origin
+        # (non-empty attribution_source). Internal gate measure; NOT a public
+        # number. Informational only — does not fail/penalize the doctor exit.
+        try:
+            _mon_db = _paths.monitor_db("read")
+        except Exception:
+            _mon_db = None
+        if _mon_db is not None:
+            _cov_known, _cov_total, _cov_pct = attribution_coverage(_mon_db)
+            if _cov_total > 0 and _cov_pct is not None:
+                _record(
+                    "attribution_coverage",
+                    "pass",
+                    f"Attribution         {_cov_pct:.0f}% known origin "
+                    f"({_cov_known}/{_cov_total} reqs)",
+                    detail=f"non-empty attribution_source on {_cov_known}/{_cov_total} requests rows",
+                )
     else:
         # Fall back to TCP check
         try:

--- a/tokenpak/proxy/monitor.py
+++ b/tokenpak/proxy/monitor.py
@@ -83,8 +83,8 @@ def _db_writer_worker():
                             compressed_tokens,injected_tokens,injected_sources,cache_read_tokens,cache_creation_tokens,
                             would_have_saved,cache_origin,user_id,
                             cache_creation_ephemeral_1h_tokens,cache_creation_ephemeral_5m_tokens,ttl_attribution,
-                            session_id,agent_id,cycle_id)
-                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                            session_id,agent_id,cycle_id,attribution_source)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                         insert_params,
                     )
                     conn.commit()
@@ -153,7 +153,8 @@ class Monitor:
                 user_id TEXT DEFAULT '',
                 session_id TEXT DEFAULT '',
                 agent_id TEXT DEFAULT '',
-                cycle_id TEXT DEFAULT ''
+                cycle_id TEXT DEFAULT '',
+                attribution_source TEXT DEFAULT ''
             )
         """)
         conn.execute("CREATE INDEX IF NOT EXISTS idx_ts ON requests(timestamp)")
@@ -240,6 +241,10 @@ class Monitor:
         for _alter in (
             "ALTER TABLE requests ADD COLUMN agent_id TEXT DEFAULT ''",
             "ALTER TABLE requests ADD COLUMN cycle_id TEXT DEFAULT ''",
+            # attribution_source <- platform-origin extractor (Path C). Non-empty
+            # only when origin is genuinely known; '' sentinel otherwise (never
+            # fabricated). Idempotent — may pre-exist from a peer migration.
+            "ALTER TABLE requests ADD COLUMN attribution_source TEXT DEFAULT ''",
         ):
             try:
                 conn.execute(_alter)
@@ -309,6 +314,7 @@ class Monitor:
         session_id="",
         agent_id="",
         cycle_id="",
+        attribution_source="",
     ):
         # ``session_id`` is the resolved Claude Code / TokenPak session id
         # (``_resolve_session_id``). Empty string when no session header was
@@ -346,6 +352,7 @@ class Monitor:
             session_id or "",
             agent_id or "",
             cycle_id or "",
+            attribution_source or "",
         )
         _queued = False
         try:
@@ -359,8 +366,8 @@ class Monitor:
                 "compressed_tokens, injected_tokens, injected_sources, cache_read_tokens, cache_creation_tokens, "
                 "would_have_saved, cache_origin, user_id, "
                 "cache_creation_ephemeral_1h_tokens, cache_creation_ephemeral_5m_tokens, ttl_attribution, "
-                "session_id, agent_id, cycle_id) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "session_id, agent_id, cycle_id, attribution_source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 insert_params,
             )
             _conn.commit()

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -1742,6 +1742,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     _mon_session_id = ""
                     _mon_agent_id = ""
                     _mon_cycle_id = ""
+                # Honest platform-origin attribution (Path C): non-empty ONLY when
+                # the origin is genuinely known (a recognized active-session file
+                # or platform User-Agent). '' sentinel otherwise — never
+                # fabricated, never attributed to the proxy itself. Read-only.
+                try:
+                    from tokenpak.services.routing_service.platform_bridge import (
+                        _openclaw_extract as _oce_mon,
+                    )
+                    _mon_origin = _oce_mon(self.headers, b"")
+                    _mon_attribution_source = (
+                        _mon_origin.attribution_source if _mon_origin is not None else ""
+                    ) or ""
+                except Exception:
+                    _mon_attribution_source = ""
                 if ps.monitor is not None:
                     try:
                         ps.monitor.log(
@@ -1774,6 +1788,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             session_id=_mon_session_id,
                             agent_id=_mon_agent_id,
                             cycle_id=_mon_cycle_id,
+                            attribution_source=_mon_attribution_source,
                         )
                     except Exception:
                         pass  # DB errors must never break the request


### PR DESCRIPTION
## Summary

Populates a real `attribution_source` on the single `monitor.db` ledger write, and surfaces an attribution-coverage measure in `doctor`. Today the proxy resolves platform-origin signals in the request pipeline but the persisted ledger row records no origin; this threads the already-built, already-tested Path-C extractor into the write path.

## Changes

- **Writer** — wire the platform-origin extractor into the single `Monitor.log()` write site. Each row records its origin when genuinely known; the `""` sentinel otherwise — never fabricated, never attributed to the proxy itself. New `attribution_source` column via `CREATE TABLE` + idempotent `ALTER` (same pattern as the session/agent/cycle columns), threaded through both INSERT paths (async queue + sync fallback).
- **Coverage** — `doctor` reports attribution coverage: % of ledger rows with a genuinely known origin. Internal diagnostic measure only — **not** a public/savings number.

## Scope

Curated surgically off `main`; additive only; no origin classification beyond the extractor's existing evidence grades; no resolver/home migration.

## Tests

Schema, persistence, honest-unknown mapping, and the coverage metric — green locally; `ruff` clean; broader monitor / extractor / doctor suites pass (120).
