### PR TITLE
docs: drop internal repo-path references from docstrings + snapshot README

### DIFF
--- a/tokenpak/_snapshots/README.md
+++ b/tokenpak/_snapshots/README.md
@@ -1,12 +1,12 @@
 # Release-gate snapshots
 
-These JSON files are the canonical, checked-in artifacts that gate every PR per **Standard 30 — Release-Gate Trust Contract** (ratified 2026-05-09). Authoritative spec: `~/vault/01_PROJECTS/tokenpak/standards/30-release-gate-trust-contract.md`.
+These JSON files are the canonical, checked-in artifacts that gate every PR per **Standard 30 — Release-Gate Trust Contract** (ratified 2026-05-09).
 
-| File | Std 30 § | Purpose |
+| File | Contract § | Purpose |
 |---|---|---|
-| `public-api.json` | §7 (R7) | Sorted list of every public symbol on every `tokenpak.*` module. PR fails if a public symbol is removed without a `removes-public-symbol:` declaration in the PR body (Std 21 §11). |
-| `telemetry-schema.json` | §7 (R7) | Frozen DDL of every user-facing SQLite store (`~/.tokenpak/telemetry.db`, `~/.tokenpak/spend_guard.db`). PR fails on schema drift unless the same PR carries a migration test (Std 10 §E8) and multi-hop migration passes (Std 10 §E9). |
-| `workflow-steps.json` | §13.3 (R11) | Sorted CI step tuples for `release*.yml` + `release-rehearsal.yml`. PR fails if a step is removed without a `removes-ci-step: <step.id>` declaration (Std 21 §12). |
+| `public-api.json` | §7 (R7) | Sorted list of every public symbol on every `tokenpak.*` module. PR fails if a public symbol is removed without a `removes-public-symbol:` declaration in the PR body. |
+| `telemetry-schema.json` | §7 (R7) | Frozen DDL of every user-facing SQLite store (`~/.tokenpak/telemetry.db`, `~/.tokenpak/spend_guard.db`). PR fails on schema drift unless the same PR carries a migration test and multi-hop migration passes. |
+| `workflow-steps.json` | §13.3 (R11) | Sorted CI step tuples for `release*.yml` + `release-rehearsal.yml`. PR fails if a step is removed without a `removes-ci-step: <step.id>` declaration. |
 
 ## Updating
 
@@ -25,7 +25,7 @@ make release-gate-check
 
 ## When a snapshot diff appears
 
-CI fails the PR with a teaching message that names the rule (Std 21 §11 for symbol removals, §12 for workflow steps, Std 10 §E8 for schema). Authoring path:
+CI fails the PR with a teaching message that names the rule. Authoring path:
 
 1. Confirm the change is intentional.
 2. Add a `.changeset/<date>-<slug>.md` entry describing why.

--- a/tokenpak/integrations/openclaw/hooks/openclaw-adapter/handler.js
+++ b/tokenpak/integrations/openclaw/hooks/openclaw-adapter/handler.js
@@ -13,9 +13,6 @@
  *
  * Never throws — all error paths fall through to console.warn so the host
  * gateway is unaffected by file-system failures.
- *
- * Source of truth: ~/vault/01_PROJECTS/tokenpak/initiatives/
- *   2026-04-28-openclaw-adapter-session-binding/03-SPEC.md §Component 1.
  */
 
 const fs = require("node:fs");

--- a/tokenpak/orchestration/dispatch/models/enums.py
+++ b/tokenpak/orchestration/dispatch/models/enums.py
@@ -1,7 +1,6 @@
 """Enumerations for TokenPak Dispatch record schemas.
 
-Every enum here is transcribed verbatim from Standards Delta v0
-(``01_PROJECTS/tokenpak/dispatch-2026-05-19/standards-delta-v0.md``) §4/§5/§6.
+Every enum here is transcribed verbatim from Standards Delta v0, §4/§5/§6.
 The enum *values* are the authoritative strings; member names are sanitized
 upper-case forms. Do NOT add, drop, or rename members without a corresponding
 Standards Delta amendment — these are contract enums, not implementation

--- a/tokenpak/proxy/spend_guard/__init__.py
+++ b/tokenpak/proxy/spend_guard/__init__.py
@@ -21,7 +21,6 @@ The whole subsystem is config-driven via ``spend_guard.*`` keys
 a no-op (returns ``GuardOutcome.passthrough()``).
 
 Authority:
-- Initiative: ``~/vault/01_PROJECTS/tokenpak/initiatives/2026-05-07-tip-spend-guard-oss/``
 - Standard 29: agent contract for the structured block error.
 - Pricing single source of truth: ``tokenpak.models.get_rates``.
 """


### PR DESCRIPTION
Editorial hygiene: removes internal source-doc path references from a few module docstrings/comments (dispatch enums, spend-guard, the OpenClaw adapter JSDoc) and the release-gate snapshot README, plus stale section-shorthand in that README. **Comments/docstrings/markdown only — no behavior change.** Public symbols, the spelled-out standard names, and the snapshot contract semantics are unchanged. 4 files, +7/−12.