### PR TITLE
chore: set package author/maintainer identity to TokenPak

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ description = "Cut LLM costs with deterministic context compression, smart routi
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    { name = "Kevin Yang", email = "hello@tokenpak.ai" },
+    { name = "TokenPak", email = "hello@tokenpak.ai" },
 ]
 maintainers = [
-    { name = "Kevin Yang", email = "hello@tokenpak.ai" },
+    { name = "TokenPak", email = "hello@tokenpak.ai" },
 ]
 keywords = [
     "llm",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -25,7 +25,7 @@
     "optimization",
     "ai"
   ],
-  "author": "Kevin Yang",
+  "author": "TokenPak",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Set the package `authors`/`maintainers` (pyproject) and SDK `author` (sdk/package.json) display name to `TokenPak`, aligning published package metadata with the project's organizational identity.

## Notes
- Display-name metadata only: package name, version, license, scripts, build-system, author email, and publisher configuration are unchanged. No publishing-semantics impact.
- No code, API, or behavior change.
