### PR TITLE
docs: use neutral examples in public docs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -935,7 +935,7 @@ File lock registry for multi-agent coordination.
 Parameters
 ----------
 agent_id : str
- Identifier for the agent claiming locks (default: $TOKENPAK_AGENT or 'cali').
+ Identifier for the agent claiming locks (default: $TOKENPAK_AGENT or 'agent-alpha').
 lock_dir : Path | str | None
  Directory where lock files are stored.
 timeout_s : int
@@ -5362,8 +5362,8 @@ Persists to a JSON file. A background thread marks stale agents.
 Usage::
 
  registry = AgentRegistry("~/.tokenpak/team/agents.json")
- registry.register("cali", capabilities=["compression", "tools"])
- registry.heartbeat("cali")
+ registry.register("agent-alpha", capabilities=["compression", "tools"])
+ registry.heartbeat("agent-alpha")
  agents = registry.list_agents()
  registry.start_health_checker()
 

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -61,7 +61,7 @@ List recorded sessions with optional filters.
  "id": "sess_abc123",
  "timestamp": "2026-03-05T14:23:11Z",
  "model": "claude-3-5-sonnet-20241022",
- "agent": "cali",
+ "agent": "agent-alpha",
  "tokens_in": 4231,
  "tokens_in_compressed": 2847,
  "tokens_out": 612,
@@ -109,7 +109,7 @@ Team-wide aggregated stats. Requires admin token.
  },
  "by_agent": [
  {
- "agent": "cali",
+ "agent": "agent-alpha",
  "requests": 542,
  "cost_usd": 19.40,
  "tokens_saved": 1320000
@@ -127,7 +127,7 @@ Per-agent detail. Requires admin token.
 **Response:**
 ```json
 {
- "agent": "cali",
+ "agent": "agent-alpha",
  "requests_today": 14,
  "cost_today_usd": 0.42,
  "requests_month": 542,

--- a/docs/adapters/ARCHITECTURE.md
+++ b/docs/adapters/ARCHITECTURE.md
@@ -11,7 +11,7 @@ TokenPak ships with two complementary adapter systems:
 | System | Location | Purpose |
 |--------|----------|---------|
 | **SDK Adapters** | `tokenpak/adapters/` | Route SDK/framework calls through proxy |
-| **Platform Adapters** | `tokenpak/agent/adapters/` | Detect calling platform (OpenClaw, Claude CLI, etc.) |
+| **Platform Adapters** | `tokenpak/agent/adapters/` | Detect calling platform (Claude CLI, SDK clients, etc.) |
 | **Telemetry Adapters** | `tokenpak/telemetry/adapters/` | Parse provider payloads into canonical usage types |
 
 This document describes the **SDK Adapters** layer — the unified interface for sending requests through the TokenPak proxy from any SDK or framework.
@@ -213,7 +213,7 @@ To add a new adapter (e.g. `CursorAdapter`):
 
 ### Platform Adapters (`tokenpak/agent/adapters/`)
 
-Detect **which client platform** is calling the proxy (OpenClaw, Claude CLI, Generic).
+Detect **which client platform** is calling the proxy (Claude CLI, SDK clients, Generic).
 Used internally by the proxy pipeline for routing hints. Not for external SDK use.
 
 ### Telemetry Adapters (`tokenpak/telemetry/adapters/`)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,7 +61,7 @@ List recorded sessions with optional filters.
  "id": "sess_abc123",
  "timestamp": "2026-03-05T14:23:11Z",
  "model": "claude-3-5-sonnet-20241022",
- "agent": "cali",
+ "agent": "agent-alpha",
  "tokens_in": 4231,
  "tokens_in_compressed": 2847,
  "tokens_out": 612,
@@ -109,7 +109,7 @@ Team-wide aggregated stats. Requires admin token.
  },
  "by_agent": [
  {
- "agent": "cali",
+ "agent": "agent-alpha",
  "requests": 542,
  "cost_usd": 19.40,
  "tokens_saved": 1320000
@@ -127,7 +127,7 @@ Per-agent detail. Requires admin token.
 **Response:**
 ```json
 {
- "agent": "cali",
+ "agent": "agent-alpha",
  "requests_today": 14,
  "cost_today_usd": 0.42,
  "requests_month": 542,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ Companies have:
 
 | Component | Purpose | License | Why this one |
 |---|---|---|---|
-| **QMD** | Text retrieval (BM25 + vectors + reranking) | MIT | Best local hybrid search, OpenClaw-native |
+| **QMD** | Text retrieval (BM25 + vectors + reranking) | MIT | Best local hybrid search, local-runtime native |
 | **LLMLingua-2** | Token-level compression | MIT | SOTA 2-20x compression, <5% quality loss |
 | **SelectiveContext** | Sentence-level filtering | MIT | Preserves readability |
 | **Whisper** | Audio transcription | MIT | Industry standard, local |
@@ -302,7 +302,7 @@ TokenPak CLI
     │
     └── tokenpak serve --port 8766
         │
-        ├── Full pipeline mode (OpenClaw, SDK clients)
+        ├── Full pipeline mode (managed CLI clients, SDK clients)
         │   ├── Intercepts LLM requests
         │   ├── Injects relevant context from index
         │   ├── Compacts conversation history

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -670,7 +670,7 @@ Examples:
 
 Inspect, manage, and dry-run-route credentials tokenpak can see from
 all registered providers (Codex CLI, Claude CLI, env vars,
-~/.tokenpak/credentials.toml, OpenClaw agent profiles).
+~/.tokenpak/credentials.toml, and external client profiles).
 
 Proxy fast-path integration still deferred — `creds route` is a
 dry-run (what would I pick) with no side effects.
@@ -1317,4 +1317,3 @@ Example:
 ### `tokenpak watch`
 
 ---
-

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1317,3 +1317,4 @@ Example:
 ### `tokenpak watch`
 
 ---
+

--- a/docs/guides/proxy-setup.md
+++ b/docs/guides/proxy-setup.md
@@ -110,7 +110,7 @@ response = client.chat.completions.create(
 
 ---
 
-### OpenClaw
+### Config-file clients
 
 In your config file:
 ```json

--- a/docs/guides/team-server.md
+++ b/docs/guides/team-server.md
@@ -144,7 +144,7 @@ Each team member/agent points their LLM client at the team server:
 export ANTHROPIC_BASE_URL=http://team-server:8766
 
 # Register this agent (optional, enables per-agent tracking)
-tokenpak agent register "cali" --server http://team-server:8766
+tokenpak agent register "agent-alpha" --server http://team-server:8766
 ```
 
 ---
@@ -212,7 +212,7 @@ Team telemetry is available via REST:
 curl -H "X-Admin-Token: your-token" http://team-server:8766/v1/telemetry/team
 
 # Per-agent detail
-curl -H "X-Admin-Token: your-token" http://team-server:8766/v1/telemetry/agents/cali
+curl -H "X-Admin-Token: your-token" http://team-server:8766/v1/telemetry/agents/agent-alpha
 ```
 
 See [API Reference](../api-reference.md) for full details.

--- a/docs/guides/telemetry.md
+++ b/docs/guides/telemetry.md
@@ -37,8 +37,8 @@ tokenpak cost --by-model
 
 # By agent (if agents are registered)
 tokenpak cost --by-agent
-# cali        $0.024   14 requests
-# trix        $0.018    9 requests
+# agent-alpha $0.024   14 requests
+# agent-beta  $0.018    9 requests
 ```
 
 ### Export
@@ -128,10 +128,10 @@ The dashboard and export API support rich filtering:
 
 ```bash
 # Via CLI
-tokenpak cost --since 2026-01-01 --model claude-3-5-sonnet --agent cali
+tokenpak cost --since 2026-01-01 --model claude-3-5-sonnet --agent agent-alpha
 
 # Via dashboard URL
-http://localhost:8766/dashboard?model=gpt-4o&agent=trix&since=2026-03-01
+http://localhost:8766/dashboard?model=gpt-4o&agent=agent-beta&since=2026-03-01
 ```
 
 Filter parameters:
@@ -141,7 +141,7 @@ Filter parameters:
 | `since` | `2026-01-01` | Start date |
 | `until` | `2026-03-31` | End date |
 | `model` | `gpt-4o-mini` | Filter by model |
-| `agent` | `cali` | Filter by agent name |
+| `agent` | `agent-alpha` | Filter by agent name |
 | `min_cost` | `0.01` | Minimum request cost |
 | `compressed_only` | `true` | Only show compressed requests |
 

--- a/docs/spend-guard.md
+++ b/docs/spend-guard.md
@@ -261,7 +261,7 @@ Your reply isn't matching the strict-whole-string vocab. Check `~/tokenpak/token
 Check `tokenpak status` and `sqlite3 ~/.tokenpak/spend_guard.db "SELECT COUNT(*) FROM spend_guard_audit"`. If zero rows: confirm `spend_guard.enabled=true` (`TOKENPAK_SPEND_GUARD_ENABLED=0` in env disables it), and that you restarted the proxy after upgrading. The proxy holds modules in memory — only restarts pick up code changes.
 
 **"How do I know what session_id the proxy assigned me?"**
-The proxy resolves session via the `X-Claude-Code-Session-Id` header (Claude Code), `X-TokenPak-Session` (OpenClaw cycles), or falls back to the model name. To force a specific session id: send `X-TokenPak-Session: my-explicit-id` on every request.
+The proxy resolves session via the `X-Claude-Code-Session-Id` header (Claude Code), `X-TokenPak-Session` (configured clients), or falls back to the model name. To force a specific session id: send `X-TokenPak-Session: my-explicit-id` on every request.
 
 **"My request is blocked because of session-cumulative — but my session has been quiet."**
 The session window reads from `~/.tokenpak/monitor.db`, which is the proxy's wire-side cost log (every completed request). If you ran an expensive cycle in the last hour under the same session id, that counts toward the cumulative. Either wait out the window, set a different session id, or temporarily raise `session_block_cost_usd`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1060,14 +1060,15 @@ python3 -c "from tokenpak.agent.semantic.term_card_resolver import TermCardResol
 
 ### 20.4 Case sensitivity collision in queue directories
 
-**Symptoms:** Tasks in lowercase queue dirs (`~/vault/Agents/trix/queue/`) never execute; active tasks are in uppercase dirs.
+**Symptoms:** Tasks in lowercase queue dirs (`~/project/agents/agent-a/queue/`) never execute; active tasks are in uppercase dirs.
 
 **Fix:**
 ```bash
 # Identify orphaned tasks first
-find ~/vault/Agents/{trix,cali}/queue -name "*.md" 2>/dev/null
-# Then remove orphaned lowercase dirs
-rm -rf ~/vault/Agents/trix/queue ~/vault/Agents/cali/queue
+find ~/project/agents/*/queue -name "*.md" 2>/dev/null
+# Then archive each confirmed orphaned lowercase queue directory
+mkdir -p ~/project/queue-archive
+mv ~/project/agents/agent-a/queue ~/project/queue-archive/agent-a-queue
 ```
 
 ---

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -2451,7 +2451,7 @@ def _build_creds_parser(sub):
         description=(
             "Inspect, manage, and dry-run-route credentials tokenpak can see from\n"
             "all registered providers (Codex CLI, Claude CLI, env vars,\n"
-            "~/.tokenpak/credentials.toml, OpenClaw agent profiles).\n\n"
+            "~/.tokenpak/credentials.toml, and external client profiles).\n\n"
             "Proxy fast-path integration still deferred — `creds route` is a\n"
             "dry-run (what would I pick) with no side effects.\n\n"
             "Examples:\n"


### PR DESCRIPTION
Summary
- replace environment-specific agent names in docs examples with neutral placeholders
- genericize config-client labels in adapter, architecture, proxy, and spend-guard docs
- replace an environment-specific queue-path example with placeholder archive guidance

Validation
- BASE_REF=github/main python3 .github/scripts/check-forbidden-impl-vocab.py
- git diff --check github/main...HEAD
- targeted changed-file scan for internal identity/path terms