### PR TITLE
release: v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.10.4] — 2026-07-05
+
+> **Release note:** version **1.10.3 was tagged but never published to PyPI.** Its release run
+> stopped fail-closed at the test gate (a release-only `pytest-timeout` enforcement issue in the
+> dev/full test shapes — no build, GitHub Release, or PyPI artifact was produced) and PyPI remained
+> at 1.10.2. 1.10.4 carries the intended 1.10.3 changes (below), plus the release-test fix.
+
+### Fixed
+- **Release test-gate stability.** A health-check integration test that polls `/health` for up to
+  ~30 seconds by design is given a per-test timeout above the global 30-second cap, so it is no
+  longer killed under the enforced `pytest-timeout` in the dev/full test shapes. Release-mechanics
+  only — no runtime behavior change.
+
 ## [1.10.3] — 2026-07-05
 
 > Patch release: a curated set of concurrency, durability, and telemetry-truth fixes for the

--- a/tests/telemetry/test_cache_miss_reasons.py
+++ b/tests/telemetry/test_cache_miss_reasons.py
@@ -151,23 +151,28 @@ def test_format_miss_reason_summary_empty():
 
 
 def test_db_insert_and_query_cache_miss():
-    db = TelemetryDB(":memory:")
-    records = [
-        CacheMissRecord("req-1", reason="route_not_cacheable", route_class="code_edit").to_row(),
-        CacheMissRecord("req-2", reason="route_not_cacheable", route_class="code_edit").to_row(),
-        CacheMissRecord("req-3", reason="flag_off").to_row(),
-    ]
-    for row in records:
-        db.insert_cache_miss(row)
+    # Close the in-memory DB deterministically (context manager) so its named
+    # shared-cache database is dropped at test end and cannot leak into a later
+    # TelemetryDB(":memory:") whose object id() happens to collide with this one.
+    with TelemetryDB(":memory:") as db:
+        records = [
+            CacheMissRecord("req-1", reason="route_not_cacheable", route_class="code_edit").to_row(),
+            CacheMissRecord("req-2", reason="route_not_cacheable", route_class="code_edit").to_row(),
+            CacheMissRecord("req-3", reason="flag_off").to_row(),
+        ]
+        for row in records:
+            db.insert_cache_miss(row)
 
-    summary = db.query_cache_miss_summary(days=7)
-    by_reason = {r["reason"]: r for r in summary}
+        summary = db.query_cache_miss_summary(days=7)
+        by_reason = {r["reason"]: r for r in summary}
 
-    assert by_reason["route_not_cacheable"]["count"] == 2
-    assert by_reason["flag_off"]["count"] == 1
+        assert by_reason["route_not_cacheable"]["count"] == 2
+        assert by_reason["flag_off"]["count"] == 1
 
 
 def test_db_cache_miss_summary_empty():
-    db = TelemetryDB(":memory:")
-    result = db.query_cache_miss_summary(days=7)
+    # A freshly-created, isolated telemetry DB has no cache-miss rows. Use the
+    # context manager so the named :memory: database is torn down after the test.
+    with TelemetryDB(":memory:") as db:
+        result = db.query_cache_miss_summary(days=7)
     assert result == []

--- a/tests/test_first_request.py
+++ b/tests/test_first_request.py
@@ -86,6 +86,9 @@ class TestProxyStartup:
 
     @pytest.mark.slow
     @pytest.mark.integration
+    # Polls /health for up to ~30s by design; give it headroom above the global
+    # 30s pytest-timeout so it is not killed mid-run in the dev/full test shapes.
+    @pytest.mark.timeout(60)
     def test_health_check_timeout_30_seconds(self, proxy_process, proxy_url):
         """Health check with 30 second timeout (requires live proxy)."""
         timeout = 30

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.10.3"
+__version__ = "1.10.4"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
-  "generated_at": "2026-07-05T07:40:47Z",
-  "package_version": "1.10.3",
+  "generated_at": "2026-07-05T15:32:43Z",
+  "package_version": "1.10.4",
   "symbols": [
     {
       "module": "tokenpak",


### PR DESCRIPTION
Promotes the validated v1.10.4 release from staging to public main.

- Single squashed release commit; tree identical to the staging release head.
- `__version__` 1.10.4; identity-clean.
- Carries the intended v1.10.3 fix set plus two release-gate stability fixes (health-check test per-test timeout; deterministic teardown of in-memory telemetry DBs in the cache-miss round-trip tests).
- The full release test + chaos matrix passed on the staging release head (workflow_dispatch preflight, fully green).

v1.10.3 was tagged but never published to PyPI (its release run stopped fail-closed at the test gate); v1.10.4 is the published successor.