### PR TITLE
TEST (do not merge): red-under-mutation for required license check

### DIFF
--- a/sdk/local/__redmutation_DELETEME__/package.json
+++ b/sdk/local/__redmutation_DELETEME__/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "redmutation-test-DELETE-ME",
+  "version": "0.0.0",
+  "license": "MIT"
+}


### PR DESCRIPTION
Throwaway PR introducing a first-party MIT license declaration to prove the required `No superseded first-party license declarations` check fails and blocks merge under ruleset 18198213. Closed + branch deleted after evidence capture.