### PR TITLE
fix: security hardening (cache, URL, hook execution)

### DIFF
--- a/tokenpak/orchestration/macros/hooks.py
+++ b/tokenpak/orchestration/macros/hooks.py
@@ -12,6 +12,7 @@ Zero-token activation: triggers fire only when events occur.
 
 import fnmatch
 import json
+import shlex
 import subprocess
 import threading
 import uuid
@@ -270,10 +271,14 @@ class TriggerRegistry:
 
             if not dry_run:
                 try:
-                    # Substitute event data in action
-                    action = trigger.action
-                    action = action.replace("$EVENT_DATA", event_data)
-                    action = action.replace("$EVENT_TYPE", event_type)
+                    # Parse first, then substitute event values as argv data.
+                    # This keeps trigger actions useful without shell-interpreting event payloads.
+                    action_argv = [
+                        arg.replace("$EVENT_DATA", event_data).replace("$EVENT_TYPE", event_type)
+                        for arg in shlex.split(trigger.action)
+                    ]
+                    if not action_argv:
+                        raise ValueError("Trigger action is empty")
 
                     # Build environment
                     run_env = dict(**dict(import_os_env()))
@@ -283,8 +288,8 @@ class TriggerRegistry:
                         run_env.update(env)
 
                     result = subprocess.run(
-                        action,
-                        shell=True,
+                        action_argv,
+                        shell=False,
                         capture_output=True,
                         text=True,
                         timeout=300,  # 5 minute timeout

--- a/tokenpak/sources/url_adapter.py
+++ b/tokenpak/sources/url_adapter.py
@@ -5,7 +5,9 @@ Respects robots.txt before fetching. No third-party deps (stdlib only).
 """
 
 import html
+import ipaddress
 import re
+import socket
 import urllib.parse
 import urllib.request
 import urllib.robotparser
@@ -25,6 +27,7 @@ _STRIP_TAGS_WITH_CONTENT = re.compile(
 _STRIP_TAGS = re.compile(r"<[^>]+>")
 # Collapse whitespace
 _COLLAPSE_WS = re.compile(r"\s{2,}")
+_METADATA_IPS = {ipaddress.ip_address("169.254.169.254")}
 
 
 def _strip_html(raw_html: str) -> str:
@@ -64,6 +67,62 @@ def _check_robots(url: str) -> bool:
         return True  # Fail-open
 
 
+def _is_blocked_address(address: str) -> bool:
+    """Return True for local/private addresses that must never be fetched."""
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return (
+        ip in _METADATA_IPS
+        or ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _validate_url_safe(url: str) -> None:
+    """Fail closed for schemes and address ranges that can SSRF local services."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise SourceFetchError(f"Unsupported URL scheme: {parsed.scheme or '<missing>'}")
+    if not parsed.hostname:
+        raise SourceFetchError("URL host is required")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise SourceFetchError("Invalid URL port") from exc
+
+    host = parsed.hostname
+    if host.lower() == "localhost" or _is_blocked_address(host):
+        raise SourceFetchError(f"Blocked local or private URL host: {host}")
+
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError:
+        return
+    for info in infos:
+        resolved = info[4][0]
+        if _is_blocked_address(resolved):
+            raise SourceFetchError(f"Blocked local or private URL host: {host}")
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Validate redirect targets before urllib follows them."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _validate_url_safe(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _urlopen_checked(req: urllib.request.Request, timeout: int):
+    opener = urllib.request.build_opener(_SafeRedirectHandler)
+    return opener.open(req, timeout=timeout)
+
+
 class URLAdapter(SourceAdapter):
     """Fetch and index web pages by URL."""
 
@@ -81,6 +140,7 @@ class URLAdapter(SourceAdapter):
             (content, Provenance)
         """
         url = source_id
+        _validate_url_safe(url)
 
         if not _check_robots(url):
             raise SourceFetchError(f"robots.txt disallows fetching: {url}")
@@ -90,7 +150,7 @@ class URLAdapter(SourceAdapter):
                 url,
                 headers={"User-Agent": "TokenPak/1.0 (context indexer)"},
             )
-            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            with _urlopen_checked(req, timeout=_HTTP_TIMEOUT) as resp:
                 raw_bytes = resp.read()
                 etag = resp.headers.get("ETag", "")
                 content_type = resp.headers.get("Content-Type", "")
@@ -133,12 +193,16 @@ class URLAdapter(SourceAdapter):
         """
         url = source_id
         try:
+            _validate_url_safe(url)
+        except SourceFetchError:
+            return False
+        try:
             req = urllib.request.Request(
                 url,
                 method="HEAD",
                 headers={"User-Agent": "TokenPak/1.0"},
             )
-            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            with _urlopen_checked(req, timeout=_HTTP_TIMEOUT) as resp:
                 etag = resp.headers.get("ETag", "").strip('"')
             if etag:
                 return etag != cached_version

--- a/tokenpak/tests/test_connector_url_adapter.py
+++ b/tokenpak/tests/test_connector_url_adapter.py
@@ -148,7 +148,7 @@ class TestURLAdapterIngest:
         html = b"<html><head><title>Test Page</title></head><body><p>Hello</p></body></html>"
         mock_resp = _make_mock_response(html, etag='"abc123"')
 
-        with patch("urllib.request.urlopen", return_value=mock_resp), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=mock_resp), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             content, prov = self._adapter().ingest("http://example.com/test")
 
@@ -161,7 +161,7 @@ class TestURLAdapterIngest:
         html = b"<html><title>X</title><body>hi</body></html>"
         mock_resp = _make_mock_response(html, etag='"etag-value"')
 
-        with patch("urllib.request.urlopen", return_value=mock_resp), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=mock_resp), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             _, prov = self._adapter().ingest("http://example.com/")
 
@@ -171,7 +171,7 @@ class TestURLAdapterIngest:
         html = b"<html><title>X</title><body>content</body></html>"
         mock_resp = _make_mock_response(html, etag="")  # No ETag
 
-        with patch("urllib.request.urlopen", return_value=mock_resp), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=mock_resp), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             _, prov = self._adapter().ingest("http://example.com/page")
 
@@ -185,7 +185,7 @@ class TestURLAdapterIngest:
                 self._adapter().ingest("http://example.com/protected")
 
     def test_ingest_raises_on_network_error(self):
-        with patch("urllib.request.urlopen", side_effect=Exception("connection refused")), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", side_effect=Exception("connection refused")), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             with pytest.raises(SourceFetchError, match="Failed to fetch"):
                 self._adapter().ingest("http://bad-host.invalid/page")
@@ -194,7 +194,7 @@ class TestURLAdapterIngest:
         plain = b"Just plain text content"
         mock_resp = _make_mock_response(plain, content_type="text/plain")
 
-        with patch("urllib.request.urlopen", return_value=mock_resp), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=mock_resp), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             content, prov = self._adapter().ingest("http://example.com/file.txt")
 
@@ -206,7 +206,7 @@ class TestURLAdapterIngest:
         html = b"<html><title>T</title><body>x</body></html>"
         mock_resp = _make_mock_response(html)
 
-        with patch("urllib.request.urlopen", return_value=mock_resp), \
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=mock_resp), \
              patch("tokenpak.sources.url_adapter._check_robots", return_value=True):
             _, prov = self._adapter().ingest("http://example.com/")
 
@@ -232,7 +232,7 @@ class TestURLAdapterHasChanged:
         head_resp.__enter__ = lambda s: s
         head_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=head_resp):
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=head_resp):
             result = self._adapter().has_changed("http://example.com/", "same-etag")
 
         assert result is False
@@ -244,13 +244,13 @@ class TestURLAdapterHasChanged:
         head_resp.__enter__ = lambda s: s
         head_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("urllib.request.urlopen", return_value=head_resp):
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", return_value=head_resp):
             result = self._adapter().has_changed("http://example.com/", "old-etag")
 
         assert result is True
 
     def test_returns_false_on_fetch_error_during_fallback(self):
         """When HEAD fails and fallback ingest also fails, assume unchanged."""
-        with patch("urllib.request.urlopen", side_effect=Exception("network error")):
+        with patch("tokenpak.sources.url_adapter._urlopen_checked", side_effect=Exception("network error")):
             result = self._adapter().has_changed("http://bad.invalid/", "any-version")
         assert result is False

--- a/tokenpak/tests/test_security_hardening.py
+++ b/tokenpak/tests/test_security_hardening.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused regressions for security hardening around local caches, URL fetches, and hooks."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from tokenpak.orchestration.macros.hooks import TriggerRegistry
+from tokenpak.sources.base_source import SourceFetchError
+from tokenpak.sources.url_adapter import URLAdapter, _SafeRedirectHandler, _validate_url_safe
+from tokenpak.vault.retrieval.vault_index import VaultIndex
+
+
+def test_vault_bm25_cache_uses_json_not_pickle(tmp_path):
+    tokenpak_dir = tmp_path / ".tokenpak"
+    blocks_dir = tokenpak_dir / "blocks"
+    blocks_dir.mkdir(parents=True)
+    index_path = tokenpak_dir / "index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "blocks": {
+                    "b1": {
+                        "source_path": "docs/a.md",
+                        "risk_class": "narrative",
+                        "must_keep": False,
+                        "raw_tokens": 3,
+                    }
+                }
+            }
+        )
+    )
+    (blocks_dir / "b1.txt").write_text("alpha beta alpha")
+
+    first = VaultIndex(str(tokenpak_dir))
+    first._load(index_path, index_path.stat().st_mtime)
+
+    cache_path = tokenpak_dir / ".bm25_cache.json"
+    assert cache_path.exists()
+    assert not (tokenpak_dir / ".bm25_cache.pkl").exists()
+
+    second = VaultIndex(str(tokenpak_dir))
+    assert second._try_load_bm25_cache(index_path, index_path.stat().st_mtime) is True
+    assert second._inverted["alpha"] == {"b1"}
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "http://127.0.0.1/admin",
+        "http://[::1]/admin",
+        "http://169.254.169.254/latest/meta-data",
+    ],
+)
+def test_url_adapter_rejects_unsafe_url_before_fetch(url, monkeypatch):
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch should not run for unsafe URL")
+
+    monkeypatch.setattr("tokenpak.sources.url_adapter._urlopen_checked", fail_fetch)
+    with pytest.raises(SourceFetchError):
+        URLAdapter().ingest(url)
+
+
+def test_url_adapter_rejects_hostname_resolving_to_private(monkeypatch):
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, ("10.0.0.5", 80))],
+    )
+    with pytest.raises(SourceFetchError, match="Blocked local or private"):
+        _validate_url_safe("https://example.com/path")
+
+
+def test_url_adapter_rejects_invalid_port():
+    with pytest.raises(SourceFetchError, match="Invalid URL port"):
+        _validate_url_safe("https://example.com:99999/path")
+
+
+def test_url_has_changed_rejects_unsafe_url_without_fetch(monkeypatch):
+    def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch should not run for unsafe URL")
+
+    monkeypatch.setattr("tokenpak.sources.url_adapter._urlopen_checked", fail_fetch)
+    assert URLAdapter().has_changed("http://127.0.0.1/admin", "cached-version") is False
+
+
+def test_url_redirect_handler_rejects_metadata_redirect():
+    handler = _SafeRedirectHandler()
+    with pytest.raises(SourceFetchError, match="Blocked local or private"):
+        handler.redirect_request(
+            None,
+            None,
+            302,
+            "Found",
+            {},
+            "http://169.254.169.254/latest/meta-data",
+        )
+
+
+def test_trigger_event_data_is_argv_not_shell(tmp_path):
+    marker = tmp_path / "shell-ran"
+    registry = TriggerRegistry(
+        triggers_path=tmp_path / "triggers.json",
+        log_path=tmp_path / "trigger-log.json",
+    )
+    registry.add(
+        event_type="file:changed",
+        pattern="*",
+        action=f"{sys.executable} -c \"import sys; print(sys.argv[1])\" $EVENT_DATA",
+    )
+
+    payload = f"changed.txt; touch {marker}"
+    entries = registry.fire("file:changed", payload)
+
+    assert len(entries) == 1
+    assert entries[0].success is True
+    assert payload in entries[0].output
+    assert not marker.exists()

--- a/tokenpak/vault/retrieval/vault_index.py
+++ b/tokenpak/vault/retrieval/vault_index.py
@@ -106,7 +106,7 @@ class VaultIndex:
 
     def _bm25_cache_path(self, index_path: Path) -> Path:
         """Return path for BM25 precomputed cache file."""
-        return index_path.parent / ".bm25_cache.pkl"
+        return index_path.parent / ".bm25_cache.json"
 
     def _try_load_bm25_cache(self, index_path: Path, mtime: float):
         """
@@ -114,13 +114,16 @@ class VaultIndex:
         Returns True and populates self if cache is valid (mtime matches).
         Returns False if cache is missing, stale, or corrupt.
         """
-        import pickle
         cache_path = self._bm25_cache_path(index_path)
         if not cache_path.exists():
             return False
         try:
-            with open(cache_path, "rb") as f:
-                cached = pickle.load(f)
+            try:
+                if cache_path.stat().st_mtime < index_path.stat().st_mtime:
+                    return False
+            except OSError:
+                return False
+            cached = json.loads(cache_path.read_text())
             if cached.get("mtime") != mtime:
                 return False  # stale — index changed
             # Restore block metadata (no content stored)
@@ -130,7 +133,7 @@ class VaultIndex:
             self._block_dl = cached["block_dl"]
             self._avg_dl = cached["avg_dl"]
             self._doc_count = cached["doc_count"]
-            self._inverted = cached["inverted"]
+            self._inverted = {term: set(block_ids) for term, block_ids in cached["inverted"].items()}
             self._last_mtime = mtime
             # Rebuild LRU cache from blocks dir (preload top-N recent)
             blocks_dir = index_path.parent / "blocks"
@@ -174,7 +177,6 @@ class VaultIndex:
 
     def _save_bm25_cache(self, index_path: Path, mtime: float):
         """Persist BM25 precomputed state to cache file for fast future loads."""
-        import pickle
         cache_path = self._bm25_cache_path(index_path)
         try:
             payload = {
@@ -185,11 +187,10 @@ class VaultIndex:
                 "block_dl": self._block_dl,
                 "avg_dl": self._avg_dl,
                 "doc_count": self._doc_count,
-                "inverted": self._inverted,
+                "inverted": {term: sorted(block_ids) for term, block_ids in self._inverted.items()},
             }
-            tmp = cache_path.with_suffix(".pkl.tmp")
-            with open(tmp, "wb") as f:
-                pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+            tmp = cache_path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(payload, separators=(",", ":")))
             tmp.replace(cache_path)
             print(f"  💾 BM25 cache saved ({cache_path.stat().st_size // 1024 // 1024}MB)")
         except Exception as e:
@@ -597,4 +598,3 @@ class VaultIndex:
         tokens_used = count_tokens(injection_text)
 
         return injection_text, tokens_used, source_refs
-


### PR DESCRIPTION
## Summary
- **Security:** harden cache handling, URL fetching (SSRF protections — reject internal/link-local/metadata addresses, validate redirects, checked urlopen), and hook execution.

## Notes
- Patch-level change for the 1.9.x line; no version bump and no public API surface change (snapshot-neutral).
- Tests added: security hardening + URL adapter.
