### PR TITLE
Add Pro upgrade CLI command

### DIFF
--- a/.changeset/pro-upgrade-cli-api-snapshot.md
+++ b/.changeset/pro-upgrade-cli-api-snapshot.md
@@ -1,0 +1,10 @@
+---
+---
+
+Release-gate: ratchet the public-API snapshot for the new `tokenpak upgrade`
+CLI command.
+
+This records the intentional additive public surface introduced by the Pro
+upgrade command: the command module, its parser/handler helpers, its URL
+constants, and the shared upgrade URL constants consumed by `license` and
+`status` output. No public symbols are removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **cli:** `tokenpak upgrade` opens the public Pro upgrade page, supports
+  `--print-url` for non-interactive use, and honors `TOKENPAK_UPGRADE_URL`.
+
+### Changed
+
+- **license/status:** Free-tier upgrade guidance now points to
+  `https://tokenpak.ai/pro`.
+
 ## [1.9.3] — 2026-06-22
 
 Security patch: path-safety hardening for `pak` install and a default-deny CORS

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -82,6 +82,14 @@ Check proxy health
 - `--fleet` — Fleet rollup view — reads rollup_daily
 - `--since` — With --fleet: window in days, e.g. '7d' (default: 7d)
 
+### `tokenpak upgrade`
+
+Open the canonical TokenPak Pro upgrade page in your default browser. Target URL is https://tokenpak.ai/pro (override with TOKENPAK_UPGRADE_URL).
+
+**Flags:**
+
+- `--print-url` — Print the upgrade URL to stdout instead of opening a browser
+
 ### `tokenpak logs`
 
 Show recent logs

--- a/tests/cli/test_upgrade_cmd.py
+++ b/tests/cli/test_upgrade_cmd.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``tokenpak upgrade`` command."""
+
+from __future__ import annotations
+
+import argparse
+
+from tokenpak import licensing as _lic
+from tokenpak._cli_core import _COMMAND_GROUPS, _core_command_names, build_parser
+from tokenpak.cli.commands import help as help_cmd
+from tokenpak.cli.commands import license_cmd, status, upgrade
+
+
+def test_upgrade_prints_default_url(monkeypatch, capsys):
+    monkeypatch.delenv(upgrade.UPGRADE_URL_ENV, raising=False)
+
+    rc = upgrade.cmd_upgrade(argparse.Namespace(print_url=True))
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "https://tokenpak.ai/pro"
+
+
+def test_upgrade_honors_env_override(monkeypatch, capsys):
+    monkeypatch.setenv(upgrade.UPGRADE_URL_ENV, "https://example.test/upgrade")
+
+    rc = upgrade.cmd_upgrade(argparse.Namespace(print_url=True))
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "https://example.test/upgrade"
+
+
+def test_upgrade_opens_browser(monkeypatch, capsys):
+    monkeypatch.delenv(upgrade.UPGRADE_URL_ENV, raising=False)
+    opened = {}
+
+    def fake_open(url: str, new: int = 0) -> bool:
+        opened["url"] = url
+        opened["new"] = new
+        return True
+
+    monkeypatch.setattr(upgrade.webbrowser, "open", fake_open)
+
+    rc = upgrade.cmd_upgrade(argparse.Namespace(print_url=False))
+
+    assert rc == 0
+    assert opened == {"url": "https://tokenpak.ai/pro", "new": 2}
+    assert "Opening https://tokenpak.ai/pro" in capsys.readouterr().out
+
+
+def test_upgrade_prints_manual_url_when_browser_does_not_open(monkeypatch, capsys):
+    monkeypatch.delenv(upgrade.UPGRADE_URL_ENV, raising=False)
+    monkeypatch.setattr(upgrade.webbrowser, "open", lambda url, new=0: False)
+
+    rc = upgrade.cmd_upgrade(argparse.Namespace(print_url=False))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "visit the URL manually" in out
+    assert "https://tokenpak.ai/pro" in out
+
+
+def test_upgrade_registered_in_help_group():
+    getting_started = dict(_COMMAND_GROUPS["Getting Started"])
+
+    assert getting_started["upgrade"] == "Open the TokenPak Pro upgrade page"
+    assert "upgrade" in _core_command_names()
+
+
+def test_upgrade_registered_in_help_registry():
+    commands = {cmd["command"]: cmd for cmd in help_cmd._load_registry()}
+
+    assert commands["upgrade"]["usage"] == "/tokenpak upgrade [--print-url]"
+    assert commands["upgrade"]["category"] == "Control"
+    assert help_cmd._ESSENTIAL_COMMANDS["upgrade"] == (
+        "Open the TokenPak Pro upgrade page"
+    )
+
+
+def test_upgrade_subparser_dispatches_to_cmd_upgrade():
+    parser = build_parser()
+
+    ns = parser.parse_args(["upgrade", "--print-url"])
+
+    assert ns.func is upgrade.cmd_upgrade
+    assert ns.print_url is True
+
+
+def test_free_tier_license_output_uses_pro_upgrade_url():
+    rendered = license_cmd._render_summary(
+        {
+            "tier": _lic.TIER_FREE,
+            "tier_label": "Free",
+            "status": "active",
+            "email": "",
+            "activated_at": "",
+            "expires_at": "",
+            "has_key": False,
+            "license_path": "/tmp/tokenpak/license.json",
+            "enabled_gated_count": 0,
+            "gated_feature_count": 1,
+        }
+    )
+
+    assert "Upgrade path: https://tokenpak.ai/pro" in rendered
+    assert "pricing" not in rendered
+    assert "coming soon" not in rendered
+
+
+def test_status_upgrade_hint_only_for_free_tier(monkeypatch):
+    monkeypatch.setattr(
+        status._lic,
+        "summary_for_cli",
+        lambda: {"tier": _lic.TIER_FREE},
+    )
+    assert status._free_tier_upgrade_hint() == (
+        "  Upgrade to Pro: https://tokenpak.ai/pro  (or run `tokenpak upgrade`)"
+    )
+
+    monkeypatch.setattr(
+        status._lic,
+        "summary_for_cli",
+        lambda: {"tier": _lic.TIER_PRO},
+    )
+    assert status._free_tier_upgrade_hint() is None
+
+
+def test_status_unreachable_path_still_shows_upgrade_hint(monkeypatch, capsys):
+    monkeypatch.setattr(status, "_fetch", lambda url: None)
+    monkeypatch.setattr(status, "_get_version", lambda: "0.test")
+    monkeypatch.setattr(
+        status,
+        "_calculate_fleet_savings",
+        lambda **kwargs: {"error": "db_not_found"},
+    )
+    monkeypatch.setattr(
+        status._lic,
+        "summary_for_cli",
+        lambda: {"tier": _lic.TIER_FREE},
+    )
+
+    status.run(no_meme=True)
+
+    out = capsys.readouterr().out
+    assert "Proxy unreachable and no monitor database found" in out
+    assert "Upgrade to Pro: https://tokenpak.ai/pro" in out

--- a/tests/test_entity_extraction_pipeline.py
+++ b/tests/test_entity_extraction_pipeline.py
@@ -1,4 +1,4 @@
-
+# ruff: noqa: I001
 import pytest
 
 # tokenpak.extraction is a namespace package in the slim OSS install — the
@@ -8,7 +8,6 @@ import pytest
 # so the release test gate stays green.
 try:
     from tokenpak.extraction import EntityExtractor, EntityType
-
     from tokenpak.vault.blocks import BlockStore
     from tokenpak.vault.indexer import VaultIndexer
 except ImportError as _exc:

--- a/tests/test_tiered_help.py
+++ b/tests/test_tiered_help.py
@@ -43,12 +43,12 @@ class TestEssentialHelp:
         assert "--all" in text
 
     def test_essential_commands_count(self):
-        """Essential commands list should have exactly 8 commands."""
-        assert len(_ESSENTIAL_COMMANDS) == 8, "Expected exactly 8 essential commands"
+        """Essential commands list should have exactly 9 commands."""
+        assert len(_ESSENTIAL_COMMANDS) == 9, "Expected exactly 9 essential commands"
 
     def test_essential_commands_are(self):
-        """Verify the correct 8 essential commands are defined."""
-        expected = {"setup", "start", "stop", "status", "cost", "savings", "doctor", "dashboard"}
+        """Verify the correct 9 essential commands are defined."""
+        expected = {"setup", "start", "stop", "status", "cost", "savings", "doctor", "dashboard", "upgrade"}
         actual = set(_ESSENTIAL_COMMANDS.keys())
         assert actual == expected, f"Essential commands mismatch. Expected {expected}, got {actual}"
 

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -253,6 +253,7 @@ _COMMAND_GROUPS = {
         ("demo", "See compression in action"),
         ("cost", "View API spend"),
         ("status", "Check proxy health"),
+        ("upgrade", "Open the TokenPak Pro upgrade page"),
         ("logs", "Show recent logs"),
     ],
     "Indexing": [
@@ -3146,6 +3147,7 @@ def build_parser():
     _build_agent_parser(sub)
     _build_replay_parser(sub)
     _build_status_parser(sub)
+    _build_upgrade_parser(sub)
     _build_usage_parser(sub)
     _build_savings_parser(sub)
     _build_recommendations_parser(sub)
@@ -3818,6 +3820,13 @@ def _build_savings_parser(sub):
 def _build_recommendations_parser(sub):
     """Build `tokenpak recommendations` parser via the modular CLI command."""
     from tokenpak.cli.commands.recommendations import build_parser
+
+    build_parser(sub)
+
+
+def _build_upgrade_parser(sub):
+    """Build `tokenpak upgrade` parser via the modular CLI command."""
+    from tokenpak.cli.commands.upgrade import build_parser
 
     build_parser(sub)
 

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -589,6 +589,10 @@
     },
     {
       "module": "tokenpak.cli.commands",
+      "name": "upgrade"
+    },
+    {
+      "module": "tokenpak.cli.commands",
       "name": "validate_config"
     },
     {
@@ -1014,6 +1018,10 @@
     {
       "module": "tokenpak.cli.commands.last",
       "name": "run"
+    },
+    {
+      "module": "tokenpak.cli.commands.license_cmd",
+      "name": "DEFAULT_UPGRADE_URL"
     },
     {
       "module": "tokenpak.cli.commands.license_cmd",
@@ -1465,6 +1473,10 @@
     },
     {
       "module": "tokenpak.cli.commands.status",
+      "name": "DEFAULT_UPGRADE_URL"
+    },
+    {
+      "module": "tokenpak.cli.commands.status",
       "name": "HAS_CLICK"
     },
     {
@@ -1534,6 +1546,26 @@
     {
       "module": "tokenpak.cli.commands.uninstall",
       "name": "run_uninstall"
+    },
+    {
+      "module": "tokenpak.cli.commands.upgrade",
+      "name": "DEFAULT_UPGRADE_URL"
+    },
+    {
+      "module": "tokenpak.cli.commands.upgrade",
+      "name": "UPGRADE_URL_ENV"
+    },
+    {
+      "module": "tokenpak.cli.commands.upgrade",
+      "name": "build_parser"
+    },
+    {
+      "module": "tokenpak.cli.commands.upgrade",
+      "name": "cmd_upgrade"
+    },
+    {
+      "module": "tokenpak.cli.commands.upgrade",
+      "name": "resolve_upgrade_url"
     },
     {
       "module": "tokenpak.cli.commands.validate_config",

--- a/tokenpak/cli/commands/__init__.py
+++ b/tokenpak/cli/commands/__init__.py
@@ -5,4 +5,4 @@ Each module provides a Click group or argparse handler for a top-level
 CLI command. Stubs are provided for all planned commands.
 """
 
-__all__ = ['status', 'cost', 'compression', 'vault', 'route', 'config', 'maintenance', 'last', 'workflow', 'replay', 'exec', 'savings', 'budget', 'dashboard', 'debug', 'diff', 'doctor', 'doctor_claude_code', 'fingerprint', 'handoff', 'help', 'index', 'install', 'metrics', 'optimize', 'preview', 'prune', 'retain', 'serve', 'setup', 'template', 'trigger', 'validate_config']
+__all__ = ['status', 'cost', 'compression', 'vault', 'route', 'config', 'maintenance', 'last', 'workflow', 'replay', 'exec', 'savings', 'budget', 'dashboard', 'debug', 'diff', 'doctor', 'doctor_claude_code', 'fingerprint', 'handoff', 'help', 'index', 'install', 'metrics', 'optimize', 'preview', 'prune', 'retain', 'serve', 'setup', 'template', 'trigger', 'upgrade', 'validate_config']

--- a/tokenpak/cli/commands/help.py
+++ b/tokenpak/cli/commands/help.py
@@ -25,6 +25,7 @@ _ESSENTIAL_COMMANDS = {
     "start": "Start the proxy",
     "stop": "Stop the proxy",
     "status": "Health, stats, and savings summary",
+    "upgrade": "Open the TokenPak Pro upgrade page",
     "cost": "API spend and token usage",
     "savings": "What TokenPak saved you",
     "doctor": "Run diagnostics and health checks",

--- a/tokenpak/cli/commands/license_cmd.py
+++ b/tokenpak/cli/commands/license_cmd.py
@@ -10,6 +10,7 @@ import json
 from typing import Any
 
 from tokenpak import licensing as _lic
+from tokenpak.cli.commands.upgrade import DEFAULT_UPGRADE_URL
 
 
 def _render_summary(s: dict[str, Any]) -> str:
@@ -36,7 +37,7 @@ def _render_summary(s: dict[str, Any]) -> str:
     lines.append("")
     if s["tier"] == _lic.TIER_FREE:
         lines.append("  You are on the Free tier. All Free-tier features are available.")
-        lines.append("  Upgrade path: https://tokenpak.ai/pricing   (coming soon)")
+        lines.append(f"  Upgrade path: {DEFAULT_UPGRADE_URL}")
         lines.append("")
     elif s["status"] == "pending_validation":
         lines.append(

--- a/tokenpak/cli/commands/status.py
+++ b/tokenpak/cli/commands/status.py
@@ -37,6 +37,13 @@ except ImportError:
     def get_rates(model: Optional[str] = None) -> dict:
         return {"input": 3.0, "cached": 0.30, "output": 15.0}
 
+try:
+    from tokenpak import licensing as _lic
+    from tokenpak.cli.commands.upgrade import DEFAULT_UPGRADE_URL
+except ImportError:
+    _lic = None
+    DEFAULT_UPGRADE_URL = "https://tokenpak.ai/pro"
+
 
 # ---------------------------------------------------------------------------
 # Meme lines — 28 curated by Kevin, random pick per invocation
@@ -78,6 +85,28 @@ MEME_LINES = [
 # ---------------------------------------------------------------------------
 
 SEP = "────────────────────────────────────────"
+
+
+def _free_tier_upgrade_hint() -> Optional[str]:
+    """Return an upgrade hint for Free-tier installs, fail-open on license errors."""
+    if _lic is None:
+        return None
+    try:
+        summary = _lic.summary_for_cli()
+    except Exception:
+        return None
+    if summary.get("tier") != getattr(_lic, "TIER_FREE", "free"):
+        return None
+    return f"  Upgrade to Pro: {DEFAULT_UPGRADE_URL}  (or run `tokenpak upgrade`)"
+
+
+def _print_free_tier_upgrade_hint() -> None:
+    hint = _free_tier_upgrade_hint()
+    if hint:
+        print()
+        print(hint)
+
+
 SEP_INNER = "─────────────────────────────────"
 PROXY_DEFAULT = "http://127.0.0.1:8766"
 DB_DEFAULT = os.environ.get(
@@ -546,6 +575,7 @@ def run(
                 print("  Start the proxy with `tokenpak serve`.\n")
             else:
                 print(f"\n  {savings_all['error']}\n")
+            _print_free_tier_upgrade_hint()
             return
         t = savings_all["totals"]
         total_reqs = t["requests"]
@@ -777,6 +807,8 @@ def run(
         print(f"  ⚠️  {errors} error(s) — run `tokenpak doctor`")
     else:
         print("  ✅ Healthy")
+
+    _print_free_tier_upgrade_hint()
 
     # === MEME LINE ===
     if not no_meme:

--- a/tokenpak/cli/commands/upgrade.py
+++ b/tokenpak/cli/commands/upgrade.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI handler for ``tokenpak upgrade``."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import webbrowser
+
+DEFAULT_UPGRADE_URL = "https://tokenpak.ai/pro"
+UPGRADE_URL_ENV = "TOKENPAK_UPGRADE_URL"
+
+
+def resolve_upgrade_url() -> str:
+    """Return the configured upgrade URL, defaulting to the public Pro page."""
+    return os.environ.get(UPGRADE_URL_ENV, DEFAULT_UPGRADE_URL)
+
+
+def cmd_upgrade(args: argparse.Namespace) -> int:
+    """Open the TokenPak Pro upgrade page in the user's default browser."""
+    url = resolve_upgrade_url()
+
+    if getattr(args, "print_url", False):
+        print(url)
+        return 0
+
+    print(f"Opening {url} in your default browser ...")
+    try:
+        opened = webbrowser.open(url, new=2)
+    except Exception as exc:
+        opened = False
+        print(f"  Could not launch a browser: {exc}", file=sys.stderr)
+
+    if not opened:
+        print()
+        print("  If the browser did not open, visit the URL manually:")
+        print(f"    {url}")
+
+    return 0
+
+
+def build_parser(sub: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Register ``tokenpak upgrade`` on a subparsers action."""
+    p = sub.add_parser(
+        "upgrade",
+        help="Open the TokenPak Pro upgrade page in your browser",
+        description=(
+            "Open the canonical TokenPak Pro upgrade page in your default "
+            f"browser. Target URL is {DEFAULT_UPGRADE_URL} "
+            f"(override with {UPGRADE_URL_ENV})."
+        ),
+    )
+    p.add_argument(
+        "--print-url",
+        action="store_true",
+        dest="print_url",
+        help="Print the upgrade URL to stdout instead of opening a browser",
+    )
+    p.set_defaults(func=cmd_upgrade)
+    return p
+
+
+__all__ = [
+    "DEFAULT_UPGRADE_URL",
+    "UPGRADE_URL_ENV",
+    "build_parser",
+    "cmd_upgrade",
+    "resolve_upgrade_url",
+]

--- a/tokenpak/core/registry/commands.json
+++ b/tokenpak/core/registry/commands.json
@@ -42,6 +42,16 @@
       "related": ["start", "logs", "doctor"]
     },
     {
+      "command": "upgrade",
+      "tier": "oss",
+      "category": "Control",
+      "description": "Open the TokenPak Pro upgrade page",
+      "aliases": [],
+      "usage": "/tokenpak upgrade [--print-url]",
+      "detail": "Opens the public Pro upgrade page in your default browser. Use --print-url for non-interactive scripts.",
+      "related": ["license", "plan", "activate"]
+    },
+    {
       "command": "logs",
       "tier": "oss",
       "category": "Control",


### PR DESCRIPTION
## Summary
- add a top-level `tokenpak upgrade` command with `--print-url` and `TOKENPAK_UPGRADE_URL` support
- point Free-tier license/status upgrade guidance at `https://tokenpak.ai/pro`
- update CLI help registry, generated CLI reference, changelog, tests, and public API snapshot

## Promotion evidence
- staging PR: tokenpak/tokenpak-staging#226
- staging merged: 2026-06-23T14:18:59Z, merge commit `51395087531273928e372c7c9b0b898f4402c094`
- public replay commit: `100ddb2329236705e3dfcc6c8bd8590c6054648a`
- public commit identity: `TokenPak <hello@tokenpak.ai>` author and committer

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_entity_extraction_pipeline.py tests/test_tiered_help.py tests/cli/test_upgrade_cmd.py tests/license/test_licensing_activation.py tests/cli/test_activate_daemon_wiring.py -q`
- `/home/sue/.local/bin/ruff check tokenpak/ tests/ --select=E,F,W,I --ignore=E501,E701,E702,E402,E741,F841 --no-cache`
- `env PATH=/tmp:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash scripts/check-cli-docs.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m tokenpak upgrade --print-url`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m tokenpak help upgrade`
- `git diff --check github/main..HEAD`