### PR TITLE
promote: staging content parity train (2026-07-10)

### DIFF
--- a/.changeset/v1120-api-snapshot-additive-symbols.md
+++ b/.changeset/v1120-api-snapshot-additive-symbols.md
@@ -1,0 +1,19 @@
+---
+---
+
+Release-gate: reconcile the public-API snapshot with the v1.12.0 mainline.
+
+The v1.12.0 release cut bumped `package_version` but did not regenerate the
+snapshot symbol list, so the release run failed closed at the API-snapshot
+check on seventeen additive symbols introduced by the receipt-only launch
+work and the user-recipe overlay loader: the new
+`tokenpak.companion.codex.accounting` module (`SCHEMA`, `build_receipt`,
+`empty_usage`, `merge_usage`, `model_from_args`, `redact_argv`,
+`usage_from_event`, `usage_from_json_line`, `utc_now`, `write_receipt`),
+their `tokenpak.companion.codex.launcher` re-exports, and
+`tokenpak.compression.recipes.user_recipes_dir`.
+
+Regenerated in a clean CI-parity environment
+(`pip install -e ".[dev,full,serve,telemetry,tokens,otel]"` + `python-multipart`);
+`gen_api_snapshot.py --check` passes against the regenerated file. Additions
+only — no public symbols removed; no runtime code changes.

--- a/tokenpak/_snapshots/public-api.json
+++ b/tokenpak/_snapshots/public-api.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-07-06T05:57:18Z",
+  "generated_at": "2026-07-10T20:33:08Z",
   "package_version": "1.12.0",
   "symbols": [
     {
@@ -1892,6 +1892,46 @@
       "name": "launch"
     },
     {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "SCHEMA"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "build_receipt"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "empty_usage"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "merge_usage"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "model_from_args"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "redact_argv"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "usage_from_event"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "usage_from_json_line"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "utc_now"
+    },
+    {
+      "module": "tokenpak.companion.codex.accounting",
+      "name": "write_receipt"
+    },
+    {
       "module": "tokenpak.companion.codex.agents_md",
       "name": "generate_agents_md"
     },
@@ -1989,7 +2029,31 @@
     },
     {
       "module": "tokenpak.companion.codex.launcher",
+      "name": "build_receipt"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
+      "name": "empty_usage"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
       "name": "main"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
+      "name": "merge_usage"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
+      "name": "usage_from_json_line"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
+      "name": "utc_now"
+    },
+    {
+      "module": "tokenpak.companion.codex.launcher",
+      "name": "write_receipt"
     },
     {
       "module": "tokenpak.companion.codex.mcp_config",
@@ -3706,6 +3770,10 @@
     {
       "module": "tokenpak.compression.recipes",
       "name": "get_oss_engine"
+    },
+    {
+      "module": "tokenpak.compression.recipes",
+      "name": "user_recipes_dir"
     },
     {
       "module": "tokenpak.compression.reference_fetcher",


### PR DESCRIPTION
Automated promotion train bringing public main to content parity with staging main (`ec9e27f1eb`).

Manifest (2 files):
```
A	.changeset/v1120-api-snapshot-additive-symbols.md
M	tokenpak/_snapshots/public-api.json
```

Gates run locally before this PR was opened: conflict-marker scan, full-tree public-leak scan (scripts/release_gate/check_release_leaks.py). Full CI runs on this PR. Merge per the public merge policy (no squash-button/web-button).