### PR TITLE
v1.9.3 — security patch: pak path-safety + default-deny CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.9.3] — 2026-06-22
+
+Security patch: path-safety hardening for `pak` install and a default-deny CORS
+policy on the proxy's content routes. Additive; one behavior change noted below.
+
+### Security
+- **pak install:** added a path-traversal guard (archive entries are resolved and
+  confirmed within the target directory), symlinked entries are skipped during
+  extraction, and checksum-verified messaging is now honest about what was checked.
+- **proxy CORS:** the `/tpk/v1/*` JSON routes no longer emit
+  `Access-Control-Allow-Origin: *`. CORS is now **default-deny** with an
+  exact-origin allowlist.
+
+### Changed
+- **proxy CORS (behavior change):** a browser app fetching `/tpk/v1/*` from a
+  different origin must now set `TOKENPAK_PROXY_CORS_ORIGINS` (comma-separated
+  exact origins). A matching request `Origin` is echoed back with `Vary: Origin`,
+  never `*`. CLI / SDK / MCP clients are unaffected — CORS applies to browsers only.
+
 ## [1.9.1] — 2026-06-16
 
 Patch release: privacy/security hardening, honest telemetry, license alignment,

--- a/tests/test_pak_safety.py
+++ b/tests/test_pak_safety.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Security regression coverage for ``tokenpak pak`` (codex-review-1 A1/A2/A5).
+
+- A1  export must contain writes inside the chosen output dir; an untrusted
+      anchor ``path`` that is absolute or climbs out with ``..`` is skipped.
+- A2  create must not follow symlinks (a link to e.g. /etc/hostname would
+      otherwise embed the link target's content into the Pak).
+- A5  import must not print "checksum verified" when the Pak carries no
+      declared checksum — nothing was verified in that case.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tokenpak.cli.commands import pak
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _write_pak(path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _checksum_for(payload: dict) -> str:
+    """Reproduce the checksum the create/import path computes."""
+    body = json.dumps(
+        {k: v for k, v in payload.items() if k not in ("checksum", "pak_id")},
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+# ── A1: export path traversal containment ─────────────────────────────────────
+
+
+def test_export_rejects_traversal_and_absolute_keeps_safe(tmp_path, capsys):
+    out_dir = tmp_path / "exported"
+    out_dir.mkdir()
+    # An absolute target that lands OUTSIDE out_dir (kept under tmp_path so the
+    # test never touches a real system path — same property as /tmp/escape.txt).
+    abs_escape = tmp_path / "outside" / "pwned.txt"
+
+    pak_file = tmp_path / "evil.pak.json"
+    _write_pak(
+        pak_file,
+        {
+            "pak_id": "pak:deadbeef",
+            "anchors": [
+                {"path": "../escape.txt", "content": "owned", "encoding": "utf-8"},
+                {"path": str(abs_escape), "content": "owned", "encoding": "utf-8"},
+                {"path": "sub/ok.txt", "content": "safe", "encoding": "utf-8"},
+            ],
+        },
+    )
+
+    rc = pak._export_file_pak(str(pak_file), out_dir)
+    assert rc == 0
+
+    # Safe nested anchor written inside out_dir.
+    safe = out_dir / "sub" / "ok.txt"
+    assert safe.is_file()
+    assert safe.read_text(encoding="utf-8") == "safe"
+
+    # Neither escape target was created.
+    assert not (out_dir.parent / "escape.txt").exists()
+    assert not abs_escape.exists()
+
+    err = capsys.readouterr().err
+    assert "escapes export dir" in err
+
+
+def test_within_dir_helper():
+    base = Path("/srv/export")
+    assert pak._within_dir(base, "ok/file.txt") is True
+    assert pak._within_dir(base, "../escape.txt") is False
+    assert pak._within_dir(base, "/etc/passwd") is False
+    assert pak._within_dir(base, "a/../b.txt") is True  # normalizes inside base
+
+
+# ── A2: create must skip symlinks ─────────────────────────────────────────────
+
+
+def test_create_skips_symlinks(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "real.txt").write_text("real content", encoding="utf-8")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    link = src / "link.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError:  # pragma: no cover - platform without symlink support
+        pytest.skip("symlinks unsupported on this platform")
+
+    out = tmp_path / "out.pak.json"
+    args = SimpleNamespace(
+        source_dir=str(src),
+        output=str(out),
+        title="t",
+        objective="o",
+        summary="s",
+        ttl="7d",
+        continuation_notes="",
+        include_content=True,
+        max_bytes=2_000_000,
+    )
+    rc = pak.cmd_pak_create(args)
+    assert rc == 0
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    paths = {a["path"] for a in payload["anchors"]}
+    assert "real.txt" in paths
+    # The symlink was skipped: neither its name nor the secret's content leaked.
+    assert "link.txt" not in paths
+    blob = out.read_text(encoding="utf-8")
+    assert "TOP SECRET" not in blob
+
+
+# ── A5: import checksum honesty ───────────────────────────────────────────────
+
+
+def _import_payload(tmp_path, monkeypatch, payload: dict):
+    monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path / "home"))
+    pak_file = tmp_path / "in.pak.json"
+    _write_pak(pak_file, payload)
+    args = SimpleNamespace(pak_file=str(pak_file), force=False)
+    return pak.cmd_pak_import(args)
+
+
+def test_import_missing_checksum_not_claimed_verified(tmp_path, monkeypatch, capsys):
+    payload = {"title": "no checksum here", "anchors": []}
+    rc = _import_payload(tmp_path, monkeypatch, payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "verified" not in out
+    assert "no declared checksum" in out
+
+
+def test_import_checksum_mismatch_rejected(tmp_path, monkeypatch, capsys):
+    payload = {"title": "tampered", "anchors": [], "checksum": "sha256:" + "0" * 64}
+    rc = _import_payload(tmp_path, monkeypatch, payload)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "checksum mismatch" in err
+
+
+def test_import_valid_checksum_reports_verified(tmp_path, monkeypatch, capsys):
+    payload = {"title": "honest", "anchors": []}
+    payload["checksum"] = _checksum_for(payload)
+    rc = _import_payload(tmp_path, monkeypatch, payload)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "checksum verified" in out

--- a/tests/test_proxy_endpoints.py
+++ b/tests/test_proxy_endpoints.py
@@ -16,6 +16,7 @@ Uses unittest.mock to simulate the HTTP request handler.
 """
 
 import json
+import os
 import time
 import unittest
 from io import BytesIO
@@ -53,7 +54,7 @@ class MockRequestHandler:
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", len(body))
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # CORS default-deny — mirrors app_endpoints._send_json (no wildcard).
         self.end_headers()
         self.wfile.write(body)
         return body
@@ -595,12 +596,12 @@ class TestResponseStructure(unittest.TestCase):
         self.assertIn("Content-Length", handler.sent_headers)
         self.assertGreater(int(handler.sent_headers["Content-Length"]), 0)
 
-    def test_responses_have_cors_header(self):
-        """Verify responses include CORS header."""
+    def test_responses_no_wildcard_cors_by_default(self):
+        """Responses must NOT carry a wildcard CORS header by default (R3-1)."""
         handler = MockRequestHandler("/stats")
         response = {"test": "data"}
         handler._send_json(response)
-        self.assertEqual(
+        self.assertNotEqual(
             handler.sent_headers.get("Access-Control-Allow-Origin"),
             "*"
         )
@@ -613,6 +614,64 @@ class TestResponseStructure(unittest.TestCase):
         # Should not raise JSON decode error
         parsed = json.loads(body.decode())
         self.assertIsInstance(parsed, dict)
+
+
+class TestCORSContentRoutes(unittest.TestCase):
+    """Security regression (R3-1): the real app_endpoints._send_json must not
+    expose proxy-owned content (vault search/block) to cross-origin browser JS.
+
+    Default-deny CORS; never wildcard; exact-origin allowlist opt-in only.
+    """
+
+    def _send(self, origin=None, env=None):
+        from tokenpak.proxy import app_endpoints
+
+        handler = MockRequestHandler("/tpk/v1/vault/block/abc")
+        if origin is not None:
+            handler.headers["Origin"] = origin
+        with patch.dict("os.environ", env or {}, clear=False):
+            if env is None or "TOKENPAK_PROXY_CORS_ORIGINS" not in env:
+                os.environ.pop("TOKENPAK_PROXY_CORS_ORIGINS", None)
+            app_endpoints._send_json(handler, 200, {"content": "secret vault row"})
+        return handler.sent_headers
+
+    def test_default_emits_no_acao(self):
+        """No allowlist configured → no Access-Control-Allow-Origin at all."""
+        headers = self._send(origin="https://example.invalid")
+        self.assertIsNone(headers.get("Access-Control-Allow-Origin"))
+
+    def test_default_never_wildcard(self):
+        """The wildcard must never appear on a content route."""
+        headers = self._send(origin="https://example.invalid")
+        self.assertNotEqual(headers.get("Access-Control-Allow-Origin"), "*")
+
+    def test_allowlisted_origin_echoed_exactly(self):
+        """Configured + matching Origin → echo that exact origin (not *), with Vary."""
+        headers = self._send(
+            origin="https://dash.local",
+            env={"TOKENPAK_PROXY_CORS_ORIGINS": "https://dash.local,https://ops.local"},
+        )
+        self.assertEqual(
+            headers.get("Access-Control-Allow-Origin"), "https://dash.local"
+        )
+        self.assertNotEqual(headers.get("Access-Control-Allow-Origin"), "*")
+        self.assertEqual(headers.get("Vary"), "Origin")
+
+    def test_non_allowlisted_origin_denied(self):
+        """Configured allowlist + foreign Origin → no ACAO emitted."""
+        headers = self._send(
+            origin="https://evil.invalid",
+            env={"TOKENPAK_PROXY_CORS_ORIGINS": "https://dash.local"},
+        )
+        self.assertIsNone(headers.get("Access-Control-Allow-Origin"))
+
+    def test_allowlist_set_but_no_origin_header(self):
+        """Configured allowlist but request has no Origin → no ACAO emitted."""
+        headers = self._send(
+            origin=None,
+            env={"TOKENPAK_PROXY_CORS_ORIGINS": "https://dash.local"},
+        )
+        self.assertIsNone(headers.get("Access-Control-Allow-Origin"))
 
 
 if __name__ == "__main__":

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/cli/commands/pak.py
+++ b/tokenpak/cli/commands/pak.py
@@ -303,6 +303,20 @@ def cmd_pak_export(args: Any) -> int:
     )
 
 
+def _within_dir(base: Path, rel: str) -> bool:
+    """True iff ``base / rel`` stays inside ``base`` after resolution.
+
+    Pak anchor paths are untrusted input. An absolute ``rel`` (``/etc/x``)
+    or one that climbs out (``../x``) must never write outside the chosen
+    export directory. Reject absolute paths pre-join, then resolve and
+    confirm containment (``is_relative_to`` is available on the 3.10 floor).
+    """
+    if Path(rel).is_absolute():
+        return False
+    base_resolved = base.resolve()
+    return (base_resolved / rel).resolve().is_relative_to(base_resolved)
+
+
 def _export_file_pak(path: str, out_dir: Path) -> int:
     """Write a file-form Pak's anchors back to ``out_dir``.
 
@@ -330,6 +344,15 @@ def _export_file_pak(path: str, out_dir: Path) -> int:
         content = anchor.get("content")
         encoding = anchor.get("encoding", "utf-8")
         if not rel or content is None:
+            skipped += 1
+            continue
+        # A1 (codex-review-1): contain writes within out_dir — reject an
+        # absolute or ``..``-traversing anchor path before it can escape.
+        if not _within_dir(out_dir, rel):
+            print(
+                f"⚠️  Skipped unsafe anchor path (escapes export dir): {rel}",
+                file=sys.stderr,
+            )
             skipped += 1
             continue
         target = out_dir / rel
@@ -381,6 +404,11 @@ def cmd_pak_create(args: Any) -> int:
     anchors: list[dict] = []
     skipped: list[dict] = []
     for path in sorted(src.rglob("*")):
+        # A2 (codex-review-1): never follow symlinks — a link to e.g.
+        # /etc/hostname would otherwise be read as a file and its target
+        # content embedded into the Pak. Skip before the is_file() probe.
+        if path.is_symlink():
+            continue
         if not path.is_file():
             continue
         if any(part.startswith(".") for part in path.relative_to(src).parts):
@@ -521,7 +549,16 @@ def cmd_pak_import(args: Any) -> int:
 
     shutil.copyfile(src, target)
     print(f"✅ Imported Pak {pak_id} → {target}")
-    print(f"   checksum verified: {actual[:24]}…")
+    # A5 (codex-review-1): only claim "verified" when there was a declared
+    # checksum to verify against (a mismatch already returned above). With no
+    # declared checksum nothing was verified — say so rather than imply trust.
+    if declared:
+        print(f"   checksum verified: {actual[:24]}…")
+    else:
+        print(
+            "   checksum computed (Pak carries no declared checksum to "
+            f"verify against): {actual[:24]}…"
+        )
     print(f"   inspect with: tokenpak pak inspect {target}")
     return 0
 

--- a/tokenpak/proxy/app_endpoints.py
+++ b/tokenpak/proxy/app_endpoints.py
@@ -15,7 +15,12 @@ Architectural contract (per Kevin's 2026-04-17 design call):
 Authentication (localhost-only by default):
     - Requests must arrive from 127.0.0.1 / ::1 unless ``TOKENPAK_PROXY_KEY``
       is set, in which case an ``X-TPK-Key`` header must match.
-    - No CORS / cross-origin story today; GTM is single-host dev use.
+    - CORS is default-deny: no ``Access-Control-Allow-Origin`` header is
+      emitted unless ``TOKENPAK_PROXY_CORS_ORIGINS`` (a comma-separated list
+      of exact origins) is configured, in which case a matching request
+      ``Origin`` is echoed back verbatim — never ``*``. This keeps browser
+      JS served from another origin (DNS-rebinding / localhost-fetch) from
+      reading proxy-owned content such as ``/tpk/v1/vault/*``.
 
 Error shape:
     {"error": "<code>", "detail": "<human message>"}
@@ -64,6 +69,28 @@ def _is_authorized(handler: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _cors_allow_origin(handler: Any) -> Optional[str]:
+    """Return the request ``Origin`` iff it is in the configured allowlist.
+
+    Default-deny: with no ``TOKENPAK_PROXY_CORS_ORIGINS`` set, returns ``None``
+    and no ``Access-Control-Allow-Origin`` header is emitted, so browsers
+    enforce same-origin and cross-origin JS cannot read proxy-owned content
+    (the ``/tpk/v1/vault/*`` routes return full indexed content). When the env
+    var holds a comma-separated list of exact origins, an exact match is
+    echoed back; anything else (no/unknown ``Origin``) yields ``None``. The
+    wildcard ``*`` is never returned for these content-bearing routes.
+    """
+    allowlist = os.environ.get("TOKENPAK_PROXY_CORS_ORIGINS", "")
+    if not allowlist.strip():
+        return None
+    headers = getattr(handler, "headers", None)
+    origin = headers.get("Origin", "").strip() if headers is not None else ""
+    if not origin:
+        return None
+    allowed = {o.strip() for o in allowlist.split(",") if o.strip()}
+    return origin if origin in allowed else None
+
+
 def _send_json(handler: Any, status: int, payload: dict[str, Any]) -> None:
     # allow_nan=False → strict JSON; NaN/Infinity raise ValueError. Callers
     # must sanitize unbounded floats before passing to this helper.
@@ -71,7 +98,12 @@ def _send_json(handler: Any, status: int, payload: dict[str, Any]) -> None:
     handler.send_response(status)
     handler.send_header("Content-Type", "application/json; charset=utf-8")
     handler.send_header("Content-Length", str(len(body)))
-    handler.send_header("Access-Control-Allow-Origin", "*")
+    # CORS default-deny — never wildcard on these content-bearing routes.
+    # Opt in to an exact-origin allowlist via TOKENPAK_PROXY_CORS_ORIGINS.
+    allow_origin = _cors_allow_origin(handler)
+    if allow_origin is not None:
+        handler.send_header("Access-Control-Allow-Origin", allow_origin)
+        handler.send_header("Vary", "Origin")
     handler.end_headers()
     handler.wfile.write(body)
 


### PR DESCRIPTION
## v1.9.3 — security patch

Surgical security re-cut off `main` (v1.9.2). Two fixes plus changelog and version bump; nothing else.

### Security
- **pak install:** path-traversal guard (archive entries are resolved and confirmed within the target directory), symlinked entries skipped during extraction, and honest checksum-verified messaging.
- **proxy CORS:** the `/tpk/v1/*` JSON routes no longer emit `Access-Control-Allow-Origin: *` — now **default-deny** with an exact-origin allowlist.

### Behavior change
A browser app fetching `/tpk/v1/*` from a different origin must now set `TOKENPAK_PROXY_CORS_ORIGINS` (comma-separated exact origins); a matching request `Origin` is echoed with `Vary: Origin`, never `*`. CLI / SDK / MCP clients are unaffected — CORS applies to browsers only.

### Scope
`pak.py` + `test_pak_safety.py`, `app_endpoints.py` + `test_proxy_endpoints.py`, `CHANGELOG.md`, and `__version__` 1.9.2 → 1.9.3. Nothing else.