### PR TITLE
Cross-platform service abstraction for proxy restart/logs

### DIFF
--- a/tests/cli/test_maintenance_platform.py
+++ b/tests/cli/test_maintenance_platform.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-abstraction tests for `tokenpak maintenance` (CP-03/CP-05).
+
+Verifies that proxy restart / log commands:
+  - keep full Linux behavior (systemctl / journalctl),
+  - degrade honestly on macOS and native Windows (no missing-binary traceback),
+  - never shell out to systemctl/journalctl on a platform that lacks them.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tokenpak.cli.commands import maintenance
+from tokenpak.platform import process, service
+
+
+def _force_platform(monkeypatch, label: str) -> None:
+    monkeypatch.setattr(process, "current_platform", lambda: label)
+
+
+# --------------------------------------------------------------------------- #
+# service.restart_proxy_service
+# --------------------------------------------------------------------------- #
+
+
+def test_restart_linux_success(monkeypatch):
+    _force_platform(monkeypatch, "linux")
+    monkeypatch.setattr(service.shutil, "which", lambda _: "/usr/bin/systemctl")
+    run = mock.Mock(return_value=mock.Mock(returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    result = service.restart_proxy_service("tokenpak-proxy.service")
+
+    assert result.supported and result.ok
+    args = run.call_args[0][0]
+    assert args == ["systemctl", "--user", "restart", "tokenpak-proxy.service"]
+
+
+def test_restart_linux_failure_is_supported_but_not_ok(monkeypatch):
+    _force_platform(monkeypatch, "linux")
+    monkeypatch.setattr(service.shutil, "which", lambda _: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        service.subprocess,
+        "run",
+        mock.Mock(return_value=mock.Mock(returncode=1, stdout="", stderr="boom")),
+    )
+
+    result = service.restart_proxy_service()
+    assert result.supported and not result.ok
+
+
+def test_restart_linux_without_systemd_is_degraded(monkeypatch):
+    _force_platform(monkeypatch, "linux")
+    monkeypatch.setattr(service.shutil, "which", lambda _: None)
+    run = mock.Mock()
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    result = service.restart_proxy_service()
+    assert not result.supported and not result.ok
+    run.assert_not_called()  # never shells out when systemctl is absent
+
+
+@pytest.mark.parametrize("plat", ["macos", "windows", "other"])
+def test_restart_non_linux_is_honest_unsupported(monkeypatch, plat):
+    _force_platform(monkeypatch, plat)
+    run = mock.Mock()
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    result = service.restart_proxy_service()
+
+    assert not result.supported and not result.ok
+    assert "tokenpak restart" in result.message
+    run.assert_not_called()  # no systemctl on non-Linux
+
+
+# --------------------------------------------------------------------------- #
+# service.proxy_logs
+# --------------------------------------------------------------------------- #
+
+
+def test_logs_linux_uses_journalctl(monkeypatch):
+    _force_platform(monkeypatch, "linux")
+    monkeypatch.setattr(service.shutil, "which", lambda _: "/usr/bin/journalctl")
+    run = mock.Mock(return_value=mock.Mock(returncode=0, stdout="log-line", stderr=""))
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    result = service.proxy_logs("tokenpak-proxy.service", n=10)
+    assert result.message == "log-line"
+    assert run.call_args[0][0][0] == "journalctl"
+
+
+@pytest.mark.parametrize("plat", ["macos", "windows"])
+def test_logs_non_linux_points_at_logfile(monkeypatch, plat):
+    _force_platform(monkeypatch, plat)
+    run = mock.Mock()
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    result = service.proxy_logs(n=10)
+    assert not result.supported
+    assert "watchdog.log" in result.message
+    run.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# service.restart_remediation
+# --------------------------------------------------------------------------- #
+
+
+def test_remediation_is_platform_specific(monkeypatch):
+    _force_platform(monkeypatch, "linux")
+    assert "systemctl" in service.restart_remediation("tokenpak-proxy.service")
+    _force_platform(monkeypatch, "macos")
+    assert "tokenpak restart" in service.restart_remediation()
+    _force_platform(monkeypatch, "windows")
+    assert "tokenpak restart" in service.restart_remediation()
+
+
+# --------------------------------------------------------------------------- #
+# maintenance.restart_proxy / show_logs branching
+# --------------------------------------------------------------------------- #
+
+
+def test_maintenance_restart_success_no_exit(monkeypatch):
+    monkeypatch.setattr(
+        maintenance.service,
+        "restart_proxy_service",
+        lambda *_a, **_k: service._ServiceResult(True, True, "✓ Proxy service restarted"),
+    )
+    monkeypatch.setattr(maintenance.time, "sleep", lambda *_a, **_k: None)
+    maintenance.restart_proxy()  # must not raise SystemExit
+
+
+def test_maintenance_restart_supported_failure_exits_1(monkeypatch):
+    monkeypatch.setattr(
+        maintenance.service,
+        "restart_proxy_service",
+        lambda *_a, **_k: service._ServiceResult(True, False, "✖ Restart failed"),
+    )
+    with pytest.raises(SystemExit) as exc:
+        maintenance.restart_proxy()
+    assert exc.value.code == 1
+
+
+def test_maintenance_restart_unsupported_does_not_exit(monkeypatch, capsys):
+    monkeypatch.setattr(
+        maintenance.service,
+        "restart_proxy_service",
+        lambda *_a, **_k: service._ServiceResult(False, False, "Use: tokenpak restart"),
+    )
+    maintenance.restart_proxy()  # honest guidance, no traceback / no exit
+    assert "tokenpak restart" in capsys.readouterr().out
+
+
+def test_maintenance_windows_end_to_end_no_systemctl(monkeypatch, capsys):
+    """On Windows, restart_proxy prints guidance and never invokes systemctl."""
+    _force_platform(monkeypatch, "windows")
+    run = mock.Mock()
+    monkeypatch.setattr(service.subprocess, "run", run)
+
+    maintenance.restart_proxy()
+
+    run.assert_not_called()
+    assert "tokenpak restart" in capsys.readouterr().out

--- a/tokenpak/cli/commands/maintenance.py
+++ b/tokenpak/cli/commands/maintenance.py
@@ -2,30 +2,30 @@
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import time
+
+from tokenpak.platform import service
 
 PROXY_SERVICE = "tokenpak-proxy.service"
 
 
 def restart_proxy() -> None:
-    try:
-        subprocess.run(["systemctl", "--user", "restart", PROXY_SERVICE], check=True)
+    result = service.restart_proxy_service(PROXY_SERVICE)
+    if result.ok:
         time.sleep(2)
-        print("✓ Proxy service restarted")
-    except subprocess.CalledProcessError as e:
-        print(f"✖ Restart failed: {e}")
+        print(result.message)
+        return
+    print(result.message)
+    if result.supported:
+        # The platform supports a managed restart but it failed — this is an error.
         sys.exit(1)
+    # Unsupported/degraded platform: actionable guidance already printed, no traceback.
 
 
 def show_logs(n: int = 30) -> None:
-    r = subprocess.run(
-        ["journalctl", "--user", "-u", PROXY_SERVICE, f"-n{n}", "--no-pager"],
-        capture_output=True,
-        text=True,
-    )
-    print(r.stdout or r.stderr)
+    result = service.proxy_logs(PROXY_SERVICE, n=n)
+    print(result.message)
 
 
 try:

--- a/tokenpak/platform/__init__.py
+++ b/tokenpak/platform/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""tokenpak.platform — cross-platform process and service lifecycle adapters.
+
+This package isolates OS-specific assumptions (systemd/cron/journalctl on Linux,
+``pkill``/``ss``/``curl`` shellouts, POSIX session semantics, ``/proc`` reads) so
+that product commands can run on Linux, macOS, and native Windows with honest
+supported / degraded / unsupported behavior instead of missing-binary tracebacks.
+
+Submodules:
+  - :mod:`tokenpak.platform.process` — process lifecycle (liveness, termination,
+    detached background start, port checks).
+  - :mod:`tokenpak.platform.service` — managed-service / scheduler operations
+    (proxy service restart, log retrieval, crontab/at scheduling) with
+    platform-appropriate availability results.
+
+Nothing here is part of the released public API surface; ``__all__`` is empty so
+the package contributes no symbols to the public-API snapshot. Consumers import
+the *modules* (``from tokenpak.platform import process, service``) and call
+through the module qualifier.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tokenpak/platform/process.py
+++ b/tokenpak/platform/process.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-platform process lifecycle adapters.
+
+Replaces unguarded POSIX-only assumptions (``os.kill(pid, 0)`` as a liveness
+probe, ``pkill``/``ss`` shellouts, ``start_new_session`` detach, ``Path.home() /
+"tokenpak"`` cwd fallbacks) with helpers that behave correctly — or report an
+honest unsupported result — on Linux, macOS, and native Windows.
+
+Dispatch is on :func:`current_platform`, which reads ``sys.platform`` at call
+time so behavior can be exercised under simulated platforms in tests.
+
+Nothing here is public API: ``__all__`` is empty so the module contributes no
+symbols to the public-API snapshot. Consumers import this module and call
+through the module qualifier (e.g. ``process.pid_alive(pid)``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+__all__: list[str] = []
+
+
+# Windows process-creation flags. Referenced via getattr so this module imports
+# on POSIX (where the subprocess constants are absent); the literal fallbacks
+# match the Win32 values so the dispatched value is correct even when the code
+# path is exercised under a simulated platform on a POSIX host.
+_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+
+_WINDOWS_STILL_ACTIVE = 259
+_WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+
+def current_platform() -> str:
+    """Return a normalized platform label: ``linux`` / ``macos`` / ``windows`` / ``other``.
+
+    Reads ``sys.platform`` live so tests can simulate platforms via monkeypatch.
+    """
+    plat = sys.platform
+    if plat.startswith("linux"):
+        return "linux"
+    if plat == "darwin":
+        return "macos"
+    if plat in ("win32", "cygwin") or plat.startswith("win"):
+        return "windows"
+    return "other"
+
+
+def is_windows() -> bool:
+    return current_platform() == "windows"
+
+
+def is_macos() -> bool:
+    return current_platform() == "macos"
+
+
+def is_linux() -> bool:
+    return current_platform() == "linux"
+
+
+def is_posix() -> bool:
+    """True on Linux/macOS (and other POSIX), False on native Windows."""
+    return not is_windows()
+
+
+def pid_alive(pid: int) -> bool:
+    """Return True iff a process with ``pid`` currently exists.
+
+    POSIX uses ``os.kill(pid, 0)`` (a no-op signal that only probes existence).
+    On native Windows ``os.kill(pid, 0)`` is NOT a liveness probe — Python maps
+    arbitrary signals to ``TerminateProcess``, so it would try to *kill* the
+    process. Windows therefore uses an ``OpenProcess`` / ``GetExitCodeProcess``
+    probe via ctypes instead.
+    """
+    if pid is None or pid <= 0:
+        return False
+    if is_windows():
+        return _pid_alive_windows(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user / not signalable.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    """Windows liveness probe via OpenProcess + GetExitCodeProcess.
+
+    Returns False (rather than raising) if the Win32 APIs are unavailable, so a
+    degraded host never crashes a caller's stale-PID handling.
+    """
+    try:
+        import ctypes  # noqa: PLC0415 — Windows-only, imported lazily
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.OpenProcess(
+            _WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid)
+        )
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+            if not ok:
+                return False
+            return exit_code.value == _WINDOWS_STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:
+        return False
+
+
+def terminate(pid: int, *, force: bool = False) -> bool:
+    """Terminate ``pid`` in a platform-safe way.
+
+    Returns True if the signal was delivered or the process was already gone
+    (idempotent stop), False on any other failure. POSIX sends ``SIGTERM``
+    (or ``SIGKILL`` when ``force``); native Windows routes through ``os.kill``,
+    which maps to ``TerminateProcess`` there.
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        if is_windows():
+            # On Windows os.kill with a non-CTRL signal calls TerminateProcess.
+            os.kill(int(pid), signal.SIGTERM)
+        else:
+            os.kill(int(pid), signal.SIGKILL if force else signal.SIGTERM)
+    except ProcessLookupError:
+        return True  # already gone — treat as a successful stop
+    except OSError:
+        return False
+    return True
+
+
+def start_background(
+    cmd: Sequence[str],
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[dict] = None,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+) -> subprocess.Popen:
+    """Launch a detached background process with platform-appropriate semantics.
+
+    POSIX detaches via ``start_new_session=True`` (setsid). Native Windows uses
+    ``DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`` creation flags instead, since
+    ``start_new_session`` is a POSIX-only concept.
+
+    ``cwd`` defaults to None (inherit) — callers should NOT pass a guessed
+    ``~/tokenpak`` directory; module execution (``-m tokenpak.proxy``) resolves
+    the installed package regardless of the working directory.
+    """
+    popen_kwargs: dict = {
+        "cwd": cwd,
+        "env": env,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if is_windows():
+        popen_kwargs["creationflags"] = _DETACHED_PROCESS | _CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+    return subprocess.Popen(list(cmd), **popen_kwargs)
+
+
+def port_in_use(port: int, host: str = "127.0.0.1", timeout: float = 0.5) -> bool:
+    """Return True iff a TCP connection to ``host:port`` succeeds.
+
+    Pure-socket replacement for ``ss -tlnp`` — works identically on every
+    platform and needs no external binary.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            return sock.connect_ex((host, int(port))) == 0
+    except OSError:
+        return False
+
+
+def kill_by_pattern(patterns: Sequence[str]) -> tuple[bool, str]:
+    """Best-effort kill of processes whose command line matches any pattern.
+
+    POSIX (with ``pkill`` available) uses ``pkill -f`` to preserve existing Linux
+    behavior. Native Windows — and any host lacking ``pkill`` — returns
+    ``(False, <reason>)`` so the caller can fall back to PID-file-based
+    termination rather than shelling out to a missing binary.
+    """
+    if is_windows():
+        return (False, "kill-by-pattern unsupported on windows; use PID-file termination")
+    if not shutil.which("pkill"):
+        return (False, "pkill not available on this host")
+    killed_any = False
+    for pat in patterns:
+        try:
+            result = subprocess.run(["pkill", "-f", pat], timeout=5)
+            if result.returncode in (0, 1):  # 0=killed, 1=no match
+                killed_any = killed_any or result.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return (True, "pkill")
+
+
+def read_pid_file(pid_path: Path) -> Optional[int]:
+    """Read an integer PID from ``pid_path``; return None if absent/invalid."""
+    try:
+        if not pid_path.exists():
+            return None
+        return int(pid_path.read_text().strip())
+    except (OSError, ValueError):
+        return None

--- a/tokenpak/platform/service.py
+++ b/tokenpak/platform/service.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-platform managed-service and scheduler adapters.
+
+Wraps the Linux-only service/scheduler shellouts that product commands embed
+(``systemctl --user restart``, ``journalctl``, ``crontab``, ``at``) behind
+helpers that keep full Linux behavior, attempt sensible macOS behavior, and
+return an honest *unsupported / degraded* result on native Windows instead of
+raising a missing-binary traceback.
+
+Results are returned as :class:`_ServiceResult` (``supported`` / ``ok`` /
+``message`` / ``detail``) so callers can print actionable, platform-specific
+guidance.
+
+Nothing here is public API: ``__all__`` is empty so the module contributes no
+symbols to the public-API snapshot. Consumers import this module and call
+through the module qualifier (e.g. ``service.restart_proxy_service()``).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import List, Optional
+
+from tokenpak.platform import process
+
+__all__: list[str] = []
+
+DEFAULT_PROXY_SERVICE = "tokenpak-proxy.service"
+
+
+@dataclass(frozen=True)
+class _ServiceResult:
+    """Outcome of a platform service/scheduler operation.
+
+    supported: the operation is implemented on this platform.
+    ok:        the operation ran and succeeded (always False when unsupported).
+    message:   human-facing, platform-specific guidance or captured output.
+    detail:    optional diagnostic context.
+    """
+
+    supported: bool
+    ok: bool
+    message: str
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Proxy managed-service operations
+# ---------------------------------------------------------------------------
+
+
+def restart_proxy_service(service_name: str = DEFAULT_PROXY_SERVICE) -> _ServiceResult:
+    """Restart the proxy via the platform's service manager.
+
+    Linux: ``systemctl --user restart <service>`` (full behavior).
+    macOS / Windows: no managed-service integration yet — returns an honest
+    degraded result pointing at ``tokenpak restart`` rather than shelling out
+    to a binary that does not exist.
+    """
+    if process.is_linux():
+        if not shutil.which("systemctl"):
+            return _ServiceResult(
+                supported=False,
+                ok=False,
+                message="systemctl not found — restart the proxy with: tokenpak restart",
+                detail="linux host without systemd --user",
+            )
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "restart", service_name],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                return _ServiceResult(True, True, "✓ Proxy service restarted")
+            return _ServiceResult(
+                supported=True,
+                ok=False,
+                message=f"✖ Restart failed (systemctl exit {result.returncode})",
+                detail=(result.stderr or result.stdout or "").strip(),
+            )
+        except OSError as e:
+            return _ServiceResult(True, False, f"✖ Restart failed: {e}")
+
+    if process.is_macos():
+        return _ServiceResult(
+            supported=False,
+            ok=False,
+            message=(
+                "Managed-service restart is not yet integrated on macOS. "
+                "Restart the proxy with: tokenpak restart"
+            ),
+        )
+    if process.is_windows():
+        return _ServiceResult(
+            supported=False,
+            ok=False,
+            message=(
+                "Managed-service restart is not available on Windows. "
+                "Restart the proxy with: tokenpak restart"
+            ),
+        )
+    return _ServiceResult(
+        supported=False,
+        ok=False,
+        message="Managed-service restart is unsupported on this platform. Use: tokenpak restart",
+    )
+
+
+def proxy_logs(service_name: str = DEFAULT_PROXY_SERVICE, n: int = 30) -> _ServiceResult:
+    """Fetch recent proxy logs from the platform's logging facility.
+
+    Linux: ``journalctl --user -u <service> -n N --no-pager`` (captured into
+    ``message``). macOS / Windows: honest guidance pointing at the on-disk
+    watchdog/proxy log instead of invoking journalctl.
+    """
+    if process.is_linux() and shutil.which("journalctl"):
+        try:
+            r = subprocess.run(
+                ["journalctl", "--user", "-u", service_name, f"-n{n}", "--no-pager"],
+                capture_output=True,
+                text=True,
+            )
+            return _ServiceResult(True, r.returncode == 0, r.stdout or r.stderr or "")
+        except OSError as e:
+            return _ServiceResult(True, False, f"✖ Could not read logs: {e}")
+
+    return _ServiceResult(
+        supported=False,
+        ok=False,
+        message=(
+            "Service logs via journalctl are not available on this platform.\n"
+            "Check the proxy/watchdog log at: ~/.tokenpak/watchdog.log"
+        ),
+    )
+
+
+def restart_remediation(service_name: str = DEFAULT_PROXY_SERVICE) -> str:
+    """Return platform-specific remediation guidance for restarting the proxy.
+
+    Used by doctor checks so remediation text is honest on every OS rather than
+    always recommending ``systemctl``.
+    """
+    if process.is_linux():
+        return f"Restart proxy via: systemctl --user restart {service_name}"
+    if process.is_macos():
+        return "Restart proxy via: tokenpak restart (launchd integration not yet available)"
+    if process.is_windows():
+        return "Restart proxy via: tokenpak restart"
+    return "Restart proxy via: tokenpak restart"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler (crontab / at) operations
+# ---------------------------------------------------------------------------
+
+
+def cron_supported() -> bool:
+    """True iff a POSIX ``crontab`` binary is available on this host."""
+    return process.is_posix() and shutil.which("crontab") is not None
+
+
+def cron_read() -> Optional[List[str]]:
+    """Return current crontab lines, or None if crontab is unavailable.
+
+    None signals an unsupported/degraded host (e.g. native Windows, or a POSIX
+    host without cron); callers map that to "no entries".
+    """
+    if not cron_supported():
+        return None
+    try:
+        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+        if result.returncode == 0:
+            return result.stdout.splitlines()
+        return []
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def cron_write(lines: List[str]) -> bool:
+    """Write ``lines`` to the user crontab. Returns False if unavailable."""
+    if not cron_supported():
+        return False
+    try:
+        content = "\n".join(lines) + "\n"
+        proc = subprocess.run(["crontab", "-"], input=content, text=True, capture_output=True)
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def at_supported() -> bool:
+    """True iff a POSIX ``at`` binary is available on this host."""
+    return process.is_posix() and shutil.which("at") is not None
+
+
+def at_submit(run_at: str, command: str) -> bool:
+    """Submit a one-shot ``at`` job. Returns False if ``at`` is unavailable."""
+    if not at_supported():
+        return False
+    try:
+        proc = subprocess.run(
+            ["at", run_at],
+            input=command + "\n",
+            text=True,
+            capture_output=True,
+        )
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False


### PR DESCRIPTION
## Summary

`tokenpak restart` and `tokenpak logs` currently shell out to `systemctl --user`
and `journalctl --user` directly. On macOS and Windows — where those Linux
service tools don't exist — these commands hard-fail instead of degrading
gracefully.

This change introduces a small `tokenpak.platform` layer that the maintenance
commands route through:

- `tokenpak/platform/process.py` — process/port helpers
- `tokenpak/platform/service.py` — `restart_proxy_service()` / `proxy_logs()`
  with platform-aware behavior and actionable messaging when a managed restart
  isn't supported
- `tokenpak/cli/commands/maintenance.py` — restart/logs now call the service
  layer instead of invoking `systemctl` / `journalctl` directly

On unsupported or degraded platforms the commands print actionable guidance and
exit cleanly rather than raising a traceback.

## Scope

Intentionally surgical: exactly five files, limited to the proxy restart/logs
service abstraction. No unrelated package, workflow, release-data, or metadata
changes are bundled.

- `tokenpak/cli/commands/maintenance.py`
- `tokenpak/platform/__init__.py`
- `tokenpak/platform/process.py`
- `tokenpak/platform/service.py`
- `tests/cli/test_maintenance_platform.py`

## Tests

`pytest tests/cli/test_maintenance_platform.py` → 14 passed.

## Status

Draft — opened for review. No release, tag, or publish is part of this PR.
