### PR TITLE
docs: correct current-version reference to v1.11.3

### DIFF
--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -1,6 +1,6 @@
 # TokenPak — Known Limitations & When NOT to Use
 
-An honest list of what isn't yet at production quality in the open-source release, and where TokenPak is *not* the right fit today. Current as of **v1.11.2** (the released version on PyPI). Each entry names a **retirement condition** — the concrete signal that removes it.
+An honest list of what isn't yet at production quality in the open-source release, and where TokenPak is *not* the right fit today. Current as of **v1.11.3** (the released version on PyPI). Each entry names a **retirement condition** — the concrete signal that removes it.
 
 ## Activation does not unlock Pro features yet
 


### PR DESCRIPTION
One-line docs-sync for the just-published 1.11.3 release. `docs/KNOWN_LIMITATIONS.md` stated v1.11.2 was 'the released version on PyPI', but 1.11.2 was tagged and never published; 1.11.3 is the current published release. No other changes.