### PR TITLE
chore(docs): residual license self-claim (Apache-2.0) + example-path hygiene

### DIFF
--- a/docs/INGEST-API-INTEGRATION.md
+++ b/docs/INGEST-API-INTEGRATION.md
@@ -205,7 +205,7 @@ This is included in health/stats responses for monitoring.
 Run the full test suite:
 
 ```bash
-cd /home/trix/Projects/tokenpak
+cd /path/to/tokenpak
 python3 -m pytest tests/test_ingest_tokenpak.proxy.py -v
 ```
 

--- a/tokenpak/sdk/local/README.md
+++ b/tokenpak/sdk/local/README.md
@@ -241,4 +241,4 @@ Tested with:
 
 ## License
 
-MIT
+Apache-2.0


### PR DESCRIPTION
Two one-line public-surface hygiene fixes (docs-only, NO-BUMP):

1. **License self-claim** — `tokenpak/sdk/local/README.md` declared `MIT` in its License section, but the package ships no own LICENSE and inherits the canonical root **Apache-2.0** license (`pyproject` declares `license = Apache-2.0`). Corrected the self-claim to Apache-2.0 to match the root license and the sibling package READMEs. No third-party MIT reference touched; no MIT introduced.

2. **Example path** — `docs/INGEST-API-INTEGRATION.md` used a machine-specific absolute path in the test-run snippet; replaced with a generic `/path/to/tokenpak` placeholder, consistent with the rest of the docs.

Branched off public `main`; identity-clean (author + committer = `TokenPak <hello@tokenpak.ai>`). Held as draft pending conformance review; final merge is a fast-forward at maintainer approval (no squash / no web-button).
