### PR TITLE
release-gate: register internal vault-path leak pattern

### DIFF
--- a/.github/workflows/identity-language-check.yml
+++ b/.github/workflows/identity-language-check.yml
@@ -89,6 +89,7 @@ jobs:
             'TIP-[0-9][0-9]'
             '\.claude/projects'
             '/home/sue/'
+            '~/vault/[0-9][0-9]_'
             'trixxie168'
             '\bStd 2[0-9]\b'
             '\bStd 3[0-9]\b'

--- a/scripts/release_gate/check_release_leaks.py
+++ b/scripts/release_gate/check_release_leaks.py
@@ -98,6 +98,7 @@ PATTERNS: list[str] = [
     r"TIP-[0-9][0-9]",
     CLAUDE_PROJECTS,
     r"/home/sue/",
+    r"~/vault/[0-9][0-9]_",
     r"trixxie168",
     r"\bStd 2[0-9]\b",
     r"\bStd 3[0-9]\b",

--- a/tests/release_gate/test_release_leak_scan.py
+++ b/tests/release_gate/test_release_leak_scan.py
@@ -82,6 +82,52 @@ def test_internal_task_id_leak_fails(tmp_path):
     assert res.returncode == 1, "internal task-ID leak must fail the gate"
 
 
+def test_internal_vault_path_leak_fails(tmp_path):
+    # Internal vault paths (~/vault/<NN>_<FOLDER>) must not leak into shipped
+    # docstrings/comments — the class scrubbed from the package in a recent
+    # public-identity hygiene pass.
+    _write(
+        tmp_path,
+        "tokenpak/proxy/notes.py",
+        "# spec lives at ~/vault/01_PROJECTS/tokenpak/initiatives/x.md\nX = 1\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "internal vault-path leak must fail the gate"
+    assert "tokenpak/proxy/notes.py" in res.stdout
+
+
+def test_internal_vault_path_various_numbered_folders_fail(tmp_path):
+    # Any two-digit numbered top-level vault folder is internal: 00_kevin,
+    # 06_RUNTIME, 03_AGENT_PACKS, ... — all caught by the single path pattern.
+    for i, ref in enumerate(
+        ("~/vault/00_kevin/y.md", "~/vault/06_RUNTIME/scripts/z.sh")
+    ):
+        _write(tmp_path, f"tokenpak/core/v{i}.py", f"# see {ref}\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "all numbered vault folders must fail the gate"
+
+
+def test_vault_path_no_false_positive_on_user_surfaces(tmp_path):
+    # The pattern is deliberately narrow — it requires the ~/vault/<NN>_ shape.
+    # Legitimate surfaces must NOT trip it:
+    #   * ~/vault/.tokenpak  -> a dotfile dir, not a numbered folder
+    #   * bare ~/vault       -> a generic path with no numbered folder
+    #   * bare 01_PROJECTS / 03_AGENT_PACKS (no ~/vault/ prefix) -> keeps the
+    #     lesson_ingest vault-schema feature clean WITHOUT needing an allowlist.
+    _write(
+        tmp_path,
+        "tokenpak/companion/memory/lesson_ingest.py",
+        "# data dir: ~/vault/.tokenpak\n"
+        "VAULT = '~/vault'\n"
+        "PACKS = '03_AGENT_PACKS'  # vault-schema folder name (feature)\n"
+        "SUB = '01_PROJECTS'\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, (
+        f"narrow vault pattern must not false-positive:\n{res.stdout}"
+    )
+
+
 def test_allowlisted_openclaw_path_passes(tmp_path):
     # `openclaw` is the legitimate, non-renamable provider/module name in the
     # OpenClaw integration subsystem.


### PR DESCRIPTION
## Summary

Extends the public-leak release gate's forbidden-pattern register with one
narrow pattern — `~/vault/[0-9][0-9]_` — so internal numbered-folder vault
paths can't leak into shipped docstrings or comments. The same pattern is
mirrored byte-for-byte into the identity-language workflow register, keeping
the release-time scanner and the per-PR delta gate in sync.

## Why

A recent docstring-hygiene pass removed a handful of internal `~/vault/<NN>_…`
paths from package source. Those references were not covered by any existing
register entry, so the class could silently regress. This change makes the
gate catch it going forward.

## Design — deliberately narrow

The pattern requires the `~/vault/<NN>_` shape (two digits + underscore after
`~/vault/`). It therefore does **not** flag legitimate surfaces:

- `~/vault/.tokenpak` (a dotfile dir, not a numbered folder)
- bare `~/vault` (no numbered folder)
- bare folder names without the `~/vault/` prefix — so the companion
  vault-schema feature that references a bare folder name needs no allowlist.

## Validation

- Both registers verified **ordered-identical** (30/30 entries).
- New pattern matches **0 files** in the package tree; the built sdist/wheel
  `--dist` scan reports **no leaks** (2182 shipped files scanned).
- Adds positive, multi-folder, and false-positive regression tests
  (`tests/release_gate/test_release_leak_scan.py`); full leak-scan suite green.
