### PR TITLE
fix(license): correct SDK and Claude Code plugin manifests to Apache-2.0

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -26,7 +26,7 @@
     "ai"
   ],
   "author": "Kevin Yang",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/tokenpak/tokenpak"

--- a/tokenpak/sdk/integrations/claude_code/plugin/.claude-plugin/plugin.json
+++ b/tokenpak/sdk/integrations/claude_code/plugin/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Corpus-aware context packing, skills, and safety hooks for tokenpak users. Adds five MCP tools, five workflow skills, and four protective hooks to Claude Code.",
   "author": "tokenpak",
   "repository": "https://github.com/tokenpak/registry",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "claude-code": ">=1.0.0"
   },


### PR DESCRIPTION
Corrects two stale `MIT` self-claims to the project's canonical `Apache-2.0` license (root `LICENSE` + `pyproject` classifier):

- `sdk/package.json` — `license`: MIT → Apache-2.0
- `tokenpak/sdk/integrations/claude_code/plugin/.claude-plugin/plugin.json` — `license`: MIT → Apache-2.0

Metadata-only; no code or behavior change. NO-BUMP (no version change, no release).