### PR TITLE
fix: CLI help/parser parity for command registry

### DIFF
--- a/tests/test_help_parser_parity.py
+++ b/tests/test_help_parser_parity.py
@@ -1,0 +1,112 @@
+"""Help<->parser parity regression test (DISPATCH-P0-4-CLI-HELP-REGISTRY-PARITY).
+
+Guards the two honesty invariants behind the CLI help catalog:
+
+1. **No phantom commands.** Every command advertised in the help registry
+   (``commands.json``) is actually invokable by the parser. A user must never
+   see a command in ``tokenpak help --all`` that returns ``Unknown command`` on
+   invoke.
+2. **No silent drift.** The number of invokable-but-unadvertised commands is
+   pinned to a reviewed snapshot. A new invokable command that is neither
+   cataloged in the registry nor a deliberate internal verb trips this test,
+   forcing a conscious decision rather than silent re-drift.
+
+Both checks derive the "invokable" set live from the argparse parser via
+:func:`tokenpak._cli_core.registered_command_names`, so the advertised count can
+never drift from what the CLI actually dispatches (``feedback_always_dynamic``).
+"""
+
+import json
+from pathlib import Path
+
+from tokenpak._cli_core import build_parser, registered_command_names
+
+REGISTRY_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "tokenpak" / "core" / "registry" / "commands.json"
+)
+
+# The nine commands brought into the help catalog by DISPATCH-P0-4: ``pak`` plus
+# its verb family, and the eight previously-invisible-but-invokable commands.
+P0_4_ADDED = {
+    "pak", "pakplan", "tip", "creds", "claude", "codex", "prove", "init", "setup",
+}
+
+# The eight phantom commands disposed by DISPATCH-P0-4 (default = REMOVE; none
+# confirmed against the Pro catalog, none with near-term OSS roadmap evidence).
+# They must never reappear as advertised commands without becoming invokable.
+P0_4_DISPOSED = {
+    "workflow", "handoff", "retain", "metrics",
+    "policy", "sla", "compression", "maintenance",
+}
+
+# Snapshot (as of DISPATCH-P0-4, 2026-06-11) of how many invokable verbs are
+# intentionally kept OUT of the public help catalog: internal / dev /
+# experimental verbs and commands pending a separate cataloging decision. These
+# are NOT phantoms -- they all dispatch. The snapshot guards against a *new*
+# invokable command silently appearing unadvertised: if you add a user-facing
+# command, catalog it in commands.json so help advertises it; if you add a
+# deliberately-internal verb, bump this number in the same change so the
+# decision is explicit and reviewed.
+EXPECTED_INTERNAL_UNADVERTISED = 34  # public OSS surface: two internal verbs present in other distributions are not registered here
+
+
+def _registry_commands():
+    data = json.loads(REGISTRY_PATH.read_text())
+    return [c["command"] for c in data.get("commands", [])]
+
+
+def test_no_phantom_commands():
+    """Every advertised command must be invokable (no ``Unknown command``)."""
+    invokable = registered_command_names(build_parser())
+    advertised = set(_registry_commands())
+    phantoms = sorted(advertised - invokable)
+    assert not phantoms, (
+        "Help registry advertises command(s) the parser will not accept "
+        f"(invoking them returns 'Unknown command'): {phantoms}"
+    )
+
+
+def test_added_commands_are_advertised_and_invokable():
+    """The P0-4 additions surface in help AND dispatch."""
+    invokable = registered_command_names(build_parser())
+    advertised = set(_registry_commands())
+    assert P0_4_ADDED <= advertised, (
+        f"missing from help registry: {sorted(P0_4_ADDED - advertised)}"
+    )
+    assert P0_4_ADDED <= invokable, (
+        f"not invokable by parser: {sorted(P0_4_ADDED - invokable)}"
+    )
+
+
+def test_disposed_phantoms_absent():
+    """The eight disposed phantoms must not reappear in the registry."""
+    advertised = set(_registry_commands())
+    leaked = sorted(advertised & P0_4_DISPOSED)
+    assert not leaked, f"disposed phantom command(s) back in registry: {leaked}"
+
+
+def test_no_silent_invisible_drift():
+    """The count of invokable-but-unadvertised verbs matches the snapshot."""
+    invokable = registered_command_names(build_parser())
+    advertised = set(_registry_commands())
+    unadvertised = invokable - advertised
+    assert len(unadvertised) == EXPECTED_INTERNAL_UNADVERTISED, (
+        "The number of invokable-but-unadvertised commands changed "
+        f"({len(unadvertised)} vs expected {EXPECTED_INTERNAL_UNADVERTISED}). "
+        "If you added a user-facing command, add it to commands.json so help "
+        "advertises it; if you added a deliberately-internal verb, bump "
+        "EXPECTED_INTERNAL_UNADVERTISED in the same change."
+    )
+
+
+def test_advertised_count_is_derived_not_hardcoded():
+    """The count help advertises is derived from the live registry, and honest.
+
+    ``help`` renders ``len(_load_registry())``; this asserts that derivation
+    matches the registry file and -- combined with ``test_no_phantom_commands``
+    -- that every counted command is genuinely invokable.
+    """
+    from tokenpak.cli.commands.help import _load_registry
+
+    assert len(_load_registry()) == len(_registry_commands())

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -350,6 +350,26 @@ def _core_command_names() -> set:
     return set(_ALL_COMMANDS) | set(_EXTRA_KNOWN_COMMANDS)
 
 
+def registered_command_names(parser=None) -> set:
+    """Enumerate every verb the built CLI parser will actually accept.
+
+    This is the authoritative *invokable* command set, read live from the
+    argparse sub-parsers rather than any hand-maintained list. The help
+    catalog (and the count it advertises) is validated against this so it can
+    never drift back into advertising commands the parser won't dispatch — see
+    ``tests/test_help_parser_parity.py``.
+    """
+    import argparse
+
+    if parser is None:
+        parser = build_parser()
+    names: set = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            names.update(action.choices.keys())
+    return names
+
+
 # ── Plugin command discovery (tokenpak.commands entry-point group) ────────────
 #
 # Installed plugins (e.g. the premium tier) register additional CLI verbs under

--- a/tokenpak/core/registry/commands.json
+++ b/tokenpak/core/registry/commands.json
@@ -282,16 +282,6 @@
       "related": ["cost", "budget", "metrics"]
     },
     {
-      "command": "metrics",
-      "tier": "pro",
-      "category": "Visibility",
-      "description": "Show detailed performance metrics",
-      "aliases": [],
-      "usage": "/tokenpak metrics [--json] [--period DAY|WEEK|MONTH]",
-      "detail": "Latency percentiles, cache hit rates, compression ratios, model usage distribution.",
-      "related": ["stats", "cost", "savings"]
-    },
-    {
       "command": "dashboard",
       "tier": "pro",
       "category": "Visibility",
@@ -320,16 +310,6 @@
       "usage": "/tokenpak diff <session_id>",
       "detail": "Side-by-side comparison of original and compressed context for a given session.",
       "related": ["replay", "compression"]
-    },
-    {
-      "command": "compression",
-      "tier": "pro",
-      "category": "Optimization",
-      "description": "Configure and inspect compression settings",
-      "aliases": [],
-      "usage": "/tokenpak compression [status|set|reset]",
-      "detail": "View active compression algorithms, configure aggressiveness, and inspect per-model settings.",
-      "related": ["recipe", "optimize", "diff"]
     },
     {
       "command": "trigger",
@@ -422,26 +402,6 @@
       "related": ["macro", "trigger", "workflow"]
     },
     {
-      "command": "workflow",
-      "tier": "team",
-      "category": "Automation",
-      "description": "Manage multi-step automation workflows",
-      "aliases": [],
-      "usage": "/tokenpak workflow [list|run|status] <name>",
-      "detail": "Define and execute DAG-based workflows across multiple models and compression steps.",
-      "related": ["macro", "trigger", "handoff"]
-    },
-    {
-      "command": "handoff",
-      "tier": "team",
-      "category": "Automation",
-      "description": "Manage agent handoff protocols",
-      "aliases": [],
-      "usage": "/tokenpak handoff [status|configure]",
-      "detail": "Configures handoff behavior when an agent transfers context to another agent or model.",
-      "related": ["workflow", "agent"]
-    },
-    {
       "command": "prune",
       "tier": "team",
       "category": "Infrastructure",
@@ -450,46 +410,6 @@
       "usage": "/tokenpak prune [--older-than DAYS] [--dry-run]",
       "detail": "Removes stale sessions, expired cache entries, and old replay data.",
       "related": ["retain", "fingerprint"]
-    },
-    {
-      "command": "retain",
-      "tier": "team",
-      "category": "Infrastructure",
-      "description": "Configure retention policies",
-      "aliases": [],
-      "usage": "/tokenpak retain [set|show] [--days N]",
-      "detail": "Set data retention policies for sessions, logs, and cache entries.",
-      "related": ["prune"]
-    },
-    {
-      "command": "policy",
-      "tier": "team",
-      "category": "Infrastructure",
-      "description": "Manage routing and access policies",
-      "aliases": [],
-      "usage": "/tokenpak policy [list|apply|remove] <name>",
-      "detail": "Define team-wide routing policies, model allowlists, and budget enforcement rules.",
-      "related": ["route", "budget", "compliance"]
-    },
-    {
-      "command": "sla",
-      "tier": "team",
-      "category": "Infrastructure",
-      "description": "Configure SLA targets and alerting",
-      "aliases": [],
-      "usage": "/tokenpak sla [set|status|test]",
-      "detail": "Set latency and availability targets. Alerts fire when SLAs are breached.",
-      "related": ["metrics", "status", "workflow"]
-    },
-    {
-      "command": "maintenance",
-      "tier": "team",
-      "category": "Infrastructure",
-      "description": "Run maintenance tasks (vacuum, reindex)",
-      "aliases": [],
-      "usage": "/tokenpak maintenance [vacuum|reindex|all]",
-      "detail": "Runs database vacuum, re-indexes vault blocks, and clears expired cache entries.",
-      "related": ["prune", "doctor"]
     },
     {
       "command": "compliance",
@@ -550,6 +470,96 @@
       "usage": "/tokenpak goals [list|add|edit|delete|detail|export]",
       "detail": "Define token or cost savings targets and monitor progress with pace tracking (ahead/on-track/behind). Supports goal history and comparison.",
       "related": ["savings", "budget", "report"]
+    },
+    {
+      "command": "pak",
+      "tier": "oss",
+      "category": "Optimization",
+      "description": "Inspect, export, and import Pak context files",
+      "aliases": [],
+      "usage": "/tokenpak pak [create|inspect|export|import|status]",
+      "detail": "Manage portable Pak context files: create, inspect, export, import, and check status (MultiPak Phase 1).",
+      "related": ["pakplan", "optimize", "index"]
+    },
+    {
+      "command": "pakplan",
+      "tier": "oss",
+      "category": "Optimization",
+      "description": "Inspect the recall foundation; preview, explain, report",
+      "aliases": [],
+      "usage": "/tokenpak pakplan [preview|explain|report]",
+      "detail": "Preview, explain, and report on the recall foundation that drives Pak context selection.",
+      "related": ["pak", "index", "optimize"]
+    },
+    {
+      "command": "tip",
+      "tier": "oss",
+      "category": "Configuration",
+      "description": "TokenPak Integration Protocol — validate, inspect, conformance",
+      "aliases": [],
+      "usage": "/tokenpak tip [validate|inspect|conformance|doctor|observe|sources|scaffold-adapter]",
+      "detail": "Work with the TokenPak Integration Protocol (TIP): validate and inspect adapters, run conformance checks, and scaffold new integrations.",
+      "related": ["config", "doctor"]
+    },
+    {
+      "command": "creds",
+      "tier": "oss",
+      "category": "Configuration",
+      "description": "Discover credentials across platforms and run diagnostics",
+      "aliases": [],
+      "usage": "/tokenpak creds",
+      "detail": "Discover API credentials across installed tools and platforms, and diagnose credential issues.",
+      "related": ["config", "doctor", "setup"]
+    },
+    {
+      "command": "claude",
+      "tier": "oss",
+      "category": "Control",
+      "description": "Launch Claude Code with the companion active",
+      "aliases": [],
+      "usage": "/tokenpak claude",
+      "detail": "Launch Claude Code with the TokenPak companion active so requests route through the proxy.",
+      "related": ["codex", "start", "status"]
+    },
+    {
+      "command": "codex",
+      "tier": "oss",
+      "category": "Control",
+      "description": "Launch Codex with the companion active",
+      "aliases": [],
+      "usage": "/tokenpak codex",
+      "detail": "Launch Codex with the TokenPak companion active so requests route through the proxy.",
+      "related": ["claude", "start", "status"]
+    },
+    {
+      "command": "prove",
+      "tier": "oss",
+      "category": "Visibility",
+      "description": "A/B value proof: direct API vs TokenPak",
+      "aliases": [],
+      "usage": "/tokenpak prove [create|run|show|list|providers]",
+      "detail": "Run A/B value proofs comparing direct API calls against TokenPak to quantify savings.",
+      "related": ["savings", "cost"]
+    },
+    {
+      "command": "init",
+      "tier": "oss",
+      "category": "Configuration",
+      "description": "Guided first-run setup (API key, port, vault path)",
+      "aliases": [],
+      "usage": "/tokenpak init",
+      "detail": "Guided first-run setup that configures your API key, proxy port, and vault path.",
+      "related": ["setup", "config"]
+    },
+    {
+      "command": "setup",
+      "tier": "oss",
+      "category": "Configuration",
+      "description": "Interactive first-time configuration wizard",
+      "aliases": [],
+      "usage": "/tokenpak setup",
+      "detail": "Interactive wizard for first-time configuration of TokenPak.",
+      "related": ["init", "config"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Align `help`/parser output with the command registry: every advertised command is invokable (no phantoms), and the set of invokable-but-unadvertised internal verbs is pinned to a reviewed snapshot.

## Notes
- Patch-level for the 1.9.x line; no version bump and no public API surface change (the new introspection helper lives in a private module).
- The internal-unadvertised snapshot is set to the current public OSS surface (34): two internal verbs present in other distributions are not registered here.
- Tests: help/parser parity (no phantoms, added commands advertised + invokable, no silent drift).
