### PR TITLE
feat(cli): load tokenpak.commands entry-point group for plugin verbs

### DIFF
--- a/tests/test_cli_plugin_dispatch.py
+++ b/tests/test_cli_plugin_dispatch.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for plugin CLI verb discovery + dispatch.
+
+The core CLI discovers verbs registered under the ``tokenpak.commands``
+entry-point group and routes them to the plugin's own (already gated) callable.
+These tests verify, with a fabricated entry point:
+
+  * a plugin verb becomes discoverable and dispatchable;
+  * the plugin callable receives the remaining argv and its int exit code
+    propagates (including a gate "upgrade" stub code such as 2, proving the
+    loader routes *through* the entitlement gate rather than around it);
+  * a built-in verb is never overridable by a colliding plugin entry;
+  * the ``TOKENPAK_ENABLE_PLUGINS=0`` opt-out disables discovery.
+
+No real plugin package is installed: ``importlib.metadata.entry_points`` is
+monkeypatched to yield fake entry points whose ``.load()`` returns a local
+callable.
+"""
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+from tokenpak import _cli_core
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for importlib.metadata.EntryPoint.
+
+    ``load()`` returns the supplied callable rather than resolving a real
+    ``module:attr`` target, so tests need no installed package.
+    """
+
+    def __init__(self, name: str, func):
+        self.name = name
+        self.group = "tokenpak.commands"
+        self._func = func
+
+    def load(self):
+        return self._func
+
+
+class _FakeEntryPoints:
+    """Stand-in for the object returned by ``entry_points()`` (3.12 style)."""
+
+    def __init__(self, eps):
+        self._eps = list(eps)
+
+    def select(self, group=None):
+        if group == "tokenpak.commands":
+            return list(self._eps)
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_cache():
+    """Reset the process-level discovery cache around each test."""
+    _cli_core._plugin_commands_cache = None
+    yield
+    _cli_core._plugin_commands_cache = None
+
+
+def _patch_entry_points(monkeypatch, eps):
+    fake = _FakeEntryPoints(eps)
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda *a, **k: fake)
+
+
+def test_plugin_verb_is_discoverable(monkeypatch):
+    """A registered tokenpak.commands verb shows up in discovery."""
+    ep = _FakeEntryPoint("daemon", lambda argv: 0)
+    _patch_entry_points(monkeypatch, [ep])
+
+    discovered = _cli_core._discover_plugin_commands(force=True)
+    assert "daemon" in discovered
+    assert discovered["daemon"] is ep
+
+
+def test_plugin_verb_dispatches_with_argv(monkeypatch):
+    """The plugin callable receives the remaining argv and its rc propagates."""
+    seen = {}
+
+    def _gated(argv):
+        # Stand-in for the plugin's gated wrapper: entitled path runs + exits 0.
+        seen["argv"] = list(argv)
+        return 0
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("daemon", _gated)])
+
+    rc = _cli_core._dispatch_plugin_command("daemon", ["start", "--port", "9000"])
+    assert rc == 0
+    assert seen["argv"] == ["start", "--port", "9000"]
+
+
+def test_unentitled_gate_stub_exit_code_propagates(monkeypatch):
+    """An unentitled invocation returns the gate's upgrade-stub code untouched.
+
+    This proves the loader routes *to* the plugin's gate; it does not bypass or
+    reimplement entitlement enforcement. A non-zero stub code (2) must survive.
+    """
+    def _gated_unentitled(argv):
+        # Mirrors the gate's behavior for a user lacking the entitlement.
+        print("This command requires an active entitlement.")
+        return 2
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("daemon", _gated_unentitled)])
+
+    rc = _cli_core._dispatch_plugin_command("daemon", ["start"])
+    assert rc == 2
+
+
+def test_core_verb_not_overridable_by_plugin(monkeypatch):
+    """A plugin entry colliding with a built-in verb is excluded (core wins)."""
+    core_verb = _cli_core._ALL_COMMANDS[0]
+    assert core_verb  # sanity: at least one built-in exists
+
+    sentinel = {"called": False}
+
+    def _plugin_impl(argv):
+        sentinel["called"] = True
+        return 99
+
+    # Register a plugin entry that tries to shadow an existing built-in verb.
+    _patch_entry_points(
+        monkeypatch, [_FakeEntryPoint(core_verb, _plugin_impl)]
+    )
+
+    discovered = _cli_core._discover_plugin_commands(force=True)
+    # The colliding name must NOT enter the plugin dispatch table.
+    assert core_verb not in discovered
+
+    # And dispatching the colliding name as a plugin must not invoke the plugin.
+    rc = _cli_core._dispatch_plugin_command(core_verb, [])
+    assert rc == 1  # not found in plugin table
+    assert sentinel["called"] is False
+
+
+def test_argparse_registered_core_verb_not_overridable(monkeypatch):
+    """A built-in registered via argparse/stub (not in _COMMAND_GROUPS) also wins.
+
+    These verbs live in the extra-known set rather than the grouped table, so
+    this guards the *full* core-name exclusion, not just the grouped subset.
+    """
+    # 'last' is a built-in verb that is NOT part of _COMMAND_GROUPS.
+    extra_verb = "last"
+    assert extra_verb in _cli_core._EXTRA_KNOWN_COMMANDS
+    assert extra_verb not in _cli_core._ALL_COMMANDS
+
+    _patch_entry_points(
+        monkeypatch, [_FakeEntryPoint(extra_verb, lambda argv: 77)]
+    )
+    discovered = _cli_core._discover_plugin_commands(force=True)
+    assert extra_verb not in discovered
+
+
+def test_plugins_disabled_via_env(monkeypatch):
+    """TOKENPAK_ENABLE_PLUGINS=0 disables discovery entirely."""
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("daemon", lambda argv: 0)])
+    monkeypatch.setenv("TOKENPAK_ENABLE_PLUGINS", "0")
+
+    discovered = _cli_core._discover_plugin_commands(force=True)
+    assert discovered == {}
+
+
+def test_broken_plugin_environment_is_safe(monkeypatch):
+    """If entry_points() raises, discovery returns empty and never propagates."""
+    def _boom(*a, **k):
+        raise RuntimeError("entry point backend exploded")
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _boom)
+
+    discovered = _cli_core._discover_plugin_commands(force=True)
+    assert discovered == {}

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -341,11 +341,106 @@ _EXTRA_KNOWN_COMMANDS = {
 def _core_command_names() -> set:
     """Return the authoritative set of all built-in CLI verb names.
 
-    The union of the grouped commands (:data:`_ALL_COMMANDS`) and the
-    argparse/stub commands (:data:`_EXTRA_KNOWN_COMMANDS`). Used by the bare
-    ``--json`` catalog and the interactive menu's lifecycle-overlay validation.
+    This is the union of the grouped commands and the argparse/stub commands.
+    Plugin discovery excludes every name in this set so a plugin can never
+    shadow a built-in verb.
     """
     return set(_ALL_COMMANDS) | set(_EXTRA_KNOWN_COMMANDS)
+
+
+# ── Plugin command discovery (tokenpak.commands entry-point group) ────────────
+#
+# Installed plugins (e.g. the premium tier) register additional CLI verbs under
+# the ``tokenpak.commands`` setuptools entry-point group. Each entry point
+# resolves to a callable that takes the remaining argv list and returns an int
+# exit code; that callable is the plugin's own gated wrapper, so entitlement
+# enforcement lives entirely inside the plugin — the core CLI only routes to it.
+#
+# Built-in verbs always win on a name collision: a plugin can never shadow a
+# command that ships in the core CLI. Discovery is lazy (only walked when an
+# unknown verb is seen or full help is rendered) and cached for the process.
+#
+# Discovery is on by default. Set ``TOKENPAK_ENABLE_PLUGINS=0`` to disable it
+# (e.g. for a fully hermetic core-only invocation).
+
+_plugin_commands_cache: Optional[dict] = None
+
+
+def _plugins_enabled() -> bool:
+    """Return False only when discovery is explicitly disabled via env."""
+    val = os.environ.get("TOKENPAK_ENABLE_PLUGINS")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _discover_plugin_commands(force: bool = False) -> dict:
+    """Discover CLI verbs registered under the ``tokenpak.commands`` group.
+
+    Returns a mapping of ``verb name -> entry point``, excluding any verb whose
+    name collides with a built-in command (built-ins always win). The result is
+    cached for the lifetime of the process. Returns an empty dict when discovery
+    is disabled or no plugins are installed. Never raises — a broken plugin
+    environment must not break the core CLI.
+    """
+    global _plugin_commands_cache
+    if _plugin_commands_cache is not None and not force:
+        return _plugin_commands_cache
+
+    discovered: dict = {}
+    if not _plugins_enabled():
+        _plugin_commands_cache = discovered
+        return discovered
+
+    core_names = _core_command_names()
+    try:
+        from importlib.metadata import entry_points
+
+        eps = entry_points()
+        # Python 3.12+ exposes .select(); older returns a dict-like mapping.
+        if hasattr(eps, "select"):
+            command_eps = eps.select(group="tokenpak.commands")
+        else:  # pragma: no cover - legacy importlib.metadata
+            command_eps = eps.get("tokenpak.commands", [])
+
+        for ep in command_eps:
+            # Built-in verbs win on collision: never let a plugin shadow core.
+            if ep.name in core_names or ep.name in discovered:
+                continue
+            discovered[ep.name] = ep
+    except Exception:
+        # Any failure to read entry points leaves the core CLI fully functional.
+        discovered = {}
+
+    _plugin_commands_cache = discovered
+    return discovered
+
+
+def _dispatch_plugin_command(verb: str, argv: list) -> int:
+    """Invoke a discovered plugin verb's callable with the remaining argv.
+
+    ``argv`` is everything after the verb itself. The loaded callable is the
+    plugin's own gated wrapper: an unentitled invocation returns the plugin's
+    upgrade stub exit code, while an entitled one runs the real command. The
+    core CLI does not inspect or alter that gating — it only routes.
+
+    Returns the plugin callable's int exit code (defaulting to 0 when the
+    callable returns ``None``), or a non-zero code if the plugin fails to load.
+    """
+    plugins = _discover_plugin_commands()
+    ep = plugins.get(verb)
+    if ep is None:
+        return 1
+    try:
+        func = ep.load()
+    except Exception as exc:  # pragma: no cover - defensive
+        print(
+            f"❌ Failed to load plugin command '{verb}': {exc}",
+            file=sys.stderr,
+        )
+        return 3
+    rc = func(argv)
+    return rc if isinstance(rc, int) else 0
 
 
 def _suggest_command(unknown: str) -> Optional[str]:
@@ -436,6 +531,12 @@ def _print_full_help():
             print(f"  {group_name}:")
             for cmd, desc in commands:
                 print(f"    {cmd:<14} {desc}")
+            print()
+        _plugin_cmds = _discover_plugin_commands()
+        if _plugin_cmds:
+            print("  Pro / plugins:")
+            for name in sorted(_plugin_cmds):
+                print(f"    {name:<14} Provided by an installed plugin")
             print()
         print("Run `tokenpak <command> --help` for command details.")
 
@@ -4867,53 +4968,24 @@ def main():
 
     # ── Intercept unknown commands for typo suggestions ───────────────────────
     raw_cmd = sys.argv[1] if len(sys.argv) > 1 else ""
-    known_cmds = set(_ALL_COMMANDS) | {
-        # also include argparse-registered commands not in groups
-        "help",
-        "start",
-        "stop",
-        "restart",
-        "logs",
-        "version",
-        "update",
-        "config",
-        "setup",
-        "compare",
-        "leaderboard",
-        "report",
-        "check-alerts",
-        "alerts",
-        "watch",
-        "integrate",
-        "openclaw",
-        "savings",
-        "recommendations",
-        "usage",
-        "preview",
-        "aggregate",
-        "requests",
-        "validate-config",
-        "vault",
-        "vault-health",
-        "compress",
-        "optimize",
-        "last",
-        "prune",
-        "retrieval",
-        "menu",
-        # Stub commands (advertised in help/registry, not yet implemented)
-        "license",
-        "plan",
-        "activate",
-        "deactivate",
-        "init",
-        "monitor",
-        # Beta 1 verb families (TIP, features, PAKPlan preview, home)
-        "tip",
-        "features",
-        "pakplan",
-        "home",
-    }
+    # Authoritative built-in verb set (grouped + argparse/stub commands). Plugin
+    # verbs are dispatched only when raw_cmd is NOT in this set, so built-ins
+    # always win on a name collision.
+    known_cmds = _core_command_names()
+    # ── Plugin verbs (tokenpak.commands entry-point group) ────────────────────
+    # A verb that is not a built-in but is registered by an installed plugin is
+    # routed straight to the plugin's own (already gated) callable. Built-ins win
+    # on collision because this branch only runs for verbs not in known_cmds, and
+    # discovery itself excludes any name that shadows a core command. Everything
+    # after the verb is forwarded verbatim so the plugin owns its own flags
+    # (including its own --help). Entitlement gating is the plugin's job.
+    if raw_cmd and not raw_cmd.startswith("-") and raw_cmd not in known_cmds:
+        _plugin_cmds = _discover_plugin_commands()
+        if raw_cmd in _plugin_cmds:
+            _verb_idx = sys.argv.index(raw_cmd)
+            _rc = _dispatch_plugin_command(raw_cmd, sys.argv[_verb_idx + 1:])
+            sys.exit(_rc)
+
     # If user asks --help on an unrecognised command, just show that command's usage + exit 0
     if (
         raw_cmd

--- a/tokenpak/cli/commands/help.py
+++ b/tokenpak/cli/commands/help.py
@@ -128,6 +128,32 @@ def print_intermediate_help() -> None:
     print("Run `tokenpak help <command>` for details on any command.")
 
 
+def _discover_plugin_command_names(known: set) -> list[str]:
+    """Return verbs registered under the ``tokenpak.commands`` entry-point group.
+
+    Excludes any name already known to the core CLI (built-ins win) and honors
+    the ``TOKENPAK_ENABLE_PLUGINS=0`` opt-out. Never raises — a broken plugin
+    environment must not break help rendering.
+    """
+    import os
+
+    val = os.environ.get("TOKENPAK_ENABLE_PLUGINS")
+    if val is not None and val.strip().lower() in ("0", "false", "no", "off"):
+        return []
+    try:
+        from importlib.metadata import entry_points
+
+        eps = entry_points()
+        if hasattr(eps, "select"):
+            command_eps = eps.select(group="tokenpak.commands")
+        else:  # pragma: no cover - legacy importlib.metadata
+            command_eps = eps.get("tokenpak.commands", [])
+        names = {ep.name for ep in command_eps if ep.name not in known}
+        return sorted(names)
+    except Exception:
+        return []
+
+
 def print_full_help(tier: Optional[str] = None) -> None:
     """Print all commands."""
     commands = _load_registry()
@@ -144,6 +170,14 @@ def print_full_help(tier: Optional[str] = None) -> None:
             aliases = cmd.get("aliases", [])
             alias_str = f"  (alias: {', '.join(aliases)})" if aliases else ""
             print(f"    {name:<16} {desc}{alias_str}")
+        print()
+
+    known = {c.get("command") for c in commands}
+    plugin_names = _discover_plugin_command_names(known)
+    if plugin_names:
+        print("  Pro / plugins:")
+        for name in plugin_names:
+            print(f"    {name:<16} Provided by an installed plugin")
         print()
 
     print("Run `tokenpak help <command>` for details.")


### PR DESCRIPTION
## What

Adds a consumer for the `tokenpak.commands` setuptools entry-point group so installed plugins (e.g. the premium tier) can register additional CLI verbs. An unknown verb matching a registered plugin entry point is routed to that plugin's own callable; built-in verbs always win on a name collision.

## Behavior

- Discovery is lazy, cached, and fail-soft — a broken plugin environment never breaks the core CLI.
- Entitlement enforcement stays entirely inside the plugin; the core CLI only routes to the verb's callable.
- With no plugin installed, the CLI behaves exactly as before.
- Set `TOKENPAK_ENABLE_PLUGINS=0` to disable discovery.

## Scope

- `tokenpak/_cli_core.py` — discovery (`_discover_plugin_commands`) + dispatch (`_dispatch_plugin_command`) wired into `main()`.
- `tokenpak/cli/commands/help.py` — discovered verbs listed under a plugins section instead of falling through to "Unknown command".
- `tests/test_cli_plugin_dispatch.py` — discovery, built-in precedence, entitlement-preserved, no-plugin, and opt-out coverage.

## Verification

- New tests pass; existing CLI behavior unchanged.
- With a plugin installed, an unknown-but-registered verb resolves to the plugin's gated response instead of "Unknown command".
- `TOKENPAK_ENABLE_PLUGINS=0` restores the prior unknown-command behavior.