### PR TITLE
ci: gate release builds on chaos tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,44 @@ jobs:
         if: matrix.shape == 'dev' && matrix.python-version == '3.12'
         run: python -m tokenpak.cli --help
 
+  chaos-tests:
+    name: Chaos tests release gate
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run make test-chaos
+        run: |
+          mkdir -p "release-readiness/${{ github.ref_name }}/test-chaos"
+          set +e
+          make PYTEST="python3 -m pytest" test-chaos 2>&1 | tee "release-readiness/${{ github.ref_name }}/test-chaos/test-chaos.log"
+          CHAOS_RC=${PIPESTATUS[0]}
+          set -e
+          exit "$CHAOS_RC"
+        env:
+          TOKENPAK_TEST_MODE: "1"
+
+      - name: Upload chaos release-readiness artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-readiness-${{ github.ref_name }}-test-chaos
+          path: |
+            release-readiness/${{ github.ref_name }}/test-chaos/
+            tests/chaos/output/*.json
+          if-no-files-found: ignore
+
   release-gate-snapshots:
     # Std 30 §7 + §13.3 (R7 + R11): snapshot checks before any build/release.
     name: Release-gate snapshot validation
@@ -239,7 +277,7 @@ jobs:
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
-    needs: [test, release-gate-snapshots, leak-scan]
+    needs: [test, chaos-tests, release-gate-snapshots, leak-scan]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ test-cov:  ## Run tests with coverage report
 		--cov-report=html:htmlcov
 	@echo "Coverage report: htmlcov/index.html"
 
+test-chaos:  ## Run chaos & resilience tests (fault injection / failure-recovery)
+	$(PYTEST) tests/chaos/ -m chaos -q --tb=short
+
 benchmark-headline:  ## Run headline 30-50% claim benchmark (standard 21 §9.8 blocking)
 	$(PYTEST) tests/benchmarks/test_headline_claim.py -v -s
 

--- a/tokenpak/_snapshots/workflow-steps.json
+++ b/tokenpak/_snapshots/workflow-steps.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-07T21:07:28Z",
+  "generated_at": "2026-06-23T17:06:14Z",
   "guarded_globs": [
     "release*.yml",
     "release-rehearsal.yml"
@@ -371,6 +371,36 @@
       "job": "build",
       "id": "",
       "name": "Verify package"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "chaos-tests",
+      "id": "",
+      "name": ""
+    },
+    {
+      "workflow": "release.yml",
+      "job": "chaos-tests",
+      "id": "",
+      "name": "Install dev dependencies"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "chaos-tests",
+      "id": "",
+      "name": "Run make test-chaos"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "chaos-tests",
+      "id": "",
+      "name": "Set up Python 3.12"
+    },
+    {
+      "workflow": "release.yml",
+      "job": "chaos-tests",
+      "id": "",
+      "name": "Upload chaos release-readiness artifact"
     },
     {
       "workflow": "release.yml",


### PR DESCRIPTION
## Summary
- gate release builds on the chaos test target before build/publish
- upload release-readiness chaos logs and JSON artifacts
- add the missing public Makefile test-chaos target used by the release job

## Verification
- python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text()); print('release.yml yaml ok')"
- make workflow-steps-check
- git diff --check github/main..HEAD
- make PYTEST="python3 -m pytest" test-chaos -> 23 passed, 1 warning

Staging PR: https://github.com/tokenpak/tokenpak-staging/pull/267
Staging merge: ca93c6ee6e863ec470e71c780b30e251e8ebdbe5