### PR TITLE
feat(dispatch): wire receipt_builder into FulfillmentLine + dispatch wheel package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,10 @@ tokenpak = [
     "dashboard/templates/**/*",
     "telemetry/dashboard/static/**/*",
     "telemetry/dashboard/templates/**/*",
+    "orchestration/dispatch/registry/*.yaml",
+    "orchestration/dispatch/registry/routes/*.yaml",
+    "orchestration/dispatch/registry/overlays/*.yaml",
+    "orchestration/dispatch/schemas/*.json",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/orchestration/dispatch/test_runner.py
+++ b/tests/orchestration/dispatch/test_runner.py
@@ -736,6 +736,82 @@ def test_spend_guard_reason_constant_threaded():
 
 
 # ---------------------------------------------------------------------------
+# Receipt wiring (follow-up #2 — parked-followups-2026-06-08)
+# ---------------------------------------------------------------------------
+
+
+def _quick_answer_intake():
+    fd = FrontDock()
+    return fd.intake(
+        "explain the run ledger",
+        autonomy_mode=AutonomyMode.AUTO_DISPATCH_LIMITED,
+        now=_NOW,
+    )
+
+
+def test_delivered_run_produces_receipt(ledger):
+    """A delivered run must have a receipt persisted and linked (follow-up #2 wire-up)."""
+
+    intake = _quick_answer_intake()
+    runtime = DispatchRuntime()
+    outcome = runtime.select_route(intake, now=_NOW)
+    assert outcome.route is not None
+
+    line = FulfillmentLine(
+        worker_llm=FakeWorkerLLM(
+            [WorkerTurn(result_payload={"answer": "SQLite via _paths"}, output_schema_valid=True, tokens_used=10)]
+        ),
+        context_provider=LocalContextProvider(),
+        ledger=ledger,
+        worker_registry=default_worker_registry(),
+        clock=lambda: _NOW,
+    )
+    result = line.run(
+        route=outcome.route,
+        manifest=intake.manifest,
+        autonomy_mode=AutonomyMode.AUTO_DISPATCH_LIMITED,
+    )
+
+    assert result.status is LineStatus.DELIVERED
+    # Receipt must be on the result and linked to the run.
+    assert result.receipt is not None
+    assert result.receipt.final_status == "delivered"
+    assert result.receipt.run_id == result.run.id
+    assert result.receipt.job_id == intake.manifest.job_id
+    assert len(result.receipt.stations) == 1
+    # run.receipt_id must be set and match.
+    persisted_run = ledger.read_run(result.run.id)
+    assert persisted_run.receipt_id == result.receipt.id
+    # Ledger read-back must return the same receipt.
+    from_ledger = ledger.read_receipt(result.receipt.id)
+    assert from_ledger is not None
+    assert from_ledger.id == result.receipt.id
+
+
+def test_non_delivered_run_produces_no_receipt(ledger):
+    """A failed or blocked run must NOT produce a receipt."""
+
+    intake = _code_task_intake()
+    route = _select_code_task(intake)
+
+    line = FulfillmentLine(
+        worker_llm=FakeWorkerLLM([WorkerTurn(output_schema_valid=False, tokens_used=1)]),
+        context_provider=LocalContextProvider(),
+        ledger=ledger,
+        worker_registry=default_worker_registry(),
+        reviewer_llm=FakeReviewerLLM("pass"),
+        clock=lambda: _NOW,
+    )
+    result = line.run(
+        route=route,
+        manifest=intake.manifest,
+        autonomy_mode=AutonomyMode.AUTO_DISPATCH_LIMITED,
+    )
+    assert result.status is LineStatus.FAILED
+    assert result.receipt is None
+
+
+# ---------------------------------------------------------------------------
 # Tool authorization through the loop (§5.3)
 # ---------------------------------------------------------------------------
 

--- a/tokenpak/orchestration/dispatch/runner.py
+++ b/tokenpak/orchestration/dispatch/runner.py
@@ -60,10 +60,12 @@ from .models.enums import (
 )
 from .models.late_result import LateResult
 from .models.manifest import DispatchManifest
+from .models.receipt import DispatchReceipt
 from .models.route import DispatchRoute, RouteStation
 from .models.run import DispatchRun
 from .models.station_run import DispatchStationRun
 from .models.worker import DispatchWorker
+from .receipt_builder import build_and_write_receipt
 from .registry.routes import is_worker_station
 from .registry.workers import (
     DispatchWorkerRegistry,
@@ -121,6 +123,7 @@ class FulfillmentResult:
     late_results: list[LateResult] = field(default_factory=list)
     effect_ids: list[str] = field(default_factory=list)
     reviewer_result: Optional[ReviewerStationResult] = None
+    receipt: Optional[DispatchReceipt] = None
     reason: str = ""
 
 
@@ -595,6 +598,16 @@ class FulfillmentLine:
         }
         line_status, run_status = status_map[package.status]
         run = self._finalize_run(run, status=run_status, decision=package.decision)
+
+        receipt = None
+        if line_status in (LineStatus.DELIVERED, LineStatus.DELIVERY_READY_WITH_WARNING):
+            receipt = build_and_write_receipt(
+                run=run,
+                ledger=self._ledger,
+                final_status=run_status,
+                clock=self._clock,
+            )
+
         return FulfillmentResult(
             status=line_status,
             run=run,
@@ -604,6 +617,7 @@ class FulfillmentLine:
             late_results=late_results,
             effect_ids=effect_ids,
             reviewer_result=reviewer_result,
+            receipt=receipt,
             reason=package.summary,
         )
 


### PR DESCRIPTION
## What
Wires `build_and_write_receipt` into the dispatch `FulfillmentLine` flow so delivered dispatch runs persist a receipt, and adds the dispatch registry/schema YAML/JSON to the wheel package-data so they ship with the package.

## Changes (3 files, +94, NO version bump)
- `tokenpak/orchestration/dispatch/runner.py` — import + call `build_and_write_receipt` on `DELIVERED` / `DELIVERY_READY_WITH_WARNING`.
- `tests/orchestration/dispatch/test_runner.py` — receipt-path test coverage.
- `pyproject.toml` — wheel package-data globs for `orchestration/dispatch/registry/**` + `schemas/*.json` (packaging only; no version change).

## Notes
Closes the gap where `build_and_write_receipt` shipped but was never called. Promotion of already-reviewed/CI-green work. No version bump, no tag, no publish in this PR.