### PR TITLE
docs: qualify route-specific savings claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ tokenpak demo
 └──────────────────────────────────────────────────────┘
 ```
 
-> Illustrative fixture — token counts vary by workload. Measure your own with `tokenpak savings`; receipt-backed ranges publish once the benchmark lane lands.
+> Illustrative fixture — token counts vary by route and workload. Measure your
+> own with `tokenpak savings`; inspect provider-cache vs. TokenPak attribution
+> with `tokenpak status --tip-cache`.
 
 ---
 
@@ -74,7 +76,13 @@ shared secret to require `Authorization: Bearer <token>` on remote requests
 
 ## What's included (Free)
 
-- **Context compression** — deterministic token reduction on real agent workloads, <50ms latency. Measure your own savings with `tokenpak savings` (reproduce the headline benchmark with `make benchmark-headline`)
+- **Context compression** — deterministic token reduction on real agent
+  workloads, <50ms latency. Savings are route-specific: direct API, CLI, and
+  uncached repeated-agent loops are the best fit, while Claude Code/TUI routes
+  may show lower incremental savings when the provider cache already handled
+  repeated context. Measure your own savings with `tokenpak savings`; inspect
+  attribution with `tokenpak status --tip-cache` (reproduce the headline
+  benchmark with `make benchmark-headline`).
 - **Client integration** — one command wires Claude Code, Cursor, Aider, and 6 other clients
 - **Model routing** — send requests to the right model automatically, with fallback rules
 - **Cost tracking** — per model, per session, per agent; local SQLite, zero cloud

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -16,7 +16,7 @@ Competitors compared: [Helicone](https://helicone.ai), [LangSmith](https://smith
 |---|---|---|---|---|---|---|---|
 | **Local-first** (proxy on your machine) | ✅ Yes | ✅ Yes (Docker) | ❌ No (enterprise BYOC only) | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No (cloud-only) |
 | **Open source** | ✅ Apache-2.0 | ✅ MIT core | ❌ No | ✅ MIT | ✅ Gateway OSS | ✅ MIT | ❌ No |
-| **Compression / token reduction** | ✅ Yes — deterministic, client-side | ✅ Yes (claimed up to 5×) | ❌ No | ❌ No | ❌ No (caching pass-through only) | ❌ No | ❌ No |
+| **Compression / token reduction** | ✅ Yes — deterministic, route-specific, client-side | ✅ Yes (claimed up to 5×) | ❌ No | ❌ No | ❌ No (caching pass-through only) | ❌ No | ❌ No |
 | **Multi-provider routing** | ✅ Yes (smart routing) | ✅ Yes (100+ providers) | ❌ No (observability only) | ✅ Yes (100+ providers) | ✅ Yes (200+ providers) | ❌ No | ✅ Yes (290+ models) |
 | **Cost tracking** | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | **Budget enforcement** (hard 429 on overage) | ✅ Yes | ✅ Yes | ❌ No | ✅ Yes | ✅ Yes | ❌ No | ✅ Yes |
@@ -43,6 +43,13 @@ This matters for three reasons:
 ### 2. Deterministic compression with reproducible benchmarks
 
 TokenPak's compression is deterministic: the same input produces the same compressed output every time. This means you can benchmark it in CI and trust the numbers. The [headline benchmark](BENCHMARKS.md) ships in the CI pipeline and runs on every commit — no black-box "up to 5×" marketing claims.
+
+Savings are route-specific. Direct API, CLI, and uncached repeated-agent loops
+are the best fit for context compression. Claude Code/TUI routes can show lower
+incremental savings when the provider cache already handled repeated context.
+`tokenpak status` and `tokenpak status --tip-cache` split provider/client cache
+from TokenPak compression and TokenPak managed-cache savings, so observed
+platform-cache hits are not credited to TokenPak.
 
 The compaction algorithm operates on the raw token stream before the request leaves your machine. It does not depend on semantic similarity lookups, embeddings, or an external service. It works offline.
 


### PR DESCRIPTION
## Summary
- qualify README savings copy as route-specific and remove stale benchmark-lane wording
- add comparison-page provider-cache caveat for Claude Code/TUI routes
- point users at tokenpak status --tip-cache for provider/client cache vs TokenPak-created savings attribution

## Staging
- tokenpak-staging PR #269 merged as 6321234bd325f338abaab67d25c47593064126e8

## Verification
- python3 -m pytest tests/test_status_tip_cache.py -q
- python3 -m tokenpak.cli status --tip-cache --no-meme
- git diff --check