### PR TITLE
release-gate: catch internal standards-citation forms in the leak scanner

### DIFF
--- a/.github/workflows/identity-language-check.yml
+++ b/.github/workflows/identity-language-check.yml
@@ -91,8 +91,17 @@ jobs:
             '/home/sue/'
             '~/vault/[0-9][0-9]_'
             'trixxie168'
-            '\bStd 2[0-9]\b'
-            '\bStd 3[0-9]\b'
+            # Internal standard / section / artifact citations. Widened
+            # 2026-06-28 (leak-gate Std/§ scanner extension) from the
+            # range-limited 'Std 2[0-9]'/'Std 3[0-9]' to ALL 'Std NN' (00-99),
+            # the no-space '§N' section form, and the 'Standards Delta'
+            # artifact name. Legitimate release-gate citations are masked per
+            # the explicit cite-lists in content_for_pattern() below; every
+            # other Std NN / §N / Standards Delta still trips. Mirror of
+            # scripts/release_gate/check_release_leaks.py PATTERNS (SYNC).
+            '\bStd [0-9]{2}\b'
+            '§[0-9]'
+            'Standards[ ]Delta'
             'Suki: auto-commit'
           )
 
@@ -290,9 +299,20 @@ jobs:
               # internal task IDs, /home/sue/ paths, .claude/projects,
               # other Std numbers, "Suki: auto-commit", etc.) remain
               # enforced even in snapshot files.
+              # Snapshot-surface citation cite-list (Std 30 amendment — Class D;
+              # mirror of RELGATE_SNAPSHOT_*_CITES in check_release_leaks.py):
+              # the generated snapshot README + workflow-steps legitimately cite
+              # Std 21/30 and sections §7 / §13.3 (R7 / R11 governance metadata).
+              # Only these enumerated citations are masked; any other Std NN /
+              # §N in a snapshot still trips. The section boundary masks "§N"
+              # at a citation end (non-section char / sentence period / EOL) but
+              # not a ".<digit>" sub-section.
               sed -E \
+                -e 's/Apache-2\.0 §[0-9]+(\.[0-9]+)*/Apache-2.0 __PUBLIC_LICENSE_SEC__/g' \
                 -e 's/\bStd 21\b/Std __PUBLIC_RELGATE_REF_21__/g' \
                 -e 's/\bStd 30\b/Std __PUBLIC_RELGATE_REF_30__/g' \
+                -e 's/§13\.3(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SNAP_SEC_13_3__\1/g' \
+                -e 's/§7(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SNAP_SEC_7__\1/g' \
                 -e 's/\bopenclaw\b/__GENERATED_SYMBOL_OPENCLAW__/g' \
                 -e 's/\bfleet\b/__GENERATED_SYMBOL_FLEET__/g' \
                 "$file"
@@ -396,15 +416,40 @@ jobs:
                 -e 's/\(fleet → TokenPak/(__PUBLIC_PERMTIER_FLEET__ → TokenPak/g' \
                 "$file"
             elif is_release_gate_impl_path "$file"; then
-              # Tier 1 — release-gate implementation/test/workflow surface:
-              # mask the specific Std 21 / Std 30 references the code
-              # legitimately implements. All other patterns (agent names,
-              # internal IDs, paths, etc.) and all other Std numbers remain
-              # enforced. openclaw is NOT masked here — Tier 1 files should
-              # not reference openclaw.
+              # Tier 1 — release-gate implementation/test/workflow surface.
+              # Mask the EXPLICIT cite-list of Std NN / §N references the code
+              # legitimately implements (Std 30 amendment — Class D; mirror of
+              # RELGATE_IMPL_*_CITES in check_release_leaks.py). Only the
+              # enumerated citations are masked — any OTHER Std NN / §N in these
+              # files still trips (no blanket path mask). All non-standards
+              # patterns (agent names, internal IDs, paths) remain enforced;
+              # openclaw is NOT masked here (Tier 1 files should not cite it).
+              # The section boundary masks "§N" at a citation end (non-section
+              # char / sentence period / EOL) but not a ".<digit>" sub-section.
               sed -E \
+                -e 's/Apache-2\.0 §[0-9]+(\.[0-9]+)*/Apache-2.0 __PUBLIC_LICENSE_SEC__/g' \
+                -e 's/\bStd 02\b/Std __PUBLIC_RELGATE_STD_02__/g' \
+                -e 's/\bStd 10\b/Std __PUBLIC_RELGATE_STD_10__/g' \
+                -e 's/\bStd 12\b/Std __PUBLIC_RELGATE_STD_12__/g' \
                 -e 's/\bStd 21\b/Std __PUBLIC_RELGATE_REF_21__/g' \
                 -e 's/\bStd 30\b/Std __PUBLIC_RELGATE_REF_30__/g' \
+                -e 's/§3\.3(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_3_3__\1/g' \
+                -e 's/§3(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_3__\1/g' \
+                -e 's/§4(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_4__\1/g' \
+                -e 's/§5(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_5__\1/g' \
+                -e 's/§6(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_6__\1/g' \
+                -e 's/§7(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_7__\1/g' \
+                -e 's/§8(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_8__\1/g' \
+                -e 's/§9\.8(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_9_8__\1/g' \
+                -e 's/§11(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_11__\1/g' \
+                -e 's/§12(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_12__\1/g' \
+                -e 's/§13\.1(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_13_1__\1/g' \
+                -e 's/§13\.2(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_13_2__\1/g' \
+                -e 's/§13\.3(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_13_3__\1/g' \
+                -e 's/§13\.4(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_13_4__\1/g' \
+                -e 's/§13(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_13__\1/g' \
+                -e 's/§14\.1(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_14_1__\1/g' \
+                -e 's/§14(\.?[^0-9.]|\.$|$)/__PUBLIC_RELGATE_SEC_14__\1/g' \
                 "$file"
             elif [ "$pat" = '\bopenclaw\b' ] && is_openclaw_public_path "$file"; then
               # Path-scoped allowlist (see is_openclaw_public_path): the
@@ -494,6 +539,21 @@ jobs:
               # .claude/projects reference is still caught.
               sed -E \
                 -e 's#~/\.claude/projects#~/__FUNC_CLAUDE_TRANSCRIPT_DIR__#g' \
+                "$file"
+            elif [ "$pat" = '§[0-9]' ]; then
+              # The exact "Apache-2.0 §6" license-section citation (e.g.
+              # "Apache-2.0 §6 grants no trademark rights") is preserved
+              # legal/trademark text in the README / package metadata, NOT an
+              # internal section ref. The no-space "§N" matches it, so mask the
+              # exact "Apache-2.0 §N" literal for the section pattern. A bare
+              # internal "§N" (or any other license-id prefix) is still caught.
+              # Apache-2.0 ONLY per the 2026-06-28 ruling — the generic
+              # "<license-id> §N" SPDX carve-out is a separate Suki/Kevin policy
+              # decision. (Reached only for non-snapshot/non-impl paths; those
+              # are handled above with their own §-citation cite-lists.) Mirror
+              # of _mask_license_citations in check_release_leaks.py.
+              sed -E \
+                -e 's/Apache-2\.0 §[0-9]+(\.[0-9]+)*/Apache-2.0 __PUBLIC_LICENSE_SEC__/g' \
                 "$file"
             else
               cat "$file"

--- a/scripts/release_gate/check_release_leaks.py
+++ b/scripts/release_gate/check_release_leaks.py
@@ -71,6 +71,7 @@ from dataclasses import dataclass
 FLEET = r"\bfleet\b"
 OPENCLAW = r"\bopenclaw\b"
 CLAUDE_PROJECTS = r"\.claude/projects"
+SECTION = r"§[0-9]"
 
 PATTERNS: list[str] = [
     r"\bSue\b",
@@ -100,8 +101,18 @@ PATTERNS: list[str] = [
     r"/home/sue/",
     r"~/vault/[0-9][0-9]_",
     r"trixxie168",
-    r"\bStd 2[0-9]\b",
-    r"\bStd 3[0-9]\b",
+    # Internal standard / section / artifact citations. Widened 2026-06-28
+    # (leak-gate Std/§ scanner extension) from the old range-limited
+    # ``Std 2[0-9]`` / ``Std 3[0-9]`` to catch ALL ``Std NN`` (00-99), the
+    # no-space ``§N`` section form, and the ``Standards Delta`` artifact name —
+    # the internal citation forms that shipped in the v1.10.0 wheel. The
+    # ``[ ]`` in the Standards-Delta pattern (vs a literal space) keeps this
+    # register file self-immune. Legitimate release-gate citations are masked
+    # per the explicit per-surface cite-lists below; every other Std NN / §N /
+    # Standards Delta still trips. Mirror: identity-language-check.yml.
+    r"\bStd [0-9]{2}\b",
+    SECTION,
+    r"Standards[ ]Delta",
     r"Suki: auto-commit",
 ]
 
@@ -202,20 +213,90 @@ def is_perm_tier_cli_path(path: str) -> bool:
 # so the forbidden-pattern grep does not match them. Substitutions never add
 # or remove newlines, so line numbers are preserved.
 # ──────────────────────────────────────────────────────────────────────────
+#
+# Release-gate citation allowlists (Std 30 amendment — Class D).
+# ----------------------------------------------------------------------
+# The widened Std/§ register (above) would otherwise forbid the release-gate
+# implementation + generated-snapshot surfaces from naming the very standards
+# they implement / record. These EXPLICIT per-surface cite-lists mask exactly
+# the enumerated citations — and ONLY those: any Std NN / §N on the same path
+# that is NOT enumerated here still trips the gate (no blanket path mask; this
+# preserves the deliberately-narrow scope of the Std-21/30-only mask it
+# replaces, per the trust-gate review). Derived by measurement against the
+# v1.10.0 tree. CHANGING A CITE-LIST IS A RELEASE-GATE MASKING-POLICY CHANGE
+# == Std 30 amendment == Kevin gate. Kept in semantic sync with the sed mirror
+# in identity-language-check.yml (SYNC OBLIGATION).
+RELGATE_IMPL_STD_CITES = ("02", "10", "12", "21", "30")
+RELGATE_IMPL_SECTION_CITES = (
+    "3", "3.3", "4", "5", "6", "7", "8", "9.8",
+    "11", "12", "13", "13.1", "13.2", "13.3", "13.4", "14", "14.1",
+)
+RELGATE_SNAPSHOT_STD_CITES = ("21", "30")
+RELGATE_SNAPSHOT_SECTION_CITES = ("7", "13.3")
+
+# A cited "§<sec>" is complete (and masked) when followed by a non-section
+# character, a sentence-ending period, or end-of-line; NOT when a digit or a
+# ".<digit>" sub-section follows. Expressed identically in the YAML sed mirror.
+_SECTION_BOUNDARY = r"(\.?[^0-9.]|\.$|$)"
+
+
+def _mask_cited_standards(
+    text: str,
+    std_cites: tuple[str, ...],
+    section_cites: tuple[str, ...],
+    tag: str,
+) -> str:
+    """Mask the enumerated Std NN / §N citations for a release-gate surface.
+
+    Only the listed citations are neutralized; any other Std/§ on the path is
+    left intact so it still trips the forbidden-pattern scan.
+    """
+    for std in std_cites:
+        text = re.sub(rf"\bStd {re.escape(std)}\b", f"Std __{tag}_STD_{std}__", text)
+    for sec in section_cites:
+        repl = f"__{tag}_SEC_{sec.replace('.', '_')}__"
+        text = re.sub(rf"§{re.escape(sec)}{_SECTION_BOUNDARY}", repl + r"\1", text)
+    return text
 
 
 def _mask_snapshot(text: str) -> str:
-    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
-    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
+    text = _mask_cited_standards(
+        text, RELGATE_SNAPSHOT_STD_CITES, RELGATE_SNAPSHOT_SECTION_CITES, "RELGATE_SNAP"
+    )
     text = re.sub(r"\bopenclaw\b", "__GEN_SYM_OPENCLAW__", text)
     text = re.sub(r"\bfleet\b", "__GEN_SYM_FLEET__", text)
     return text
 
 
 def _mask_relgate_impl(text: str) -> str:
-    text = re.sub(r"\bStd 21\b", "Std __RELGATE_REF_21__", text)
-    text = re.sub(r"\bStd 30\b", "Std __RELGATE_REF_30__", text)
-    return text
+    return _mask_cited_standards(
+        text, RELGATE_IMPL_STD_CITES, RELGATE_IMPL_SECTION_CITES, "RELGATE_IMPL"
+    )
+
+
+# Exact Apache-2.0 license-section citation. The README/package-metadata
+# trademark notice cites the license section with a no-space "§6"
+# ("Apache-2.0 §6 grants no trademark rights"), which is preserved legal text,
+# NOT an internal section reference — and the no-space §[0-9] pattern would
+# otherwise false-positive on it (the earlier FP validation only covered the
+# SPACE-form legal citation "§ 512"). Surfaced by the package-wide scrub
+# (2026-06-28).
+#
+# Scope ruling (2026-06-28): Apache-2.0 ONLY. The broader generic
+# "<license-id> §N" SPDX carve-out is deliberately NOT used here; widening to
+# other SPDX identifiers is a separate masking-policy decision that requires
+# explicit Suki/Kevin approval with evidence. Matches the full section number so
+# "§10" / "§6.1" mask cleanly. Mirror: identity-language-check.yml.
+APACHE_LEGAL_SECTION = r"Apache-2\.0 §[0-9]+(?:\.[0-9]+)*"
+
+
+def _mask_license_citations(text: str) -> str:
+    """Mask the exact ``Apache-2.0 §N`` legal/trademark citation on ANY path.
+
+    Only ``Apache-2.0 §N`` is neutralized; a bare internal ``§N`` (or any other
+    license-id prefix) is left intact and still trips the §[0-9] rule.
+    """
+    return re.sub(APACHE_LEGAL_SECTION, "Apache-2.0 __LICENSE_SEC__", text)
 
 
 def _mask_openclaw_functional(text: str) -> str:
@@ -273,6 +354,11 @@ def _mask_fleet_functional(text: str) -> str:
 def mask_content(pattern: str, path: str, text: str) -> str:
     """Return ``text`` with the legitimate public-surface forms masked for this
     (pattern, path) pair. Dispatch order mirrors the delta gate exactly."""
+    if pattern == SECTION:
+        # License-section legal citations ("Apache-2.0 §6") are preserved legal
+        # text on ANY path and must never trip the §N rule. Pre-mask them, then
+        # apply the normal path-scoped masking on the result.
+        text = _mask_license_citations(text)
     if is_release_gate_snapshot_path(path):
         return _mask_snapshot(text)
     if pattern == FLEET and is_fleet_public_path(path):

--- a/tests/release_gate/test_release_leak_scan.py
+++ b/tests/release_gate/test_release_leak_scan.py
@@ -82,52 +82,6 @@ def test_internal_task_id_leak_fails(tmp_path):
     assert res.returncode == 1, "internal task-ID leak must fail the gate"
 
 
-def test_internal_vault_path_leak_fails(tmp_path):
-    # Internal vault paths (~/vault/<NN>_<FOLDER>) must not leak into shipped
-    # docstrings/comments — the class scrubbed from the package in a recent
-    # public-identity hygiene pass.
-    _write(
-        tmp_path,
-        "tokenpak/proxy/notes.py",
-        "# spec lives at ~/vault/01_PROJECTS/tokenpak/initiatives/x.md\nX = 1\n",
-    )
-    res = _run_tree(tmp_path)
-    assert res.returncode == 1, "internal vault-path leak must fail the gate"
-    assert "tokenpak/proxy/notes.py" in res.stdout
-
-
-def test_internal_vault_path_various_numbered_folders_fail(tmp_path):
-    # Any two-digit numbered top-level vault folder is internal: 00_kevin,
-    # 06_RUNTIME, 03_AGENT_PACKS, ... — all caught by the single path pattern.
-    for i, ref in enumerate(
-        ("~/vault/00_kevin/y.md", "~/vault/06_RUNTIME/scripts/z.sh")
-    ):
-        _write(tmp_path, f"tokenpak/core/v{i}.py", f"# see {ref}\n")
-    res = _run_tree(tmp_path)
-    assert res.returncode == 1, "all numbered vault folders must fail the gate"
-
-
-def test_vault_path_no_false_positive_on_user_surfaces(tmp_path):
-    # The pattern is deliberately narrow — it requires the ~/vault/<NN>_ shape.
-    # Legitimate surfaces must NOT trip it:
-    #   * ~/vault/.tokenpak  -> a dotfile dir, not a numbered folder
-    #   * bare ~/vault       -> a generic path with no numbered folder
-    #   * bare 01_PROJECTS / 03_AGENT_PACKS (no ~/vault/ prefix) -> keeps the
-    #     lesson_ingest vault-schema feature clean WITHOUT needing an allowlist.
-    _write(
-        tmp_path,
-        "tokenpak/companion/memory/lesson_ingest.py",
-        "# data dir: ~/vault/.tokenpak\n"
-        "VAULT = '~/vault'\n"
-        "PACKS = '03_AGENT_PACKS'  # vault-schema folder name (feature)\n"
-        "SUB = '01_PROJECTS'\n",
-    )
-    res = _run_tree(tmp_path)
-    assert res.returncode == 0, (
-        f"narrow vault pattern must not false-positive:\n{res.stdout}"
-    )
-
-
 def test_allowlisted_openclaw_path_passes(tmp_path):
     # `openclaw` is the legitimate, non-renamable provider/module name in the
     # OpenClaw integration subsystem.
@@ -238,3 +192,250 @@ def test_dist_mode_allowlist_applies_after_prefix_strip(tmp_path):
     )
     res = _run_dist(dist)
     assert res.returncode == 0, f"allowlist must apply to sdist paths:\n{res.stdout}"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Std / § / Standards-Delta register extension (leak-gate Std/§ scanner
+# extension, 2026-06-28). Closes the gap that let internal ``Std NN`` (outside
+# 20-39), no-space ``§N`` section refs, and the ``Standards Delta`` artifact
+# name ship in the v1.10.0 wheel. Each case also implicitly checks the
+# explicit per-surface cite-list masks (un-cited Std/§ must still trip) and the
+# false-positive safety against the legal corpus.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_std_out_of_range_leak_fails(tmp_path):
+    # Std 41 is outside the old 20-39 window AND carries a §16 section ref —
+    # exactly the form that shipped in v1.10.0.
+    _write(tmp_path, "tokenpak/core/x.py", "# per Std 41 §16 dispatch contract\nX = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "Std-out-of-range + section leak must fail"
+
+
+def test_std_low_number_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/y.py", "# product constitution per Std 02\nY = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "low Std number leak must fail"
+
+
+def test_section_ref_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/z.py", "# see §4.1 for the rule\nZ = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "bare section-ref leak must fail"
+
+
+def test_standards_delta_leak_fails(tmp_path):
+    _write(tmp_path, "tokenpak/core/d.py", "# transcribed from Standards Delta v0\nD = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "Standards Delta artifact-name leak must fail"
+
+
+def test_fp_crypto_curve_passes(tmp_path):
+    # NIST curve names contain "P-256" / "P-384" — must NOT match §/Std.
+    _write(tmp_path, "tokenpak/crypto/keys.py", "# uses NIST P-256 and P-384 curves\nK = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"crypto curve names must pass:\n{res.stdout}"
+
+
+def test_fp_iso_std_passes(tmp_path):
+    # "Std 14001" is a 5-digit ISO number, not a 2-digit \bStd NN\b citation.
+    _write(tmp_path, "tokenpak/quality/iso.py", "# conforms to ISO Std 14001\nI = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"ISO Std 14001 must pass:\n{res.stdout}"
+
+
+def test_fp_legal_section_word_passes(tmp_path):
+    _write(tmp_path, "tokenpak/legal/dmca.py", "# safe harbor under section 230\nL = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"legal 'section 230' prose must pass:\n{res.stdout}"
+
+
+def test_fp_legal_section_sign_citation_passes(tmp_path):
+    # The internal form is uniformly no-space ("§N"); a legal citation uses a
+    # SPACE ("§ 512"), so the no-space §[0-9] pattern structurally cannot hit it.
+    _write(tmp_path, "tokenpak/legal/cite.py", "# see 17 U.S.C. § 512(c)\nC = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"legal '§ 512' (space form) must pass:\n{res.stdout}"
+
+
+def test_fp_bare_section_sign_passes(tmp_path):
+    _write(tmp_path, "tokenpak/docs/sym.py", "# the § sign denotes a section\nS = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"bare § (no digit) must pass:\n{res.stdout}"
+
+
+def test_relgate_impl_cited_std_section_passes(tmp_path):
+    # scripts/release_gate/** legitimately implements Std 30 and cites §7.
+    _write(tmp_path, "scripts/release_gate/foo.py", "# implements Std 30 §7 R7\nF = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"cited Std/§ on impl path must pass:\n{res.stdout}"
+
+
+def test_relgate_impl_sentence_period_citation_passes(tmp_path):
+    # A cited section followed by a sentence period ("§13.3.") must NOT
+    # self-fail the gate.
+    _write(tmp_path, "scripts/release_gate/bar.py", "# governed by Std 30 §13.3.\nB = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"sentence-period citation must pass:\n{res.stdout}"
+
+
+def test_relgate_impl_uncited_std_still_fails(tmp_path):
+    # Std 99 is NOT on the impl cite-list — the mask is explicit, not blanket.
+    _write(tmp_path, "scripts/release_gate/baz.py", "# bogus Std 99 reference\nZ = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "un-cited Std on impl path must still fail"
+
+
+def test_relgate_impl_uncited_subsection_still_fails(tmp_path):
+    # §13 and §13.1-.4 are cited; §13.5 is NOT — the boundary keeps it tripping.
+    _write(tmp_path, "scripts/release_gate/qux.py", "# stray §13.5 ref\nQ = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "un-cited sub-section on impl path must still fail"
+
+
+def test_snapshot_cited_section_passes(tmp_path):
+    # Generated snapshot metadata legitimately cites §7 (R7).
+    _write(tmp_path, "tokenpak/_snapshots/x.json", '{"note": "api-snapshot-check §7 R7"}\n')
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"cited §7 in snapshot must pass:\n{res.stdout}"
+
+
+def test_snapshot_uncited_section_still_fails(tmp_path):
+    # §4 is NOT on the snapshot cite-list ({7, 13.3}) — must still trip.
+    _write(tmp_path, "tokenpak/_snapshots/y.json", '{"note": "stray §4 ref"}\n')
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "un-cited §4 in snapshot must still fail"
+
+
+def test_non_relgate_path_cited_section_still_fails(tmp_path):
+    # The same §7 that is masked on a release-gate path is a leak elsewhere:
+    # proves the cite-list is path-scoped, not global.
+    _write(tmp_path, "tokenpak/proxy/leak.py", "# transcribed §7 note\nP = 1\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "§7 outside release-gate paths must still fail"
+
+
+def test_fp_license_section_citation_passes(tmp_path):
+    # Preserved legal/trademark text: the README trademark clause cites the
+    # license section with a NO-SPACE "§6" ("Apache-2.0 §6 grants no trademark
+    # rights") — the §[0-9] pattern matches it, so the exact Apache-2.0 §N
+    # allowlist must let it pass. (The space-form "§ 512" FP test does not cover
+    # this.)
+    _write(
+        tmp_path,
+        "tokenpak/_meta/readme_snippet.md",
+        "Brand assets are not licensed under Apache-2.0 (Apache-2.0 §6 grants "
+        "no trademark rights).\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"Apache-2.0 license-section citation must pass:\n{res.stdout}"
+
+
+def test_apache_license_multidigit_section_passes(tmp_path):
+    # The allowlist matches the full section number, so a multi-digit / dotted
+    # section masks cleanly (no partial-mask leak).
+    _write(tmp_path, "tokenpak/_meta/readme_snippet.md", "see Apache-2.0 §10.2 hypothetical\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, f"multi-digit Apache section must pass:\n{res.stdout}"
+
+
+def test_license_carveout_requires_apache_prefix(tmp_path):
+    # The allowlist is narrow: a bare internal "§6" with no Apache-2.0 prefix is
+    # still a leak and must still trip.
+    _write(tmp_path, "tokenpak/_meta/note.md", "internal rule per §6 of the spec\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "bare §6 (no Apache-2.0 prefix) must still fail"
+
+
+def test_non_apache_license_section_fails(tmp_path):
+    # Scope ruling (2026-06-28): Apache-2.0 ONLY. The generic "<license-id> §N"
+    # SPDX carve-out is NOT used, so a non-Apache license-section citation (e.g.
+    # "MIT §6") is NOT allowlisted and still trips the §[0-9] rule. (Widening to
+    # other SPDX identifiers is a separate Suki/Kevin policy decision.)
+    _write(tmp_path, "tokenpak/_meta/note.md", "see MIT §6 for the clause\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "non-Apache license-section citation must fail (Apache-only allowlist)"
+
+
+def test_pattern_register_parity_with_delta_gate():
+    # Mechanical SYNC OBLIGATION check: the full-tree register (PATTERNS in
+    # check_release_leaks.py) and the per-PR delta gate
+    # (identity-language-check.yml `patterns=( ... )`) MUST carry the identical
+    # forbidden-pattern set. Guards against the two scanners drifting. The YAML
+    # extraction reads ONLY array-ENTRY lines (a lone quoted string), skipping
+    # comment lines inside the block.
+    import importlib.util
+    import re as _re
+
+    spec = importlib.util.spec_from_file_location("_crl_parity", SCANNER)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_crl_parity"] = mod
+    spec.loader.exec_module(mod)
+    py_set = set(mod.PATTERNS)
+
+    yml = (REPO_ROOT / ".github" / "workflows" / "identity-language-check.yml").read_text(
+        encoding="utf-8"
+    )
+    block = _re.search(r"patterns=\((.*?)\n\s*\)", yml, _re.S).group(1)
+    y_set = set()
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        m = _re.fullmatch(r"'([^']*)'", stripped)  # entry line = a lone quoted string
+        if m:
+            y_set.add(m.group(1))
+
+    assert py_set == y_set, (
+        "scanner register and delta gate drifted:\n"
+        f"  only in scanner: {py_set - y_set}\n"
+        f"  only in delta gate: {y_set - py_set}"
+    )
+
+
+
+# Vault-path leak pattern (preserved from public PR #251 — must not regress).
+def test_internal_vault_path_leak_fails(tmp_path):
+    # Internal vault paths (~/vault/<NN>_<FOLDER>) must not leak into shipped
+    # docstrings/comments — the class scrubbed from the package in a recent
+    # public-identity hygiene pass.
+    _write(
+        tmp_path,
+        "tokenpak/proxy/notes.py",
+        "# spec lives at ~/vault/01_PROJECTS/tokenpak/initiatives/x.md\nX = 1\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "internal vault-path leak must fail the gate"
+    assert "tokenpak/proxy/notes.py" in res.stdout
+
+
+def test_internal_vault_path_various_numbered_folders_fail(tmp_path):
+    # Any two-digit numbered top-level vault folder is internal: 00_kevin,
+    # 06_RUNTIME, 03_AGENT_PACKS, ... — all caught by the single path pattern.
+    for i, ref in enumerate(
+        ("~/vault/00_kevin/y.md", "~/vault/06_RUNTIME/scripts/z.sh")
+    ):
+        _write(tmp_path, f"tokenpak/core/v{i}.py", f"# see {ref}\n")
+    res = _run_tree(tmp_path)
+    assert res.returncode == 1, "all numbered vault folders must fail the gate"
+
+
+def test_vault_path_no_false_positive_on_user_surfaces(tmp_path):
+    # The pattern is deliberately narrow — it requires the ~/vault/<NN>_ shape.
+    # Legitimate surfaces must NOT trip it:
+    #   * ~/vault/.tokenpak  -> a dotfile dir, not a numbered folder
+    #   * bare ~/vault       -> a generic path with no numbered folder
+    #   * bare 01_PROJECTS / 03_AGENT_PACKS (no ~/vault/ prefix) -> keeps the
+    #     lesson_ingest vault-schema feature clean WITHOUT needing an allowlist.
+    _write(
+        tmp_path,
+        "tokenpak/companion/memory/lesson_ingest.py",
+        "# data dir: ~/vault/.tokenpak\n"
+        "VAULT = '~/vault'\n"
+        "PACKS = '03_AGENT_PACKS'  # vault-schema folder name (feature)\n"
+        "SUB = '01_PROJECTS'\n",
+    )
+    res = _run_tree(tmp_path)
+    assert res.returncode == 0, (
+        f"narrow vault pattern must not false-positive:\n{res.stdout}"
+    )


### PR DESCRIPTION
## Summary

Extend the public-leak release gate (`scripts/release_gate/check_release_leaks.py`) and its mirrored
per-PR delta gate (`.github/workflows/identity-language-check.yml`) to catch internal
standards-citation forms the previous range-limited rule did not — built off **current `main`** so it
preserves every existing public pattern.

## What changes

- **Patterns (both surfaces):** the full two-digit numbered-standard form (supersedes the two narrow
  range-limited rules), the no-space section-marker form, and the internal working-document name.
- **Legal allowlist:** an exact `Apache-2.0` license-section allowlist so the legitimate trademark
  notice in the long-description still passes. Exact-literal — **not** a broad section exemption;
  a section citation under any other license id still fails.
- **Release-gate masking:** the release-gate implementation and snapshot surfaces mask **only** their
  own standards-section citations via explicit path-scoped cite-lists. Agent names, private paths, the
  numbered-vault-folder pattern, and task IDs remain fully enforced on those paths.

## Safety / validation

- **Preserves all existing public patterns** — diff vs `main` only *replaces* the old range-limited
  numbered-standard rules with the wider form and adds the new rules; **no existing pattern removed**
  (the numbered-vault-folder protection is explicitly retained + tested).
- **Both surfaces synced** — mechanical register-parity test (symmetric difference none) + behavioral
  parity across the matrix.
- **38 regression cases** — internal forms fail; the exact `Apache-2.0` legal citation passes;
  non-Apache license sections, space-form/long-number near-misses, and bare markers behave correctly;
  release-gate/snapshot citations mask while agent names / private paths / vault-folder / task IDs on
  those same paths still fail.
- Built distribution scan of the current clean tree passes (1876 files, 0 leaks). Scope is 3 files;
  no shipped package code changes.

## Status

**Held — do not merge.** Opened for review and an explicit maintainer merge gate (release-gate policy
change). No release, tag, or publish action.
