### PR TITLE
cli: surface setup in quick help

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,6 +7,10 @@ _To update: edit `tokenpak/cli.py` then run `python scripts/generate-cli-docs.py
 
 ## Group: Getting Started
 
+### `tokenpak setup`
+
+Guided first-run setup
+
 ### `tokenpak start`
 
 Start the TokenPak proxy server, which routes LLM API requests through
@@ -1245,10 +1249,6 @@ Show compression savings summary.
 **Flags:**
 
 - `--days` — Rolling window in days (default: 30)
-
-### `tokenpak setup`
-
-Interactive wizard for first-time TokenPak configuration.
 
 ### `tokenpak telemetry`
 

--- a/tests/test_tiered_help.py
+++ b/tests/test_tiered_help.py
@@ -15,6 +15,23 @@ from tokenpak.cli.commands.help import (
 )
 
 
+class TestQuickHelp:
+    """Test top-level beginner help output."""
+
+    def test_top_level_help_shows_setup(self):
+        """tokenpak --help should surface setup in the beginner quick start."""
+        result = subprocess.run(
+            ["python3", "-m", "tokenpak.cli", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+
+        assert result.returncode == 0
+        assert "Quick Start:" in result.stdout
+        assert "  setup        Guided first-run setup" in result.stdout
+
+
 class TestEssentialHelp:
     """Test default help output shows only essential commands."""
 

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -242,11 +242,12 @@ def _proxy_get(path: str, port: Optional[int] = None) -> "dict | None":
 _FIRST_RUN_FLAG = Path.home() / ".tokenpak" / ".seen_intro"
 
 # Commands shown in quick --help (beginner view)
-_QUICK_COMMANDS = ["start", "demo", "cost", "status"]
+_QUICK_COMMANDS = ["setup", "start", "demo", "cost", "status"]
 
 # All commands grouped for `tokenpak help`
 _COMMAND_GROUPS = {
     "Getting Started": [
+        ("setup", "Guided first-run setup"),
         ("start", "Start the proxy"),
         ("stop", "Stop the proxy"),
         ("restart", "Restart the proxy"),
@@ -471,6 +472,7 @@ def _print_quick_help():
         "TokenPak — LLM Proxy with Prompt Packing\n"
         "\n"
         "Quick Start:\n"
+        "  setup        Guided first-run setup\n"
         "  start        Start the proxy (localhost:8766)\n"
         "  stop         Stop the running proxy\n"
         "  restart      Restart the proxy\n"


### PR DESCRIPTION
## Summary
- show Configuration already exists at /home/sue/.tokenpak/config.yaml
Non-interactive mode: skipping reconfigure. in beginner Usage: tokenpak <command> [options]

TokenPak — LLM Proxy with Prompt Packing

Quick Start:
  start        Start the proxy (localhost:8766)
  stop         Stop the running proxy
  restart      Restart the proxy
  logs         Show recent proxy logs
  serve        Serve the proxy (alias for start)
  demo         See Prompt Packing in action
  cost         View your API spend
  savings      View Savings Ledger
  status       Check proxy health

Tools:
  index        Index a directory for compression
  template     Manage prompt templates
  config       Config management (sync, validate, migrate)
  dashboard    Real-time health dashboard
  doctor       Run diagnostics & auto-fix issues
  fingerprint  Fingerprint sync and cache management
  preview      Preview compression dry-run (see token savings)
  compress     Compress text/JSON/code directly
  optimize     Optimize prompts for better Prompt Packing efficiency
  last         Show details of last compressed request
  vault        Vault index health diagnostic and repair
  diff         Show context changes (Pro)
  prune        Prune old audit log entries
  version      Show current version

Run `tokenpak help` for all commands.
Run `tokenpak <command> --help` for command details. Quick Start output
- add setup to the quick/fallback Getting Started command lists
- regenerate CLI reference docs
- add top-level quick-help regression coverage

## Verification
- python3 -m pytest tests/test_tiered_help.py -q -> 28 passed, 1 warning
- python3 -m ruff check tokenpak/_cli_core.py tests/test_tiered_help.py
- python3 scripts/generate-cli-docs.py --stdout diff check
- python3 -m tokenpak.cli --help
- git diff --check

Staging PR: https://github.com/tokenpak/tokenpak-staging/pull/268
Staging merge: 9f4bfd85aae6d0dfc8225b33dce40890904eec9d
WPR gap: P0-2 setup hidden from first-time-user help.