### PR TITLE
fix(proxy): upstream transport reliability — bounded retry recovery + pool client eviction

### DIFF
--- a/tests/proxy/test_upstream_retry_policy.py
+++ b/tests/proxy/test_upstream_retry_policy.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import httpx
+
+from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff
+from tokenpak.proxy.upstream_retry import (
+    UpstreamRetryPolicy,
+    build_terminal_recovery_payload,
+    extract_tip_plan_id,
+    persist_failed_request_metadata,
+    request_is_deterministic,
+    response_has_truncated_json,
+)
+
+
+def _policy(max_attempts: int = 3) -> UpstreamRetryPolicy:
+    return UpstreamRetryPolicy(
+        max_attempts=max_attempts,
+        backoff=RateLimitBackoff(base_wait=0.01, max_wait=60.0, jitter_factor=0.0),
+    )
+
+
+def test_dropped_pre_stream_connection_retries_safely() -> None:
+    policy = _policy(max_attempts=2)
+
+    decision = policy.retry_for_exception(
+        httpx.ReadError("upstream connection dropped mid-stream"),
+        0,
+        stream_started=False,
+    )
+
+    assert decision.should_retry is True
+    assert decision.reason == "ReadError"
+
+
+def test_dropped_mid_stream_connection_fails_visibly_with_recovery_status() -> None:
+    policy = _policy(max_attempts=2)
+
+    decision = policy.retry_for_exception(
+        httpx.ReadError("upstream connection dropped mid-stream"),
+        0,
+        stream_started=True,
+    )
+    payload = build_terminal_recovery_payload(
+        request_id="req-123",
+        tip_plan_id="tip-456",
+        error_type="upstream_stream_terminal_failure",
+        message="stream already started",
+        stream_started=True,
+    )
+
+    assert decision.should_retry is False
+    assert decision.reason == "client_output_already_started"
+    assert payload["error"]["request_id"] == "req-123"
+    assert payload["error"]["tip_plan_id"] == "tip-456"
+    assert payload["error"]["recovery_status"] == "terminally_failed"
+    assert payload["error"]["stream_started"] is True
+
+
+def test_non_streaming_retry_succeeds_before_response_bytes_are_sent() -> None:
+    policy = _policy(max_attempts=3)
+    calls = 0
+    sleeps: list[float] = []
+    result = None
+
+    for attempt in range(policy.max_attempts):
+        try:
+            calls += 1
+            if calls == 1:
+                raise httpx.RemoteProtocolError("server disconnected")
+            result = b'{"ok": true}'
+            break
+        except policy.retryable_exceptions as exc:
+            decision = policy.retry_for_exception(exc, attempt, stream_started=False)
+            assert decision.should_retry is True
+            sleeps.append(decision.delay_seconds)
+
+    assert result == b'{"ok": true}'
+    assert calls == 2
+    assert sleeps == [0.01]
+
+
+def test_429_honors_retry_after() -> None:
+    policy = _policy(max_attempts=2)
+
+    decision = policy.retry_for_response(
+        429,
+        {"Retry-After": "9"},
+        0,
+        stream_started=False,
+    )
+
+    assert decision.should_retry is True
+    assert decision.delay_seconds == 9
+    assert decision.reason == "http_429"
+
+
+def test_deterministic_mode_never_retries() -> None:
+    body = json.dumps(
+        {"messages": [{"role": "user", "content": "[TIP: deterministic=on] run eval"}]}
+    ).encode()
+    policy = UpstreamRetryPolicy.from_env(
+        body=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert request_is_deterministic(body, {"Content-Type": "application/json"}) is True
+    response_decision = policy.retry_for_response(
+        429,
+        {"Retry-After": "1"},
+        0,
+        stream_started=False,
+    )
+    assert response_decision.should_retry is False
+    assert response_decision.reason == "deterministic_mode"
+    assert (
+        policy.retry_for_exception(
+            httpx.ConnectTimeout("timeout"),
+            0,
+            stream_started=False,
+        ).should_retry
+        is False
+    )
+
+
+def test_truncated_upstream_json_is_retryable_before_output() -> None:
+    assert response_has_truncated_json(
+        200,
+        {"Content-Type": "application/json"},
+        b'{"message": "unterminated',
+    )
+    assert not response_has_truncated_json(
+        400,
+        {"Content-Type": "application/json"},
+        b'{"message": "unterminated',
+    )
+    assert not response_has_truncated_json(
+        200,
+        {"Content-Type": "application/json", "Content-Encoding": "gzip"},
+        b"\x1f\x8bcompressed",
+    )
+
+
+def test_extract_tip_plan_id_prefers_headers_then_body() -> None:
+    assert (
+        extract_tip_plan_id({"X-TIP-Plan-ID": "from-header"}, b"{}", "req")
+        == "from-header"
+    )
+    assert (
+        extract_tip_plan_id({}, b'{"metadata":{"tip_plan_id":"from-body"}}', "req")
+        == "from-body"
+    )
+    assert extract_tip_plan_id({}, b"{}", "req") == "tip-plan-req"
+
+
+def test_failed_request_metadata_persists_redacted_recovery_record(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOKENPAK_UPSTREAM_RECOVERY_DIR", str(tmp_path))
+
+    path = persist_failed_request_metadata(
+        request_id="req-1",
+        tip_plan_id="tip-1",
+        target_url="https://api.example.test/v1/messages",
+        method="POST",
+        headers={"Authorization": "Bearer secret", "Content-Type": "application/json"},
+        body=b'{"messages":[{"role":"user","content":"continue"}]}',
+        stream_started=True,
+        recovery_status="terminally_failed",
+        error_type="ReadError",
+        error_message="dropped",
+    )
+
+    assert path is not None
+    data = json.loads(path.read_text())
+    assert "Authorization" not in data["headers"]
+    assert data["headers"]["Content-Type"] == "application/json"
+    assert data["continue_requires_visible_turn"] is True
+    assert data["supports_hidden_replay"] is False
+    assert "body_utf8" not in data
+    assert data["body_sha256"]
+    assert oct(tmp_path.stat().st_mode & 0o777) == "0o700"
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_failed_request_metadata_persists_full_body_only_when_enabled(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOKENPAK_UPSTREAM_RECOVERY_DIR", str(tmp_path))
+    monkeypatch.setenv("TOKENPAK_RETRY_PERSIST_BODY", "1")
+
+    path = persist_failed_request_metadata(
+        request_id="req-body",
+        tip_plan_id="tip-body",
+        target_url="https://api.example.test/v1/messages",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        body=b'{"messages":[{"role":"user","content":"continue"}]}',
+        stream_started=False,
+        recovery_status="terminally_failed",
+        error_type="ReadError",
+        error_message="dropped",
+    )
+
+    assert path is not None
+    data = json.loads(path.read_text())
+    assert data["body_utf8"] == '{"messages":[{"role":"user","content":"continue"}]}'
+
+
+def test_high_concurrency_sends_queue_and_bound_correctly(monkeypatch) -> None:
+    from tokenpak.proxy import server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "_UPSTREAM_CONCURRENCY", 1)
+    proxy_server._upstream_semaphores.clear()
+    proxy_server._upstream_inflight.clear()
+    sem = proxy_server._get_upstream_semaphore("openai", "session-a")
+
+    assert sem.acquire(timeout=0)
+    events: list[object] = []
+
+    def waiter() -> None:
+        events.append("waiting")
+        acquired = sem.acquire(timeout=0.5)
+        events.append(acquired)
+        if acquired:
+            sem.release()
+
+    thread = threading.Thread(target=waiter)
+    thread.start()
+    time.sleep(0.05)
+    assert events == ["waiting"]
+
+    sem.release()
+    thread.join(timeout=1)
+    assert events == ["waiting", True]

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -365,7 +365,7 @@ def test_pool_metrics_reuse_rate_formula():
 def test_pool_metrics_to_dict_keys():
     m = PoolMetrics(total_requests=5, reused_connections=3, new_connections=2, errors=0)
     d = m.to_dict()
-    assert set(d.keys()) == {"total_requests", "reused_connections", "new_connections", "errors", "reuse_rate"}
+    assert set(d.keys()) == {"total_requests", "reused_connections", "new_connections", "errors", "evicted_clients", "reuse_rate"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_connection_pool_eviction.py
+++ b/tests/test_connection_pool_eviction.py
@@ -268,6 +268,60 @@ def test_streaming_downstream_error_does_not_evict():
 
 
 # ---------------------------------------------------------------------------
+# Session reaper / LRU disposal safety
+# ---------------------------------------------------------------------------
+
+def test_idle_reap_retires_instead_of_closing():
+    """An idle-looking session client may be mid-way through a long stream
+    (last_used is a checkout stamp) — the reaper must retire, not close."""
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(
+        transport, session_client_idle_seconds=0.0, retire_close_grace_seconds=3600.0
+    )
+    first = pool._get_session_client(NETLOC, "sess-old")
+
+    # Any later checkout triggers the idle reap of sess-old.
+    pool._get_session_client(NETLOC, "sess-new")
+
+    assert (NETLOC, "sess-old") not in pool._session_clients
+    assert first.is_closed is False, "reaped client must stay open for in-flights"
+    assert pool.metrics()["retired_pending_close"] >= 1
+    pool.close()
+    assert first.is_closed is True
+
+
+def test_lru_eviction_retires_instead_of_closing():
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(
+        transport, session_client_max=1, retire_close_grace_seconds=3600.0
+    )
+    first = pool._get_session_client(NETLOC, "sess-a")
+    pool._get_session_client(NETLOC, "sess-b")  # cap 1 → LRU-evicts sess-a
+
+    assert (NETLOC, "sess-a") not in pool._session_clients
+    assert first.is_closed is False
+    pool.close()
+    assert first.is_closed is True
+
+
+def test_request_completion_restamps_session_last_used():
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(transport)
+    client = pool._get_session_client(NETLOC, "sess-1")
+    key = (NETLOC, "sess-1")
+    pool._session_clients[key] = (client, 0.0)  # artificially ancient
+
+    pool.request("POST", URL, content=b"{}", session_key="sess-1")
+    assert pool._session_clients[key][1] > 0.0
+
+    pool._session_clients[key] = (client, 0.0)
+    with pool.stream("POST", URL, content=b"{}", session_key="sess-1") as resp:
+        resp.read()
+    assert pool._session_clients[key][1] > 0.0, "stream exit must re-stamp"
+    pool.close()
+
+
+# ---------------------------------------------------------------------------
 # Config / metrics surface
 # ---------------------------------------------------------------------------
 

--- a/tests/test_connection_pool_eviction.py
+++ b/tests/test_connection_pool_eviction.py
@@ -1,0 +1,316 @@
+"""
+Tests for connection-pool client eviction on transport errors
+
+Covers:
+- request() transport error evicts the netloc client (retry gets a fresh one)
+- retry loop recovers after eviction (the incident regression case)
+- session-keyed client eviction
+- eviction disabled via config keeps the failed client pooled
+- PoolTimeout is excluded from eviction (local saturation, not a dead link)
+- stale client reference never evicts the replacement client
+- evicted clients are retired (kept open for in-flight grace), then closed
+- streaming: connect/send failure and mid-stream failure both evict
+- downstream (non-httpx) errors in the streaming body do not evict
+- from_env() parses the new timeout/eviction env vars
+- metrics expose evicted_clients and retired_pending_close
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from tokenpak.proxy.connection_pool import ConnectionPool, PoolConfig
+
+URL = "http://upstream.test/v1/messages"
+NETLOC = "upstream.test"
+
+
+class _FlakyTransport(httpx.BaseTransport):
+    """Raises a transport error for the first *fail_times* requests, then succeeds."""
+
+    def __init__(self, fail_times: int = 1, exc_factory=None):
+        self.calls = 0
+        self.fail_times = fail_times
+        self.exc_factory = exc_factory or (
+            lambda: httpx.ReadError("[Errno 104] Connection reset by peer")
+        )
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self.exc_factory()
+        return httpx.Response(200, json={"ok": True})
+
+
+class _ExplodingStream(httpx.SyncByteStream):
+    """Yields one chunk, then dies like a reset upstream connection."""
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield b'data: {"type":"ping"}\n\n'
+        raise httpx.ReadError("connection reset mid-stream")
+
+
+class _MidStreamFailTransport(httpx.BaseTransport):
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            stream=_ExplodingStream(),
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+
+def _pool_with_transport(transport: httpx.BaseTransport, **cfg_kwargs) -> ConnectionPool:
+    """Pool whose clients all use *transport* (no real sockets)."""
+    pool = ConnectionPool(PoolConfig(http2=False, **cfg_kwargs))
+    pool._make_client = lambda: httpx.Client(transport=transport)  # type: ignore[method-assign]
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# request() path
+# ---------------------------------------------------------------------------
+
+def test_request_transport_error_evicts_client():
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    assert NETLOC not in pool._clients, "failed client should be evicted"
+    second = pool._get_client(NETLOC)
+    assert second is not first
+    m = pool.metrics()
+    assert m["evicted_clients"] == 1
+    assert m["errors"] == 1
+    pool.close()
+
+
+def test_retry_loop_recovers_after_eviction():
+    """The incident regression: a retry after a dead-connection failure must
+    reach upstream on a fresh client instead of re-failing on the same one."""
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport)
+
+    resp = None
+    for _attempt in range(2):
+        try:
+            resp = pool.request("POST", URL, content=b"{}")
+            break
+        except httpx.TransportError:
+            continue
+
+    assert resp is not None and resp.status_code == 200
+    assert transport.calls == 2
+    assert pool.metrics()["evicted_clients"] == 1
+    pool.close()
+
+
+def test_session_client_eviction_and_recovery():
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport)
+    first = pool._get_session_client(NETLOC, "sess-1")
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}", session_key="sess-1")
+
+    assert (NETLOC, "sess-1") not in pool._session_clients
+    second = pool._get_session_client(NETLOC, "sess-1")
+    assert second is not first
+
+    resp = pool.request("POST", URL, content=b"{}", session_key="sess-1")
+    assert resp.status_code == 200
+    pool.close()
+
+
+def test_eviction_disabled_via_config():
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport, evict_on_transport_error=False)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    assert pool._clients.get(NETLOC) is first, "client must stay pooled when disabled"
+    assert pool.metrics()["evicted_clients"] == 0
+    pool.close()
+
+
+def test_pool_timeout_is_not_evicted():
+    transport = _FlakyTransport(fail_times=1, exc_factory=lambda: httpx.PoolTimeout("busy"))
+    pool = _pool_with_transport(transport)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.PoolTimeout):
+        pool.request("POST", URL, content=b"{}")
+
+    assert pool._clients.get(NETLOC) is first
+    assert pool.metrics()["evicted_clients"] == 0
+    pool.close()
+
+
+def test_stale_reference_does_not_evict_replacement():
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(transport)
+    first = pool._get_client(NETLOC)
+
+    assert pool._evict_client(NETLOC, None, first) is True
+    replacement = pool._get_client(NETLOC)
+    assert replacement is not first
+
+    # A second eviction attempt with the stale reference must be a no-op.
+    assert pool._evict_client(NETLOC, None, first) is False
+    assert pool._clients.get(NETLOC) is replacement
+    assert pool.metrics()["evicted_clients"] == 1
+    pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Retire/close lifecycle
+# ---------------------------------------------------------------------------
+
+def test_retired_client_kept_open_during_grace_then_closed():
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport, retire_close_grace_seconds=3600.0)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    assert first.is_closed is False, "in-flight grace: evicted client stays open"
+    assert pool.metrics()["retired_pending_close"] == 1
+
+    pool.close()
+    assert first.is_closed is True
+    assert pool.metrics()["retired_pending_close"] == 0
+
+
+def test_retired_client_closed_after_grace_expiry():
+    transport = _FlakyTransport(fail_times=2)
+    pool = _pool_with_transport(transport, retire_close_grace_seconds=0.0)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    # Grace of 0: the next reap (triggered by the next eviction) closes it.
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    assert first.is_closed is True
+    pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Streaming path
+# ---------------------------------------------------------------------------
+
+def test_streaming_connect_failure_evicts():
+    transport = _FlakyTransport(fail_times=1)
+    pool = _pool_with_transport(transport)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(httpx.ReadError):
+        with pool.stream("POST", URL, content=b"{}") as resp:
+            resp.read()
+
+    assert NETLOC not in pool._clients
+    m = pool.metrics()
+    assert m["evicted_clients"] == 1
+    assert m["errors"] == 1
+    assert pool._get_client(NETLOC) is not first
+    pool.close()
+
+
+def test_streaming_midstream_failure_evicts():
+    pool = _pool_with_transport(_MidStreamFailTransport())
+    first = pool._get_client(NETLOC)
+
+    chunks = []
+    with pytest.raises(httpx.ReadError):
+        with pool.stream("POST", URL, content=b"{}") as resp:
+            # chunk_size smaller than the first upstream chunk so iter_bytes
+            # flushes it before the mid-stream failure surfaces.
+            for chunk in resp.iter_bytes(chunk_size=8):
+                chunks.append(chunk)
+
+    assert chunks, "the pre-failure chunk should have been delivered"
+    assert NETLOC not in pool._clients
+    m = pool.metrics()
+    assert m["evicted_clients"] == 1
+    assert m["errors"] == 1
+    assert pool._get_client(NETLOC) is not first
+    pool.close()
+
+
+def test_streaming_downstream_error_does_not_evict():
+    """A non-httpx error inside the with-body (e.g. the downstream client
+    hanging up on us) says nothing about upstream health — no eviction."""
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(transport)
+    first = pool._get_client(NETLOC)
+
+    with pytest.raises(BrokenPipeError):
+        with pool.stream("POST", URL, content=b"{}"):
+            raise BrokenPipeError("downstream client went away")
+
+    assert pool._clients.get(NETLOC) is first
+    m = pool.metrics()
+    assert m["evicted_clients"] == 0
+    assert m["errors"] == 0
+    pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Config / metrics surface
+# ---------------------------------------------------------------------------
+
+def test_from_env_parses_new_vars():
+    env = {
+        "TOKENPAK_POOL_CONNECT_TIMEOUT": "5",
+        "TOKENPAK_POOL_READ_TIMEOUT": "120",
+        "TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR": "0",
+        "TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS": "60",
+    }
+    with patch.dict(os.environ, env):
+        cfg = PoolConfig.from_env()
+    assert cfg.connect_timeout == 5.0
+    assert cfg.read_timeout == 120.0
+    assert cfg.evict_on_transport_error is False
+    assert cfg.retire_close_grace_seconds == 60.0
+
+
+def test_from_env_defaults_for_new_vars():
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in (
+            "TOKENPAK_POOL_CONNECT_TIMEOUT",
+            "TOKENPAK_POOL_READ_TIMEOUT",
+            "TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR",
+            "TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS",
+        )
+    }
+    try:
+        cfg = PoolConfig.from_env()
+        assert cfg.connect_timeout == 10.0
+        assert cfg.read_timeout == 300.0
+        assert cfg.evict_on_transport_error is True
+        assert cfg.retire_close_grace_seconds == 900.0
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
+def test_metrics_expose_eviction_counters():
+    pool = ConnectionPool(PoolConfig(http2=False))
+    m = pool.metrics()
+    assert m["evicted_clients"] == 0
+    assert m["retired_pending_close"] == 0
+    pool.close()

--- a/tests/test_proxy_server_async.py
+++ b/tests/test_proxy_server_async.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import gzip
 import json
+import tempfile
 import threading
 import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -565,13 +566,109 @@ class TestForwardRequest(unittest.IsolatedAsyncioTestCase):
 
         request = await self._make_request()
 
-        with patch("tokenpak.proxy.server_async._should_intercept", return_value=False):
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch.dict("os.environ", {"TOKENPAK_UPSTREAM_RECOVERY_DIR": tmpdir}), \
+             patch("tokenpak.proxy.server_async._should_intercept", return_value=False), \
+             patch("tokenpak.proxy.server_async.asyncio.sleep", new_callable=AsyncMock):
             from tokenpak.proxy.server_async import _forward_request
             response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
 
         self.assertEqual(response.status_code, 502)
         data = json.loads(response.body)
-        self.assertEqual(data["error"]["type"], "proxy_error")
+        self.assertEqual(data["error"]["type"], "upstream_terminal_failure")
+        self.assertEqual(data["error"]["recovery_status"], "terminally_failed")
+        self.assertEqual(async_client.request.await_count, 3)
+
+    async def test_non_streaming_retry_succeeds_before_response_bytes_are_sent(self):
+        import httpx
+
+        from tokenpak.proxy import server_async as module
+
+        ps = self._make_ps()
+        module._proxy_server_ref = ps
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"ok": true}'
+        mock_response.headers = {"content-type": "application/json"}
+
+        async_client = AsyncMock()
+        async_client.request = AsyncMock(
+            side_effect=[httpx.ReadError("dropped before response"), mock_response]
+        )
+        module._async_client = async_client
+
+        request = await self._make_request()
+
+        with patch("tokenpak.proxy.server_async._should_intercept", return_value=False), \
+             patch("tokenpak.proxy.server_async.asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            from tokenpak.proxy.server_async import _forward_request
+            response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"ok": true}')
+        self.assertEqual(async_client.request.await_count, 2)
+        sleep_mock.assert_awaited_once()
+
+    async def test_non_streaming_429_honors_retry_after(self):
+        from tokenpak.proxy import server_async as module
+
+        ps = self._make_ps()
+        module._proxy_server_ref = ps
+
+        rate_limited = MagicMock()
+        rate_limited.status_code = 429
+        rate_limited.content = b'{"error": "rate limited"}'
+        rate_limited.headers = {"retry-after": "2.5", "content-type": "application/json"}
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+        ok_response.content = b'{"ok": true}'
+        ok_response.headers = {"content-type": "application/json"}
+
+        async_client = AsyncMock()
+        async_client.request = AsyncMock(side_effect=[rate_limited, ok_response])
+        module._async_client = async_client
+
+        request = await self._make_request()
+
+        with patch("tokenpak.proxy.server_async._should_intercept", return_value=False), \
+             patch("tokenpak.proxy.server_async.asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            from tokenpak.proxy.server_async import _forward_request
+            response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(async_client.request.await_count, 2)
+        sleep_mock.assert_awaited_once_with(2.5)
+
+    async def test_deterministic_mode_never_retries(self):
+        import httpx
+
+        from tokenpak.proxy import server_async as module
+
+        ps = self._make_ps()
+        module._proxy_server_ref = ps
+
+        async_client = AsyncMock()
+        async_client.request = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        module._async_client = async_client
+
+        body = json.dumps(
+            {"messages": [{"role": "user", "content": "[TIP: deterministic=on] run eval"}]}
+        ).encode()
+        request = await self._make_request(body=body, headers={"content-type": "application/json"})
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch.dict("os.environ", {"TOKENPAK_UPSTREAM_RECOVERY_DIR": tmpdir}), \
+             patch("tokenpak.proxy.server_async._should_intercept", return_value=False), \
+             patch("tokenpak.proxy.server_async.asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            from tokenpak.proxy.server_async import _forward_request
+            response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
+
+        self.assertEqual(response.status_code, 502)
+        data = json.loads(response.body)
+        self.assertEqual(data["error"]["type"], "upstream_terminal_failure")
+        self.assertEqual(async_client.request.await_count, 1)
+        sleep_mock.assert_not_awaited()
 
     async def test_gzip_response_decoded(self):
         from tokenpak.proxy import server_async as module
@@ -848,6 +945,150 @@ class TestForwardRequestStreaming(unittest.IsolatedAsyncioTestCase):
             response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
 
         self.assertIsInstance(response, StreamingResponse)
+        chunks = [chunk async for chunk in response.body_iterator]
+        self.assertIn(sse_chunk, chunks)
+
+    async def test_streaming_pre_open_drop_retries_safely(self):
+        import httpx
+        from starlette.responses import StreamingResponse
+
+        from tokenpak.proxy import server_async as module
+
+        ps = self._make_ps()
+        module._proxy_server_ref = ps
+
+        sse_chunk = b"data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n\n"
+
+        class FailingUpstreamCM:
+            async def __aenter__(self):
+                raise httpx.ReadError("dropped before headers")
+
+            async def __aexit__(self, *args):
+                return False
+
+        class SuccessUpstreamCM:
+            status_code = 200
+            headers = {"content-type": "text/event-stream"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def aiter_bytes(self, chunk_size=4096):
+                yield sse_chunk
+
+        async_client = AsyncMock()
+        async_client.stream = Mock(side_effect=[FailingUpstreamCM(), SuccessUpstreamCM()])
+        module._async_client = async_client
+
+        streaming_body = json.dumps({
+            "model": "claude",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}]
+        }).encode()
+        request = await self._make_request(body=streaming_body)
+
+        with patch("tokenpak.proxy.server_async._should_intercept", return_value=True), \
+             patch("tokenpak.proxy.server_async._is_messages_endpoint", return_value=True), \
+             patch("tokenpak.proxy.server_async._record_telemetry"), \
+             patch("tokenpak.proxy.server_async.asyncio.sleep", new_callable=AsyncMock), \
+             patch("tokenpak.proxy.router.ProviderRouter") as MockRouter:
+            route = MagicMock()
+            route.model = "claude"
+            MockRouter.return_value.route.return_value = route
+            from tokenpak.proxy.server_async import _forward_request
+            response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
+
+        self.assertIsInstance(response, StreamingResponse)
+        chunks = [chunk async for chunk in response.body_iterator]
+        self.assertIn(sse_chunk, chunks)
+        self.assertEqual(async_client.stream.call_count, 2)
+
+    async def test_streaming_midstream_drop_returns_terminal_recovery_event(self):
+        import httpx
+
+        from tokenpak.proxy import server_async as module
+
+        ps = self._make_ps()
+        module._proxy_server_ref = ps
+
+        class DroppingUpstreamCM:
+            status_code = 200
+            headers = {"content-type": "text/event-stream"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def aiter_bytes(self, chunk_size=4096):
+                yield b'data: {"type":"message_delta"}\n\n'
+                raise httpx.ReadError("dropped mid-stream")
+
+        async_client = AsyncMock()
+        async_client.stream = Mock(return_value=DroppingUpstreamCM())
+        module._async_client = async_client
+
+        streaming_body = json.dumps({
+            "model": "claude",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}]
+        }).encode()
+        request = await self._make_request(
+            body=streaming_body,
+            headers={"x-request-id": "req-async", "x-tip-plan-id": "tip-async"},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch.dict("os.environ", {"TOKENPAK_UPSTREAM_RECOVERY_DIR": tmpdir}), \
+             patch("tokenpak.proxy.server_async._should_intercept", return_value=True), \
+             patch("tokenpak.proxy.server_async._is_messages_endpoint", return_value=True), \
+             patch("tokenpak.proxy.server_async._record_telemetry"), \
+             patch("tokenpak.proxy.router.ProviderRouter") as MockRouter:
+            route = MagicMock()
+            route.model = "claude"
+            MockRouter.return_value.route.return_value = route
+            from tokenpak.proxy.server_async import _forward_request
+            response = await _forward_request(request, "https://api.anthropic.com/v1/messages")
+            body = b"".join([chunk async for chunk in response.body_iterator])
+
+        self.assertIn(b"upstream_stream_terminal_failure", body)
+        self.assertIn(b"terminally_failed", body)
+        self.assertIn(b"req-async", body)
+        self.assertIn(b"tip-async", body)
+
+    async def test_async_upstream_concurrency_queues_and_bounds(self):
+        from tokenpak.proxy import server_async as module
+
+        old_limit = module.ASYNC_UPSTREAM_CONCURRENCY
+        module.ASYNC_UPSTREAM_CONCURRENCY = 1
+        module._async_upstream_semaphores.clear()
+        module._async_upstream_inflight.clear()
+        try:
+            sem = await module._get_async_upstream_semaphore("openai", "session-a")
+            await sem.acquire()
+            events: list[object] = []
+
+            async def waiter() -> None:
+                events.append("waiting")
+                acquired = await asyncio.wait_for(sem.acquire(), timeout=0.5)
+                events.append(acquired)
+                if acquired:
+                    sem.release()
+
+            task = asyncio.create_task(waiter())
+            await asyncio.sleep(0.05)
+            self.assertEqual(events, ["waiting"])
+            sem.release()
+            await task
+            self.assertEqual(events, ["waiting", True])
+        finally:
+            module.ASYNC_UPSTREAM_CONCURRENCY = old_limit
+            module._async_upstream_semaphores.clear()
+            module._async_upstream_inflight.clear()
 
 
 # ===========================================================================

--- a/tokenpak/proxy/connection_pool.py
+++ b/tokenpak/proxy/connection_pool.py
@@ -25,6 +25,16 @@ Env vars (all optional)
     Seconds before idle keep-alive connections are evicted (default: ``30``).
 ``TOKENPAK_HTTP2``
     Set to ``0`` to disable HTTP/2 (default: ``1`` — enabled).
+``TOKENPAK_POOL_CONNECT_TIMEOUT``
+    Seconds to wait for a new TCP connection (default: ``10``).
+``TOKENPAK_POOL_READ_TIMEOUT``
+    Seconds to wait for upstream response bytes (default: ``300``).
+``TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR``
+    Set to ``0`` to keep a client pooled after a transport error
+    (default: ``1`` — evict so retries get a fresh connection).
+``TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS``
+    Seconds an evicted client is kept open for in-flight requests before
+    being closed (default: ``900``).
 
 Performance impact
 ------------------
@@ -45,7 +55,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import httpx
 
@@ -65,6 +75,22 @@ def _http2_available() -> bool:
 
 
 _H2_AVAILABLE: bool = _http2_available()
+
+
+# ---------------------------------------------------------------------------
+# Transport-error classification for client eviction
+# ---------------------------------------------------------------------------
+
+# PoolTimeout means the local pool was saturated, not that a connection is
+# broken — evicting the whole client would discard healthy connections.
+_EVICT_EXCLUDED_ERRORS: tuple = (httpx.PoolTimeout,)
+
+
+def _is_evictable_transport_error(exc: BaseException) -> bool:
+    """True when *exc* suggests the client's pooled connection(s) may be dead."""
+    return isinstance(exc, httpx.TransportError) and not isinstance(
+        exc, _EVICT_EXCLUDED_ERRORS
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +117,13 @@ class PoolConfig:
         Seconds to wait for a response (default: 300 — LLM responses can be slow).
     http2 : bool
         Enable HTTP/2 when ``h2`` is installed (default: True).
+    evict_on_transport_error : bool
+        Evict a client from the pool when a request on it raises a transport
+        error, so retries get a fresh client/connection instead of the same
+        dead one (default: True).
+    retire_close_grace_seconds : float
+        How long an evicted client is retained (unclosed) so requests still
+        in flight on it can finish before ``close()`` (default: 900).
     """
 
     max_connections: int = 20
@@ -99,6 +132,8 @@ class PoolConfig:
     connect_timeout: float = 10.0
     read_timeout: float = 300.0
     http2: bool = True
+    evict_on_transport_error: bool = True
+    retire_close_grace_seconds: float = 900.0
     # Per-session upstream client pool — used when the caller passes a
     # session_key to stream()/request(). Each unique session_key gets its
     # own httpx.Client (and thus its own HTTP/2 connection to upstream),
@@ -116,7 +151,15 @@ class PoolConfig:
             max_connections=int(os.environ.get("TOKENPAK_POOL_MAX_CONNECTIONS", "20")),
             max_keepalive_connections=int(os.environ.get("TOKENPAK_POOL_MAX_KEEPALIVE", "10")),
             keepalive_expiry=float(os.environ.get("TOKENPAK_POOL_KEEPALIVE_EXPIRY", "30")),
+            connect_timeout=float(os.environ.get("TOKENPAK_POOL_CONNECT_TIMEOUT", "10")),
+            read_timeout=float(os.environ.get("TOKENPAK_POOL_READ_TIMEOUT", "300")),
             http2=os.environ.get("TOKENPAK_HTTP2", "1") != "0",
+            evict_on_transport_error=(
+                os.environ.get("TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR", "1") != "0"
+            ),
+            retire_close_grace_seconds=float(
+                os.environ.get("TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS", "900")
+            ),
             session_client_max=int(os.environ.get("TOKENPAK_SESSION_CLIENTS_MAX", "32")),
             session_client_idle_seconds=float(
                 os.environ.get("TOKENPAK_SESSION_CLIENT_IDLE_SECS", "300")
@@ -137,6 +180,7 @@ class PoolMetrics:
     reused_connections: int = 0
     new_connections: int = 0
     errors: int = 0
+    evicted_clients: int = 0
 
     @property
     def reuse_rate(self) -> float:
@@ -151,6 +195,7 @@ class PoolMetrics:
             "reused_connections": self.reused_connections,
             "new_connections": self.new_connections,
             "errors": self.errors,
+            "evicted_clients": self.evicted_clients,
             "reuse_rate": self.reuse_rate,
         }
 
@@ -197,6 +242,11 @@ class ConnectionPool:
         # off the main pool lock's critical path.
         self._session_clients: Dict[tuple, tuple] = {}
         self._session_lock = threading.Lock()
+        # Clients evicted after a transport error. They are not closed
+        # immediately — other threads may still be mid-request on them —
+        # but retired here and closed once the grace period has passed.
+        self._retired_clients: List[Tuple[httpx.Client, float]] = []
+        self._retired_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Client management
@@ -292,6 +342,60 @@ class ConnectionPool:
             self._session_clients[key] = (client, now)
             return client
 
+    def _evict_client(
+        self, netloc: str, session_key: Optional[str], client: httpx.Client
+    ) -> bool:
+        """
+        Remove *client* from the pool after a transport error so the next
+        checkout builds a fresh client (and therefore fresh connections).
+
+        Identity-checked: if the pool already holds a replacement client for
+        the slot, nothing is evicted — a burst of failures on one dead client
+        evicts it exactly once. The evicted client is retired, not closed,
+        so requests still in flight on it can finish; retired clients are
+        closed by :meth:`_reap_retired` after the grace period.
+        """
+        if not self._config.evict_on_transport_error:
+            return False
+        evicted = False
+        if session_key:
+            key = (netloc, session_key)
+            with self._session_lock:
+                entry = self._session_clients.get(key)
+                if entry is not None and entry[0] is client:
+                    self._session_clients.pop(key)
+                    evicted = True
+        else:
+            with self._lock:
+                if self._clients.get(netloc) is client:
+                    self._clients.pop(netloc)
+                    evicted = True
+        if evicted:
+            with self._retired_lock:
+                self._retired_clients.append((client, time.monotonic()))
+            with self._metrics_lock:
+                self._metrics.evicted_clients += 1
+        self._reap_retired()
+        return evicted
+
+    def _reap_retired(self, force: bool = False) -> None:
+        """Close retired clients whose in-flight grace period has passed."""
+        cutoff = time.monotonic() - self._config.retire_close_grace_seconds
+        to_close: List[httpx.Client] = []
+        with self._retired_lock:
+            keep: List[Tuple[httpx.Client, float]] = []
+            for client, retired_at in self._retired_clients:
+                if force or retired_at <= cutoff:
+                    to_close.append(client)
+                else:
+                    keep.append((client, retired_at))
+            self._retired_clients = keep
+        for client in to_close:
+            try:
+                client.close()
+            except Exception:
+                pass
+
     # ------------------------------------------------------------------
     # Public request interface
     # ------------------------------------------------------------------
@@ -357,10 +461,12 @@ class ConnectionPool:
                 else:
                     self._metrics.new_connections += 1
             return response
-        except Exception:
+        except Exception as exc:
             with self._metrics_lock:
                 self._metrics.errors += 1
                 self._metrics.new_connections += 1
+            if _is_evictable_transport_error(exc):
+                self._evict_client(netloc, session_key, client)
             raise
 
     def stream(
@@ -399,7 +505,14 @@ class ConnectionPool:
             self._metrics.total_requests += 1
 
         return _StreamingContext(
-            client, method, url, content, headers, self._metrics, self._metrics_lock
+            client,
+            method,
+            url,
+            content,
+            headers,
+            self._metrics,
+            self._metrics_lock,
+            on_transport_error=lambda: self._evict_client(netloc, session_key, client),
         )
 
     # ------------------------------------------------------------------
@@ -420,7 +533,10 @@ class ConnectionPool:
     def metrics(self) -> dict:
         """Return a copy of the current pool metrics."""
         with self._metrics_lock:
-            return self._metrics.to_dict()
+            data = self._metrics.to_dict()
+        with self._retired_lock:
+            data["retired_pending_close"] = len(self._retired_clients)
+        return data
 
     def reset_metrics(self) -> None:
         """Reset all pool counters to zero."""
@@ -447,6 +563,7 @@ class ConnectionPool:
                 except Exception:
                     pass
             self._session_clients.clear()
+        self._reap_retired(force=True)
 
     def session_client_snapshot(self) -> Dict[str, Any]:
         """Return a diagnostic snapshot of the per-session client pool."""
@@ -489,14 +606,21 @@ class _StreamingContext:
         headers: Optional[dict],
         metrics: PoolMetrics,
         lock: threading.Lock,
+        on_transport_error: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._ctx = client.stream(method, url, content=content, headers=headers)
         self._metrics = metrics
         self._lock = lock
         self._response: Optional[httpx.Response] = None
+        self._on_transport_error = on_transport_error
+        self._error_recorded = False
 
     def __enter__(self) -> httpx.Response:
-        self._response = self._ctx.__enter__()
+        try:
+            self._response = self._ctx.__enter__()
+        except Exception as exc:
+            self._record_error(exc)
+            raise
         with self._lock:
             proto = self._response.http_version
             if (
@@ -508,8 +632,30 @@ class _StreamingContext:
                 self._metrics.new_connections += 1
         return self._response
 
-    def __exit__(self, *args) -> None:
-        self._ctx.__exit__(*args)
+    def __exit__(self, exc_type, exc, tb) -> None:
+        try:
+            self._ctx.__exit__(exc_type, exc, tb)
+        finally:
+            if exc is not None:
+                self._record_error(exc)
+
+    def _record_error(self, exc: BaseException) -> None:
+        """Count an upstream error once and evict the client if it looks dead.
+
+        Only ``httpx.HTTPError`` counts — the streaming ``with`` body also
+        writes to the downstream client socket, and a downstream disconnect
+        (e.g. ``BrokenPipeError``) says nothing about upstream health.
+        """
+        if not isinstance(exc, httpx.HTTPError) or self._error_recorded:
+            return
+        self._error_recorded = True
+        with self._lock:
+            self._metrics.errors += 1
+        if self._on_transport_error is not None and _is_evictable_transport_error(exc):
+            try:
+                self._on_transport_error()
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/tokenpak/proxy/connection_pool.py
+++ b/tokenpak/proxy/connection_pool.py
@@ -309,17 +309,16 @@ class ConnectionPool:
         now = time.monotonic() if hasattr(time, "monotonic") else time.time()
         key = (netloc, session_key)
         with self._session_lock:
-            # Reap idle clients
+            # Reap idle clients. Retire instead of closing inline: last_used
+            # is a checkout stamp, so a client mid-way through a long stream
+            # can look idle — closing it here corrupts the live request.
             idle_cutoff = now - cfg.session_client_idle_seconds
             stale_keys = [
                 k for k, (_, last) in self._session_clients.items() if last < idle_cutoff
             ]
             for k in stale_keys:
                 client, _ = self._session_clients.pop(k)
-                try:
-                    client.close()
-                except Exception:
-                    pass
+                self._retire(client)
 
             entry = self._session_clients.get(key)
             if entry is not None:
@@ -327,20 +326,32 @@ class ConnectionPool:
                 self._session_clients[key] = (client, now)
                 return client
 
-            # Enforce cap — LRU-evict oldest
+            # Enforce cap — LRU-evict oldest (retired, same mid-flight hazard)
             while len(self._session_clients) >= cfg.session_client_max:
                 oldest_key = min(
                     self._session_clients.items(), key=lambda kv: kv[1][1]
                 )[0]
                 client, _ = self._session_clients.pop(oldest_key)
-                try:
-                    client.close()
-                except Exception:
-                    pass
+                self._retire(client)
 
             client = self._make_client()
             self._session_clients[key] = (client, now)
             return client
+
+    def _touch_session(self, netloc: str, session_key: str) -> None:
+        """Re-stamp a session client's last_used after a request completes,
+        so long-running streams don't age it into the idle reaper's window."""
+        key = (netloc, session_key)
+        now = time.monotonic()
+        with self._session_lock:
+            entry = self._session_clients.get(key)
+            if entry is not None:
+                self._session_clients[key] = (entry[0], now)
+
+    def _retire(self, client: httpx.Client) -> None:
+        """Queue *client* to be closed after the in-flight grace period."""
+        with self._retired_lock:
+            self._retired_clients.append((client, time.monotonic()))
 
     def _evict_client(
         self, netloc: str, session_key: Optional[str], client: httpx.Client
@@ -371,8 +382,7 @@ class ConnectionPool:
                     self._clients.pop(netloc)
                     evicted = True
         if evicted:
-            with self._retired_lock:
-                self._retired_clients.append((client, time.monotonic()))
+            self._retire(client)
             with self._metrics_lock:
                 self._metrics.evicted_clients += 1
         self._reap_retired()
@@ -460,6 +470,8 @@ class ConnectionPool:
                     self._metrics.reused_connections += 1
                 else:
                     self._metrics.new_connections += 1
+            if session_key:
+                self._touch_session(netloc, session_key)
             return response
         except Exception as exc:
             with self._metrics_lock:
@@ -513,6 +525,11 @@ class ConnectionPool:
             self._metrics,
             self._metrics_lock,
             on_transport_error=lambda: self._evict_client(netloc, session_key, client),
+            on_complete=(
+                (lambda: self._touch_session(netloc, session_key))
+                if session_key
+                else None
+            ),
         )
 
     # ------------------------------------------------------------------
@@ -607,12 +624,14 @@ class _StreamingContext:
         metrics: PoolMetrics,
         lock: threading.Lock,
         on_transport_error: Optional[Callable[[], Any]] = None,
+        on_complete: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._ctx = client.stream(method, url, content=content, headers=headers)
         self._metrics = metrics
         self._lock = lock
         self._response: Optional[httpx.Response] = None
         self._on_transport_error = on_transport_error
+        self._on_complete = on_complete
         self._error_recorded = False
 
     def __enter__(self) -> httpx.Response:
@@ -638,6 +657,11 @@ class _StreamingContext:
         finally:
             if exc is not None:
                 self._record_error(exc)
+            if self._on_complete is not None:
+                try:
+                    self._on_complete()
+                except Exception:
+                    pass
 
     def _record_error(self, exc: BaseException) -> None:
         """Count an upstream error once and evict the client if it looks dead.

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -39,8 +39,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional
 from urllib.parse import urlparse
 
-import httpx
-
 from tokenpak import __version__ as _tokenpak_version
 from tokenpak.cache.telemetry import CacheMetrics
 from tokenpak.cache.telemetry import get_collector as _get_cache_collector
@@ -87,33 +85,22 @@ from .router import INTERCEPT_HOSTS, ProviderRouter, estimate_cost
 from .startup import format_startup_report, run_startup_checks
 from .stats import CompressionStats
 from .streaming import extract_sse_tokens
-
-# ---------------------------------------------------------------------------
-# Upstream retry configuration — transparent retry on transient 5xx and
-# protocol errors so the Claude CLI never sees the mid-stream disconnects
-# Anthropic currently produces at ~15% on large requests.
-# ---------------------------------------------------------------------------
-MAX_UPSTREAM_RETRIES: int = int(os.environ.get("TOKENPAK_UPSTREAM_RETRIES", "3"))
-
-_RETRYABLE_UPSTREAM_EXCEPTIONS: tuple = (
-    httpx.RemoteProtocolError,
-    httpx.LocalProtocolError,
-    httpx.ReadError,
-    httpx.WriteError,
-    httpx.ConnectError,
-    httpx.ConnectTimeout,
-    httpx.ReadTimeout,
+from .upstream_retry import (
+    UpstreamRetryPolicy,
+    UpstreamTruncatedJSONError,
+    build_terminal_recovery_payload,
+    extract_tip_plan_id,
+    persist_failed_request_metadata,
+    response_has_truncated_json,
 )
 
-
-def _is_retryable_upstream_status(status_code: int) -> bool:
-    return status_code in (502, 503, 504)
-
-
-def _upstream_retry_backoff(attempt: int) -> float:
-    # 0.2s, 0.6s, 1.8s — bounded
-    return min(2.5, 0.2 * (3 ** attempt))
-
+# ---------------------------------------------------------------------------
+# Upstream retry configuration.
+#
+# Retry behavior is factored into UpstreamRetryPolicy so the streaming and
+# non-streaming paths share the same transient-error, deterministic-mode, and
+# Retry-After rules.
+# ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
 # Per-(provider, session) outbound concurrency limiter.
@@ -878,6 +865,12 @@ class _ProxyHandler(BaseHTTPRequestHandler):
 
         content_length = int(self.headers.get("Content-Length", 0))
         body: Optional[bytes] = self.rfile.read(content_length) if content_length > 0 else None
+        _original_body = body
+        _retry_policy = UpstreamRetryPolicy.from_env(
+            body=body,
+            headers=dict(self.headers),
+        )
+        _tip_plan_id = extract_tip_plan_id(dict(self.headers), body, _req_id)
 
         model = "unknown"
         input_tokens = 0
@@ -1466,15 +1459,17 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 # string` JSON parse errors in the client's SSE reader).
                 sse_buffer = b""
                 _stream_wrote_to_client = False
-                for _ustream_attempt in range(MAX_UPSTREAM_RETRIES):
+                for _ustream_attempt in range(_retry_policy.max_attempts):
                     _stream_retry = False
                     try:
                         with pool.stream(method, target_url, content=body, headers=fwd_headers, session_key=_session_key) as resp:
-                            if (
-                                _is_retryable_upstream_status(resp.status_code)
-                                and not _stream_wrote_to_client
-                                and _ustream_attempt < MAX_UPSTREAM_RETRIES - 1
-                            ):
+                            _retry_decision = _retry_policy.retry_for_response(
+                                resp.status_code,
+                                resp.headers,
+                                _ustream_attempt,
+                                stream_started=_stream_wrote_to_client,
+                            )
+                            if _retry_decision.should_retry:
                                 # Drain body to release the pooled connection, then retry
                                 for _ in resp.iter_bytes(chunk_size=4096):
                                     pass
@@ -1529,17 +1524,20 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                                         break
                                     if should_log and is_messages:
                                         sse_buffer += chunk
-                    except _RETRYABLE_UPSTREAM_EXCEPTIONS:
+                    except _retry_policy.retryable_exceptions as _stream_exc:
                         # Once we've committed to writing to the client, can't retry —
                         # the CLI's SSE parser would see a truncated-then-restarted stream.
-                        if _stream_wrote_to_client:
-                            raise
-                        if _ustream_attempt >= MAX_UPSTREAM_RETRIES - 1:
+                        _retry_decision = _retry_policy.retry_for_exception(
+                            _stream_exc,
+                            _ustream_attempt,
+                            stream_started=_stream_wrote_to_client,
+                        )
+                        if not _retry_decision.should_retry:
                             raise
                         _stream_retry = True
 
                     if _stream_retry:
-                        time.sleep(_upstream_retry_backoff(_ustream_attempt))
+                        time.sleep(_retry_decision.delay_seconds)
                         continue
                     break
 
@@ -1557,24 +1555,51 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 # Server disconnected, 502/503/504). Safe because the client
                 # has not yet received any bytes at this point.
                 resp = None
-                for _ustream_attempt in range(MAX_UPSTREAM_RETRIES):
+                for _ustream_attempt in range(_retry_policy.max_attempts):
                     try:
                         resp = pool.request(method, target_url, content=body, headers=fwd_headers, session_key=_session_key)
-                        if (
-                            _is_retryable_upstream_status(resp.status_code)
-                            and _ustream_attempt < MAX_UPSTREAM_RETRIES - 1
-                        ):
+                        _retry_decision = _retry_policy.retry_for_response(
+                            resp.status_code,
+                            resp.headers,
+                            _ustream_attempt,
+                            stream_started=False,
+                        )
+                        if _retry_decision.should_retry:
                             try:
                                 resp.close()
                             except Exception:
                                 pass
-                            time.sleep(_upstream_retry_backoff(_ustream_attempt))
+                            time.sleep(_retry_decision.delay_seconds)
                             continue
+                        if response_has_truncated_json(
+                            resp.status_code,
+                            resp.headers,
+                            resp.content,
+                        ):
+                            _retry_decision = _retry_policy.retry_for_truncated_json(
+                                _ustream_attempt,
+                                stream_started=False,
+                            )
+                            if _retry_decision.should_retry:
+                                try:
+                                    resp.close()
+                                except Exception:
+                                    pass
+                                time.sleep(_retry_decision.delay_seconds)
+                                continue
+                            raise UpstreamTruncatedJSONError(
+                                "Upstream returned truncated JSON before response bytes were sent"
+                            )
                         break
-                    except _RETRYABLE_UPSTREAM_EXCEPTIONS:
-                        if _ustream_attempt >= MAX_UPSTREAM_RETRIES - 1:
+                    except _retry_policy.retryable_exceptions as _nonstream_exc:
+                        _retry_decision = _retry_policy.retry_for_exception(
+                            _nonstream_exc,
+                            _ustream_attempt,
+                            stream_started=False,
+                        )
+                        if not _retry_decision.should_retry:
                             raise
-                        time.sleep(_upstream_retry_backoff(_ustream_attempt))
+                        time.sleep(_retry_decision.delay_seconds)
                         continue
                 assert resp is not None
 
@@ -1971,6 +1996,25 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             except Exception:
                 pass  # logging must never break the proxy
             # Build an actionable error message depending on the exception type
+            _is_retry_boundary_error = (
+                _retry_policy.is_retryable_exception(exc)
+                or isinstance(exc, UpstreamTruncatedJSONError)
+                or (_client_headers_sent and is_streaming)
+            )
+            _recovery_record_path = None
+            if _is_retry_boundary_error:
+                _recovery_record_path = persist_failed_request_metadata(
+                    request_id=_req_id,
+                    tip_plan_id=_tip_plan_id,
+                    target_url=target_url,
+                    method=method,
+                    headers=fwd_headers if "fwd_headers" in locals() else dict(self.headers),
+                    body=body if body is not None else _original_body,
+                    stream_started=bool(_client_headers_sent),
+                    recovery_status="terminally_failed",
+                    error_type=exc_type,
+                    error_message=exc_msg,
+                )
             if "timeout" in exc_type.lower() or isinstance(exc, TimeoutError):
                 user_detail = (
                     "The upstream LLM provider did not respond in time. "
@@ -2014,18 +2058,28 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             # parser surfaces it as "Unterminated string". Extra
                             # blank lines between frames are legal per the SSE spec
                             # and harmless when the upstream cut off cleanly.
+                            _terminal_payload = build_terminal_recovery_payload(
+                                request_id=_req_id,
+                                tip_plan_id=_tip_plan_id,
+                                error_type="upstream_stream_terminal_failure",
+                                message=(
+                                    "Upstream connection dropped mid-stream "
+                                    f"({exc_type}). The stream was not replayed "
+                                    "because client-visible output had already started."
+                                ),
+                                stream_started=True,
+                                recovery_record=(
+                                    str(_recovery_record_path)
+                                    if _recovery_record_path is not None
+                                    else None
+                                ),
+                            )
                             _sse_err = (
                                 "\n\n"
                                 "event: error\n"
                                 "data: " + json.dumps({
                                     "type": "error",
-                                    "error": {
-                                        "type": "overloaded_error",
-                                        "message": (
-                                            f"Upstream connection dropped mid-stream "
-                                            f"({exc_type}). Retry the request."
-                                        ),
-                                    },
+                                    **_terminal_payload,
                                 }) + "\n\n"
                             ).encode("utf-8")
                             self.wfile.write(_sse_err)
@@ -2035,14 +2089,37 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                     # Non-streaming: headers+partial body already flushed; nothing
                     # safe to append. Just let the connection close.
                 else:
-                    err = json.dumps({
-                        "error": {
-                            "type": "proxy_error",
-                            "message": user_detail,
-                            "detail": exc_msg,
-                            "hint": "Run `tokenpak doctor` for diagnostics or `tokenpak status` for recent errors.",
+                    if _is_retry_boundary_error:
+                        err_payload = build_terminal_recovery_payload(
+                            request_id=_req_id,
+                            tip_plan_id=_tip_plan_id,
+                            error_type="upstream_terminal_failure",
+                            message=user_detail,
+                            stream_started=False,
+                            recovery_record=(
+                                str(_recovery_record_path)
+                                if _recovery_record_path is not None
+                                else None
+                            ),
+                        )
+                        err_payload["error"]["detail"] = exc_msg
+                        err_payload["error"]["hint"] = (
+                            "Retry later or use a future explicit recovery command; "
+                            "TokenPak did not hide a replay."
+                        )
+                    else:
+                        err_payload = {
+                            "error": {
+                                "type": "proxy_error",
+                                "message": user_detail,
+                                "detail": exc_msg,
+                                "hint": (
+                                    "Run `tokenpak doctor` for diagnostics or "
+                                    "`tokenpak status` for recent errors."
+                                ),
+                            }
                         }
-                    }).encode()
+                    err = json.dumps(err_payload).encode()
                     self.send_response(502)
                     self.send_header("Content-Type", "application/json")
                     self.send_header("Content-Length", str(len(err)))

--- a/tokenpak/proxy/server_async.py
+++ b/tokenpak/proxy/server_async.py
@@ -44,6 +44,16 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
+from .circuit_breaker import provider_from_url
+from .upstream_retry import (
+    UpstreamRetryPolicy,
+    UpstreamTruncatedJSONError,
+    build_terminal_recovery_payload,
+    extract_tip_plan_id,
+    persist_failed_request_metadata,
+    response_has_truncated_json,
+)
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -53,6 +63,10 @@ MAX_CONCURRENCY = int(os.environ.get("TOKENPAK_CONCURRENCY", "200"))
 HTTPX_POOL_SIZE = int(os.environ.get("TOKENPAK_HTTPX_POOL_SIZE", "100"))
 HTTPX_TIMEOUT = float(os.environ.get("TOKENPAK_HTTPX_TIMEOUT", "300"))
 INTERCEPT_HOSTS = {"api.anthropic.com", "api.openai.com"}
+ASYNC_UPSTREAM_CONCURRENCY = int(os.environ.get("TOKENPAK_UPSTREAM_CONCURRENCY", "3"))
+ASYNC_UPSTREAM_ACQUIRE_TIMEOUT = float(
+    os.environ.get("TOKENPAK_UPSTREAM_ACQUIRE_TIMEOUT", "30")
+)
 
 # ---------------------------------------------------------------------------
 # Module-level shared state (set by ProxyServer before uvicorn starts)
@@ -79,6 +93,54 @@ def _client() -> httpx.AsyncClient:
     if _async_client is None:
         raise RuntimeError("AsyncProxyApp: httpx client not ready")
     return _async_client
+
+
+# ---------------------------------------------------------------------------
+# Async upstream concurrency limiter
+# ---------------------------------------------------------------------------
+
+_async_upstream_semaphores: Dict[tuple[str, str], asyncio.BoundedSemaphore] = {}
+_async_upstream_inflight: Dict[tuple[str, str], int] = {}
+_async_upstream_sem_lock = asyncio.Lock()
+
+
+async def _get_async_upstream_semaphore(
+    provider: str, session_key: Optional[str] = None
+) -> asyncio.BoundedSemaphore:
+    key = (provider or "_unknown", session_key or "_shared")
+    async with _async_upstream_sem_lock:
+        sem = _async_upstream_semaphores.get(key)
+        if sem is None:
+            sem = asyncio.BoundedSemaphore(ASYNC_UPSTREAM_CONCURRENCY)
+            _async_upstream_semaphores[key] = sem
+            _async_upstream_inflight[key] = 0
+        return sem
+
+
+async def _async_upstream_inflight_delta(
+    provider: str, delta: int, session_key: Optional[str] = None
+) -> int:
+    key = (provider or "_unknown", session_key or "_shared")
+    async with _async_upstream_sem_lock:
+        count = max(0, _async_upstream_inflight.get(key, 0) + delta)
+        if delta < 0 and count == 0:
+            _async_upstream_inflight.pop(key, None)
+            _async_upstream_semaphores.pop(key, None)
+        else:
+            _async_upstream_inflight[key] = count
+        return count
+
+
+async def _close_async_response(resp: object) -> None:
+    close = getattr(resp, "aclose", None)
+    if close is not None:
+        result = close()
+        if asyncio.iscoroutine(result):
+            await result
+        return
+    close = getattr(resp, "close", None)
+    if close is not None:
+        close()
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +330,12 @@ async def _forward_request(request: Request, target_url: str) -> Response:
 
     # Read body
     body = await request.body()
+    request_id = request.headers.get("x-request-id") or str(uuid.uuid4())[:8]
+    retry_policy = UpstreamRetryPolicy.from_env(
+        body=body,
+        headers=dict(request.headers),
+    )
+    tip_plan_id = extract_tip_plan_id(dict(request.headers), body, request_id)
 
     # Check request size against thresholds (monitoring)
     try:
@@ -361,52 +429,113 @@ async def _forward_request(request: Request, target_url: str) -> Response:
 
     output_tokens = 0
     client = _client()
+    stream_response_owns_slot = False
+    slot_acquired = False
+    sem_provider = provider_from_url(target_url)
+    session_key = (
+        request.headers.get("x-tokenpak-session-id")
+        or request.headers.get("x-session-id")
+        or request.headers.get("x-correlation-id")
+    )
+    if not session_key and request.client is not None:
+        session_key = f"{request.client.host}:{request.client.port}"
+
+    upstream_sem = await _get_async_upstream_semaphore(sem_provider, session_key)
+    try:
+        await asyncio.wait_for(
+            upstream_sem.acquire(),
+            timeout=ASYNC_UPSTREAM_ACQUIRE_TIMEOUT,
+        )
+        slot_acquired = True
+        await _async_upstream_inflight_delta(sem_provider, +1, session_key)
+    except asyncio.TimeoutError:
+        return JSONResponse(
+            {
+                "error": {
+                    "type": "upstream_concurrency_exhausted",
+                    "message": (
+                        f"Too many concurrent requests to '{sem_provider}' "
+                        f"(>{ASYNC_UPSTREAM_CONCURRENCY} in flight). Retry shortly."
+                    ),
+                    "hint": (
+                        "Raise TOKENPAK_UPSTREAM_CONCURRENCY or reduce the "
+                        "number of concurrent companion sessions."
+                    ),
+                }
+            },
+            status_code=503,
+            headers={"Retry-After": "5"},
+        )
 
     try:
         if is_streaming:
             # ── SSE streaming path ────────────────────────────────────────
-            sse_buffer = bytearray()
-            upstream_req = client.build_request(
-                request.method, target_url, content=body, headers=fwd_headers
-            )
+            stream_cm = None
+            upstream = None
 
-            async def sse_stream_generator():
-                nonlocal output_tokens, cache_read_tokens, cache_creation_tokens
+            for attempt in range(retry_policy.max_attempts):
                 try:
-                    async with client.stream(
+                    stream_cm = client.stream(
                         request.method,
                         target_url,
                         content=body,
                         headers=fwd_headers,
                         timeout=HTTPX_TIMEOUT,
-                    ) as resp:
-                        async for chunk in resp.aiter_bytes(chunk_size=4096):
-                            if chunk:
-                                sse_buffer.extend(chunk)
-                                yield chunk
-                    # Parse SSE usage after stream complete
-                    if should_log and is_messages and sse_buffer:
-                        usage = _parse_sse_tokens(bytes(sse_buffer))
-                        output_tokens = usage["output_tokens"]
-                        cache_read_tokens = usage["cache_read_input_tokens"]
-                        cache_creation_tokens = usage["cache_creation_input_tokens"]
-                except Exception as e:
-                    yield b""
+                    )
+                    upstream = await stream_cm.__aenter__()
+                    retry_decision = retry_policy.retry_for_response(
+                        upstream.status_code,
+                        upstream.headers,
+                        attempt,
+                        stream_started=False,
+                    )
+                    if retry_decision.should_retry:
+                        try:
+                            async for _ in upstream.aiter_bytes(chunk_size=4096):
+                                pass
+                        finally:
+                            await stream_cm.__aexit__(None, None, None)
+                        await asyncio.sleep(retry_decision.delay_seconds)
+                        stream_cm = None
+                        upstream = None
+                        continue
+                    break
+                except retry_policy.retryable_exceptions as stream_exc:
+                    if stream_cm is not None:
+                        try:
+                            await stream_cm.__aexit__(
+                                type(stream_exc),
+                                stream_exc,
+                                stream_exc.__traceback__,
+                            )
+                        except Exception:
+                            pass
+                    retry_decision = retry_policy.retry_for_exception(
+                        stream_exc,
+                        attempt,
+                        stream_started=False,
+                    )
+                    if not retry_decision.should_retry:
+                        raise
+                    await asyncio.sleep(retry_decision.delay_seconds)
+                    stream_cm = None
+                    upstream = None
+                    continue
 
-            # We need response headers from upstream — do a peek
-            async with client.stream(
-                request.method, target_url, content=body, headers=fwd_headers, timeout=HTTPX_TIMEOUT
-            ) as upstream:
-                resp_headers = {
-                    k: v
-                    for k, v in upstream.headers.items()
-                    if k.lower()
-                    not in ("content-length", "transfer-encoding", "connection", "keep-alive")
-                }
+            if stream_cm is None or upstream is None:
+                raise httpx.ReadError("Upstream stream did not open")
 
-                async def _inner_stream():
-                    nonlocal output_tokens, cache_read_tokens, cache_creation_tokens
-                    _buf = bytearray()
+            resp_headers = {
+                k: v
+                for k, v in upstream.headers.items()
+                if k.lower()
+                not in ("content-length", "transfer-encoding", "connection", "keep-alive")
+            }
+
+            async def _inner_stream():
+                nonlocal output_tokens, cache_read_tokens, cache_creation_tokens
+                _buf = bytearray()
+                try:
                     async for chunk in upstream.aiter_bytes(chunk_size=4096):
                         if chunk:
                             _buf.extend(chunk)
@@ -430,27 +559,108 @@ async def _forward_request(request: Request, target_url: str) -> Response:
                         cache_creation_tokens,
                         latency_ms,
                     )
+                except retry_policy.retryable_exceptions as stream_exc:
+                    with ps._session_lock:
+                        ps.session["errors"] += 1
+                    record_path = persist_failed_request_metadata(
+                        request_id=request_id,
+                        tip_plan_id=tip_plan_id,
+                        target_url=target_url,
+                        method=request.method,
+                        headers=fwd_headers,
+                        body=body,
+                        stream_started=True,
+                        recovery_status="terminally_failed",
+                        error_type=type(stream_exc).__name__,
+                        error_message=str(stream_exc),
+                    )
+                    payload = build_terminal_recovery_payload(
+                        request_id=request_id,
+                        tip_plan_id=tip_plan_id,
+                        error_type="upstream_stream_terminal_failure",
+                        message=str(stream_exc),
+                        stream_started=True,
+                        recovery_record=str(record_path) if record_path else None,
+                    )
+                    yield (
+                        b"\n\nevent: error\ndata: "
+                        + json.dumps(payload, sort_keys=True).encode()
+                        + b"\n\n"
+                    )
+                finally:
+                    try:
+                        await stream_cm.__aexit__(None, None, None)
+                    finally:
+                        upstream_sem.release()
+                        await _async_upstream_inflight_delta(
+                            sem_provider,
+                            -1,
+                            session_key,
+                        )
 
-                response = StreamingResponse(
-                    _inner_stream(),
-                    status_code=upstream.status_code,
-                    headers=resp_headers,
-                    media_type="text/event-stream",
-                )
-                response.headers["X-Accel-Buffering"] = "no"
-                response.headers["Cache-Control"] = "no-cache"
-                response.headers["Access-Control-Allow-Origin"] = "*"
-                return response
+            response = StreamingResponse(
+                _inner_stream(),
+                status_code=upstream.status_code,
+                headers=resp_headers,
+                media_type="text/event-stream",
+            )
+            response.headers["X-Accel-Buffering"] = "no"
+            response.headers["Cache-Control"] = "no-cache"
+            response.headers["Access-Control-Allow-Origin"] = "*"
+            stream_response_owns_slot = True
+            return response
 
         else:
             # ── Non-streaming path ────────────────────────────────────────
-            resp = await client.request(
-                request.method,
-                target_url,
-                content=body,
-                headers=fwd_headers,
-                timeout=HTTPX_TIMEOUT,
-            )
+            resp = None
+            for attempt in range(retry_policy.max_attempts):
+                try:
+                    resp = await client.request(
+                        request.method,
+                        target_url,
+                        content=body,
+                        headers=fwd_headers,
+                        timeout=HTTPX_TIMEOUT,
+                    )
+                    retry_decision = retry_policy.retry_for_response(
+                        resp.status_code,
+                        resp.headers,
+                        attempt,
+                        stream_started=False,
+                    )
+                    if retry_decision.should_retry:
+                        await _close_async_response(resp)
+                        await asyncio.sleep(retry_decision.delay_seconds)
+                        continue
+                    if response_has_truncated_json(
+                        resp.status_code,
+                        resp.headers,
+                        resp.content,
+                    ):
+                        retry_decision = retry_policy.retry_for_truncated_json(
+                            attempt,
+                            stream_started=False,
+                        )
+                        if retry_decision.should_retry:
+                            await _close_async_response(resp)
+                            await asyncio.sleep(retry_decision.delay_seconds)
+                            continue
+                        raise UpstreamTruncatedJSONError(
+                            "Upstream returned truncated JSON before response bytes were sent"
+                        )
+                    break
+                except retry_policy.retryable_exceptions as nonstream_exc:
+                    retry_decision = retry_policy.retry_for_exception(
+                        nonstream_exc,
+                        attempt,
+                        stream_started=False,
+                    )
+                    if not retry_decision.should_retry:
+                        raise
+                    await asyncio.sleep(retry_decision.delay_seconds)
+                    continue
+
+            assert resp is not None
             resp_body = resp.content
 
             if should_log and is_messages:
@@ -499,6 +709,29 @@ async def _forward_request(request: Request, target_url: str) -> Response:
         with ps._session_lock:
             ps.session["errors"] += 1
         exc_type = type(exc).__name__
+        if retry_policy.is_retryable_exception(exc) or isinstance(exc, UpstreamTruncatedJSONError):
+            record_path = persist_failed_request_metadata(
+                request_id=request_id,
+                tip_plan_id=tip_plan_id,
+                target_url=target_url,
+                method=request.method,
+                headers=fwd_headers,
+                body=body,
+                stream_started=False,
+                recovery_status="terminally_failed",
+                error_type=exc_type,
+                error_message=str(exc),
+            )
+            payload = build_terminal_recovery_payload(
+                request_id=request_id,
+                tip_plan_id=tip_plan_id,
+                error_type="upstream_terminal_failure",
+                message=str(exc),
+                stream_started=False,
+                recovery_record=str(record_path) if record_path else None,
+            )
+            payload["error"]["detail"] = f"{exc_type}: {exc}"
+            return JSONResponse(payload, status_code=502)
         return JSONResponse(
             {
                 "error": {
@@ -510,6 +743,10 @@ async def _forward_request(request: Request, target_url: str) -> Response:
             },
             status_code=502,
         )
+    finally:
+        if slot_acquired and not stream_response_owns_slot:
+            upstream_sem.release()
+            await _async_upstream_inflight_delta(sem_provider, -1, session_key)
 
 
 def _record_telemetry(

--- a/tokenpak/proxy/upstream_retry.py
+++ b/tokenpak/proxy/upstream_retry.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded upstream retry policy for proxy send failures.
+
+The policy is deliberately request-boundary scoped: it may retry before any
+client-visible output, but it never restarts a stream after headers or chunks
+have been emitted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+import httpx
+
+from tokenpak.proxy.handlers.rate_limit import RateLimitBackoff
+
+RETRYABLE_UPSTREAM_EXCEPTIONS: tuple[type[Exception], ...] = (
+    httpx.RemoteProtocolError,
+    httpx.LocalProtocolError,
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.ConnectError,
+    httpx.TimeoutException,
+)
+
+RETRYABLE_UPSTREAM_STATUSES = frozenset({429, 502, 503, 504})
+NON_RETRYABLE_UPSTREAM_STATUSES = frozenset({400, 401, 403, 404})
+
+_SENSITIVE_HEADERS = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "x-api-key",
+        "api-key",
+        "openai-api-key",
+        "anthropic-api-key",
+        "x-goog-api-key",
+        "cookie",
+        "set-cookie",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    """Decision returned by :class:`UpstreamRetryPolicy`."""
+
+    should_retry: bool
+    delay_seconds: float = 0.0
+    reason: str = ""
+
+
+class UpstreamTruncatedJSONError(Exception):
+    """Raised when upstream returns truncated JSON after retries are exhausted."""
+
+
+def _header_get(headers: Mapping[str, object] | None, name: str) -> Optional[str]:
+    if not headers:
+        return None
+    wanted = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == wanted:
+            return str(value)
+    return None
+
+
+def _parse_retry_after(raw: object) -> Optional[float]:
+    if raw is None:
+        return None
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _looks_jsonish(headers: Mapping[str, object] | None, body: bytes | None) -> bool:
+    content_type = (_header_get(headers, "content-type") or "").lower()
+    if "json" in content_type:
+        return True
+    stripped = (body or b"").lstrip()
+    return stripped.startswith((b"{", b"["))
+
+
+def local_json_body_is_valid(
+    body: bytes | None, headers: Mapping[str, object] | None = None
+) -> bool:
+    """Return False only for clearly JSON request bodies that fail local parse."""
+
+    if not body or not _looks_jsonish(headers, body):
+        return True
+    try:
+        json.loads(body.decode("utf-8"))
+    except Exception:
+        return False
+    return True
+
+
+def request_is_deterministic(
+    body: bytes | None, headers: Mapping[str, object] | None = None
+) -> bool:
+    """Detect request-level deterministic mode without mutating the body."""
+
+    deterministic_header = _header_get(headers, "x-tokenpak-deterministic")
+    if deterministic_header and deterministic_header.strip().lower() in {"1", "true", "on"}:
+        return True
+    if not body:
+        return False
+    lowered = body[:8192].lower()
+    if b"[tip:" in lowered and b"deterministic=on" in lowered:
+        return True
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    tokenpak = data.get("tokenpak")
+    if isinstance(tokenpak, dict) and tokenpak.get("deterministic") is True:
+        return True
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        md_tokenpak = metadata.get("tokenpak")
+        if isinstance(md_tokenpak, dict) and md_tokenpak.get("deterministic") is True:
+            return True
+        if metadata.get("deterministic") is True:
+            return True
+    return False
+
+
+def extract_tip_plan_id(
+    headers: Mapping[str, object] | None,
+    body: bytes | None,
+    request_id: str,
+) -> str:
+    """Extract a stable plan id when present, else derive one from request id."""
+
+    for name in (
+        "x-tokenpak-plan-id",
+        "x-tip-plan-id",
+        "x-tokenpak-tip-plan-id",
+        "tip-plan-id",
+    ):
+        value = _header_get(headers, name)
+        if value:
+            return value
+    if body:
+        try:
+            data = json.loads(body.decode("utf-8"))
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            for key in ("tip_plan_id", "plan_id", "request_plan_id"):
+                value = data.get(key)
+                if value:
+                    return str(value)
+            metadata = data.get("metadata")
+            if isinstance(metadata, dict):
+                for key in ("tip_plan_id", "plan_id", "request_plan_id"):
+                    value = metadata.get(key)
+                    if value:
+                        return str(value)
+    return f"tip-plan-{request_id}"
+
+
+def response_has_truncated_json(
+    status_code: int,
+    headers: Mapping[str, object] | None,
+    body: bytes | None,
+) -> bool:
+    """Return True for invalid/truncated upstream JSON received before output."""
+
+    content_encoding = (_header_get(headers, "content-encoding") or "").lower()
+    if content_encoding and content_encoding != "identity":
+        return False
+    if status_code >= 400 or not body or not _looks_jsonish(headers, body):
+        return False
+    try:
+        json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        msg = exc.msg.lower()
+        return (
+            "unterminated" in msg
+            or "expecting value" in msg
+            or "expecting ',' delimiter" in msg
+            or "expecting property name" in msg
+        )
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+@dataclass
+class UpstreamRetryPolicy:
+    """Shared bounded retry behavior for streaming and non-streaming sends."""
+
+    max_attempts: int = 3
+    retry_enabled: bool = True
+    deterministic: bool = False
+    local_request_valid: bool = True
+    backoff: RateLimitBackoff | None = None
+
+    @classmethod
+    def from_env(
+        cls,
+        body: bytes | None = None,
+        headers: Mapping[str, object] | None = None,
+    ) -> "UpstreamRetryPolicy":
+        raw_attempts = os.environ.get("TOKENPAK_UPSTREAM_RETRIES", "3")
+        try:
+            max_attempts = max(1, int(raw_attempts))
+        except ValueError:
+            max_attempts = 3
+        deterministic = request_is_deterministic(body, headers)
+        local_valid = local_json_body_is_valid(body, headers)
+        return cls(
+            max_attempts=max_attempts,
+            retry_enabled=not deterministic and local_valid,
+            deterministic=deterministic,
+            local_request_valid=local_valid,
+            backoff=RateLimitBackoff(
+                base_wait=_float_env("TOKENPAK_UPSTREAM_RETRY_BASE_WAIT", 0.2),
+                max_wait=_float_env("TOKENPAK_UPSTREAM_RETRY_MAX_WAIT", 60.0),
+                jitter_factor=0.0,
+            ),
+        )
+
+    @property
+    def retryable_exceptions(self) -> tuple[type[Exception], ...]:
+        return RETRYABLE_UPSTREAM_EXCEPTIONS
+
+    def is_retryable_exception(self, exc: Exception) -> bool:
+        return isinstance(exc, RETRYABLE_UPSTREAM_EXCEPTIONS)
+
+    def _blocked_reason(self, stream_started: bool) -> Optional[str]:
+        if self.deterministic:
+            return "deterministic_mode"
+        if not self.local_request_valid:
+            return "invalid_local_request_json"
+        if stream_started:
+            return "client_output_already_started"
+        if not self.retry_enabled:
+            return "retry_disabled"
+        return None
+
+    def _delay(self, attempt: int, retry_after: object = None) -> float:
+        backoff = self.backoff or RateLimitBackoff(
+            base_wait=0.2, max_wait=2.5, jitter_factor=0.0
+        )
+        return backoff.wait_time(attempt, retry_after=_parse_retry_after(retry_after))
+
+    def retry_for_exception(
+        self,
+        exc: Exception,
+        attempt: int,
+        *,
+        stream_started: bool,
+    ) -> RetryDecision:
+        blocked = self._blocked_reason(stream_started)
+        if blocked:
+            return RetryDecision(False, reason=blocked)
+        if not self.is_retryable_exception(exc):
+            return RetryDecision(False, reason="non_retryable_exception")
+        if attempt >= self.max_attempts - 1:
+            return RetryDecision(False, reason="attempts_exhausted")
+        return RetryDecision(
+            True,
+            delay_seconds=self._delay(attempt),
+            reason=type(exc).__name__,
+        )
+
+    def retry_for_response(
+        self,
+        status_code: int,
+        headers: Mapping[str, object] | None,
+        attempt: int,
+        *,
+        stream_started: bool,
+    ) -> RetryDecision:
+        blocked = self._blocked_reason(stream_started)
+        if blocked:
+            return RetryDecision(False, reason=blocked)
+        if status_code in NON_RETRYABLE_UPSTREAM_STATUSES:
+            return RetryDecision(False, reason=f"non_retryable_http_{status_code}")
+        if status_code not in RETRYABLE_UPSTREAM_STATUSES:
+            return RetryDecision(False, reason=f"non_retryable_http_{status_code}")
+        if attempt >= self.max_attempts - 1:
+            return RetryDecision(False, reason="attempts_exhausted")
+        retry_after = _header_get(headers, "retry-after") if status_code == 429 else None
+        return RetryDecision(
+            True,
+            delay_seconds=self._delay(attempt, retry_after=retry_after),
+            reason=f"http_{status_code}",
+        )
+
+    def retry_for_truncated_json(
+        self,
+        attempt: int,
+        *,
+        stream_started: bool,
+    ) -> RetryDecision:
+        blocked = self._blocked_reason(stream_started)
+        if blocked:
+            return RetryDecision(False, reason=blocked)
+        if attempt >= self.max_attempts - 1:
+            return RetryDecision(False, reason="attempts_exhausted")
+        return RetryDecision(
+            True,
+            delay_seconds=self._delay(attempt),
+            reason="truncated_upstream_json",
+        )
+
+
+def build_terminal_recovery_payload(
+    *,
+    request_id: str,
+    tip_plan_id: str,
+    error_type: str,
+    message: str,
+    stream_started: bool,
+    recovery_record: str | None = None,
+) -> dict:
+    """Build the structured terminal recovery error envelope."""
+
+    error = {
+        "type": error_type,
+        "message": message,
+        "request_id": request_id,
+        "tip_plan_id": tip_plan_id,
+        "recovery_status": "terminally_failed",
+        "retryable": False,
+        "stream_started": stream_started,
+        "continue_later": True,
+    }
+    if recovery_record:
+        error["recovery_record"] = recovery_record
+    return {"error": error}
+
+
+def _redact_headers(headers: Mapping[str, object] | None) -> dict:
+    if not headers:
+        return {}
+    return {
+        str(key): str(value)
+        for key, value in headers.items()
+        if str(key).lower() not in _SENSITIVE_HEADERS
+    }
+
+
+def _recovery_dir() -> Path:
+    path = Path(
+        os.path.expanduser(
+            os.environ.get(
+                "TOKENPAK_UPSTREAM_RECOVERY_DIR",
+                "~/.tokenpak/recovery/upstream",
+            )
+        )
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    return path
+
+
+def persist_failed_request_metadata(
+    *,
+    request_id: str,
+    tip_plan_id: str,
+    target_url: str,
+    method: str,
+    headers: Mapping[str, object] | None,
+    body: bytes | None,
+    stream_started: bool,
+    recovery_status: str,
+    error_type: str,
+    error_message: str,
+) -> Optional[Path]:
+    """Persist redacted metadata for a later explicit drain/continue command."""
+
+    try:
+        body_bytes = body or b""
+        payload = {
+            "request_id": request_id,
+            "tip_plan_id": tip_plan_id,
+            "target_url": target_url,
+            "method": method,
+            "headers": _redact_headers(headers),
+            "body_sha256": hashlib.sha256(body_bytes).hexdigest() if body else "",
+            "body_bytes": len(body_bytes),
+            "body_preview_utf8": body_bytes[:2048].decode("utf-8", errors="replace"),
+            "stream_started": stream_started,
+            "recovery_status": recovery_status,
+            "error_type": error_type,
+            "error_message": error_message[:1000],
+            "created_at": time.time(),
+            "supports_hidden_replay": False,
+            "continue_requires_visible_turn": stream_started,
+        }
+        if os.environ.get("TOKENPAK_RETRY_PERSIST_BODY", "0") == "1":
+            payload["body_utf8"] = body_bytes.decode("utf-8", errors="replace")
+        path = _recovery_dir() / f"{request_id}.json"
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return path
+    except OSError:
+        return None


### PR DESCRIPTION
## Summary

Promotes two integration-verified proxy transport-reliability fixes to the public line:

1. **Bounded upstream retry recovery** (`tokenpak/proxy/upstream_retry.py` + sync/async server wiring): policy-driven pre-byte retry for transient upstream failures (connection resets, protocol errors, retryable statuses honoring Retry-After), strict no-retry once client output has started, deterministic-mode opt-out, truncated-JSON detection, and redacted failed-request recovery metadata.
2. **Connection-pool client eviction + safe retirement** (`tokenpak/proxy/connection_pool.py`): a client that raises a transport error is evicted (identity-checked) so retries get a fresh connection instead of the same dead HTTP/2 connection; evicted/reaped/LRU-displaced clients are retired and closed after a grace period instead of being closed under in-flight requests; `last_used` re-stamped on completion; new `evicted_clients`/`retired_pending_close` metrics; env-tunable pool timeouts (`TOKENPAK_POOL_CONNECT_TIMEOUT`, `TOKENPAK_POOL_READ_TIMEOUT`); eviction disableable via `TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR=0`.

Together these fix a failure mode where one stale pooled connection could exhaust every retry attempt and surface to clients as an empty 502, and where TLS-level corruption could occur when a pooled client was closed while another request was mid-flight on it.

## Provenance

- Cherry-picked from the integration line at commits noted in each commit trailer; integration PRs passed the full 28-check suite there (heads `72240654e8`: 27 success/1 pending non-required; `189f896574`: 28/28).
- Base: public main `386f7a93fd`. Diff: 8 files, +1,892 / −132 — three content commits, no unrelated changes bundled.
- Identity: author and committer `TokenPak <hello@tokenpak.ai>` on all commits; no co-authored-by trailers.

## Validation on this base

- `pytest tests/proxy/test_upstream_retry_policy.py tests/test_proxy_server_async.py tests/test_connection_pool_eviction.py tests/test_connection_pool.py -q` → **127 passed**
- `ruff check` on changed source files → passed
- `git diff --check` → clean
- Forbidden-surface scan over diff + commit messages → clean

## Scope

- Owner approval: granted (recorded in the internal audit trail); this PR is promotion only — no version bump, no tag, no release workflow, no publish.
- Rollback: single squash commit on main; revert restores prior public behavior (both features are additive with env kill-switches: `TOKENPAK_UPSTREAM_RETRIES=1` minimizes retry, `TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR=0` disables eviction).

## G-1 — promotion diff evidence

```
 tests/proxy/test_upstream_retry_policy.py | 239 +++++++++++++++++
 tests/test_connection_pool.py             |   2 +-
 tests/test_connection_pool_eviction.py    | 370 ++++++++++++++++++++++++++
 tests/test_proxy_server_async.py          | 245 ++++++++++++++++-
 tokenpak/proxy/connection_pool.py         | 204 ++++++++++++--
 tokenpak/proxy/server.py                  | 197 +++++++++-----
 tokenpak/proxy/server_async.py            | 341 ++++++++++++++++++++----
 tokenpak/proxy/upstream_retry.py          | 426 ++++++++++++++++++++++++++++++
 8 files changed, 1892 insertions(+), 132 deletions(-)
```

Per-commit provenance (integration-line source recorded in each cherry-pick trailer):
```
f6d3c6ebdc fix(proxy): retire session clients from reaper/LRU paths instead of closing mid-flight
a8b29ab7e2 fix(proxy): evict pooled clients on transport errors so retries recover
23ef86c476 fix(proxy): bound upstream retry recovery
```
