### PR TITLE
release: v1.11.3 — fix concurrent skills-install empty-dir race (supersede unpublished v1.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.11.3] — 2026-07-08
+
+> **Release note:** version **1.11.2 was tagged but never published to PyPI.**
+> Its release run stopped fail-closed at the test gate on a concurrency safety
+> check for the Codex skills installer — no build, GitHub Release, or PyPI
+> artifact was produced and the last published release remained 1.11.1. 1.11.3
+> carries the intended 1.11.2 changes (below), plus the installer fix.
+
+### Fixed
+- **Codex skills installer never exposes an empty skill directory under
+  concurrent installs.** A replaced skill is now retired as a timestamped
+  generation and reclaimed only once it is old enough that no reader can still
+  be enumerating it, instead of being deleted the instant it is superseded.
+  Because `os.replace` only rebinds a name, a reader (Codex scanning the skills
+  directory) that opened the old directory just before the swap could otherwise
+  observe it emptied mid-scan; retaining the prior generation until it ages out
+  closes that window.
+
 ## [1.11.2] — 2026-07-08
 
 > Patch release: tighten the runnable examples guidance, repair user recipe

--- a/tests/companion/test_codex_skills_path.py
+++ b/tests/companion/test_codex_skills_path.py
@@ -8,6 +8,7 @@ test pins the canonical target and the defensive dual-path uninstall.
 """
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -162,6 +163,8 @@ def test_install_leaves_no_temp_or_backup_dirs(monkeypatch, tmp_path: Path):
 
 
 def test_install_sweeps_stale_stage_and_backup(monkeypatch, tmp_path: Path):
+    import os
+
     monkeypatch.setattr(si, "_BUNDLED_SKILLS", _bundled_dir_with(tmp_path, ["a"]))
     target = tmp_path / "agents" / "skills"
     target.mkdir(parents=True)
@@ -170,11 +173,42 @@ def test_install_sweeps_stale_stage_and_backup(monkeypatch, tmp_path: Path):
     (stale_stage / "junk").write_text("x")
     stale_backup = target / f"{si._BACKUP_PREFIX}a-4242"
     stale_backup.mkdir()
+    # Leftovers from a *crashed prior* install are old; age them past the
+    # reclamation gate so a normal launch sweeps them.
+    old = time.time() - (si._RECLAIM_MIN_AGE_S + 60)
+    for stale in (stale_stage, stale_backup):
+        os.utime(stale, (old, old))
 
     si.install_skills(target_dir=target)
 
     assert not stale_stage.exists(), "stale stage dir was not swept"
     assert not stale_backup.exists(), "stale backup dir was not swept"
+    assert (target / "a" / "SKILL.md").exists()
+
+
+def test_recent_retired_generation_is_not_reclaimed_but_aged_one_is(
+    monkeypatch, tmp_path: Path
+):
+    """The age gate keeps a freshly-retired generation (a reader may still
+    hold it) and reclaims one older than the threshold."""
+    import os
+
+    monkeypatch.setattr(si, "_BUNDLED_SKILLS", _bundled_dir_with(tmp_path, ["a"]))
+    target = tmp_path / "agents" / "skills"
+    target.mkdir(parents=True)
+
+    young = target / f"{si._BACKUP_PREFIX}a-young"
+    young.mkdir()
+    (young / "SKILL.md").write_text("# a\n")
+    aged = target / f"{si._BACKUP_PREFIX}a-aged"
+    aged.mkdir()
+    old = time.time() - (si._RECLAIM_MIN_AGE_S + 60)
+    os.utime(aged, (old, old))
+
+    si.install_skills(target_dir=target)
+
+    assert young.exists(), "a recently-retired generation must be retained"
+    assert not aged.exists(), "an aged retired generation must be reclaimed"
     assert (target / "a" / "SKILL.md").exists()
 
 

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -17,7 +17,7 @@ Sub-package imports:
 
 from __future__ import annotations
 
-__version__ = "1.11.2"
+__version__ = "1.11.3"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "generated_at": "2026-07-06T05:57:18Z",
-  "package_version": "1.11.2",
+  "package_version": "1.11.3",
   "symbols": [
     {
       "module": "tokenpak",

--- a/tokenpak/companion/codex/skills_installer.py
+++ b/tokenpak/companion/codex/skills_installer.py
@@ -15,8 +15,16 @@ is serialized with a TokenPak-owned interprocess lock, each skill is
 staged in full inside a unique temp sibling and then published with fast
 renames — so a reader (Codex scanning the directory) never sees a
 half-copied skill and only ever sees an installed skill absent for the
-span of a single rename.  Stale stage/backup leftovers from a crashed
-prior install are swept defensively without failing a normal launch.
+span of a single rename.
+
+The prior copy of a replaced skill is retained as a timestamped generation
+rather than deleted the instant it is superseded: ``os.replace`` only
+rebinds a name, so a reader that opened the old directory before the swap
+still holds that inode, and deleting it immediately would empty the inode
+mid-``readdir``.  Retired generations and stale stage/backup leftovers from
+a crashed prior install are reclaimed on a later launch once older than
+:data:`_RECLAIM_MIN_AGE_S` — past any live enumeration — so cleanup never
+races a reader and old generations are never retained indefinitely.
 """
 
 from __future__ import annotations
@@ -26,6 +34,7 @@ import os
 import shutil
 import tempfile
 import threading
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -47,6 +56,14 @@ _BACKUP_PREFIX = ".tokenpak-backup-"
 # genuinely empty.
 _LOCK_SUFFIX = ".tokenpak-install.lock"
 _THREAD_LOCK = threading.RLock()
+
+# Minimum age (seconds) before a superseded skill generation or a leftover
+# stage/backup dir is reclaimed. A directory enumeration (``opendir`` +
+# ``readdir``) completes well within this window, so anything older than it
+# cannot still be held by a live reader — reclaiming it can never empty a
+# directory out from under an in-flight ``os.listdir``. Kept as a module
+# attribute so tests can force immediate reclamation (set to 0).
+_RECLAIM_MIN_AGE_S = 5.0
 
 
 def bundled_skill_names() -> list[str]:
@@ -109,25 +126,45 @@ def _install_lock(target: Path) -> Iterator[None]:
 
 
 def _sweep_stale_temp(target: Path) -> None:
-    """Remove leftover stage/backup dirs from a crashed prior install.
+    """Reclaim aged retired generations and crash-leftover stage/backup dirs.
 
-    Called while holding the install lock, so any such directory is
-    guaranteed stale (no live install is using it).  Best-effort: an
-    entry that cannot be removed is skipped rather than aborting a normal
-    launch over a harmless leftover.
+    Sweeps both ``target`` and its parent (where publish stages and retires)
+    for ``_STAGE_PREFIX`` / ``_BACKUP_PREFIX`` entries, removing only those
+    older than :data:`_RECLAIM_MIN_AGE_S`.  Called while holding the install
+    lock.
+
+    The age gate is what makes reclamation safe under concurrent readers: a
+    retired skill generation (a directory a reader may have opened just
+    before it was superseded) is kept until no reader could still be
+    mid-``readdir`` of it, then removed — so cleanup never empties an inode
+    out from under an in-flight ``os.listdir``, and generations are not
+    retained forever.  A too-young entry is left for a later launch.
+    Best-effort: an entry that cannot be removed (or stat'd) is skipped
+    rather than aborting a normal launch over a harmless leftover.
     """
+    now = time.time()
     for root in (target, target.parent):
         try:
             entries = list(root.iterdir())
         except OSError:
             continue
         for entry in entries:
-            if entry.name.startswith(_STAGE_PREFIX) or entry.name.startswith(_BACKUP_PREFIX):
-                with contextlib.suppress(OSError):
-                    if entry.is_dir():
-                        shutil.rmtree(entry)
-                    else:
-                        entry.unlink()
+            if not (
+                entry.name.startswith(_STAGE_PREFIX)
+                or entry.name.startswith(_BACKUP_PREFIX)
+            ):
+                continue
+            try:
+                age = now - entry.stat().st_mtime
+            except OSError:
+                continue
+            if age < _RECLAIM_MIN_AGE_S:
+                continue  # possibly still observable by a live reader — keep it
+            with contextlib.suppress(OSError):
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink()
 
 
 def _publish_skill(src: Path, dst: Path, target: Path) -> Path:
@@ -140,17 +177,25 @@ def _publish_skill(src: Path, dst: Path, target: Path) -> Path:
     first, so the only window in which ``dst`` is absent is between two
     rename syscalls.  On a failed swap the prior ``dst`` is restored so a
     launch never strands the user with a missing skill.
+
+    A superseded ``dst`` is retired to a uniquely-named backup and left in
+    place — NOT deleted here.  ``os.replace`` only rebinds the name, so a
+    reader that opened the old ``dst`` before the swap still holds that
+    inode; deleting it now would empty it mid-``readdir``.  The retired
+    generation is reclaimed by a later launch's :func:`_sweep_stale_temp`
+    once it is older than :data:`_RECLAIM_MIN_AGE_S`.
     """
     stage = Path(tempfile.mkdtemp(prefix=f"{_STAGE_PREFIX}{dst.name}-", dir=target.parent))
-    backup = target.parent / f"{_BACKUP_PREFIX}{dst.name}-{os.getpid()}"
+    # Retirement target for a superseded generation. Unique per publish
+    # (reuse the stage's random suffix) so concurrent/repeated publishes
+    # never collide on one backup path, and each ages out on its own.
+    unique = stage.name.rsplit("-", 1)[-1]
+    backup = target.parent / f"{_BACKUP_PREFIX}{dst.name}-{unique}"
     try:
         # Full copy into the staged sibling while it is invisible as dst.
         shutil.copytree(src, stage, dirs_exist_ok=True)
         moved_aside = False
         if dst.exists():
-            with contextlib.suppress(OSError):
-                if backup.exists():
-                    shutil.rmtree(backup)
             os.replace(dst, backup)
             moved_aside = True
         try:
@@ -161,11 +206,11 @@ def _publish_skill(src: Path, dst: Path, target: Path) -> Path:
                 with contextlib.suppress(OSError):
                     os.replace(backup, dst)
             raise
-        if moved_aside:
-            with contextlib.suppress(OSError):
-                shutil.rmtree(backup)
+        # The retired generation (``backup``) is deliberately left for a
+        # later _sweep_stale_temp — see the docstring (reader-vs-delete race).
     finally:
-        # Clean the stage dir if it was not consumed by the swap.
+        # Clean the stage dir if it was not consumed by the swap. The stage
+        # is never observable under a skill name, so removing it now is safe.
         with contextlib.suppress(OSError):
             if stage.exists():
                 shutil.rmtree(stage)


### PR DESCRIPTION
## Summary

Patch release **v1.11.3**. Version 1.11.2 was tagged but never published to
PyPI — its release run stopped fail-closed at the test gate on a concurrency
safety check for the Codex skills installer, so no 1.11.2 artifacts were built
or uploaded and the last published release remained 1.11.1. **1.11.3 carries the
intended 1.11.2 changes plus the installer fix.**

## The fix

Under concurrent `tokenpak codex` launches, a reader scanning the skills
directory could observe an **empty** skill directory even though the published
skill was complete — the failure behind the blocked release:

```
tests/companion/test_codex_skills_path.py::test_concurrent_installs_never_expose_partial_skill
AssertionError: reader saw half-published skills: [('b', [])]
```

Root cause: `os.listdir` is `opendir` + iterative `readdir` (not an atomic
snapshot), and `os.replace` only rebinds a *name*. When a skill was replaced,
the installer moved the old directory aside and **deleted it synchronously**; a
reader that had opened the old directory just before the swap still held that
inode and saw it emptied mid-enumeration.

Fix: a replaced skill is now **retired** as a timestamped generation and
reclaimed on a later launch only once it is older than a small age threshold —
far longer than any directory enumeration — so cleanup can never empty an inode
out from under an in-flight `os.listdir`, and generations are never retained
indefinitely. The existing interprocess lock, in-process lock, parent-directory
staging, and defensive dual-sweep are preserved; retired-generation names are
now unique per publish.

## Validation

- New test pins the age gate (a freshly-retired generation is retained, an aged
  one is reclaimed); the stale-sweep test ages its planted leftovers.
- High-iteration concurrency stress: 1000/1000 clean (reproduces the pre-fix
  failure within ~25 trials).
- Fresh-install, upgrade-path, and uninstall smoke pass.

## Scope

Narrow: the installer fix + its tests, the version bump to 1.11.3, the changelog
entry, and the public-API snapshot `package_version`. No other changes.
