### PR TITLE
release: v1.9.2 — session-handoff capture + session-id binding

### DIFF
--- a/.changeset/v1.9.2-session-handoff.md
+++ b/.changeset/v1.9.2-session-handoff.md
@@ -1,0 +1,20 @@
+---
+---
+
+v1.9.2 — session-handoff capture + session-id binding.
+
+Adds cross-tool session continuity for the companion and proxy:
+
+- The companion MCP server now binds the live session id from the pre-send
+  hook marker before each tool dispatch, so `journal_write`, `journal_read`,
+  and `session_info` resolve the active session without restarting the
+  long-lived server. A new session id (e.g. after `/clear`) is picked up
+  automatically.
+- The proxy gains a session-handoff capture bridge so a session started in
+  one tool can be continued in another.
+
+Public API: adds `current_session_id()` — defined in
+`tokenpak.companion.mcp.tools` and re-exported via
+`tokenpak.companion.mcp.server`. The public-API snapshot is regenerated to
+record exactly these two `current_session_id` entries; no other public
+symbol is added or removed.

--- a/tests/companion/test_session_marker.py
+++ b/tests/companion/test_session_marker.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the companion session-marker bridge.
+
+The pre_send hook (one process) persists the live session id to a run-dir
+marker; the long-lived MCP server (another process) reads it back via
+``current_session_id`` and binds ``CompanionState.session_id`` before each
+tool dispatch. These tests cover both ends plus the hook entry point.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from tokenpak.companion.hooks import pre_send
+from tokenpak.companion.mcp import server as mcp_server
+from tokenpak.companion.mcp.tools import CompanionState, current_session_id
+
+# ---------------------------------------------------------------------------
+# _write_session_marker (hook side)
+# ---------------------------------------------------------------------------
+
+
+def test_session_marker_written_atomically(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    pre_send._write_session_marker("sess-123")
+    marker = tmp_path / "run" / "current-session"
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8") == "sess-123"
+    # tmp+replace leaves no residue
+    assert not (tmp_path / "run" / "current-session.tmp").exists()
+
+
+def test_session_marker_strips_whitespace(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    pre_send._write_session_marker("  sess-xyz \n")
+    assert (tmp_path / "run" / "current-session").read_text() == "sess-xyz"
+
+
+def test_session_marker_overwrites_previous(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    pre_send._write_session_marker("sess-first")
+    pre_send._write_session_marker("sess-second")
+    assert (tmp_path / "run" / "current-session").read_text() == "sess-second"
+
+
+def test_session_marker_never_raises(tmp_path, monkeypatch):
+    """Marker write is best-effort: an unwritable dir must not raise."""
+    blocker = tmp_path / "blocked"
+    blocker.write_text("a file where the dir should be")
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(blocker))
+    pre_send._write_session_marker("sess-x")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# pre_send hook entry point
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(monkeypatch, payload: dict) -> int:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(payload)))
+    return pre_send.main()
+
+
+def test_session_marker_written_by_hook_main(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    rc = _run_hook(monkeypatch, {"session_id": "sess-hook", "prompt": "hi"})
+    assert rc == 0
+    assert (tmp_path / "run" / "current-session").read_text() == "sess-hook"
+
+
+def test_session_marker_not_written_without_session_id(tmp_path, monkeypatch):
+    """The anon-{pid} journal fallback is NOT a handoff identity — no marker."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    rc = _run_hook(monkeypatch, {"prompt": "hi"})
+    assert rc == 0
+    assert not (tmp_path / "run" / "current-session").exists()
+
+
+def test_session_marker_not_written_when_companion_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    monkeypatch.setenv("TOKENPAK_COMPANION_ENABLED", "0")
+    rc = _run_hook(monkeypatch, {"session_id": "sess-off", "prompt": "hi"})
+    assert rc == 0
+    assert not (tmp_path / "run" / "current-session").exists()
+
+
+# ---------------------------------------------------------------------------
+# current_session_id (MCP server side)
+# ---------------------------------------------------------------------------
+
+
+def test_session_marker_read_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "current-session").write_text("  sess-live \n", encoding="utf-8")
+    assert current_session_id() == "sess-live"
+
+
+def test_session_marker_absent_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    assert current_session_id() == ""
+
+
+def test_session_marker_hook_to_reader_roundtrip(tmp_path, monkeypatch):
+    """End-to-end: the hook writes, the reader sees the same id."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    pre_send._write_session_marker("sess-rt")
+    assert current_session_id() == "sess-rt"
+
+
+# ---------------------------------------------------------------------------
+# MCP server per-dispatch binding
+# ---------------------------------------------------------------------------
+
+
+def _call_unknown_tool(state: CompanionState, sent: list) -> None:
+    """Dispatch a tools/call; capture responses instead of writing stdout."""
+    mcp_server._handle_tools_call(1, {"name": "no-such-tool", "arguments": {}}, state)
+
+
+def test_session_marker_binds_state_on_dispatch(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "current-session").write_text("sess-bound", encoding="utf-8")
+    sent = []
+    monkeypatch.setattr(mcp_server, "_send", lambda obj: sent.append(obj))
+
+    state = CompanionState()
+    assert state.session_id == ""
+    _call_unknown_tool(state, sent)
+    assert state.session_id == "sess-bound"
+
+
+def test_session_marker_binding_refreshes_per_call(tmp_path, monkeypatch):
+    """A new marker (e.g. after /clear starts a new session) is picked up on
+    the next dispatch without restarting the server."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    run = tmp_path / "run"
+    run.mkdir()
+    sent = []
+    monkeypatch.setattr(mcp_server, "_send", lambda obj: sent.append(obj))
+    state = CompanionState()
+
+    (run / "current-session").write_text("sess-one", encoding="utf-8")
+    _call_unknown_tool(state, sent)
+    assert state.session_id == "sess-one"
+
+    (run / "current-session").write_text("sess-two", encoding="utf-8")
+    _call_unknown_tool(state, sent)
+    assert state.session_id == "sess-two"
+
+
+def test_session_marker_missing_keeps_existing_binding(tmp_path, monkeypatch):
+    """No marker → the previously-bound session id is retained, not cleared."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    sent = []
+    monkeypatch.setattr(mcp_server, "_send", lambda obj: sent.append(obj))
+    state = CompanionState()
+    state.session_id = "sess-kept"
+    _call_unknown_tool(state, sent)
+    assert state.session_id == "sess-kept"

--- a/tests/proxy/test_journal_handoff_capture.py
+++ b/tests/proxy/test_journal_handoff_capture.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the cross-tool session handoff capture in the proxy app API.
+
+Covers:
+  - ``_is_handoff`` detection (typed entry vs HANDOFF_MARKER content sniff)
+  - ``_extract_field`` edge cases (case, whitespace, embedded colons, absent)
+  - ``_record_handoff`` artifact layout (current.json pointer, events.jsonl
+    append log, readable capsule) + deterministic handoff_id
+  - journal POST handler: sessions-table registration on first write and
+    handoff mirroring into the 200 response
+  - legacy-data compat: a journal.db with pre-existing entries but no session
+    row is registered non-destructively (additive, idempotent)
+  - capsule reserved-alias resolution (``active``/``latest``/``current`` →
+    newest real capsule by mtime, never a frozen alias file)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import time
+
+from tokenpak.proxy import app_endpoints as ae
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeHandler:
+    """Minimal stand-in for the HTTP handler `_send_json` writes through."""
+
+    def __init__(self):
+        self.status = None
+        self.headers_sent = {}
+        self.wfile = io.BytesIO()
+        self.headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers_sent[key] = value
+
+    def end_headers(self):
+        pass
+
+    def body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _post_journal(session_id: str, content: str, entry_type: str = "user") -> FakeHandler:
+    h = FakeHandler()
+    ae._handle_journal_post(h, session_id, {"content": content, "entry_type": entry_type})
+    return h
+
+
+# ---------------------------------------------------------------------------
+# _is_handoff
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_detected_by_entry_type():
+    assert ae._is_handoff("handoff", "anything") is True
+
+
+def test_handoff_entry_type_case_and_whitespace_insensitive():
+    assert ae._is_handoff("  Handoff ", "x") is True
+    assert ae._is_handoff("HANDOFF", "") is True
+
+
+def test_handoff_detected_by_marker_in_content():
+    assert ae._is_handoff("user", "notes\nHANDOFF_MARKER: phase-3\nmore") is True
+
+
+def test_handoff_not_detected_for_plain_entry():
+    assert ae._is_handoff("user", "just a normal journal note") is False
+
+
+def test_handoff_empty_inputs_are_safe():
+    assert ae._is_handoff("", "") is False
+    assert ae._is_handoff(None, None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _extract_field
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_extract_field_basic():
+    content = "intro\nHANDOFF_MARKER: phase-3-ready\ntail"
+    assert ae._extract_field(content, "HANDOFF_MARKER") == "phase-3-ready"
+
+
+def test_handoff_extract_field_strips_whitespace():
+    content = "   HANDOFF_MARKER:    spaced out   "
+    assert ae._extract_field(content, "HANDOFF_MARKER") == "spaced out"
+
+
+def test_handoff_extract_field_value_may_contain_colons():
+    content = "SECRET_DECISION: use plan B: the colon-bearing one"
+    assert ae._extract_field(content, "SECRET_DECISION") == "use plan B: the colon-bearing one"
+
+
+def test_handoff_extract_field_missing_returns_empty():
+    assert ae._extract_field("no fields here", "HANDOFF_MARKER") == ""
+
+
+def test_handoff_extract_field_empty_content_returns_empty():
+    assert ae._extract_field("", "HANDOFF_MARKER") == ""
+    assert ae._extract_field(None, "HANDOFF_MARKER") == ""  # type: ignore[arg-type]
+
+
+def test_handoff_extract_field_first_match_wins():
+    content = "HANDOFF_MARKER: first\nHANDOFF_MARKER: second"
+    assert ae._extract_field(content, "HANDOFF_MARKER") == "first"
+
+
+# ---------------------------------------------------------------------------
+# _record_handoff — artifact layout
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_record_writes_pointer_log_and_capsule(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    monkeypatch.setenv("TOKENPAK_TOOL", "claude-code")
+    content = "HANDOFF_MARKER: m-1\nSECRET_DECISION: keep going\nbody text"
+    record = ae._record_handoff("sess-a", content)
+
+    current = tmp_path / "run" / "handoff" / "current.json"
+    events = tmp_path / "run" / "handoff" / "events.jsonl"
+    capsule = tmp_path / "capsules" / "sess-a.md"
+    assert current.exists() and events.exists() and capsule.exists()
+    # no tmp residue from the atomic write
+    assert not (tmp_path / "run" / "handoff" / "current.json.tmp").exists()
+
+    loaded = json.loads(current.read_text(encoding="utf-8"))
+    assert loaded == record
+    assert loaded["session_id"] == "sess-a"
+    assert loaded["marker"] == "m-1"
+    assert loaded["secret_decision"] == "keep going"
+    assert loaded["source_tool"] == "claude-code"
+    assert loaded["payload_ref"] == "journal:sess-a"
+
+    cap_text = capsule.read_text(encoding="utf-8")
+    assert "m-1" in cap_text and "keep going" in cap_text
+
+
+def test_handoff_events_log_appends(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    ae._record_handoff("sess-a", "HANDOFF_MARKER: one")
+    ae._record_handoff("sess-a", "HANDOFF_MARKER: two")
+    lines = (tmp_path / "run" / "handoff" / "events.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["marker"] == "one"
+    assert json.loads(lines[1])["marker"] == "two"
+    # current.json points at the latest
+    latest = json.loads((tmp_path / "run" / "handoff" / "current.json").read_text())
+    assert latest["marker"] == "two"
+
+
+def test_handoff_id_deterministic_from_marker(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    r1 = ae._record_handoff("sess-a", "HANDOFF_MARKER: stable\nnoise 1")
+    r2 = ae._record_handoff("sess-b", "HANDOFF_MARKER: stable\nnoise 2")
+    assert r1["handoff_id"] == r2["handoff_id"]  # basis is the marker
+    r3 = ae._record_handoff("sess-c", "no marker at all")
+    assert r3["handoff_id"] != r1["handoff_id"]  # falls back to content basis
+
+
+# ---------------------------------------------------------------------------
+# Journal POST handler — sessions-table registration + handoff mirroring
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_journal_post_registers_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    h = _post_journal("sess-reg", "first entry")
+    assert h.status == 200
+
+    con = sqlite3.connect(str(tmp_path / "journal.db"))
+    rows = list(con.execute("SELECT session_id, project_dir FROM sessions"))
+    con.close()
+    assert len(rows) == 1
+    assert rows[0][0] == "sess-reg"
+    assert rows[0][1] == os.getcwd()
+
+
+def test_handoff_journal_post_registration_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    _post_journal("sess-reg", "entry one")
+    _post_journal("sess-reg", "entry two")
+
+    con = sqlite3.connect(str(tmp_path / "journal.db"))
+    n_sessions = con.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    n_entries = con.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+    con.close()
+    assert n_sessions == 1
+    assert n_entries == 2
+
+
+def test_handoff_journal_post_legacy_db_compat(tmp_path, monkeypatch):
+    """Legacy-data guard: a journal.db with pre-existing entries but NO session
+    row (data written before session registration existed) is migrated
+    additively — the session row appears on the next write and prior entries
+    survive untouched."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    from tokenpak.companion.journal.store import JournalStore
+
+    store = JournalStore(db_path=tmp_path / "journal.db")
+    store.add_entry(session_id="sess-legacy", entry_type="user", content="old entry")
+    con = sqlite3.connect(str(tmp_path / "journal.db"))
+    assert con.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+    con.close()
+
+    h = _post_journal("sess-legacy", "new entry after upgrade")
+    assert h.status == 200
+
+    con = sqlite3.connect(str(tmp_path / "journal.db"))
+    sessions = list(con.execute("SELECT session_id FROM sessions"))
+    entries = [
+        r[0] for r in con.execute(
+            "SELECT content FROM entries WHERE session_id='sess-legacy' ORDER BY id"
+        )
+    ]
+    con.close()
+    assert sessions == [("sess-legacy",)]
+    assert entries == ["old entry", "new entry after upgrade"]
+
+
+def test_handoff_journal_post_mirrors_handoff_in_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    h = _post_journal("sess-h", "HANDOFF_MARKER: ready\nSECRET_DECISION: ship it")
+    assert h.status == 200
+    body = h.body()
+    assert body["status"] == "ok"
+    assert body["handoff"]["marker"] == "ready"
+    assert body["handoff"]["secret_decision"] == "ship it"
+    assert (tmp_path / "run" / "handoff" / "current.json").exists()
+
+
+def test_handoff_journal_post_plain_entry_has_no_handoff_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    h = _post_journal("sess-p", "ordinary note")
+    assert h.status == 200
+    assert "handoff" not in h.body()
+    assert not (tmp_path / "run" / "handoff").exists()
+
+
+def test_handoff_journal_post_typed_handoff_entry_mirrors(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    h = _post_journal("sess-t", "no marker line here", entry_type="handoff")
+    assert h.status == 200
+    body = h.body()
+    assert body["handoff"]["marker"] == ""
+    assert body["handoff"]["summary"] == "no marker line here"
+
+
+# ---------------------------------------------------------------------------
+# Capsule reserved-alias resolution
+# ---------------------------------------------------------------------------
+
+
+def _get_capsule(session_id: str) -> FakeHandler:
+    h = FakeHandler()
+    ae._handle_capsule_get(h, session_id, {})
+    return h
+
+
+def test_handoff_capsule_alias_resolves_newest_real_capsule(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    capdir = tmp_path / "capsules"
+    capdir.mkdir(parents=True)
+    older = capdir / "sess-old.md"
+    newer = capdir / "sess-new.md"
+    stale_alias = capdir / "active.md"
+    older.write_text("# old capsule\n")
+    stale_alias.write_text("# stale alias body\n")
+    newer.write_text("# new capsule\n")
+    past = time.time() - 3600
+    os.utime(older, (past, past))
+    os.utime(stale_alias, (past - 60, past - 60))
+
+    for alias in ("active", "latest", "current", "ACTIVE", " active "):
+        h = _get_capsule(alias)
+        assert h.status == 200, alias
+        assert h.body()["session_id"] == "sess-new", alias
+
+
+def test_handoff_capsule_alias_never_resolves_alias_files(tmp_path, monkeypatch):
+    """Even if an alias file is the newest .md on disk, it is skipped."""
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    capdir = tmp_path / "capsules"
+    capdir.mkdir(parents=True)
+    real = capdir / "sess-real.md"
+    real.write_text("# real\n")
+    past = time.time() - 3600
+    os.utime(real, (past, past))
+    (capdir / "active.md").write_text("# alias newest\n")
+
+    h = _get_capsule("active")
+    assert h.status == 200
+    assert h.body()["session_id"] == "sess-real"
+
+
+def test_handoff_capsule_alias_404_when_no_real_capsules(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    capdir = tmp_path / "capsules"
+    capdir.mkdir(parents=True)
+    (capdir / "active.md").write_text("# only the alias exists\n")
+    h = _get_capsule("active")
+    assert h.status == 404
+
+
+def test_handoff_capsule_exact_id_lookup_unchanged(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKENPAK_COMPANION_JOURNAL_DIR", str(tmp_path))
+    capdir = tmp_path / "capsules"
+    capdir.mkdir(parents=True)
+    (capdir / "sess-abc123.md").write_text("# target\n")
+    h = _get_capsule("abc123")
+    assert h.status == 200
+    assert h.body()["session_id"] == "sess-abc123"

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-16T16:23:40Z",
-  "package_version": "1.9.0",
+  "generated_at": "2026-06-18T00:45:53Z",
+  "package_version": "1.9.2",
   "symbols": [
     {
       "module": "tokenpak",
@@ -2117,6 +2117,10 @@
     },
     {
       "module": "tokenpak.companion.mcp.server",
+      "name": "current_session_id"
+    },
+    {
+      "module": "tokenpak.companion.mcp.server",
       "name": "main"
     },
     {
@@ -2134,6 +2138,10 @@
     {
       "module": "tokenpak.companion.mcp.tools",
       "name": "ToolDef"
+    },
+    {
+      "module": "tokenpak.companion.mcp.tools",
+      "name": "current_session_id"
     },
     {
       "module": "tokenpak.companion.memory",

--- a/tokenpak/companion/hooks/pre_send.py
+++ b/tokenpak/companion/hooks/pre_send.py
@@ -60,6 +60,14 @@ def main() -> int:
     if os.environ.get("TOKENPAK_COMPANION_ENABLED", "1").lower() in ("0", "false", "no"):
         return 0
 
+    # Session-binding keystone: persist the live session id so the
+    # (separate-process) companion MCP server can bind to it. The MCP server
+    # never sees the hook payload, so this run-dir marker is the only bridge.
+    # Only the real session id is bound — the anon-{pid} journal fallback below
+    # is NOT a handoff identity. Best-effort; never fails the hook.
+    if session_id:
+        _write_session_marker(session_id)
+
     # Token estimation: transcript size + prompt text, both // 4 (instant).
     # Cron/one-shot `--print` invocations have no transcript on the first hook
     # fire — fall back to the prompt text so we still journal the cycle.
@@ -136,6 +144,23 @@ def main() -> int:
         print("  ".join(parts), file=sys.stderr)
 
     return 0
+
+
+def _write_session_marker(session_id: str) -> None:
+    """Persist the live session id to the run-dir marker so the companion MCP
+    server (a separate process) can bind ``state.session_id`` to it. Atomic
+    write via tmp+replace. Best-effort; never fails the hook."""
+    try:
+        run_dir = Path(os.environ.get(
+            "TOKENPAK_COMPANION_JOURNAL_DIR",
+            str(Path.home() / ".tokenpak" / "companion"),
+        )) / "run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        tmp = run_dir / "current-session.tmp"
+        tmp.write_text(session_id.strip(), encoding="utf-8")
+        tmp.replace(run_dir / "current-session")
+    except Exception:
+        pass  # never fail the hook
 
 
 def _get_daily_total() -> float:

--- a/tokenpak/companion/mcp/server.py
+++ b/tokenpak/companion/mcp/server.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import sys
 
-from .tools import TOOLS, CompanionState
+from .tools import TOOLS, CompanionState, current_session_id
 
 
 def _send(obj: dict) -> None:
@@ -62,6 +62,15 @@ def _handle_tools_call(req_id: int | str, params: dict, state: CompanionState) -
     tool_name = params.get("name", "")
     args = params.get("arguments", {})
     state.call_count += 1
+
+    # Bind the live session id from the pre_send hook marker before each
+    # dispatch. The hook (a separate process) writes the marker; this is how
+    # the long-lived MCP server learns the active session for journal_write,
+    # journal_read, and session_info. Refreshed per call so /clear (new
+    # session id) is picked up without restarting the server.
+    _sid = current_session_id()
+    if _sid:
+        state.session_id = _sid
 
     # Find the tool
     tool = None

--- a/tokenpak/companion/mcp/tools.py
+++ b/tokenpak/companion/mcp/tools.py
@@ -12,6 +12,7 @@ goes through CompanionState methods so it's centralized and testable.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -22,6 +23,24 @@ from ..config import CompanionConfig
 # Matches pre_send.py's fallback (sonnet input rate). Kept local rather than
 # imported so tools.py has no cross-module coupling with the hook.
 _COMPANION_DEFAULT_INPUT_RATE_USD_PER_MTOK = 3.0
+
+
+def current_session_id() -> str:
+    """Read the live session id from the run-dir marker written by the
+    pre_send hook (session binding). The MCP server is a separate process
+    from the hook, so this file is the only channel by which it learns the
+    active session id. Returns "" if no marker exists yet."""
+    try:
+        run_dir = Path(os.environ.get(
+            "TOKENPAK_COMPANION_JOURNAL_DIR",
+            str(Path.home() / ".tokenpak" / "companion"),
+        )) / "run"
+        marker = run_dir / "current-session"
+        if marker.exists():
+            return marker.read_text(encoding="utf-8").strip()
+    except Exception:
+        pass
+    return ""
 
 
 @dataclass

--- a/tokenpak/proxy/app_endpoints.py
+++ b/tokenpak/proxy/app_endpoints.py
@@ -25,6 +25,7 @@ Error shape:
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import os
 import time
@@ -392,6 +393,100 @@ def _get_journal_store() -> Any:
     return JournalStore(db_path=_companion_dir() / "journal.db")
 
 
+# ---------------------------------------------------------------------------
+# Cross-tool handoff bridge.
+#
+# A per-tool session id is not retrievable by the other tool, so a journal
+# entry alone cannot bridge two different clients (e.g. Claude Code ↔ Codex).
+# The authoritative bridge is a shared handoff namespace under the companion
+# run dir: ``current.json`` (latest pointer) + ``events.jsonl`` (append log).
+# The reader pulls the latest without knowing the writer's session id. A
+# readable current-session capsule is written alongside as the lossy
+# summary/export layer (NOT the authority).
+# ---------------------------------------------------------------------------
+
+# Reserved capsule aliases that resolve to the newest real capsule by mtime,
+# rather than a frozen on-disk symlink (which can silently go stale).
+_CAPSULE_LATEST_ALIASES = {"active", "latest", "current"}
+
+
+def _is_handoff(entry_type: str, content: str) -> bool:
+    """A journal entry is a handoff if explicitly typed ``handoff`` or if it
+    carries a HANDOFF_MARKER line. Content-sniffing keeps the model-facing
+    journal_write tool unchanged (it always sends entry_type=user)."""
+    if (entry_type or "").strip().lower() == "handoff":
+        return True
+    return "HANDOFF_MARKER" in (content or "")
+
+
+def _extract_field(content: str, field: str) -> str:
+    """Pull a ``FIELD: value`` line out of free-form handoff content."""
+    needle = field + ":"
+    for line in (content or "").splitlines():
+        s = line.strip()
+        if s.upper().startswith(needle):
+            return s[len(needle):].strip()
+    return ""
+
+
+def _record_handoff(session_id: str, content: str) -> dict[str, Any]:
+    """Write the authoritative shared handoff record and a readable
+    current-session capsule. Returns the handoff record dict.
+
+    Layout (under the companion run dir):
+        run/handoff/current.json   — latest pointer (atomic tmp+replace)
+        run/handoff/events.jsonl   — append-only event log
+        capsules/<session_id>.md   — readable summary (newest → resolves `active`)
+    """
+    import hashlib
+
+    cdir = _companion_dir()
+    marker = _extract_field(content, "HANDOFF_MARKER") or ""
+    secret = _extract_field(content, "SECRET_DECISION") or ""
+    source_tool = os.environ.get("TOKENPAK_TOOL", "") or "unknown"
+    now = time.time()
+    iso = _dt.datetime.fromtimestamp(now, _dt.timezone.utc).isoformat()
+    basis = marker or content
+    handoff_id = hashlib.sha256(basis.encode("utf-8", "ignore")).hexdigest()[:16]
+
+    record = {
+        "handoff_id": handoff_id,
+        "session_id": session_id,
+        "source_tool": source_tool,
+        "updated_at": iso,
+        "marker": marker,
+        "secret_decision": secret,
+        "summary": content[:2000],
+        "payload_ref": f"journal:{session_id}",
+    }
+
+    hdir = cdir / "run" / "handoff"
+    hdir.mkdir(parents=True, exist_ok=True)
+    # current.json — atomic write
+    tmp = hdir / "current.json.tmp"
+    tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(hdir / "current.json")
+    # events.jsonl — append log
+    with (hdir / "events.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    # Readable current-session capsule (newest mtime → resolves `active`)
+    capdir = cdir / "capsules"
+    capdir.mkdir(parents=True, exist_ok=True)
+    cap_body = (
+        f"# Handoff capsule — session {session_id}\n\n"
+        f"- updated_at: {iso}\n"
+        f"- source_tool: {source_tool}\n"
+        f"- handoff_id: {handoff_id}\n\n"
+        f"## Marker\n{marker or '(none)'}\n\n"
+        f"## Secret decision\n{secret or '(none)'}\n\n"
+        f"## Summary\n{content[:4000]}\n"
+    )
+    (capdir / f"{session_id}.md").write_text(cap_body, encoding="utf-8")
+
+    return record
+
+
 def _handle_budget_get(handler: Any, qs: dict[str, list[str]]) -> None:
     """Return current session + daily cost snapshot."""
     try:
@@ -484,6 +579,15 @@ def _handle_journal_post(handler: Any, session_id: str, body: dict[str, Any]) ->
     entry_type = str(body.get("entry_type", "user")).strip() or "user"
     try:
         store = _get_journal_store()
+        # Register the session row on first write so the sessions table is
+        # populated and the journal session listing is meaningful. add_entry
+        # alone never created a session row, which is why the table could be
+        # empty despite entries existing.
+        try:
+            if store.get_session(session_id) is None:
+                store.start_session(session_id, project_dir=os.getcwd())
+        except Exception:
+            pass  # registration is best-effort; never block the entry write
         store.add_entry(
             session_id=session_id,
             entry_type=entry_type,
@@ -492,7 +596,19 @@ def _handle_journal_post(handler: Any, session_id: str, body: dict[str, Any]) ->
     except Exception as exc:
         _send_error(handler, 500, "journal_write_failed", str(exc))
         return
-    _send_json(handler, 200, {"status": "ok", "session_id": session_id, "entry_type": entry_type})
+    # Mirror handoff facts to the authoritative shared namespace + a readable
+    # current-session capsule so a different client can retrieve the latest
+    # handoff without knowing the writer's per-tool session id.
+    handoff = None
+    if _is_handoff(entry_type, content):
+        try:
+            handoff = _record_handoff(session_id, content)
+        except Exception:
+            handoff = None  # mirroring is best-effort; the entry already landed
+    out = {"status": "ok", "session_id": session_id, "entry_type": entry_type}
+    if handoff:
+        out["handoff"] = handoff
+    _send_json(handler, 200, out)
 
 
 # ---------------------------------------------------------------------------
@@ -617,10 +733,23 @@ def _handle_capsule_get(handler: Any, session_id: str, qs: dict[str, list[str]])
         _send_error(handler, 500, "capsule_module_unavailable", str(exc))
         return
     match = None
-    for p in capsule_dir.glob("*.md"):
-        if session_id in p.stem:
-            match = p
-            break
+    if session_id.strip().lower() in _CAPSULE_LATEST_ALIASES:
+        # Reserved aliases resolve to the NEWEST real capsule by mtime, not an
+        # on-disk alias file (a frozen symlink keeps its target's mtime and can
+        # silently serve a stale handoff). Skip the alias files themselves so
+        # we never resolve back to a stale target.
+        candidates = sorted(
+            (p for p in capsule_dir.glob("*.md")
+             if p.name not in ("active.md", "latest.md", "current.md")),
+            key=lambda x: x.stat().st_mtime,
+            reverse=True,
+        )
+        match = candidates[0] if candidates else None
+    else:
+        for p in capsule_dir.glob("*.md"):
+            if session_id in p.stem:
+                match = p
+                break
     if match is None:
         _send_error(handler, 404, "capsule_not_found", session_id)
         return


### PR DESCRIPTION
## v1.9.2 — session-handoff capture + session-id binding

Adds cross-tool session continuity for the companion and proxy.

### What's new
- **Companion session-id binding.** The companion MCP server now binds the live session id from the pre-send hook marker before each tool dispatch, so `journal_write`, `journal_read`, and `session_info` resolve the active session without restarting the long-lived server. A new session id (e.g. after `/clear`) is picked up automatically.
- **Proxy session-handoff capture.** The proxy gains a session-handoff capture bridge so a session started in one tool can be continued in another.

### Public API
Adds `current_session_id()` — defined in `tokenpak.companion.mcp.tools` and re-exported via `tokenpak.companion.mcp.server`. The public-API snapshot is regenerated to record exactly these two `current_session_id` entries; **no other public symbol is added or removed.**

### Scope (9 files)
companion `hooks/pre_send.py`, `mcp/server.py`, `mcp/tools.py`; `proxy/app_endpoints.py`; `tests/companion/test_session_marker.py`, `tests/proxy/test_journal_handoff_capture.py`; version bump (`__init__.py` → 1.9.2); regenerated `_snapshots/public-api.json`; changeset.

### Verification
- Branch = current `main` + this feature delta only.
- Local gates green; public-API snapshot `--check` green (delta = `current_session_id` ×2, zero removals).
