### PR TITLE
release-gate: catch internal standards-citation forms in the leak scanner

### DIFF
--- a/.github/workflows/identity-language-check.yml
+++ b/.github/workflows/identity-language-check.yml
@@ -91,8 +91,9 @@ jobs:
             '/home/sue/'
             '~/vault/[0-9][0-9]_'
             'trixxie168'
-            '\bStd 2[0-9]\b'
-            '\bStd 3[0-9]\b'
+            '\bStd [0-9]{2}\b'
+            '§[0-9]'
+            'Standards Delta'
             'Suki: auto-commit'
           )
 
@@ -286,13 +287,15 @@ jobs:
               #     `tokenpak.creds.providers.openclaw`,
               #     `tokenpak.sdk.openclaw`, or bare provider-name strings)
               #
-              # Other patterns (agent names Sue/Cali/Trix/Suki/Aya/Dee/ReiPo,
-              # internal task IDs, /home/sue/ paths, .claude/projects,
-              # other Std numbers, "Suki: auto-commit", etc.) remain
-              # enforced even in snapshot files.
+              # Std NN / §N here are release-gate governance metadata about the
+              # snapshot (e.g. "Std 30 §13.1 R9" CI step names) — inherently a
+              # standards-section citation, so mask ALL of them. Other patterns
+              # (agent names Sue/Cali/Trix/Suki/Aya/Dee/ReiPo, internal task IDs,
+              # /home/sue/ paths, .claude/projects, "Suki: auto-commit", etc.)
+              # remain enforced even in snapshot files.
               sed -E \
-                -e 's/\bStd 21\b/Std __PUBLIC_RELGATE_REF_21__/g' \
-                -e 's/\bStd 30\b/Std __PUBLIC_RELGATE_REF_30__/g' \
+                -e 's/\bStd ([0-9]{2})\b/Std __PUBLIC_RELGATE_STD_\1__/g' \
+                -e 's/§([0-9])/§__PUBLIC_RELGATE_SEC__\1/g' \
                 -e 's/\bopenclaw\b/__GENERATED_SYMBOL_OPENCLAW__/g' \
                 -e 's/\bfleet\b/__GENERATED_SYMBOL_FLEET__/g' \
                 "$file"
@@ -397,14 +400,15 @@ jobs:
                 "$file"
             elif is_release_gate_impl_path "$file"; then
               # Tier 1 — release-gate implementation/test/workflow surface:
-              # mask the specific Std 21 / Std 30 references the code
-              # legitimately implements. All other patterns (agent names,
-              # internal IDs, paths, etc.) and all other Std numbers remain
-              # enforced. openclaw is NOT masked here — Tier 1 files should
-              # not reference openclaw.
+              # these files implement the release-gate standards and cite them by
+              # number, so mask ALL Std NN + §N standards-section citations. A
+              # §N/Std NN here is inherently a reference to the standard being
+              # implemented, never an agent name / private path / task-ID — all
+              # those patterns are NOT masked here and remain fully enforced.
+              # openclaw is NOT masked here — Tier 1 files should not reference it.
               sed -E \
-                -e 's/\bStd 21\b/Std __PUBLIC_RELGATE_REF_21__/g' \
-                -e 's/\bStd 30\b/Std __PUBLIC_RELGATE_REF_30__/g' \
+                -e 's/\bStd ([0-9]{2})\b/Std __PUBLIC_RELGATE_STD_\1__/g' \
+                -e 's/§([0-9])/§__PUBLIC_RELGATE_SEC__\1/g' \
                 "$file"
             elif [ "$pat" = '\bopenclaw\b' ] && is_openclaw_public_path "$file"; then
               # Path-scoped allowlist (see is_openclaw_public_path): the
@@ -494,6 +498,17 @@ jobs:
               # .claude/projects reference is still caught.
               sed -E \
                 -e 's#~/\.claude/projects#~/__FUNC_CLAUDE_TRANSCRIPT_DIR__#g' \
+                "$file"
+            elif [ "$pat" = '§[0-9]' ]; then
+              # Legal license-section allowlist: "Apache-2.0 §N" is a reference to
+              # a section of the Apache-2.0 license (the trademark notice cites §6),
+              # not an internal standards citation. Mask that EXACT literal so the
+              # §[0-9] rule does not flag it on non-release-gate paths (the README
+              # and generated METADATA/PKG-INFO carry it). Every other §N is still
+              # caught. (Release-gate impl/snapshot paths are handled by the
+              # branches above, which mask all §N there.)
+              sed -E \
+                -e 's/Apache-2\.0 §[0-9]+(\.[0-9]+)*/Apache-2.0 __LEGAL_SECTION__/g' \
                 "$file"
             else
               cat "$file"

--- a/scripts/release_gate/check_release_leaks.py
+++ b/scripts/release_gate/check_release_leaks.py
@@ -71,6 +71,22 @@ from dataclasses import dataclass
 FLEET = r"\bfleet\b"
 OPENCLAW = r"\bopenclaw\b"
 CLAUDE_PROJECTS = r"\.claude/projects"
+# Internal standards-citation forms. The internal style is "Std NN" (any
+# two-digit standard number — supersedes the older Std 2x/3x-only rules so
+# Std 00-19 and Std 40-99 are also caught), "§N" section markers (no space —
+# the internal form is uniformly §-attached, e.g. ``§4.1``; the no-space shape
+# structurally avoids legal space-form citations like ``§ 512``), and the
+# "Standards Delta" working-document name (exact phrase; no hyphen/case variant
+# occurs in the tree). The legitimate legal license-section citation
+# ``Apache-2.0 §N`` is allowlisted in ``mask_content`` (an EXACT-literal legal
+# allowlist, NOT a broad ``§`` exemption).
+STD_NUM = r"\bStd [0-9]{2}\b"
+SECTION = r"§[0-9]"
+STANDARDS_DELTA = r"Standards Delta"
+# Exact legal license-section citation that must remain public (trademark notice
+# ``Apache-2.0 §6 grants no trademark rights`` in the README/long-description).
+# Matches the full section number so ``§10``/``§6.1`` mask cleanly, not partially.
+APACHE_LEGAL_SECTION = r"Apache-2\.0 §[0-9]+(?:\.[0-9]+)*"
 
 PATTERNS: list[str] = [
     r"\bSue\b",
@@ -100,8 +116,9 @@ PATTERNS: list[str] = [
     r"/home/sue/",
     r"~/vault/[0-9][0-9]_",
     r"trixxie168",
-    r"\bStd 2[0-9]\b",
-    r"\bStd 3[0-9]\b",
+    STD_NUM,
+    SECTION,
+    STANDARDS_DELTA,
     r"Suki: auto-commit",
 ]
 
@@ -204,18 +221,29 @@ def is_perm_tier_cli_path(path: str) -> bool:
 # ──────────────────────────────────────────────────────────────────────────
 
 
+def _mask_relgate_standards(text: str) -> str:
+    """Mask EVERY standards-section citation (``Std NN`` + ``§N``) on a path.
+
+    Used on the release-gate implementation + snapshot surfaces only. These files
+    implement the release-gate standards and cite them by number; a ``§N`` /
+    ``Std NN`` here is inherently a reference to the standard being implemented,
+    never an agent name / private path / task-ID (those patterns are NOT touched
+    here and remain fully enforced). Substitutions keep the line count stable.
+    """
+    text = re.sub(r"\bStd ([0-9]{2})\b", r"Std __RELGATE_STD_\1__", text)
+    text = re.sub(r"§([0-9])", r"§__RELGATE_SEC__\1", text)
+    return text
+
+
 def _mask_snapshot(text: str) -> str:
-    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
-    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
+    text = _mask_relgate_standards(text)
     text = re.sub(r"\bopenclaw\b", "__GEN_SYM_OPENCLAW__", text)
     text = re.sub(r"\bfleet\b", "__GEN_SYM_FLEET__", text)
     return text
 
 
 def _mask_relgate_impl(text: str) -> str:
-    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
-    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
-    return text
+    return _mask_relgate_standards(text)
 
 
 def _mask_openclaw_functional(text: str) -> str:
@@ -273,6 +301,14 @@ def _mask_fleet_functional(text: str) -> str:
 def mask_content(pattern: str, path: str, text: str) -> str:
     """Return ``text`` with the legitimate public-surface forms masked for this
     (pattern, path) pair. Dispatch order mirrors the delta gate exactly."""
+    if pattern == SECTION:
+        # Legal license-section allowlist: ``Apache-2.0 §N`` is a reference to a
+        # section of the Apache-2.0 license (the trademark notice cites §6), not
+        # an internal standards citation. Mask the exact literal so the
+        # ``§[0-9]`` rule does not flag it, on ANY path (it appears in the README
+        # and the generated METADATA / PKG-INFO). EXACT-literal legal allowlist —
+        # every other ``§N`` is still caught.
+        text = re.sub(APACHE_LEGAL_SECTION, "Apache-2.0 __LEGAL_SECTION__", text)
     if is_release_gate_snapshot_path(path):
         return _mask_snapshot(text)
     if pattern == FLEET and is_fleet_public_path(path):

--- a/tests/release_gate/test_release_leak_scan.py
+++ b/tests/release_gate/test_release_leak_scan.py
@@ -238,3 +238,163 @@ def test_dist_mode_allowlist_applies_after_prefix_strip(tmp_path):
     )
     res = _run_dist(dist)
     assert res.returncode == 0, f"allowlist must apply to sdist paths:\n{res.stdout}"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Internal standards-citation rules: Std NN / §N / Standards Delta, plus the
+# Apache-2.0 §N legal allowlist and the release-gate masking. Matrix mirrors the
+# delta gate (identity-language-check.yml); the parity test at the end proves
+# the two registers stay in sync.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_std_out_of_range_leak_fails(tmp_path):
+    # Std 41 is outside the old Std 2x/3x range and previously shipped.
+    _write(tmp_path, "tokenpak/orchestration/x.py", "# per Std 41 dispatch contract\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "Std-number outside 20-39 must now fail"
+
+
+def test_std_low_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/x.py", "# per Std 02 product constitution\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "low Std number must fail"
+
+
+def test_section_ref_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/x.py", "# see §4.1 for the lane contract\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "section reference must fail"
+
+
+def test_standards_delta_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/x.py", "# transcribed from Standards Delta v0\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "Standards Delta reference must fail"
+
+
+def test_apache_legal_section_passes(tmp_path):
+    # The Apache-2.0 §N license-section citation is legitimate legal text and is
+    # allowlisted (exact literal). This is the README/long-description trademark
+    # notice that must remain public.
+    _write(
+        tmp_path,
+        "README.md",
+        "Not licensed under Apache-2.0 (Apache-2.0 §6 grants no trademark rights).\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"Apache-2.0 legal section citation must pass:\n{res.stdout}"
+
+
+def test_apache_legal_section_multidigit_passes(tmp_path):
+    # The allowlist matches the full section number, so a multi-digit / dotted
+    # section masks cleanly (no partial-mask leak).
+    _write(tmp_path, "README.md", "see Apache-2.0 §10.2 hypothetical\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"multi-digit Apache section must pass:\n{res.stdout}"
+
+
+def test_legal_section_space_form_passes(tmp_path):
+    # A space-form legal citation (e.g. "§ 230") is not the internal no-space
+    # form and must not match.
+    _write(tmp_path, "docs_pkg/legal.md", "under § 230 of the Act\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"space-form section citation must pass:\n{res.stdout}"
+
+
+def test_iso_standard_number_passes(tmp_path):
+    # "Std 14001" is a long number; \bStd [0-9]{2}\b requires exactly two digits
+    # at a word boundary, so it does not match.
+    _write(tmp_path, "tokenpak/core/x.py", "# ISO Std 14001 environmental\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"ISO Std 14001 must not false-positive:\n{res.stdout}"
+
+
+def test_bare_section_sign_passes(tmp_path):
+    # A bare section sign with no trailing digit is not the §N citation form.
+    _write(tmp_path, "tokenpak/core/x.py", "# the § sign by itself\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"bare section sign must pass:\n{res.stdout}"
+
+
+def test_relgate_impl_std_section_masked(tmp_path):
+    # Release-gate implementation files cite the standards they implement; §N /
+    # Std NN there are masked.
+    _write(
+        tmp_path,
+        "scripts/release_gate/foo.py",
+        "# Std 30 §7 (R7) release-gate snapshot rule\nX = 1\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"release-gate Std/section citation must pass:\n{res.stdout}"
+
+
+def test_snapshot_std_section_masked(tmp_path):
+    # Snapshot governance metadata (CI step names) cite standards sections.
+    _write(
+        tmp_path,
+        "tokenpak/_snapshots/workflow-steps.json",
+        '{"name": "Sdist / wheel purity (Std 30 §13.1 R9)"}\n',
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"snapshot Std/section citation must pass:\n{res.stdout}"
+
+
+def test_section_outside_relgate_paths_fails(tmp_path):
+    # The release-gate mask is path-scoped: the SAME §N on a normal shipped path
+    # is still caught.
+    _write(tmp_path, "tokenpak/proxy/x.py", "# internal §7 note\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "section ref outside release-gate paths must fail"
+
+
+def test_agent_name_still_fails_on_relgate_path(tmp_path):
+    # The release-gate mask covers ONLY §N / Std NN; an agent name on the same
+    # path is still caught.
+    _write(tmp_path, "scripts/release_gate/foo.py", "# last reviewed by Suki\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "agent name must still fail on a release-gate path"
+    assert "scripts/release_gate/foo.py" in res.stdout
+
+
+def test_private_path_still_fails_on_relgate_path(tmp_path):
+    _write(tmp_path, "scripts/release_gate/foo.py", 'CACHE = "/home/sue/.cache"\n')
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "private path must still fail on a release-gate path"
+
+
+def test_task_id_still_fails_on_relgate_path(tmp_path):
+    _write(tmp_path, "scripts/release_gate/foo.py", "# tracked in TSR-1234\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "task ID must still fail on a release-gate path"
+
+
+def test_pattern_register_parity_with_delta_gate():
+    # Mechanical parity: the full-tree register and the delta gate
+    # (identity-language-check.yml) MUST carry the identical forbidden-pattern set
+    # (SYNC OBLIGATION). Guards against the two scanners drifting.
+    import re as _re
+
+    scanner_src = SCANNER.read_text(encoding="utf-8")
+    # resolve the named-constant entries to their regex literals
+    consts = dict(_re.findall(r'^([A-Z_]+) = (r?"[^"]*")', scanner_src, _re.M))
+    py_entries = []
+    block = _re.search(r"PATTERNS: list\[str\] = \[(.*?)\n\]", scanner_src, _re.S).group(1)
+    for tok in _re.findall(r"(r\"[^\"]*\"|[A-Z_]+)", block):
+        if tok in consts:
+            py_entries.append(consts[tok])
+        elif tok.startswith('r"'):
+            py_entries.append(tok)
+    py_set = {eval(e) for e in py_entries}  # noqa: S307 - test-only literal eval
+
+    yml = (REPO_ROOT / ".github" / "workflows" / "identity-language-check.yml").read_text(
+        encoding="utf-8"
+    )
+    yblock = _re.search(r"patterns=\((.*?)\n\s*\)", yml, _re.S).group(1)
+    y_set = set(_re.findall(r"'([^']*)'", yblock))
+
+    assert py_set == y_set, (
+        "scanner register and delta gate drifted:\n"
+        f"  only in scanner: {py_set - y_set}\n"
+        f"  only in delta gate: {y_set - py_set}"
+    )


### PR DESCRIPTION
## Summary

Extend the public-leak release gate (`scripts/release_gate/check_release_leaks.py`)
and its mirrored per-PR delta gate (`.github/workflows/identity-language-check.yml`)
to catch internal standards-citation forms that the previous, range-limited
numbered-standard rule did not. Closes the gap that allowed internal
development-time citations to ship.

## What changes

- **Patterns** (added to both scanner surfaces): the full two-digit
  numbered-standard form (supersedes the two narrow range-limited rules), the
  no-space section-marker form, and the internal working-document name.
- **Legal allowlist:** an explicit, exact license-section allowlist so the
  legitimate `Apache-2.0` trademark notice in the long-description / generated
  package metadata still passes. This is an exact-literal allowlist — **not** a
  broad section-marker exemption; every other section reference is still caught.
- **Release-gate masking:** the release-gate implementation and snapshot surfaces
  (which legitimately cite the standards they implement) mask **only** their own
  standards-section citations, path-scoped. Agent names, private paths, task IDs,
  and every other rule remain fully enforced on those paths.

## Safety / validation

- **Both scanner surfaces stay in sync** — a mechanical register-parity test
  asserts the Python register and the YAML delta gate carry the identical set;
  behavioral parity verified across the full matrix.
- **17 new regression cases** (`tests/release_gate/test_release_leak_scan.py`):
  internal forms fail; the legal license-section citation passes via the
  allowlist; space-form and long-number near-misses pass; release-gate / snapshot
  citations pass via the mask while agent names / private paths / task IDs on the
  same paths still fail.
- The current (scrubbed) public tree **passes the new scanner in `--dist` mode**.
- Scope is exactly three files; no shipped package code changes.

## Governance

This is a **release-gate policy change** (Class D). **Held — do not merge.**
Requires governance review + an explicit maintainer merge gate. No release, tag,
publish, or artifact action.
