### PR TITLE
cli: add recipe list command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -182,6 +182,8 @@ Manage compression recipes
 
 **Subcommands:**
 
+- `list`
+  - `--category` — Filter by category (general, python, javascript, markdown, config, common_patterns)
 - `create`
   - `NAME` — Recipe name (e.g. my-legal-cleanup)
   - `--output-dir` — Directory to write the recipe file (default: current dir) (default: .)

--- a/tests/test_recipe_cli.py
+++ b/tests/test_recipe_cli.py
@@ -1,0 +1,37 @@
+"""CLI regression tests for OSS recipe discovery."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_tokenpak(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tokenpak.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+
+
+def test_recipe_list_lists_baked_in_catalog() -> None:
+    result = _run_tokenpak("recipe", "list")
+
+    assert result.returncode == 0, result.stderr
+    assert "Baked-in Compression Recipes" in result.stdout
+    assert "Total recipes: 50" in result.stdout
+    assert "py-docstring-to-signature" in result.stdout
+
+
+def test_recipe_list_filters_by_category() -> None:
+    result = _run_tokenpak("recipe", "list", "--category", "python")
+
+    assert result.returncode == 0, result.stderr
+    assert "python (10)" in result.stdout
+    assert "py-docstring-to-signature" in result.stdout
+    assert "markdown (5)" not in result.stdout

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -7058,6 +7058,15 @@ def _build_demo_parser(sub):
     )
     rsub2 = p_recipe.add_subparsers(dest="recipe_cmd", required=False)
 
+    # recipe list
+    p_rlist = rsub2.add_parser("list", help="List baked-in OSS compression recipes")
+    p_rlist.add_argument(
+        "--category",
+        default=None,
+        help="Filter by category (general, python, javascript, markdown, config, common_patterns)",
+    )
+    p_rlist.set_defaults(func=cmd_recipe_list)
+
     # recipe create
     p_rcreate = rsub2.add_parser("create", help="Scaffold a new custom recipe YAML file")
     p_rcreate.add_argument("name", help="Recipe name (e.g. my-legal-cleanup)")
@@ -7126,7 +7135,7 @@ def _build_demo_parser(sub):
     p_rbench.set_defaults(func=cmd_recipe_benchmark)
     p_recipe.set_defaults(func=_bare_help(
         "recipe", "Custom recipe development tooling",
-        ["create", "validate", "test", "benchmark"],
+        ["list", "create", "validate", "test", "benchmark"],
     ))
 
     # ── Demo ───────────────────────────────────────────────────────────────────
@@ -7309,6 +7318,33 @@ def _run_compression_demo():
     print()
 
 
+def _print_oss_recipe_catalog(engine, category: str | None = None) -> None:
+    """Print the baked-in OSS recipe catalog, optionally filtered by category."""
+    summary = engine.summary()
+    print("TokenPak — Baked-in Compression Recipes")
+    print("=" * 50)
+    print(f"Total recipes: {summary['total']}")
+    print()
+
+    categories = [category] if category else engine.categories()
+
+    for cat in categories:
+        recipes = engine.by_category(cat)
+        if not recipes:
+            print(f"  [no recipes in category '{cat}']")
+            continue
+        print(f"  ── {cat} ({len(recipes)}) ──")
+        for r in recipes:
+            hint = f"~{int(r.compression_hint*100)}%" if r.compression_hint > 0 else "   "
+            print(f"    {r.name:<45}  {hint}  {r.description[:60]}")
+        print()
+
+    print(
+        "Use `tokenpak demo --recipe <name>` for details, "
+        "or `tokenpak demo --file <path>` to see applicable recipes."
+    )
+
+
 def cmd_demo(args):
     """Show OSS compression recipes and demonstrate recipe selection."""
     from tokenpak.compression.recipes import get_oss_engine
@@ -7381,29 +7417,18 @@ def cmd_demo(args):
         return
 
     # ── List all (optionally filtered by category)
-    summary = engine.summary()
-    print("TokenPak — Baked-in Compression Recipes")
-    print("=" * 50)
-    print(f"Total recipes: {summary['total']}")
-    print()
-
-    categories = [args.category] if args.category else engine.categories()
-
-    for cat in categories:
-        recipes = engine.by_category(cat)
-        if not recipes:
-            print(f"  [no recipes in category '{cat}']")
-            continue
-        print(f"  ── {cat} ({len(recipes)}) ──")
-        for r in recipes:
-            hint = f"~{int(r.compression_hint*100)}%" if r.compression_hint > 0 else "   "
-            print(f"    {r.name:<45}  {hint}  {r.description[:60]}")
-        print()
-
-    print("Use --recipe <name> for details, --file <path> to see applicable recipes.")
+    _print_oss_recipe_catalog(engine, category=args.category)
 
 
 # ── Recipe SDK CLI commands ────────────────────────────────────────────────────
+
+
+def cmd_recipe_list(args):
+    """List baked-in OSS compression recipes."""
+    from tokenpak.compression.recipes import get_oss_engine
+
+    engine = get_oss_engine()
+    _print_oss_recipe_catalog(engine, category=args.category)
 
 
 def cmd_recipe_create(args):


### PR DESCRIPTION
## Summary
- add tokenpak recipe list with optional --category filtering
- share the baked-in OSS recipe catalog renderer with tokenpak demo --list
- update generated CLI reference and add regression tests for recipe discovery

## Staging
- tokenpak-staging PR #272 merged as 267b059026ed07f18651c38c69d5be192bc216fb

## WPR
- closes WPR P1-4 recipe list
- verifies WPR P0-1 packaging path with wheel smoke: built wheel contains 50 tokenpak/recipes_oss YAML files and installed wheel loads all 50 recipes

## Verification
- python3 -m pytest tests/test_recipe_cli.py tests/test_oss_recipes.py -q
- python3 -m ruff check tokenpak/_cli_core.py tests/test_recipe_cli.py
- python3 scripts/generate-cli-docs.py --stdout > /tmp/wpr-recipe-list-cli-reference-check.md && diff -u docs/cli-reference.md /tmp/wpr-recipe-list-cli-reference-check.md
- python3 -m tokenpak.cli recipe list --category python
- git diff --check HEAD~1..HEAD
- python3 -m build --wheel --outdir /tmp/wpr-p01-wheel-dist
- installed wheel smoke: recipe loader returns 50; installed tokenpak recipe list --category python succeeds