### PR TITLE
promote: staging content parity train (2026-07-13)

### DIFF
--- a/.changeset/codex-parallel-session-isolation.md
+++ b/.changeset/codex-parallel-session-isolation.md
@@ -1,0 +1,11 @@
+---
+"tokenpak": patch
+---
+
+Fix Codex parallel-session isolation with shared, deterministic per-workspace,
+and unique per-session homes. Provision only allowlisted non-runtime files,
+install integrations into the selected home, publish validated lifecycle
+sentinels atomically, retain global skills when other homes can reference them, and
+enforce bounded preserve-first isolated-home retention with doctor visibility.
+Lock diagnostics now identify live and stopped holders on Linux, fail closed on
+inspection races, and retain a bounded portable contention fallback elsewhere.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -671,7 +671,7 @@ Examples:
   tokenpak codex
   tokenpak codex --install-only    # set up without launching Codex
   tokenpak codex doctor            # verify installation
-  tokenpak codex uninstall         # reverse installation
+  tokenpak codex uninstall         # clean selected home; preserve shared skills in use
   tokenpak codex --budget 5.00
   tokenpak codex "Fix the login bug"
   tokenpak codex --model o3 -s workspace-write

--- a/docs/spend-guard.md
+++ b/docs/spend-guard.md
@@ -119,6 +119,19 @@ The default ratio 0.80 is published as `tokenpak.proxy.spend_guard.DEFAULT_BLOCK
 
 HTTP status: **402 Payment Required**. This is **not** a model failure — your client must surface the prompt to the operator (or pre-declare via `[TIP: ...]` if running headless) and **must not auto-retry** the same request body. The proxy enforces anti-loop dedup on the request hash for 30 seconds.
 
+### Guard state unavailable (operator repair)
+
+If Spend Guard cannot read or maintain its local guard state, it still blocks
+before provider send, but no held request exists to release. The response keeps
+`error.type=tokenpak_spend_guard_blocked` for client compatibility and carries
+`reason=spend_guard_state_unavailable`, `pending_id=null`,
+`approval_prompt=null`, `approval_prompt_available=false`, and
+`recovery_status=operator_action_required`.
+
+Do not show a Yes/No approval UI for this state and do not auto-proceed through
+Continuum or another Pro automation path. Repair the local guard state, run
+`tokenpak doctor`, and restart the TokenPak proxy before retrying.
+
 ### Hard-block (terminal)
 
 Same shape but `error.type=tokenpak_spend_guard_hard_blocked`, `retryable: false`, `recovery_status: terminally_blocked`. Even `[TIP: bypass=on]` cannot release this — the hard-block ceiling is immutable.

--- a/tests/companion/test_codex_launcher.py
+++ b/tests/companion/test_codex_launcher.py
@@ -12,15 +12,23 @@ input.  Scope note: this does not exercise the ``codex mcp`` / ``codex
 features`` probe-avoidance behavior — that lives in ``hooks.py`` /
 ``mcp_config.py``, outside this packet's ``expected_files_changed``.
 """
+
 from __future__ import annotations
 
+import errno
 import json
-from types import SimpleNamespace
+import os
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
 
 import pytest
 
 from tokenpak import _cli_core
 from tokenpak.companion.codex import launcher
+from tokenpak.companion.codex import session_home as sh
 from tokenpak.companion.codex import state_lock as sl
 
 
@@ -103,6 +111,24 @@ def test_preflight_noninteractive_times_out(capsys):
     assert "still locked after" in err
 
 
+def test_preflight_wall_timeout_bounds_a_stuck_probe(capsys):
+    def stuck_probe():
+        time.sleep(0.25)
+        return _status(locked=False)
+
+    started = time.monotonic()
+    rc = launcher._preflight_state_lock(
+        prober=stuck_probe,
+        interactive=False,
+        timeout_s=0.05,
+    )
+    elapsed = time.monotonic() - started
+
+    assert rc == 1
+    assert elapsed < 0.15
+    assert "wall-time limit" in capsys.readouterr().err
+
+
 def test_preflight_tty_esc_cancels(capsys):
     clock = _Clock()
     rc = launcher._preflight_state_lock(
@@ -134,6 +160,32 @@ def test_preflight_stopped_holder_appears_mid_wait():
     assert rc == 1
 
 
+def test_preflight_incomplete_result_mid_wait_short_circuits(capsys):
+    clock = _Clock()
+    incomplete = sl.LockStatus(
+        home="/h",
+        db_path="/h/state_5.sqlite",
+        exists=True,
+        locked=True,
+        detail="inspection incomplete",
+        diagnostics_complete=False,
+        incomplete_reasons=["probe_timeout"],
+    )
+    seq = iter([_status(locked=True), incomplete])
+
+    rc = launcher._preflight_state_lock(
+        prober=lambda: next(seq),
+        interactive=False,
+        timeout_s=30,
+        poll_interval_s=0.5,
+        sleep=clock.tick,
+        monotonic=clock,
+    )
+
+    assert rc == 1
+    assert "inspection incomplete" in capsys.readouterr().err
+
+
 # ── main() wires the preflight before exec, and --install-only skips it ─
 
 
@@ -148,6 +200,20 @@ class _FakeConfig:
         return None
 
 
+def _stub_session_env(monkeypatch, tmp_path: Path) -> None:
+    user_home = tmp_path / "user"
+    source_home = user_home / ".codex"
+    source_home.mkdir(parents=True)
+    (source_home / "config.toml").write_text('model = "gpt-test"\n')
+    (source_home / "auth.json").write_text('{"test": true}\n')
+    (source_home / "auth.json").chmod(0o600)
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path / "tokenpak-home"))
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "isolated")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
 def _stub_setup(monkeypatch, tmp_path):
     """Stub the launcher's setup steps so main() reaches the preflight."""
     from tokenpak.companion.codex import (
@@ -157,61 +223,544 @@ def _stub_setup(monkeypatch, tmp_path):
         skills_installer,
     )
 
+    _stub_session_env(monkeypatch, tmp_path)
     cfg = _FakeConfig(tmp_path / "journal")
-    monkeypatch.setattr(
-        launcher.CompanionConfig, "from_env", classmethod(lambda cls: cfg)
-    )
+    monkeypatch.setattr(launcher.CompanionConfig, "from_env", classmethod(lambda cls: cfg))
     monkeypatch.setattr(rates_snapshot, "refresh", lambda: tmp_path / "rates.json")
     monkeypatch.setattr(mcp_config, "get_env_vars", lambda config: {})
-    monkeypatch.setattr(mcp_config, "register", lambda env_vars=None: True)
-    monkeypatch.setattr(agents_md, "install_agents_md", lambda target="global": tmp_path / "AGENTS.md")
+    monkeypatch.setattr(mcp_config, "_register", lambda env_vars=None, codex_home=None: True)
+    monkeypatch.setattr(
+        agents_md,
+        "_install_agents_md",
+        lambda target="global", codex_home=None: Path(codex_home) / "AGENTS.md",
+    )
     monkeypatch.setattr(skills_installer, "install_skills", lambda target_dir=None: [])
+    monkeypatch.setattr(
+        skills_installer,
+        "_configure_skills",
+        lambda config_path, skills_root=None: [],
+    )
 
 
 def test_main_aborts_when_preflight_blocks(monkeypatch, tmp_path):
     _stub_setup(monkeypatch, tmp_path)
-    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda: 7)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: 7)
 
-    def _no_exec(*a, **k):
-        raise AssertionError("must not exec when preflight blocks")
+    def _must_not_run(*_args, **_kwargs):
+        raise AssertionError("must not launch when preflight blocks")
 
-    monkeypatch.setattr(launcher.os, "execvpe", _no_exec)
+    monkeypatch.setattr(launcher, "_run_codex_process", _must_not_run)
     assert launcher.main([]) == 7
+    assert not (tmp_path / "user" / ".codex" / "codex.pid").exists()
+    assert not list((tmp_path / "tokenpak-home").rglob("codex.pid"))
 
 
-def test_main_install_only_skips_preflight(monkeypatch, tmp_path):
+def test_shared_mode_real_holder_probe_refuses_before_setup(monkeypatch, tmp_path, capsys):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    database = tmp_path / "user" / ".codex" / "state_77.sqlite"
+    holder = sqlite3.connect(database, isolation_level=None)
+    holder.execute("CREATE TABLE records (id INTEGER)")
+    holder.execute("BEGIN EXCLUSIVE")
+    real_preflight = launcher._preflight_state_lock
+
+    def fast_preflight(**kwargs):
+        clock = _Clock()
+
+        def probe_once():
+            status = sl.probe(kwargs["home"])
+            clock.t = 5.0
+            return status
+
+        return real_preflight(
+            prober=probe_once,
+            interactive=False,
+            timeout_s=5,
+            sleep=lambda _seconds: None,
+            monotonic=clock,
+            home=kwargs["home"],
+        )
+
+    monkeypatch.setattr(launcher, "_preflight_state_lock", fast_preflight)
+    monkeypatch.setattr(
+        launcher.CompanionConfig,
+        "from_env",
+        classmethod(
+            lambda cls: (_ for _ in ()).throw(
+                AssertionError("shared contention must block before setup")
+            )
+        ),
+    )
+    try:
+        assert launcher.main(["--install-only"]) == 1
+        stderr = capsys.readouterr().err
+        assert f"PID {os.getpid()} (running)" in stderr
+        assert "holder PID unavailable" not in stderr
+        assert not (database.parent / "codex.pid").exists()
+    finally:
+        holder.execute("ROLLBACK")
+        holder.close()
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+def test_shared_mode_existing_database_launches_with_portable_clear_probe(
+    monkeypatch, tmp_path, platform_id
+):
+    from tokenpak.companion.codex import state_lock
+
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    database = tmp_path / "user" / ".codex" / "state_77.sqlite"
+    connection = sqlite3.connect(database)
+    connection.execute("CREATE TABLE records (id INTEGER)")
+    connection.close()
+    monkeypatch.setattr(sys, "platform", platform_id)
+    monkeypatch.setattr(state_lock, "_portable_codex_processes", lambda *_args: ([], True))
+
+    assert launcher.main(["--install-only"]) == 0
+
+
+def test_shared_mode_gives_each_reusable_preflight_a_fresh_deadline(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    calls: list[dict[str, object]] = []
+
+    def clear_preflight(**kwargs):
+        calls.append(kwargs)
+        assert "deadline" not in kwargs
+        return None
+
+    monkeypatch.setattr(launcher, "_preflight_state_lock", clear_preflight)
+
+    assert launcher.main(["--install-only"]) == 0
+    assert len(calls) >= 3
+
+
+def test_invalid_mode_fails_before_preflight_or_filesystem_write(monkeypatch, tmp_path):
+    _stub_session_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "automatic")
+    monkeypatch.setattr(
+        launcher,
+        "_preflight_state_lock",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid mode must fail before preflight")
+        ),
+    )
+
+    assert launcher.main([]) == 2
+    assert not (tmp_path / "tokenpak-home").exists()
+
+
+def test_main_install_only_preflights_and_releases_lease(monkeypatch, tmp_path):
     _stub_setup(monkeypatch, tmp_path)
     called = {"n": 0}
 
-    def _preflight():
+    def _preflight(**_kwargs):
         called["n"] += 1
         return None
 
     monkeypatch.setattr(launcher, "_preflight_state_lock", _preflight)
     rc = launcher.main(["--install-only"])
     assert rc == 0
-    assert called["n"] == 0, "install-only must not run the lock preflight"
+    assert called["n"] == 1
+    assert not list((tmp_path / "tokenpak-home").rglob("codex.pid"))
 
 
-def test_main_execs_when_preflight_clear(monkeypatch, tmp_path):
+def test_shared_install_preserves_existing_config_and_skips_skill_refs(monkeypatch, tmp_path):
+    from tokenpak.companion.codex import skills_installer
+
     _stub_setup(monkeypatch, tmp_path)
-    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda: None)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    config = tmp_path / "user" / ".codex" / "config.toml"
+    original = config.read_bytes()
+    monkeypatch.setattr(
+        skills_installer,
+        "_configure_skills",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("shared mode must not mutate config for skill discovery")
+        ),
+    )
+
+    assert launcher.main(["--install-only"]) == 0
+    assert config.read_bytes() == original
+
+
+def test_main_supervises_when_preflight_clear(monkeypatch, tmp_path, capsys):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
     captured = {}
 
-    class _Exec(Exception):
-        pass
-
-    def _fake_exec(file, argv, env):
-        captured["file"] = file
+    def _fake_run(argv, env, *, on_start=None):
         captured["argv"] = argv
-        raise _Exec
+        captured["env"] = env
+        assert on_start is not None
+        on_start(os.getpid())
+        return 0, launcher.empty_usage()
 
-    monkeypatch.setattr(launcher.os, "execvpe", _fake_exec)
-
-    with pytest.raises(_Exec):
-        launcher.main([])
-    assert captured["file"] == "codex"
+    monkeypatch.setattr(launcher, "_run_codex_process", _fake_run)
+    assert launcher.main([]) == 0
     assert captured["argv"][0] == "codex"
+    assert captured["env"]["TOKENPAK_CODEX_SESSION_MODE"] == "isolated"
+    assert captured["env"]["CODEX_HOME"].startswith(
+        str(tmp_path / "tokenpak-home" / "companion" / "codex" / "sessions")
+    )
+    assert not list((tmp_path / "tokenpak-home").rglob("codex.pid"))
+    stderr = capsys.readouterr().err
+    for label in (
+        "session mode:",
+        "workspace:",
+        "CODEX_HOME:",
+        "source home:",
+        "config:",
+        "auth:",
+        "MCP config:",
+        "hooks:",
+        "AGENTS.md:",
+        "skills:",
+        "PID sentinel:",
+    ):
+        assert label in stderr
+
+
+@pytest.mark.parametrize("mode", ["shared", "workspace", "isolated"])
+def test_retention_sweep_precedes_selected_home_creation_for_every_mode(
+    monkeypatch, tmp_path, mode
+):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", mode)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    events: list[str] = []
+
+    class Cleanup:
+        removed = ()
+        errors = ()
+
+    def cleanup(*_args, preserve_home=None, **_kwargs):
+        events.append("cleanup")
+        if mode in {"workspace", "isolated"}:
+            assert preserve_home is not None
+            assert not Path(preserve_home).exists()
+        return Cleanup()
+
+    def refuse(paths):
+        events.append("acquire")
+        raise RuntimeError("stop after ordering assertion")
+
+    monkeypatch.setattr(sh, "cleanup_isolated_homes", cleanup)
+    monkeypatch.setattr(sh.SessionLease, "acquire", staticmethod(refuse))
+
+    assert launcher.main(["--install-only"]) == 1
+    assert events == ["cleanup", "acquire"]
+
+
+@pytest.mark.parametrize("mode", ["shared", "workspace"])
+def test_switching_modes_runs_retention_without_another_isolated_launch(
+    monkeypatch, tmp_path, mode
+):
+    _stub_setup(monkeypatch, tmp_path)
+    source = tmp_path / "user" / ".codex"
+    tokenpak_home = tmp_path / "tokenpak-home"
+    orphan = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id=f"orphan-before-{mode}",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(orphan)
+    old = time.time() - sh.RETENTION_MAX_AGE_S - 60
+    os.utime(orphan.home, (old, old))
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", mode)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+
+    assert launcher.main(["--install-only"]) == 0
+    assert not orphan.home.exists()
+
+
+def test_storage_pressure_sweep_precedes_failed_provision_retry(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    source = tmp_path / "user" / ".codex"
+    tokenpak_home = tmp_path / "tokenpak-home"
+    orphan = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="pressure-orphan",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(orphan)
+    old = time.time() - 300
+    os.utime(orphan.home, (old, old))
+    original = sh.provision
+    calls = 0
+
+    def no_space(paths, *, home_fd=None):
+        nonlocal calls
+        calls += 1
+        if paths == orphan:
+            return original(paths, home_fd=home_fd)
+        raise OSError(errno.ENOSPC, "injected storage pressure")
+
+    monkeypatch.setattr(sh, "provision", no_space)
+
+    assert launcher.main(["--install-only"]) == 1
+    assert calls == 2
+    assert not orphan.home.exists()
+
+
+def test_storage_pressure_during_home_creation_sweeps_and_retries_once(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    source = tmp_path / "user" / ".codex"
+    tokenpak_home = tmp_path / "tokenpak-home"
+    orphan = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="acquire-pressure-orphan",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(orphan)
+    old = time.time() - 300
+    os.utime(orphan.home, (old, old))
+    original_acquire = sh.SessionLease.acquire
+    calls = 0
+
+    def acquire(paths):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(errno.EDQUOT, "injected selected-home quota pressure")
+        return original_acquire(paths)
+
+    monkeypatch.setattr(sh.SessionLease, "acquire", staticmethod(acquire))
+
+    assert launcher.main(["--install-only"]) == 0
+    assert calls == 2
+    assert not orphan.home.exists()
+
+
+def test_shared_mode_pre_sweep_recovers_receipted_quarantine(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    source = tmp_path / "user" / ".codex"
+    tokenpak_home = tmp_path / "tokenpak-home"
+    orphan = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="quarantine-before-shared",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(orphan)
+    old = time.time() - 300
+    os.utime(orphan.home, (old, old))
+    original_remove = sh._remove_tree_contents_at
+
+    def fail_once(*_args, **_kwargs):
+        raise sh.HomeInUseError("injected resumable quarantine")
+
+    monkeypatch.setattr(sh, "_remove_tree_contents_at", fail_once)
+    failed = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+    assert failed.errors and "injected resumable quarantine" in failed.errors[0]
+    root = sh.sessions_root(tokenpak_home)
+    assert any(path.name.startswith(sh._RETENTION_QUARANTINE_PREFIX) for path in root.iterdir())
+
+    monkeypatch.setattr(sh, "_remove_tree_contents_at", original_remove)
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "shared")
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+
+    assert launcher.main(["--install-only"]) == 0
+    assert not any(path.name.startswith(sh._RETENTION_QUARANTINE_PREFIX) for path in root.iterdir())
+    assert '"action": "completed"' in (root / sh._RETENTION_RECEIPT_NAME).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_post_session_sweep_removes_orphan_created_during_last_child(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    source = tmp_path / "user" / ".codex"
+    tokenpak_home = tmp_path / "tokenpak-home"
+    created: list[sh.SessionPaths] = []
+
+    def fake_run(_argv, _env, *, on_start=None):
+        assert on_start is not None
+        on_start(os.getpid())
+        orphan = sh.select_paths(
+            "isolated",
+            workspace_dir=tmp_path,
+            session_id="created-during-final-child",
+            tokenpak_home=tokenpak_home,
+            source_home=source,
+        )
+        sh.provision(orphan)
+        old = time.time() - sh.RETENTION_MAX_AGE_S - 60
+        os.utime(orphan.home, (old, old))
+        created.append(orphan)
+        return 0, launcher.empty_usage()
+
+    monkeypatch.setattr(launcher, "_run_codex_process", fake_run)
+
+    assert launcher.main([]) == 0
+    assert len(created) == 1
+    assert not created[0].home.exists()
+
+
+def test_retention_failure_never_masks_child_exit_code(monkeypatch, tmp_path):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+    calls = 0
+
+    def broken_cleanup(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise KeyError("malformed governed-cleanup metadata")
+
+    def fake_run(_argv, _env, *, on_start=None):
+        assert on_start is not None
+        on_start(os.getpid())
+        return 7, launcher.empty_usage()
+
+    monkeypatch.setattr(sh, "cleanup_isolated_homes", broken_cleanup)
+    monkeypatch.setattr(launcher, "_run_codex_process", fake_run)
+
+    assert launcher.main([]) == 7
+    assert calls == 3
+
+
+def test_sentinel_release_failure_never_masks_child_exit_code(monkeypatch, tmp_path, capsys):
+    _stub_setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
+
+    def fake_run(_argv, _env, *, on_start=None):
+        assert on_start is not None
+        on_start(os.getpid())
+        return 7, launcher.empty_usage()
+
+    def preserve_sentinel(_self):
+        _self._released = True
+        if _self.home_fd is not None:
+            os.close(_self.home_fd)
+            _self.home_fd = None
+        raise RuntimeError("injected exact-owner cleanup failure")
+
+    monkeypatch.setattr(launcher, "_run_codex_process", fake_run)
+    monkeypatch.setattr(sh.SessionLease, "release", preserve_sentinel)
+
+    assert launcher.main([]) == 7
+    assert "PID sentinel cleanup preserved for inspection" in capsys.readouterr().err
+
+
+def test_launcher_live_child_transfer_temp_is_preserved_during_concurrent_retention(
+    monkeypatch, tmp_path
+):
+    user_home = tmp_path / "user"
+    source = user_home / ".codex"
+    source.mkdir(parents=True)
+    tokenpak_home = tmp_path / "tokenpak-home"
+    monkeypatch.setenv("HOME", str(user_home))
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="concurrent-live-handoff",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    lease = sh.SessionLease.acquire(paths, session_id="concurrent-live-handoff")
+    lease.begin_transfer()
+    dead_parent = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=2_000_000_000,
+        start_time_ticks=1,
+        session_id=lease.sentinel.session_id,
+        mode="isolated",
+        home=str(paths.home.resolve()),
+    )
+    paths.pid_sentinel.write_text(json.dumps(dead_parent.__dict__) + "\n", encoding="utf-8")
+    paths.pid_sentinel.chmod(0o600)
+    lease.sentinel = dead_parent
+
+    transfer_temp_ready = threading.Event()
+    allow_transfer = threading.Event()
+    cleanup_done = threading.Event()
+    release_child = tmp_path / "release-child"
+    original_replace = sh.os.replace
+    child_temp: list[tuple[str, sh.PidSentinel]] = []
+    launch_results: list[tuple[int, dict[str, int | None]]] = []
+    cleanup_results: list[sh._CleanupResult] = []
+    errors: list[BaseException] = []
+
+    def paused_replace(src, dst, *args, **kwargs):
+        if isinstance(src, str) and sh._SENTINEL_TEMP_RE.fullmatch(src):
+            candidate = sh.read_pid_sentinel(Path(src), dir_fd=lease.home_fd)
+            assert candidate is not None
+            child_temp.append((src, candidate))
+            transfer_temp_ready.set()
+            if not allow_transfer.wait(5):
+                raise RuntimeError("timed out waiting for concurrent retention")
+        return original_replace(src, dst, *args, **kwargs)
+
+    def run_launcher_child() -> None:
+        code = (
+            "import pathlib,time\n"
+            f"flag=pathlib.Path({str(release_child)!r})\n"
+            "deadline=time.time()+10\n"
+            "while not flag.exists() and time.time()<deadline: time.sleep(0.01)\n"
+        )
+        try:
+            launch_results.append(
+                launcher._run_codex_process(
+                    [sys.executable, "-c", code],
+                    os.environ.copy(),
+                    on_start=lease.transfer_to,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def cleanup() -> None:
+        try:
+            cleanup_results.append(
+                sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+        finally:
+            cleanup_done.set()
+
+    monkeypatch.setattr(sh.os, "replace", paused_replace)
+    launch_thread = threading.Thread(target=run_launcher_child)
+    cleanup_thread = threading.Thread(target=cleanup)
+    try:
+        launch_thread.start()
+        assert transfer_temp_ready.wait(5)
+        assert sh.read_pid_sentinel(paths.pid_sentinel) == dead_parent
+        assert child_temp and sh.sentinel_is_live(child_temp[0][1], expected_home=paths.home)
+        assert not list(paths.home.glob("*.sqlite*"))
+
+        cleanup_thread.start()
+        assert not cleanup_done.wait(0.1)
+        allow_transfer.set()
+        cleanup_thread.join(10)
+        assert not cleanup_thread.is_alive()
+        assert cleanup_results and cleanup_results[0].removed == ()
+        assert paths.home.is_dir()
+        current = sh.read_pid_sentinel(paths.pid_sentinel)
+        assert current is not None and current.pid == child_temp[0][1].pid
+    finally:
+        allow_transfer.set()
+        release_child.touch()
+        launch_thread.join(15)
+        if cleanup_thread.is_alive():
+            cleanup_thread.join(15)
+        lease.release()
+
+    assert errors == []
+    assert launch_results and launch_results[0][0] == 0
 
 
 # ── explicit no-body accounting receipt mode ───────────────────────────
@@ -312,25 +861,21 @@ def test_codex_manual_namespace_preserves_receipt_only_flag():
     assert ns.args == ["--version"]
 
 
-def test_main_receipt_mode_runs_child_and_writes_no_body_receipt(
-    monkeypatch, tmp_path
-):
+def test_main_receipt_mode_runs_child_and_writes_no_body_receipt(monkeypatch, tmp_path):
     _stub_setup(monkeypatch, tmp_path)
-    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda: None)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
     monkeypatch.setattr(launcher, "_fleet_state_enabled", lambda: False)
 
     captured = {}
 
-    def _fake_run(argv, env=None):
+    def _fake_run(argv, env, *, on_start=None):
         captured["argv"] = list(argv)
         captured["env"] = dict(env or {})
-        return SimpleNamespace(returncode=0)
+        assert on_start is not None
+        on_start(os.getpid())
+        return 0, launcher.empty_usage()
 
-    def _no_exec(*_a, **_k):
-        raise AssertionError("receipt mode must not exec-replace")
-
-    monkeypatch.setattr(launcher.subprocess, "run", _fake_run)
-    monkeypatch.setattr(launcher.os, "execvpe", _no_exec)
+    monkeypatch.setattr(launcher, "_run_codex_process", _fake_run)
 
     receipt_path = tmp_path / "receipt.json"
     prompt_body = "BODY_SENTINEL_PROMPT_MUST_NOT_BE_STORED"
@@ -365,9 +910,7 @@ def test_main_receipt_mode_runs_child_and_writes_no_body_receipt(
     assert receipt["attribution"]["tokenpak_mechanism_active"] is True
 
 
-def test_receipt_only_mode_skips_companion_setup_and_writes_no_body_receipt(
-    monkeypatch, tmp_path
-):
+def test_receipt_only_mode_skips_companion_setup_and_writes_no_body_receipt(monkeypatch, tmp_path):
     from tokenpak.companion.codex import (
         agents_md,
         mcp_config,
@@ -378,30 +921,26 @@ def test_receipt_only_mode_skips_companion_setup_and_writes_no_body_receipt(
     def _setup_must_not_run(*_a, **_k):
         raise AssertionError("receipt-only mode must not run companion setup")
 
+    _stub_session_env(monkeypatch, tmp_path)
     monkeypatch.setattr(launcher.CompanionConfig, "from_env", _setup_must_not_run)
     monkeypatch.setattr(rates_snapshot, "refresh", _setup_must_not_run)
-    monkeypatch.setattr(mcp_config, "register", _setup_must_not_run)
-    monkeypatch.setattr(agents_md, "install_agents_md", _setup_must_not_run)
+    monkeypatch.setattr(mcp_config, "_register", _setup_must_not_run)
+    monkeypatch.setattr(agents_md, "_install_agents_md", _setup_must_not_run)
     monkeypatch.setattr(skills_installer, "install_skills", _setup_must_not_run)
-    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda: None)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
     monkeypatch.setenv("TOKENPAK_COMPANION_PROFILE", "aggressive")
     monkeypatch.setenv("TOKENPAK_MANAGED", "1")
 
     captured = {}
 
-    def _fake_run(argv, env=None):
+    def _fake_run(argv, env, *, on_start=None):
         captured["argv"] = list(argv)
         captured["env"] = dict(env or {})
-        return SimpleNamespace(returncode=0)
+        assert on_start is not None
+        on_start(os.getpid())
+        return 0, launcher.empty_usage()
 
-    monkeypatch.setattr(launcher.subprocess, "run", _fake_run)
-    monkeypatch.setattr(
-        launcher.os,
-        "execvpe",
-        lambda *_a, **_k: (_ for _ in ()).throw(
-            AssertionError("receipt-only mode must not exec-replace")
-        ),
-    )
+    monkeypatch.setattr(launcher, "_run_codex_process", _fake_run)
 
     receipt_path = tmp_path / "receipt-only.json"
     prompt_body = "BODY_SENTINEL_PROMPT_MUST_NOT_BE_STORED"
@@ -417,6 +956,10 @@ def test_receipt_only_mode_skips_companion_setup_and_writes_no_body_receipt(
     assert captured["env"]["TOKENPAK_CODEX_RECEIPT_OUT"] == str(receipt_path)
     assert "TOKENPAK_COMPANION_PROFILE" not in captured["env"]
     assert "TOKENPAK_MANAGED" not in captured["env"]
+    assert captured["env"]["TOKENPAK_CODEX_SESSION_MODE"] == "isolated"
+    assert captured["env"]["CODEX_HOME"].startswith(
+        str(tmp_path / "tokenpak-home" / "companion" / "codex" / "sessions")
+    )
 
     raw = receipt_path.read_text(encoding="utf-8")
     assert prompt_body not in raw
@@ -440,12 +983,12 @@ def test_receipt_only_mode_skips_companion_setup_and_writes_no_body_receipt(
 
 def test_json_receipt_mode_extracts_usage_without_storing_body(monkeypatch, tmp_path):
     _stub_setup(monkeypatch, tmp_path)
-    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda: None)
+    monkeypatch.setattr(launcher, "_preflight_state_lock", lambda **_kwargs: None)
     monkeypatch.setattr(launcher, "_fleet_state_enabled", lambda: False)
 
     class _FakeStdout:
-        def __iter__(self):
-            return iter(
+        def __init__(self):
+            self._lines = iter(
                 [
                     '{"type":"message","text":"BODY_SENTINEL_COMPLETION"}\n',
                     (
@@ -455,14 +998,21 @@ def test_json_receipt_mode_extracts_usage_without_storing_body(monkeypatch, tmp_
                 ]
             )
 
+        def readline(self):
+            return next(self._lines, "")
+
     class _FakePopen:
         stdout = _FakeStdout()
+        pid = os.getpid()
 
         def __init__(self, *_a, **_k):
             return None
 
         def wait(self):
             return 0
+
+        def poll(self):
+            return None
 
     monkeypatch.setattr(launcher.subprocess, "Popen", _FakePopen)
 
@@ -483,3 +1033,117 @@ def test_json_receipt_mode_extracts_usage_without_storing_body(monkeypatch, tmp_
     assert receipt["metrics"]["output_tokens"] == 6
     assert receipt["metrics"]["total_tokens"] == 16
     assert receipt["attribution"]["provider_native_caching_involved"] is True
+
+
+def test_process_supervision_uses_fast_child_result_when_transfer_is_too_late(monkeypatch):
+    class FastProcess:
+        pid = 12345
+        stdout = None
+        waited = False
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def poll(self):
+            return 0
+
+        def wait(self):
+            self.waited = True
+            return 0
+
+    process = FastProcess()
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *_a, **_k: process)
+
+    result, _usage = launcher._run_codex_process(
+        ["codex", "--version"],
+        {},
+        on_start=lambda _pid: (_ for _ in ()).throw(RuntimeError("already exited")),
+    )
+
+    assert result == 0
+    assert process.waited
+
+
+def test_json_supervision_continues_after_interrupts_and_reaps(monkeypatch, capsys):
+    class InterruptingStdout:
+        def __init__(self):
+            self.calls = 0
+
+        def readline(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise KeyboardInterrupt
+            if self.calls == 2:
+                return '{"type":"usage","usage":{"input_tokens":2,"output_tokens":3}}\n'
+            return ""
+
+    class InterruptingProcess:
+        pid = 12346
+        stdout = InterruptingStdout()
+
+        def __init__(self, *_args, **_kwargs):
+            self.wait_calls = 0
+
+        def wait(self):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise KeyboardInterrupt
+            return 0
+
+    process = InterruptingProcess()
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *_a, **_k: process)
+
+    result, usage = launcher._run_codex_process(["codex", "exec", "--json"], {})
+
+    assert result == 0
+    assert usage["input_tokens"] == 2
+    assert usage["output_tokens"] == 3
+    assert process.wait_calls == 2
+    assert '"type":"usage"' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [
+        BrokenPipeError(),
+        UnicodeEncodeError("ascii", "é", 0, 1, "ordinal not in range"),
+    ],
+    ids=["broken-pipe", "encoding-error"],
+)
+def test_json_output_failure_is_drained_and_child_reaped(monkeypatch, write_error):
+    class Output:
+        def __init__(self):
+            self.lines = iter(["one\n", "two\n", ""])
+            self.read_count = 0
+
+        def readline(self):
+            self.read_count += 1
+            return next(self.lines)
+
+    class Process:
+        pid = 12347
+        stdout = Output()
+
+        def __init__(self, *_args, **_kwargs):
+            self.waited = False
+
+        def wait(self):
+            self.waited = True
+            return 0
+
+    class BrokenOutput:
+        def write(self, _line):
+            raise write_error
+
+        def flush(self):
+            raise AssertionError("flush must not follow failed write")
+
+    process = Process()
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *_a, **_k: process)
+    monkeypatch.setattr(launcher.sys, "stdout", BrokenOutput())
+
+    result, _usage = launcher._run_codex_process(["codex", "exec", "--json"], {})
+
+    assert result == 0
+    assert process.waited
+    assert process.stdout.read_count == 3

--- a/tests/companion/test_codex_selected_home_surfaces.py
+++ b/tests/companion/test_codex_selected_home_surfaces.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Selected-CODEX_HOME provisioning surfaces never fall back to live state."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tokenpak.cli.commands import uninstall as top_level_uninstall
+from tokenpak.companion.codex import (
+    agents_md,
+    doctor,
+    hooks,
+    mcp_config,
+    session_home,
+    state_lock,
+    uninstall,
+)
+from tokenpak.companion.codex import skills_installer as skills
+from tokenpak.companion.codex.session_home import select_paths
+
+
+@pytest.fixture(autouse=True)
+def _isolated_user_home(monkeypatch, tmp_path: Path):
+    home = tmp_path / "test-user-home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("TOKENPAK_CODEX_SESSION_MODE", raising=False)
+
+
+def _fake_bundled(tmp_path: Path) -> Path:
+    bundled = tmp_path / "bundled"
+    for name in ("alpha", "beta"):
+        skill = bundled / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"# {name}\n")
+    return bundled
+
+
+def test_hooks_and_agents_install_into_selected_home(tmp_path: Path):
+    selected = tmp_path / "selected-codex"
+    other = tmp_path / "other-codex"
+    other.mkdir()
+
+    hooks_path = hooks._install_hooks(codex_home=selected)
+    agents_path = agents_md._install_agents_md(codex_home=selected)
+
+    assert hooks_path == selected / "hooks.json"
+    assert agents_path == selected / "AGENTS.md"
+    assert hooks_path.is_file()
+    assert agents_path.is_file()
+    assert list(other.iterdir()) == []
+
+
+def test_selected_home_plumbing_does_not_expand_public_signatures():
+    assert tuple(inspect.signature(agents_md.install_agents_md).parameters) == ("target",)
+    assert tuple(inspect.signature(hooks.install_hooks).parameters) == ("target",)
+    assert tuple(inspect.signature(hooks.ensure_hooks_feature_enabled).parameters) == ()
+    assert tuple(inspect.signature(mcp_config.is_registered).parameters) == ()
+    assert tuple(inspect.signature(mcp_config.register).parameters) == ("env_vars",)
+    assert tuple(inspect.signature(mcp_config.unregister).parameters) == ()
+    assert tuple(inspect.signature(uninstall.remove_mcp).parameters) == ()
+
+
+def test_codex_commands_receive_selected_home(monkeypatch, tmp_path: Path):
+    selected = tmp_path / "selected-codex"
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs["env"]))
+        return Result()
+
+    monkeypatch.setattr(mcp_config.subprocess, "run", fake_run)
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+
+    assert mcp_config._is_registered(selected)
+    assert mcp_config._unregister(selected)
+    assert hooks._ensure_hooks_feature_enabled(selected)
+
+    assert calls
+    assert all(env["CODEX_HOME"] == str(selected) for _, env in calls)
+    assert (selected / "config.toml").is_file()
+
+
+def test_mcp_registration_writes_selected_config(monkeypatch, tmp_path: Path):
+    selected = tmp_path / "selected-codex"
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    class Result:
+        stdout = ""
+        stderr = ""
+
+        def __init__(self, returncode: int):
+            self.returncode = returncode
+
+    results = iter((Result(1), Result(0)))
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs["env"]))
+        return next(results)
+
+    monkeypatch.setattr(mcp_config.subprocess, "run", fake_run)
+
+    assert mcp_config._register({"TOKENPAK_COMPANION_PROFILE": "test"}, codex_home=selected)
+    assert calls[0][0][:3] == ["codex", "mcp", "get"]
+    assert calls[1][0][:3] == ["codex", "mcp", "add"]
+    assert all(env["CODEX_HOME"] == str(selected) for _, env in calls)
+
+
+def test_skills_payload_is_global_but_selected_configs_reference_it(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    root = tmp_path / "home" / ".agents" / "skills"
+    first = tmp_path / "selected-one" / "config.toml"
+    second = tmp_path / "selected-two" / "config.toml"
+    first.parent.mkdir(parents=True)
+    first.write_text('model = "gpt-test"\n')
+
+    installed = skills.install_skills(root)
+    first_refs = skills._configure_skills(first, skills_root=root)
+    second_refs = skills._configure_skills(second, skills_root=root)
+
+    assert first_refs == installed
+    assert second_refs == installed
+    assert skills._configured_skill_paths(first) == installed
+    assert skills._configured_skill_paths(second) == installed
+    assert 'model = "gpt-test"' in first.read_text()
+    assert all(path.parent == root for path in installed)
+    assert not (first.parent / "skills").exists()
+    assert not (second.parent / "skills").exists()
+
+
+def test_skills_config_is_idempotent_and_excludes_runtime_files(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    root = tmp_path / ".agents" / "skills"
+    config = tmp_path / "codex-home" / "config.toml"
+    skills.install_skills(root)
+    for forbidden in (
+        "state_5.sqlite",
+        "logs_2.sqlite",
+        "state_5.sqlite-wal",
+        "logs_2.sqlite-shm",
+        "history.jsonl",
+    ):
+        (tmp_path / forbidden).write_text("must remain outside selected home")
+
+    skills._configure_skills(config, skills_root=root)
+    once = config.read_text()
+    skills._configure_skills(config, skills_root=root)
+
+    assert config.read_text() == once
+    assert config.read_text().count(skills._SKILLS_CONFIG_BEGIN) == 1
+    assert not any(name in config.read_text() for name in (".sqlite", "history.jsonl"))
+    assert set(config.parent.iterdir()) == {config}
+
+
+@pytest.mark.parametrize("original", ["", 'model = "gpt-test"', 'model = "gpt-test"\n'])
+def test_skills_config_cleanup_restores_original_bytes(monkeypatch, tmp_path: Path, original: str):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    root = tmp_path / ".agents" / "skills"
+    config = tmp_path / "codex-home" / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text(original, encoding="utf-8")
+    skills.install_skills(root)
+
+    skills._configure_skills(config, skills_root=root)
+    assert skills._clean_skills_config(config)
+
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_default_skill_roots_follow_runtime_home(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(skills, "_DEFAULT_TARGET", None)
+    monkeypatch.setattr(skills, "_LEGACY_TARGET", None)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert skills._default_skills_root() == tmp_path / ".agents" / "skills"
+    assert skills._legacy_skills_root() == tmp_path / ".codex" / "skills"
+
+
+def test_doctor_real_checks_report_and_use_every_selected_path(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    selected = tmp_path / "selected-codex"
+    workspace = tmp_path / "project"
+    paths = select_paths("workspace", workspace_dir=workspace, selected_home=selected)
+    selected.mkdir(parents=True)
+    hooks._install_hooks(codex_home=selected)
+    agents_md._install_agents_md(codex_home=selected)
+    skills.install_skills(paths.skills_root)
+    skills._configure_skills(paths.config, skills_root=paths.skills_root)
+
+    class Result:
+        returncode = 0
+        stdout = "hooks under development true\n"
+        stderr = ""
+
+    seen_envs = []
+
+    def fake_run(command, **kwargs):
+        seen_envs.append(kwargs["env"])
+        return Result()
+
+    monkeypatch.setattr(doctor.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        doctor,
+        "CHECKS",
+        [
+            ("hooks feature", doctor.check_hooks_feature),
+            ("MCP registration", doctor.check_mcp_registered),
+            ("hooks.json schema", doctor.check_hooks_json),
+            ("AGENTS.md", doctor.check_agents_md),
+            ("skills installed", doctor.check_skills_installed),
+            ("skills selected config", doctor._check_skills_config),
+        ],
+    )
+    assert doctor._run_selected(paths=paths) == 0
+    output = capsys.readouterr().out
+
+    expected = {
+        "session mode": "workspace",
+        "workspace": str(paths.workspace),
+        "CODEX_HOME": str(selected),
+        "source home": str(paths.source_home),
+        "config": str(selected / "config.toml"),
+        "auth": str(selected / "auth.json"),
+        "MCP config": str(selected / "config.toml"),
+        "hooks": str(selected / "hooks.json"),
+        "AGENTS.md": str(selected / "AGENTS.md"),
+        "skills": str(paths.skills_root),
+        "PID sentinel": str(selected / "codex.pid"),
+    }
+    for label, value in expected.items():
+        assert f"{label}: {value}" in output
+    assert seen_envs
+    assert all(env["CODEX_HOME"] == str(selected) for env in seen_envs)
+    assert not (Path.home() / ".codex").exists()
+
+
+def test_doctor_reports_isolated_orphans_and_disk_usage(monkeypatch, tmp_path: Path):
+    tokenpak_home = tmp_path / "tokenpak-home"
+    monkeypatch.setenv("TOKENPAK_HOME", str(tokenpak_home))
+    source = Path.home() / ".codex"
+    source.mkdir()
+    paths = select_paths(
+        "isolated",
+        session_id="doctor-orphan",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    session_home.provision(paths)
+    old = time.time() - 120
+    os.utime(paths.home, (old, old))
+    token = doctor._ACTIVE_RETENTION_REPORT.set(None)
+    try:
+        orphan_status, orphan_detail = doctor._check_orphaned_codex_homes()
+        disk_status, disk_detail = doctor._check_codex_home_disk_usage()
+    finally:
+        doctor._ACTIVE_RETENTION_REPORT.reset(token)
+
+    assert orphan_status == doctor._WARN
+    assert "orphaned=1" in orphan_detail
+    assert disk_status is True
+    assert "500 MB" in disk_detail
+
+
+def test_uninstall_cleans_only_selected_home_artifacts(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    root = Path.home() / ".agents" / "skills"
+    selected = tmp_path / "selected-codex"
+    other = tmp_path / "other-codex"
+    paths = select_paths("workspace", selected_home=selected)
+    other.mkdir(parents=True)
+
+    hooks._install_hooks(codex_home=selected)
+    agents_md._install_agents_md(codex_home=selected)
+    skills.install_skills(root)
+    skills._configure_skills(paths.config, skills_root=root)
+    other_config = other / "config.toml"
+    skills._configure_skills(other_config, skills_root=root)
+    (other / "hooks.json").write_text(json.dumps({"keep": True}))
+    (other / "AGENTS.md").write_text("# Keep\n")
+    selected.chmod(0o700)
+
+    monkeypatch.setattr(uninstall, "_remove_mcp", lambda codex_home=None: True)
+    monkeypatch.setattr(uninstall, "clean_rates_snapshot", lambda: (False, "absent"))
+
+    assert uninstall._run_selected(paths=paths) == 0
+    assert not paths.hooks.exists()
+    assert not paths.agents.exists()
+    assert skills._configured_skill_paths(paths.config) == []
+    assert (other / "hooks.json").is_file()
+    assert (other / "AGENTS.md").is_file()
+    assert skills._configured_skill_paths(other_config)
+    assert all(path.is_dir() for path in skills._configured_skill_paths(other_config))
+
+
+def test_explicit_global_skill_removal_preserves_unrelated_skills(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    canonical = Path.home() / ".agents" / "skills"
+    legacy = Path.home() / ".codex" / "skills"
+    skills.install_skills(canonical)
+    skills.install_skills(legacy)
+    unrelated = canonical / "unrelated"
+    unrelated.mkdir()
+    (unrelated / "SKILL.md").write_text("# unrelated\n")
+    paths = select_paths("workspace", selected_home=tmp_path / "selected-codex")
+    monkeypatch.setattr(uninstall, "_remove_mcp", lambda codex_home=None: True)
+    monkeypatch.setattr(uninstall, "clean_rates_snapshot", lambda: (False, "absent"))
+
+    assert uninstall._run_selected(paths=paths, remove_global_skills=True) == 0
+    assert unrelated.is_dir()
+    assert skills.list_installed_skills(canonical) == []
+    assert skills.list_installed_skills(legacy) == []
+
+
+def test_shared_uninstall_removes_global_skills_when_no_managed_home_references_exist(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    canonical = Path.home() / ".agents" / "skills"
+    skills.install_skills(canonical)
+    selected = Path.home() / ".codex"
+    paths = select_paths("shared", selected_home=selected)
+    monkeypatch.setattr(uninstall, "_remove_mcp", lambda codex_home=None: True)
+    monkeypatch.setattr(uninstall, "clean_rates_snapshot", lambda: (False, "absent"))
+
+    assert uninstall._run_selected(paths=paths) == 0
+    assert skills.list_installed_skills(canonical) == []
+
+
+def test_shared_uninstall_preserves_global_skills_referenced_by_workspace_home(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setattr(skills, "_BUNDLED_SKILLS", _fake_bundled(tmp_path))
+    canonical = Path.home() / ".agents" / "skills"
+    skills.install_skills(canonical)
+    tokenpak_home = Path.home() / ".tokenpak"
+    workspace = select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=Path.home() / ".codex",
+    )
+    session_home.provision(workspace)
+    selected = select_paths("shared", selected_home=Path.home() / ".codex")
+    monkeypatch.setattr(uninstall, "_remove_mcp", lambda codex_home=None: True)
+    monkeypatch.setattr(uninstall, "clean_rates_snapshot", lambda: (False, "absent"))
+
+    assert uninstall._run_selected(paths=selected) == 0
+    assert skills.list_installed_skills(canonical) == ["alpha", "beta"]
+
+
+def test_top_level_uninstall_explicitly_requests_global_skill_removal(monkeypatch):
+    calls: list[bool] = []
+    monkeypatch.setattr(uninstall, "_run_global", lambda: calls.append(True) or 0)
+
+    outcome, _detail = top_level_uninstall._teardown_codex()
+
+    assert outcome == "done"
+    assert calls == [True]
+
+
+def test_doctor_and_uninstall_reject_invalid_mode_without_writes(
+    monkeypatch, tmp_path: Path, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "automatic")
+    monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path / "tokenpak-home"))
+
+    assert doctor.run() == 2
+    assert uninstall.run() == 2
+    assert "expected shared|workspace|isolated" in capsys.readouterr().err
+    assert not (tmp_path / "tokenpak-home").exists()
+
+
+def test_isolated_doctor_and_uninstall_require_selected_codex_home(
+    monkeypatch, tmp_path: Path, capsys
+):
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "isolated")
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setenv("TOKENPAK_HOME", str(tmp_path / "tokenpak-home"))
+
+    assert doctor.run() == 2
+    assert uninstall.run() == 2
+    error = capsys.readouterr().err
+    assert "isolated mode has no selected home" in error
+    assert not (tmp_path / "tokenpak-home").exists()
+
+
+def test_isolated_inspection_rejects_codex_home_outside_session_root(monkeypatch, tmp_path: Path):
+    tokenpak_home = tmp_path / "tokenpak-home"
+    monkeypatch.setenv("TOKENPAK_CODEX_SESSION_MODE", "isolated")
+    monkeypatch.setenv("TOKENPAK_HOME", str(tokenpak_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "outside-session"))
+
+    assert doctor.run() == 2
+    assert uninstall.run() == 2
+
+
+def test_uninstall_refuses_live_selected_home_before_any_mutation(monkeypatch, tmp_path: Path):
+    source = tmp_path / "source"
+    source.mkdir()
+    paths = select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        selected_home=tmp_path / "selected-codex",
+        source_home=source,
+    )
+    lease = session_home.SessionLease.acquire(paths, session_id="active-uninstall-test")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        uninstall,
+        "remove_mcp",
+        lambda *_a, **_k: calls.append("mcp"),
+    )
+    try:
+        assert uninstall._run_selected(paths=paths) == 1
+        assert calls == []
+        assert paths.pid_sentinel.exists()
+    finally:
+        lease.release()
+
+
+def test_uninstall_reprobes_after_lease_before_mutation(monkeypatch, tmp_path: Path):
+    paths = select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        selected_home=tmp_path / "selected-codex",
+        source_home=tmp_path / "source",
+    )
+    paths.home.mkdir()
+    clear = state_lock.LockStatus(
+        home=paths.home,
+        db_path=paths.home / "state_5.sqlite",
+        exists=True,
+        locked=False,
+    )
+    contended = state_lock.LockStatus(
+        home=paths.home,
+        db_path=paths.home / "state_5.sqlite",
+        exists=True,
+        locked=True,
+        holder_pids=[4242],
+        running_pids=[4242],
+        detail="state_5.sqlite has live Codex database holder(s): PID 4242 (running)",
+    )
+    statuses = iter((clear, contended))
+    monkeypatch.setattr(state_lock, "probe", lambda _home: next(statuses))
+    calls: list[str] = []
+    monkeypatch.setattr(uninstall, "_remove_mcp", lambda *_a, **_k: calls.append("mcp"))
+
+    assert uninstall._run_selected(paths=paths) == 1
+    assert calls == []
+    assert not paths.pid_sentinel.exists()

--- a/tests/companion/test_codex_session_home.py
+++ b/tests/companion/test_codex_session_home.py
@@ -1,0 +1,1759 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic tests for Codex session-home selection and lifecycle."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from tokenpak.companion.codex import session_home as sh
+
+
+@pytest.fixture
+def homes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    user_home = tmp_path / "user"
+    source = user_home / ".codex"
+    source.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.delenv(sh.ENV_CODEX_HOME, raising=False)
+    monkeypatch.delenv(sh.ENV_SESSION_MODE, raising=False)
+    (source / "config.toml").write_text('model = "gpt-test"\n', encoding="utf-8")
+    (source / "auth.json").write_text('{"test": true}\n', encoding="utf-8")
+    (source / "auth.json").chmod(0o600)
+    return source, tmp_path / "tokenpak"
+
+
+@pytest.mark.parametrize("mode", sh.VALID_MODES)
+def test_resolve_mode_accepts_only_advertised_values(mode: str) -> None:
+    assert sh.resolve_mode(mode) == mode
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["", "auto", "attach", "per-project", "bogus", " Shared", "WORKSPACE", "isolated "],
+)
+def test_invalid_mode_fails_closed(mode: str) -> None:
+    with pytest.raises(sh.InvalidSessionMode, match="expected shared\\|workspace\\|isolated"):
+        sh.resolve_mode(mode)
+
+
+def test_shared_retains_existing_codex_home(
+    homes: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    custom = source.parent / "custom-codex"
+    monkeypatch.setenv(sh.ENV_CODEX_HOME, str(custom))
+    paths = sh.select_paths("shared", tokenpak_home=tokenpak_home)
+    assert paths.home == custom
+    assert sh.provision(paths).created is False
+    assert not custom.exists()
+
+
+def test_workspace_homes_are_stable_per_project_and_database_separate(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    project_a.mkdir()
+    project_b.mkdir()
+    (project_a / ".git").mkdir()
+    nested_a = project_a / "packages" / "component"
+    nested_a.mkdir(parents=True)
+
+    a1 = sh.select_paths(
+        "workspace",
+        workspace_dir=project_a,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    a2 = sh.select_paths(
+        "workspace",
+        workspace_dir=nested_a,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    b = sh.select_paths(
+        "workspace",
+        workspace_dir=project_b,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+
+    assert a1.home == a2.home
+    assert a1.workspace == project_a.resolve()
+    assert a1.home != b.home
+    assert a1.home.parent == tokenpak_home / "companion" / "codex" / "workspaces"
+    assert a1.home / "state_5.sqlite" != b.home / "state_5.sqlite"
+    assert a1.home / "logs_2.sqlite" != b.home / "logs_2.sqlite"
+
+    for paths, marker in ((a1, "project-a"), (b, "project-b")):
+        sh.provision(paths)
+        with sqlite3.connect(paths.home / "state_5.sqlite") as connection:
+            connection.execute("CREATE TABLE marker (value TEXT NOT NULL)")
+            connection.execute("INSERT INTO marker VALUES (?)", (marker,))
+    with sqlite3.connect(a1.home / "state_5.sqlite") as connection:
+        assert connection.execute("SELECT value FROM marker").fetchone() == ("project-a",)
+    with sqlite3.connect(b.home / "state_5.sqlite") as connection:
+        assert connection.execute("SELECT value FROM marker").fetchone() == ("project-b",)
+
+
+def test_workspace_inspection_ignores_inherited_codex_home(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    monkeypatch.setenv(sh.ENV_CODEX_HOME, str(tmp_path / "unrelated-home"))
+    paths = sh.current_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    assert paths.home == sh.workspaces_root(tokenpak_home) / sh.workspace_hash(
+        sh.project_root(tmp_path)
+    )
+
+
+def test_isolated_sessions_always_receive_unique_homes(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    ids = iter(["fixed-session-one", "fixed-session-two"])
+    monkeypatch.setattr(sh.uuid, "uuid4", lambda: type("UUID", (), {"hex": next(ids)})())
+    first = sh.select_paths(
+        "isolated", workspace_dir=tmp_path, tokenpak_home=tokenpak_home, source_home=source
+    )
+    second = sh.select_paths(
+        "isolated", workspace_dir=tmp_path, tokenpak_home=tokenpak_home, source_home=source
+    )
+    assert first.home != second.home
+    assert first.home.parent == tokenpak_home / "companion" / "codex" / "sessions"
+
+
+def test_provision_uses_closed_allowlist_and_never_copies_runtime_state(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    forbidden = (
+        "state_5.sqlite",
+        "state_5.sqlite-wal",
+        "state_5.sqlite-shm",
+        "logs_2.sqlite",
+        "logs_2.sqlite-wal",
+        "logs_2.sqlite-shm",
+        "history.jsonl",
+        "session_index.jsonl",
+    )
+    for name in forbidden:
+        (source / name).write_bytes(b"must-not-copy")
+    (source / "sessions").mkdir()
+    (source / "sessions" / "live.jsonl").write_text("must-not-copy", encoding="utf-8")
+
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="allowlist-test",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    result = sh.provision(paths)
+
+    assert result.seeded == ("config.toml",)
+    assert result.linked_credentials == ("auth.json",)
+    assert paths.config.read_text(encoding="utf-8") == 'model = "gpt-test"\n'
+    assert paths.config.stat().st_mode & 0o777 == 0o600
+    assert paths.auth.is_symlink()
+    assert paths.auth.resolve() == (source / "auth.json").resolve()
+    assert not any((paths.home / name).exists() for name in forbidden)
+    assert not (paths.home / "sessions").exists()
+    assert {entry.name for entry in paths.home.iterdir()} == {"config.toml", "auth.json"}
+
+
+def test_config_symlink_cannot_smuggle_database_bytes(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="symlink-source",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    source_config = source / "config.toml"
+    source_config.unlink()
+    database = source / "state_9.sqlite"
+    database.write_bytes(b"SQLite format 3\x00runtime")
+    source_config.symlink_to(database)
+
+    result = sh.provision(paths)
+    assert result.seeded == ()
+    assert not paths.config.exists()
+    assert not (paths.home / database.name).exists()
+
+
+def test_config_seed_removes_storage_overrides_that_break_isolation(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    (source / "config.toml").write_text(
+        'model = "gpt-test"\n'
+        f'sqlite_home = "{source}"\n'
+        f'log_dir = "{source / "log"}"\n'
+        "\n[tui]\n"
+        "animations = false\n",
+        encoding="utf-8",
+    )
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+
+    result = sh.provision(paths)
+    seeded = paths.config.read_text(encoding="utf-8")
+    assert result.seeded == ("config.toml",)
+    assert 'model = "gpt-test"' in seeded
+    assert "[tui]" in seeded
+    assert "animations = false" in seeded
+    assert "sqlite_home" not in seeded
+    assert "log_dir" not in seeded
+
+
+def test_existing_config_is_revalidated_and_storage_redirects_are_removed(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    paths.config.write_text(
+        f'model = "gpt-test"\nsqlite_home = "{source}"\nlog_dir = "{source}"\n',
+        encoding="utf-8",
+    )
+
+    sh.provision(paths)
+
+    selected = paths.config.read_text(encoding="utf-8")
+    assert "sqlite_home" not in selected
+    assert "log_dir" not in selected
+    assert paths.config.stat().st_mode & 0o777 == 0o600
+
+
+def test_preexisting_selected_config_symlink_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    paths.config.unlink()
+    paths.config.symlink_to(source / "config.toml")
+
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        sh.provision(paths)
+    assert paths.config.is_symlink()
+
+
+def test_auth_source_and_existing_target_links_must_be_exact_and_safe(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    database = source / "state_8.sqlite"
+    database.write_bytes(b"SQLite format 3\x00runtime")
+    source_auth = source / "auth.json"
+    source_auth.unlink()
+    source_auth.symlink_to(database)
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="unsafe-auth-source",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    result = sh.provision(paths)
+    assert result.linked_credentials == ()
+    assert not paths.auth.exists()
+
+    source_auth.unlink()
+    source_auth.write_text('{"safe": true}\n', encoding="utf-8")
+    source_auth.chmod(0o600)
+    paths.auth.symlink_to(database)
+    with pytest.raises(RuntimeError, match="unsafe target"):
+        sh.provision(paths)
+    assert paths.auth.resolve() == database
+
+
+def test_live_0700_tokenpak_and_0775_companion_create_private_codex_boundary(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    tokenpak_home.mkdir(mode=0o700)
+    companion = tokenpak_home / "companion"
+    companion.mkdir(mode=0o775)
+    tokenpak_home.chmod(0o700)
+    companion.chmod(0o775)
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="private-chain",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    old_umask = os.umask(0o022)
+    try:
+        sh.provision(paths)
+    finally:
+        os.umask(old_umask)
+
+    assert tokenpak_home.stat().st_mode & 0o777 == 0o700
+    assert companion.stat().st_mode & 0o777 == 0o775
+    for directory in (
+        tokenpak_home / "companion" / "codex",
+        tokenpak_home / "companion" / "codex" / "sessions",
+        paths.home,
+    ):
+        assert directory.stat().st_mode & 0o777 == 0o700
+
+    paths.home.chmod(0o755)
+    with pytest.raises(sh.HomeInUseError, match="owned 0700 directory"):
+        sh.provision(paths)
+
+
+def test_existing_nonprivate_codex_boundary_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    (tokenpak_home / "companion" / "codex").mkdir(parents=True)
+    tokenpak_home.chmod(0o700)
+    (tokenpak_home / "companion").chmod(0o775)
+    (tokenpak_home / "companion" / "codex").chmod(0o775)
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="broad-codex-boundary",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+
+    with pytest.raises(sh.HomeInUseError, match="owned 0700 directory"):
+        sh.provision(paths)
+
+
+@pytest.mark.parametrize("name", ["hooks.json", "AGENTS.md"])
+def test_selected_managed_file_symlink_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path, name: str
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    outside = tmp_path / f"outside-{name}"
+    outside.write_text("must not change", encoding="utf-8")
+    (paths.home / name).symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="managed file is unsafe"):
+        sh.provision(paths)
+    assert outside.read_text(encoding="utf-8") == "must not change"
+
+
+@pytest.mark.parametrize("alias_kind", ["symlink", "hardlink"])
+@pytest.mark.parametrize(
+    "database_name",
+    ["state_99.sqlite", "state_99.sqlite-wal", "state_99.sqlite-shm", "state_99.sqlite-journal"],
+)
+def test_selected_runtime_database_alias_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path, alias_kind: str, database_name: str
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    shared_database = source / database_name
+    shared_database.write_bytes(b"SQLite format 3\x00shared")
+    selected_database = paths.home / database_name
+    if alias_kind == "symlink":
+        selected_database.symlink_to(shared_database)
+    else:
+        os.link(shared_database, selected_database)
+
+    with pytest.raises(RuntimeError, match="runtime database is aliased or unsafe"):
+        sh.provision(paths)
+    assert shared_database.read_bytes() == b"SQLite format 3\x00shared"
+
+
+def test_selected_home_symlink_fails_closed(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    target = tmp_path / "redirect-target"
+    target.mkdir()
+    selected = tmp_path / "selected-link"
+    selected.symlink_to(target, target_is_directory=True)
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        selected_home=selected,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    with pytest.raises(RuntimeError, match="unsafe"):
+        sh.provision(paths)
+    assert list(target.iterdir()) == []
+
+
+def test_selected_environment_and_report_cover_every_managed_path(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    env = paths.environment({"PATH": "/test/bin"})
+    report = dict(paths.report_rows())
+
+    assert env[sh.ENV_CODEX_HOME] == str(paths.home)
+    assert env[sh.ENV_SESSION_MODE] == "workspace"
+    assert env["PATH"] == "/test/bin"
+    for expected in (
+        paths.home,
+        paths.config,
+        paths.auth,
+        paths.mcp_config,
+        paths.hooks,
+        paths.agents,
+        paths.skills_root,
+        paths.pid_sentinel,
+    ):
+        assert str(expected) in report.values()
+
+
+def test_pid_sentinel_is_validated_transferred_and_cleaned(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="lease-test",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+
+    lease = sh.SessionLease.acquire(paths, session_id="lease-test")
+    launcher_record = sh.read_pid_sentinel(paths.pid_sentinel)
+    assert launcher_record is not None
+    assert launcher_record.pid == os.getpid()
+    assert sh.sentinel_is_live(launcher_record, expected_home=paths.home)
+
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import sys; print('ready', flush=True); sys.stdin.readline()",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "ready"
+        lease.transfer_to(child.pid)
+        child_record = sh.read_pid_sentinel(paths.pid_sentinel)
+        assert child_record is not None
+        assert child_record.pid == child.pid
+        assert child_record.session_id == launcher_record.session_id
+        assert sh.sentinel_is_live(child_record, expected_home=paths.home)
+        assert child.stdin is not None
+        child.stdin.write("\n")
+        child.stdin.close()
+        assert child.wait(timeout=5) == 0
+    finally:
+        if child.poll() is None and child.stdin is not None and not child.stdin.closed:
+            child.stdin.close()
+        child.wait(timeout=5)
+        if child.stdout is not None:
+            child.stdout.close()
+        lease.release()
+
+    assert not paths.pid_sentinel.exists()
+
+
+def test_live_home_lease_refuses_parallel_owner(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    first = sh.SessionLease.acquire(paths, session_id="first")
+    try:
+        with pytest.raises(sh.HomeInUseError, match="already claimed"):
+            sh.SessionLease.acquire(paths, session_id="second")
+    finally:
+        first.release()
+
+
+def test_invalid_pid_sentinel_is_never_replaced(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    paths.pid_sentinel.write_text("not validated json\n", encoding="utf-8")
+    with pytest.raises(sh.HomeInUseError, match="refusing unsafe replacement"):
+        sh.SessionLease.acquire(paths)
+    assert paths.pid_sentinel.read_text(encoding="utf-8") == "not validated json\n"
+
+
+@pytest.mark.parametrize("kind", ["symlink", "fifo", "oversized"])
+def test_nonregular_or_oversized_pid_sentinel_fails_closed_without_blocking(
+    homes: tuple[Path, Path], tmp_path: Path, kind: str
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    if kind == "symlink":
+        outside = tmp_path / "outside-sentinel"
+        outside.write_text("do not read", encoding="utf-8")
+        paths.pid_sentinel.symlink_to(outside)
+    elif kind == "fifo":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO sentinel test requires POSIX")
+        os.mkfifo(paths.pid_sentinel, 0o600)
+    else:
+        paths.pid_sentinel.write_bytes(b"x" * (sh._MAX_SENTINEL_BYTES + 1))
+        paths.pid_sentinel.chmod(0o600)
+
+    with pytest.raises(sh.HomeInUseError, match="refusing unsafe replacement"):
+        sh.SessionLease.acquire(paths)
+
+
+def test_stale_valid_sentinel_is_reclaimed_without_signalling(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="stale-test",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    stale = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=2_000_000_000,
+        start_time_ticks=1,
+        session_id="stale",
+        mode="isolated",
+        home=str(paths.home.resolve()),
+    )
+    paths.pid_sentinel.write_text(json.dumps(asdict(stale)) + "\n", encoding="utf-8")
+    paths.pid_sentinel.chmod(0o600)
+
+    lease = sh.SessionLease.acquire(paths, session_id="replacement")
+    try:
+        current = sh.read_pid_sentinel(paths.pid_sentinel)
+        assert current is not None
+        assert current.pid == os.getpid()
+        assert current.session_id == "replacement"
+    finally:
+        lease.release()
+
+
+def test_initial_sentinel_short_write_never_publishes_partial_canonical(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    guard = paths.home / sh._LEASE_GUARD_NAME
+    guard.write_bytes(b"\0")
+    guard.chmod(0o600)
+    original = sh._write_all
+
+    def fail_sentinel(fd: int, data: bytes) -> None:
+        if data.startswith(b'{"home"'):
+            os.write(fd, data[:7])
+            raise OSError("injected partial sentinel write")
+        original(fd, data)
+
+    monkeypatch.setattr(sh, "_write_all", fail_sentinel)
+    with pytest.raises(OSError, match="injected partial"):
+        sh.SessionLease.acquire(paths)
+    assert not paths.pid_sentinel.exists()
+    assert not any(sh._SENTINEL_TEMP_RE.fullmatch(path.name) for path in paths.home.iterdir())
+
+    monkeypatch.setattr(sh, "_write_all", original)
+    lease = sh.SessionLease.acquire(paths)
+    lease.release()
+
+
+def test_initial_sentinel_post_rename_enospc_rolls_back_exact_owner_for_retry(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="post-rename-enospc",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    original = sh._fsync_directory
+    calls = 0
+
+    def fail_canonical_fsync(fd: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError(errno.ENOSPC, "injected post-rename fsync pressure")
+        original(fd)
+
+    monkeypatch.setattr(sh, "_fsync_directory", fail_canonical_fsync)
+    with pytest.raises(OSError, match="post-rename fsync pressure"):
+        sh.SessionLease.acquire(paths, session_id="post-rename-enospc")
+    assert not paths.pid_sentinel.exists()
+
+    lease = sh.SessionLease.acquire(paths, session_id="post-rename-enospc-retry")
+    try:
+        assert sh.read_pid_sentinel(paths.pid_sentinel) == lease.sentinel
+    finally:
+        lease.release()
+
+
+def test_initial_sentinel_temp_fsync_enospc_leaves_no_untracked_artifact(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="temp-fsync-enospc",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    original = sh._fsync_directory
+
+    def no_space(_fd: int) -> None:
+        raise OSError(errno.ENOSPC, "injected temp directory fsync pressure")
+
+    monkeypatch.setattr(sh, "_fsync_directory", no_space)
+    with pytest.raises(OSError, match="temp directory fsync pressure"):
+        sh.SessionLease.acquire(paths, session_id="temp-fsync-enospc")
+    assert not paths.pid_sentinel.exists()
+    assert not any(sh._is_sentinel_temp_candidate(path.name) for path in paths.home.iterdir())
+
+    monkeypatch.setattr(sh, "_fsync_directory", original)
+    lease = sh.SessionLease.acquire(paths, session_id="temp-fsync-enospc-retry")
+    lease.release()
+
+
+def test_transfer_post_rename_enospc_remains_exactly_owned_for_release(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="transfer-fsync-enospc",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    lease = sh.SessionLease.acquire(paths, session_id="transfer-fsync-enospc")
+    lease.begin_transfer()
+    original = sh._fsync_directory
+    calls = 0
+
+    def fail_canonical_fsync(fd: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError(errno.ENOSPC, "injected transfer canonical fsync pressure")
+        original(fd)
+
+    monkeypatch.setattr(sh, "_fsync_directory", fail_canonical_fsync)
+    with pytest.raises(OSError, match="transfer canonical fsync pressure"):
+        lease.transfer_to(os.getpid())
+    current = sh.read_pid_sentinel(paths.pid_sentinel)
+    assert current == lease.sentinel
+    assert current is not None and current.pid == os.getpid()
+
+    monkeypatch.setattr(sh, "_fsync_directory", original)
+    assert lease.release() is True
+    assert not paths.pid_sentinel.exists()
+    assert not any(sh._is_sentinel_temp_candidate(path.name) for path in paths.home.iterdir())
+
+
+def test_partial_acquire_temp_is_recovered_but_partial_transfer_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    acquire_temp = paths.home / f".codex.pid.acquire.{uuid.uuid4().hex}.tmp"
+    acquire_temp.write_text("partial", encoding="utf-8")
+    acquire_temp.chmod(0o600)
+
+    lease = sh.SessionLease.acquire(paths)
+    lease.release()
+    assert not acquire_temp.exists()
+
+    transfer_temp = paths.home / f".codex.pid.transfer.{uuid.uuid4().hex}.tmp"
+    transfer_temp.write_text("partial", encoding="utf-8")
+    transfer_temp.chmod(0o600)
+    with pytest.raises(sh.HomeInUseError, match="partial transfer sentinel"):
+        sh.SessionLease.acquire(paths)
+    assert transfer_temp.exists()
+
+
+def test_complete_stale_acquire_temp_is_reclaimed(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    stale = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=2_000_000_000,
+        start_time_ticks=1,
+        session_id="crashed-acquire",
+        mode="workspace",
+        home=str(paths.home.resolve()),
+    )
+    temp = paths.home / f".codex.pid.acquire.{uuid.uuid4().hex}.tmp"
+    temp.write_text(json.dumps(asdict(stale)) + "\n", encoding="utf-8")
+    temp.chmod(0o600)
+
+    lease = sh.SessionLease.acquire(paths)
+    try:
+        assert not temp.exists()
+        assert sh.read_pid_sentinel(paths.pid_sentinel) == lease.sentinel
+    finally:
+        lease.release()
+
+
+def _write_proc_stat(
+    proc_root: Path, pid: int, *, state: str = "S", start_ticks: int = 100
+) -> None:
+    stat_path = proc_root / str(pid) / "stat"
+    stat_path.parent.mkdir(parents=True)
+    fields = [state, *(["0"] * 18), str(start_ticks)]
+    stat_path.write_text(f"{pid} (fixture process) {' '.join(fields)}\n", encoding="utf-8")
+
+
+def test_portable_posix_identity_uses_locale_stable_start_time(monkeypatch) -> None:
+    if os.name != "posix":
+        pytest.skip("POSIX ps fallback test")
+    captured: dict[str, object] = {}
+
+    class Result:
+        returncode = 0
+        stdout = "S+ Sat Jul 11 18:00:00 2026\n"
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return Result()
+
+    monkeypatch.setattr(sh.subprocess, "run", fake_run)
+
+    first = sh._portable_process_identity(123)
+    second = sh._portable_process_identity(123)
+
+    assert first == second
+    assert first is not None and first[0] == "S" and first[1] > 0
+    assert captured["env"]["LC_ALL"] == "C"
+
+
+def test_proc_stat_read_failure_is_unknown_without_portable_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proc_root = tmp_path / "proc"
+    _write_proc_stat(proc_root, 123, start_ticks=77)
+    target = proc_root / "123" / "stat"
+    original = Path.read_text
+
+    def unreadable(path: Path, *args, **kwargs):
+        if path == target:
+            raise PermissionError(errno.EACCES, "injected unreadable proc stat")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", unreadable)
+
+    evidence, identity = sh._process_identity_evidence(123, proc_root=proc_root)
+
+    assert evidence == sh._PROCESS_UNKNOWN
+    assert identity is None
+
+
+def test_linux_proc_read_failure_never_publishes_portable_lease_identity(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="linux-proc-read-failure",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    target = Path("/proc") / str(os.getpid()) / "stat"
+    original = Path.read_text
+
+    def unreadable(path: Path, *args, **kwargs):
+        if path == target:
+            raise PermissionError(errno.EACCES, "injected Linux proc stat failure")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(Path, "read_text", unreadable)
+    monkeypatch.setattr(
+        sh,
+        "_portable_process_identity",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("Linux lease publication must not cross identity domains")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="cannot validate launcher PID"):
+        sh.SessionLease.acquire(paths)
+
+    assert not paths.home.exists()
+    assert not paths.pid_sentinel.exists()
+
+
+def test_nonlinux_default_proc_absence_uses_portable_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    pid = 2_000_000_000
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(
+        sh,
+        "_portable_process_identity",
+        lambda candidate: ("S", 77) if candidate == pid else None,
+    )
+
+    assert sh._proc_identity(pid) == ("S", 77)
+
+
+def test_shared_lease_path_backend_supports_platforms_without_directory_fds(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, _tokenpak_home = homes
+    paths = sh.select_paths(
+        "shared",
+        workspace_dir=tmp_path,
+        source_home=source,
+        selected_home=source,
+    )
+
+    def path_backend(selected: sh.SessionPaths):
+        selected.home.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return None
+
+    monkeypatch.setattr(sh, "_open_selected_home", path_backend)
+    lease = sh.SessionLease.acquire(paths, session_id="path-backend")
+    try:
+        assert sh.read_pid_sentinel(paths.pid_sentinel) == lease.sentinel
+    finally:
+        lease.release()
+    assert not paths.pid_sentinel.exists()
+
+
+def test_stopped_lease_owner_is_still_live_and_refused(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    proc_root = tmp_path / "proc"
+    _write_proc_stat(proc_root, 101, state="T", start_ticks=11)
+    _write_proc_stat(proc_root, 202, state="R", start_ticks=22)
+    stopped = sh.SessionLease.acquire(paths, pid=101, session_id="stopped", proc_root=proc_root)
+    try:
+        with pytest.raises(sh.HomeInUseError, match="already claimed by PID 101"):
+            sh.SessionLease.acquire(paths, pid=202, session_id="second", proc_root=proc_root)
+    finally:
+        stopped.release()
+
+
+def test_dead_process_cannot_acquire_or_receive_lease(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="dead-owner",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    proc_root = tmp_path / "proc"
+    _write_proc_stat(proc_root, 303, state="Z", start_ticks=33)
+    _write_proc_stat(proc_root, 606, state="R", start_ticks=66)
+    with pytest.raises(RuntimeError, match="is not running"):
+        sh.SessionLease.acquire(paths, pid=303, proc_root=proc_root)
+    lease = sh.SessionLease.acquire(paths, pid=606, proc_root=proc_root)
+    try:
+        with pytest.raises(RuntimeError, match="is not running"):
+            lease.transfer_to(303)
+    finally:
+        lease.release()
+
+
+def test_live_wrong_home_sentinel_is_preserved(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    proc_root = tmp_path / "proc"
+    _write_proc_stat(proc_root, 404, state="S", start_ticks=44)
+    _write_proc_stat(proc_root, 505, state="R", start_ticks=55)
+    wrong = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=404,
+        start_time_ticks=44,
+        session_id="wrong-home",
+        mode="workspace",
+        home=str(tmp_path / "different-home"),
+    )
+    original = json.dumps(asdict(wrong)) + "\n"
+    paths.pid_sentinel.write_text(original, encoding="utf-8")
+    paths.pid_sentinel.chmod(0o600)
+
+    with pytest.raises(sh.HomeInUseError, match="bound to another home"):
+        sh.SessionLease.acquire(paths, pid=505, proc_root=proc_root)
+    assert paths.pid_sentinel.read_text(encoding="utf-8") == original
+
+
+def test_release_removes_only_exact_sentinel(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="exact-release",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    lease = sh.SessionLease.acquire(paths, session_id="exact-release")
+    changed = sh.PidSentinel(
+        schema=lease.sentinel.schema,
+        pid=lease.sentinel.pid,
+        start_time_ticks=lease.sentinel.start_time_ticks + 1,
+        session_id=lease.sentinel.session_id,
+        mode=lease.sentinel.mode,
+        home=lease.sentinel.home,
+    )
+    paths.pid_sentinel.write_text(json.dumps(asdict(changed)) + "\n", encoding="utf-8")
+    paths.pid_sentinel.chmod(0o600)
+
+    assert lease.release() is False
+    assert sh.read_pid_sentinel(paths.pid_sentinel) == changed
+
+
+def _retention_home(
+    source: Path,
+    tokenpak_home: Path,
+    tmp_path: Path,
+    name: str,
+    *,
+    age_s: float = 120.0,
+    payload_bytes: int = 0,
+) -> sh.SessionPaths:
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id=name,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    if payload_bytes:
+        (paths.home / "payload.bin").write_bytes(b"x" * payload_bytes)
+    timestamp = time.time() - age_s
+    os.utime(paths.home, (timestamp, timestamp))
+    return paths
+
+
+def test_retention_enforces_five_homes_oldest_first(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    created = [
+        _retention_home(source, tokenpak_home, tmp_path, f"session-{index}", age_s=600 - index)
+        for index in range(6)
+    ]
+
+    result = sh.cleanup_isolated_homes(tokenpak_home)
+
+    assert result.removed == (created[0].home,)
+    assert len(result.after.homes) == sh.RETENTION_MAX_HOMES
+    assert all(path.home.exists() for path in created[1:])
+
+
+def test_retention_age_and_size_thresholds(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    exact = _retention_home(
+        source,
+        tokenpak_home,
+        tmp_path,
+        "exact-age",
+        age_s=sh.RETENTION_MAX_AGE_S - 10,
+    )
+    old = _retention_home(
+        source,
+        tokenpak_home,
+        tmp_path,
+        "over-age",
+        age_s=sh.RETENTION_MAX_AGE_S + 10,
+    )
+    result = sh.cleanup_isolated_homes(tokenpak_home)
+    assert old.home in result.removed
+    assert exact.home.exists()
+
+    sized = _retention_home(source, tokenpak_home, tmp_path, "over-size", payload_bytes=4096)
+    monkeypatch.setattr(sh, "RETENTION_MAX_TOTAL_BYTES", 1)
+    result = sh.cleanup_isolated_homes(tokenpak_home)
+    assert sized.home in result.removed
+
+
+def test_retention_plan_exact_boundaries_do_not_evict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sh, "RETENTION_MAX_TOTAL_BYTES", 100)
+    info = sh._IsolatedHomeInfo(
+        path=tmp_path / "exact",
+        device=1,
+        inode=1,
+        mtime=1.0,
+        age_s=sh.RETENTION_MAX_AGE_S,
+        size_bytes=100,
+        size_complete=True,
+        state="orphan-stale",
+    )
+    report = sh._RetentionReport(tmp_path, (info,), 100, True)
+    assert sh._retention_plan(report, preserve_home=None, remove_all_orphans=False) == []
+
+    over = sh._IsolatedHomeInfo(
+        **{**info.__dict__, "path": tmp_path / "over", "age_s": info.age_s + 1}
+    )
+    report = sh._RetentionReport(tmp_path, (over,), 101, True)
+    assert sh._retention_plan(report, preserve_home=None, remove_all_orphans=False) == [
+        (over, "age")
+    ]
+    over_size = sh._IsolatedHomeInfo(
+        **{
+            **info.__dict__,
+            "path": tmp_path / "over-size",
+            "age_s": sh.RETENTION_MAX_AGE_S - 1,
+            "size_bytes": 101,
+        }
+    )
+    report = sh._RetentionReport(tmp_path, (over_size,), 101, True)
+    assert sh._retention_plan(report, preserve_home=None, remove_all_orphans=False) == [
+        (over_size, "size")
+    ]
+
+
+def test_retention_preserves_live_and_malformed_sentinel_homes(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    live = _retention_home(source, tokenpak_home, tmp_path, "live-retention")
+    malformed = _retention_home(source, tokenpak_home, tmp_path, "malformed-retention")
+    malformed.pid_sentinel.write_text("partial", encoding="utf-8")
+    malformed.pid_sentinel.chmod(0o600)
+    lease = sh.SessionLease.acquire(live, session_id="live-retention")
+    try:
+        result = sh.cleanup_isolated_homes(
+            tokenpak_home,
+            remove_all_orphans=True,
+        )
+        assert result.removed == ()
+        assert live.home.exists()
+        assert malformed.home.exists()
+        states = {home.path.name: home.state for home in result.after.homes}
+        assert states["live-retention"] == "active"
+        assert states["malformed-retention"] == "unsafe"
+    finally:
+        lease.release()
+
+
+def _write_private_sentinel(path: Path, sentinel: sh.PidSentinel) -> None:
+    path.write_text(json.dumps(asdict(sentinel)) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+@pytest.mark.parametrize("phase", ["acquire", "transfer"])
+def test_retention_partial_temp_artifact_protects_home(
+    homes: tuple[Path, Path], tmp_path: Path, phase: str
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, f"partial-{phase}")
+    artifact = candidate.home / f".codex.pid.{phase}.{uuid.uuid4().hex}.tmp"
+    artifact.write_text("partial", encoding="utf-8")
+    artifact.chmod(0o600)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert artifact.is_file()
+    state = {home.path: home.state for home in result.after.homes}
+    assert state[candidate.home] == "unsafe"
+    assert result.errors and "inventory incomplete" in result.errors[-1]
+
+
+@pytest.mark.parametrize("suffix", ["not-a-publisher-uuid", "contains\nnewline"])
+def test_retention_invalid_temp_pattern_is_recognized_and_protected(
+    homes: tuple[Path, Path], tmp_path: Path, suffix: str
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "invalid-temp-pattern")
+    artifact = candidate.home / f".codex.pid.acquire.{suffix}.tmp"
+    artifact.write_text("partial", encoding="utf-8")
+    artifact.chmod(0o600)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert artifact.is_file()
+    assert result.after.homes[0].state == "unsafe"
+
+
+@pytest.mark.parametrize("phase", ["acquire", "transfer"])
+def test_retention_live_temp_artifact_protects_before_sqlite_open(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch, phase: str
+) -> None:
+    from tokenpak.companion.codex import state_lock
+
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, f"live-{phase}")
+    identity = sh._proc_identity(os.getpid())
+    assert identity is not None
+    live = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=os.getpid(),
+        start_time_ticks=identity[1],
+        session_id=f"live-{phase}",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    artifact = candidate.home / f".codex.pid.{phase}.{uuid.uuid4().hex}.tmp"
+    _write_private_sentinel(artifact, live)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+    assert not list(candidate.home.glob("*.sqlite*"))
+    monkeypatch.setattr(
+        state_lock,
+        "probe",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("temp-protected home must not reach SQLite holder probing")
+        ),
+    )
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    info = next(home for home in result.after.homes if home.path == candidate.home)
+    assert info.state == "active"
+    assert info.pid == os.getpid()
+
+
+def test_retention_dead_parent_and_live_child_transfer_temp_preserves_home(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tokenpak.companion.codex import state_lock
+
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "dead-parent-live-child")
+    dead_parent = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=2_000_000_000,
+        start_time_ticks=1,
+        session_id="dead-parent-live-child",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    _write_private_sentinel(candidate.pid_sentinel, dead_parent)
+    identity = sh._proc_identity(os.getpid())
+    assert identity is not None
+    live_child = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=os.getpid(),
+        start_time_ticks=identity[1],
+        session_id=dead_parent.session_id,
+        mode="isolated",
+        home=dead_parent.home,
+    )
+    transfer = candidate.home / f".codex.pid.transfer.{uuid.uuid4().hex}.tmp"
+    _write_private_sentinel(transfer, live_child)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+    assert not list(candidate.home.glob("*.sqlite*"))
+    monkeypatch.setattr(
+        state_lock,
+        "probe",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("live transfer temp must protect before SQLite probing")
+        ),
+    )
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert sh.read_pid_sentinel(candidate.pid_sentinel) == dead_parent
+    assert sh.read_pid_sentinel(transfer) == live_child
+    info = next(home for home in result.after.homes if home.path == candidate.home)
+    assert info.state == "active"
+    assert info.pid == os.getpid()
+
+
+def test_retention_unknown_temp_pid_evidence_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "unknown-temp-pid")
+    identity = sh._proc_identity(os.getpid())
+    assert identity is not None
+    live = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=os.getpid(),
+        start_time_ticks=identity[1],
+        session_id="unknown-temp-pid",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    artifact = candidate.home / f".codex.pid.acquire.{uuid.uuid4().hex}.tmp"
+    _write_private_sentinel(artifact, live)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+    monkeypatch.setattr(
+        sh,
+        "_process_identity_evidence",
+        lambda *_a, **_k: (sh._PROCESS_UNKNOWN, None),
+    )
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert result.after.homes[0].state == "unsafe"
+
+
+def test_retention_unknown_canonical_pid_evidence_fails_closed(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "unknown-canonical-pid")
+    identity = sh._proc_identity(os.getpid())
+    assert identity is not None
+    canonical = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=os.getpid(),
+        start_time_ticks=identity[1],
+        session_id="unknown-canonical-pid",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    _write_private_sentinel(candidate.pid_sentinel, canonical)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+    monkeypatch.setattr(
+        sh,
+        "_process_identity_evidence",
+        lambda *_a, **_k: (sh._PROCESS_UNKNOWN, None),
+    )
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert result.after.homes[0].state == "unsafe"
+
+
+def test_retention_pid_reuse_is_proven_stale_and_reclaimable(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "reused-canonical-pid")
+    proc_root = tmp_path / "reuse-proc"
+    _write_proc_stat(proc_root, 4242, start_ticks=22)
+    reused = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=4242,
+        start_time_ticks=11,
+        session_id="reused-canonical-pid",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    _write_private_sentinel(candidate.pid_sentinel, reused)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+
+    result = sh.cleanup_isolated_homes(
+        tokenpak_home,
+        remove_all_orphans=True,
+        proc_root=proc_root,
+    )
+
+    assert result.removed == (candidate.home,)
+    assert not candidate.home.exists()
+
+
+def test_missing_proc_root_is_unknown_and_never_reclaimable(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "missing-proc-root")
+    canonical = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=4242,
+        start_time_ticks=11,
+        session_id="missing-proc-root",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    _write_private_sentinel(candidate.pid_sentinel, canonical)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+    missing_proc = tmp_path / "proc-not-mounted"
+
+    result = sh.cleanup_isolated_homes(
+        tokenpak_home,
+        remove_all_orphans=True,
+        proc_root=missing_proc,
+    )
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert result.after.homes[0].state == "unsafe"
+
+
+def test_retention_complete_dead_transfer_remains_protected_handoff(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "dead-handoff")
+    handoff = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=2_000_000_000,
+        start_time_ticks=1,
+        session_id="dead-handoff",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    artifact = candidate.home / f".codex.pid.transfer.{uuid.uuid4().hex}.tmp"
+    _write_private_sentinel(artifact, handoff)
+    old = time.time() - 300
+    os.utime(candidate.home, (old, old))
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert result.after.homes[0].state == "handoff"
+    assert result.errors and "inventory incomplete" in result.errors[-1]
+
+
+def test_retention_never_touches_workspace_homes(homes: tuple[Path, Path], tmp_path: Path) -> None:
+    source, tokenpak_home = homes
+    workspace = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(workspace)
+    isolated = _retention_home(source, tokenpak_home, tmp_path, "isolated-only")
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == (isolated.home,)
+    assert workspace.home.exists()
+
+
+def test_isolated_leaf_creation_and_sentinel_publication_hold_retention_guard(
+    homes: tuple[Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "isolated",
+        workspace_dir=tmp_path,
+        session_id="coordinated-publication",
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    entered_leaf = threading.Event()
+    allow_publication = threading.Event()
+    cleanup_done = threading.Event()
+    original = sh._open_isolated_leaf_at
+    leases: list[sh.SessionLease] = []
+    cleanups: list[sh._CleanupResult] = []
+    errors: list[BaseException] = []
+    monkeypatch.setattr(sh, "_GUARD_LOCK_TIMEOUT_S", 30.0)
+
+    def paused_leaf(selected: sh.SessionPaths, root_fd: int) -> int:
+        entered_leaf.set()
+        if not allow_publication.wait(5):
+            raise RuntimeError("timed out waiting to publish isolated leaf")
+        return original(selected, root_fd)
+
+    def acquire() -> None:
+        try:
+            leases.append(sh.SessionLease.acquire(paths, session_id="coordinated-publication"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def cleanup() -> None:
+        try:
+            cleanups.append(sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+        finally:
+            cleanup_done.set()
+
+    monkeypatch.setattr(sh, "_open_isolated_leaf_at", paused_leaf)
+    acquire_thread = threading.Thread(target=acquire)
+    acquire_thread.start()
+    assert entered_leaf.wait(5)
+
+    cleanup_thread = threading.Thread(target=cleanup)
+    cleanup_thread.start()
+    assert not cleanup_done.wait(0.1)
+    allow_publication.set()
+    acquire_thread.join(30)
+    cleanup_thread.join(30)
+
+    assert not acquire_thread.is_alive()
+    assert not cleanup_thread.is_alive()
+    assert errors == []
+    assert len(leases) == 1
+    assert len(cleanups) == 1
+    assert cleanups[0].removed == ()
+    assert paths.home.is_dir()
+    assert sh.read_pid_sentinel(paths.pid_sentinel) == leases[0].sentinel
+    leases[0].release()
+
+
+def test_lifecycle_thread_guard_acquisition_is_bounded(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    paths = sh.select_paths(
+        "workspace",
+        workspace_dir=tmp_path,
+        tokenpak_home=tokenpak_home,
+        source_home=source,
+    )
+    sh.provision(paths)
+    guard_file = tmp_path / "bounded-thread-guard"
+    guard_fd = os.open(guard_file, os.O_RDWR | os.O_CREAT, 0o600)
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_thread_guard() -> None:
+        with sh._THREAD_LEASE_LOCK:
+            held.set()
+            release.wait(5)
+
+    holder = threading.Thread(target=hold_thread_guard)
+    holder.start()
+    assert held.wait(5)
+    monkeypatch.setattr(sh, "_GUARD_LOCK_TIMEOUT_S", 0.05)
+    started = time.monotonic()
+    try:
+        with pytest.raises(sh.HomeInUseError, match="thread guard"):
+            with sh._bounded_guard_lock(guard_fd):
+                raise AssertionError("bounded guard unexpectedly acquired")
+        assert time.monotonic() - started < 0.25
+    finally:
+        os.close(guard_fd)
+        release.set()
+        holder.join(5)
+    assert not holder.is_alive()
+
+
+def test_cleanup_failure_leaves_quarantine_and_durable_receipt(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    isolated = _retention_home(source, tokenpak_home, tmp_path, "quarantine-crash")
+
+    def fail_cleanup(*_args, **_kwargs):
+        raise sh.HomeInUseError("injected cleanup crash")
+
+    original = sh._remove_tree_contents_at
+    monkeypatch.setattr(sh, "_remove_tree_contents_at", fail_cleanup)
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.errors and "injected cleanup crash" in result.errors[0]
+    assert not isolated.home.exists()
+    root = sh.sessions_root(tokenpak_home)
+    assert any(path.name.startswith(sh._RETENTION_QUARANTINE_PREFIX) for path in root.iterdir())
+    receipt = root / sh._RETENTION_RECEIPT_NAME
+    assert '"action": "planned"' in receipt.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(sh, "_remove_tree_contents_at", original)
+    recovered = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert recovered.errors == ()
+    assert recovered.removed == (isolated.home,)
+    assert not any(path.name.startswith(sh._RETENTION_QUARANTINE_PREFIX) for path in root.iterdir())
+    assert '"action": "completed"' in receipt.read_text(encoding="utf-8")
+
+
+def test_unproven_quarantine_is_preserved_with_explicit_error(
+    homes: tuple[Path, Path],
+) -> None:
+    _source, tokenpak_home = homes
+    opened = sh._open_managed_sessions_root(tokenpak_home, create=True)
+    assert opened is not None
+    _root, root_fd = opened
+    os.close(root_fd)
+    root = sh.sessions_root(tokenpak_home)
+    quarantine = root / f"{sh._RETENTION_QUARANTINE_PREFIX}{uuid.uuid4().hex}"
+    quarantine.mkdir(mode=0o700)
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert quarantine.is_dir()
+    assert result.errors and "no planned retention receipt" in result.errors[0]
+
+
+def test_conflicting_quarantine_receipts_never_purge(
+    homes: tuple[Path, Path],
+) -> None:
+    _source, tokenpak_home = homes
+    opened = sh._open_managed_sessions_root(tokenpak_home, create=True)
+    assert opened is not None
+    root, root_fd = opened
+    quarantine_name = f"{sh._RETENTION_QUARANTINE_PREFIX}{uuid.uuid4().hex}"
+    quarantine = root / quarantine_name
+    quarantine.mkdir(mode=0o700)
+    (quarantine / "keep.txt").write_text("preserve", encoding="utf-8")
+    info = quarantine.stat()
+    base = {
+        "schema": "tokenpak.codex.retention.v1",
+        "action": "planned",
+        "home": "receipt-victim",
+        "device": info.st_dev,
+        "inode": info.st_ino,
+        "size_bytes": 1,
+        "reason": "count",
+        "quarantine": quarantine_name,
+        "timestamp_ns": time.time_ns(),
+    }
+    try:
+        sh._append_retention_receipt(root_fd, base)
+        sh._append_retention_receipt(
+            root_fd,
+            {**base, "home": "different-home", "inode": info.st_ino + 1},
+        )
+    finally:
+        os.close(root_fd)
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert quarantine.is_dir()
+    assert (quarantine / "keep.txt").read_text(encoding="utf-8") == "preserve"
+    assert any("conflicting planned retention receipts" in error for error in result.errors)
+
+
+def test_malformed_quarantine_reason_is_preserved_as_invalid_receipt(
+    homes: tuple[Path, Path],
+) -> None:
+    _source, tokenpak_home = homes
+    opened = sh._open_managed_sessions_root(tokenpak_home, create=True)
+    assert opened is not None
+    root, root_fd = opened
+    os.close(root_fd)
+    quarantine_name = f"{sh._RETENTION_QUARANTINE_PREFIX}{uuid.uuid4().hex}"
+    quarantine = root / quarantine_name
+    quarantine.mkdir(mode=0o700)
+    (quarantine / "keep.txt").write_text("preserve", encoding="utf-8")
+    info = quarantine.stat()
+    malformed = {
+        "schema": "tokenpak.codex.retention.v1",
+        "action": "planned",
+        "home": "receipt-victim",
+        "device": info.st_dev,
+        "inode": info.st_ino,
+        "size_bytes": 1,
+        "quarantine": quarantine_name,
+        "timestamp_ns": time.time_ns(),
+    }
+    receipt = root / sh._RETENTION_RECEIPT_NAME
+    receipt.write_text(json.dumps(malformed) + "\n", encoding="utf-8")
+    receipt.chmod(0o600)
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert quarantine.is_dir()
+    assert (quarantine / "keep.txt").read_text(encoding="utf-8") == "preserve"
+    assert any("invalid retention receipt" in error for error in result.errors)
+
+
+def test_incomplete_retention_inventory_preserves_all_ordinary_homes(
+    homes: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "rechecked")
+    outside = tmp_path / "outside-retention"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep", encoding="utf-8")
+    escape = sh.sessions_root(tokenpak_home) / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert result.errors and "inventory incomplete" in result.errors[-1]
+    assert candidate.home.exists()
+    assert escape.is_symlink()
+    assert (outside / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_retention_rechecks_candidate_before_removal(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "rechecked")
+    original = sh._inspect_isolated_home_at
+    calls = 0
+
+    def becomes_active(*args, **kwargs):
+        nonlocal calls
+        info = original(*args, **kwargs)
+        if info.path == candidate.home:
+            calls += 1
+            if calls == 2:
+                return sh._IsolatedHomeInfo(
+                    **{**info.__dict__, "state": "active", "pid": os.getpid()}
+                )
+        return info
+
+    monkeypatch.setattr(sh, "_inspect_isolated_home_at", becomes_active)
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.errors and "changed before cleanup" in result.errors[0]
+    assert candidate.home.exists()
+
+
+def test_retention_rechecks_sentinel_artifacts_after_holder_probe(
+    homes: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tokenpak.companion.codex import state_lock
+
+    source, tokenpak_home = homes
+    candidate = _retention_home(source, tokenpak_home, tmp_path, "post-probe-race")
+    identity = sh._proc_identity(os.getpid())
+    assert identity is not None
+    live = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=os.getpid(),
+        start_time_ticks=identity[1],
+        session_id="post-probe-race",
+        mode="isolated",
+        home=str(candidate.home.resolve()),
+    )
+    transfer = candidate.home / f".codex.pid.transfer.{uuid.uuid4().hex}.tmp"
+
+    def raced_probe(home, *, deadline=None):
+        assert home == candidate.home
+        _write_private_sentinel(transfer, live)
+        return state_lock.LockStatus(
+            home=home,
+            db_path=home / "state.sqlite",
+            exists=False,
+            locked=False,
+        )
+
+    monkeypatch.setattr(state_lock, "probe", raced_probe)
+
+    result = sh.cleanup_isolated_homes(tokenpak_home, remove_all_orphans=True)
+
+    assert result.removed == ()
+    assert candidate.home.is_dir()
+    assert transfer.is_file()
+    assert result.errors and "changed after holder inspection" in result.errors[0]

--- a/tests/companion/test_codex_skills_path.py
+++ b/tests/companion/test_codex_skills_path.py
@@ -6,6 +6,7 @@ does not scan (its discovery paths are ``.agents/skills`` and
 ``$HOME/.agents/skills``).  Those installs were effectively dead.  This
 test pins the canonical target and the defensive dual-path uninstall.
 """
+
 from __future__ import annotations
 
 import time
@@ -16,21 +17,23 @@ import pytest
 from tokenpak.companion.codex import skills_installer as si
 
 # ---------------------------------------------------------------------------
-# _DEFAULT_TARGET — spec-canonical user path
+# Runtime default — spec-canonical user path
 # ---------------------------------------------------------------------------
 
+
 def test_default_target_is_agents_skills_not_codex_skills():
-    assert si._DEFAULT_TARGET == Path.home() / ".agents" / "skills"
-    assert si._DEFAULT_TARGET != Path.home() / ".codex" / "skills"
+    assert si._default_skills_root() == Path.home() / ".agents" / "skills"
+    assert si._default_skills_root() != Path.home() / ".codex" / "skills"
 
 
 def test_legacy_target_is_pre_l3_codex_skills_path():
-    assert si._LEGACY_TARGET == Path.home() / ".codex" / "skills"
+    assert si._legacy_skills_root() == Path.home() / ".codex" / "skills"
 
 
 # ---------------------------------------------------------------------------
 # install_skills uses the new path when no target_dir is provided
 # ---------------------------------------------------------------------------
+
 
 def test_install_skills_writes_to_explicit_target(tmp_path: Path):
     target = tmp_path / "agents_skills"
@@ -47,9 +50,7 @@ def test_install_skills_default_target_is_dot_agents(monkeypatch, tmp_path: Path
     fake_home = tmp_path / "fakehome"
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
-    # The module captured _DEFAULT_TARGET at import time; rebind it for
-    # the assertion so we test the constant's *intent* (canonical path),
-    # not just the import-time literal.
+    # An override keeps this test independent from the process user's home.
     new_default = fake_home / ".agents" / "skills"
     monkeypatch.setattr(si, "_DEFAULT_TARGET", new_default)
     installed = si.install_skills()
@@ -63,6 +64,7 @@ def test_install_skills_default_target_is_dot_agents(monkeypatch, tmp_path: Path
 # ---------------------------------------------------------------------------
 # uninstall_skills sweeps BOTH the new and legacy paths by default
 # ---------------------------------------------------------------------------
+
 
 def test_uninstall_skills_sweeps_both_targets(monkeypatch, tmp_path: Path):
     new_target = tmp_path / "agents" / "skills"
@@ -85,9 +87,7 @@ def test_uninstall_skills_sweeps_both_targets(monkeypatch, tmp_path: Path):
         assert not (legacy_target / name).exists()
 
 
-def test_uninstall_skills_with_explicit_target_does_not_sweep_legacy(
-    monkeypatch, tmp_path: Path
-):
+def test_uninstall_skills_with_explicit_target_does_not_sweep_legacy(monkeypatch, tmp_path: Path):
     new_target = tmp_path / "agents" / "skills"
     legacy_target = tmp_path / "codex" / "skills"
     monkeypatch.setattr(si, "_DEFAULT_TARGET", new_target)
@@ -107,16 +107,13 @@ def test_uninstall_skills_with_explicit_target_does_not_sweep_legacy(
 # orphaned_legacy_skills surfaces pre-L3 installs for doctor reporting
 # ---------------------------------------------------------------------------
 
-def test_orphaned_legacy_skills_empty_when_nothing_at_legacy_path(
-    monkeypatch, tmp_path: Path
-):
+
+def test_orphaned_legacy_skills_empty_when_nothing_at_legacy_path(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(si, "_LEGACY_TARGET", tmp_path / "nowhere")
     assert si._orphaned_legacy_skills() == []
 
 
-def test_orphaned_legacy_skills_lists_installed_pre_l3_skills(
-    monkeypatch, tmp_path: Path
-):
+def test_orphaned_legacy_skills_lists_installed_pre_l3_skills(monkeypatch, tmp_path: Path):
     legacy_target = tmp_path / "codex_skills"
     monkeypatch.setattr(si, "_LEGACY_TARGET", legacy_target)
     si.install_skills(target_dir=legacy_target)
@@ -186,9 +183,7 @@ def test_install_sweeps_stale_stage_and_backup(monkeypatch, tmp_path: Path):
     assert (target / "a" / "SKILL.md").exists()
 
 
-def test_recent_retired_generation_is_not_reclaimed_but_aged_one_is(
-    monkeypatch, tmp_path: Path
-):
+def test_recent_retired_generation_is_not_reclaimed_but_aged_one_is(monkeypatch, tmp_path: Path):
     """The age gate keeps a freshly-retired generation (a reader may still
     hold it) and reclaims one older than the threshold."""
     import os
@@ -215,9 +210,7 @@ def test_recent_retired_generation_is_not_reclaimed_but_aged_one_is(
 def test_concurrent_installs_never_expose_partial_skill(monkeypatch, tmp_path: Path):
     import threading
 
-    monkeypatch.setattr(
-        si, "_BUNDLED_SKILLS", _bundled_dir_with(tmp_path, ["a", "b", "c"])
-    )
+    monkeypatch.setattr(si, "_BUNDLED_SKILLS", _bundled_dir_with(tmp_path, ["a", "b", "c"]))
     target = tmp_path / "agents" / "skills"
     target.mkdir(parents=True)
 
@@ -248,6 +241,9 @@ def test_concurrent_installs_never_expose_partial_skill(monkeypatch, tmp_path: P
                     continue  # briefly absent during the rename swap — fine
                 if not {"SKILL.md", "body.md"} <= entries:
                     observed_partial.append((name, sorted(entries)))
+            # Yield so a slow filesystem cannot let this observation loop
+            # starve the serialized installer threads indefinitely.
+            time.sleep(0.0005)
 
     installers = [threading.Thread(target=_installer) for _ in range(4)]
     reader = threading.Thread(target=_reader)

--- a/tests/companion/test_codex_state_lock.py
+++ b/tests/companion/test_codex_state_lock.py
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the Codex local-database lock preflight.
-
-Re-authored as part of the isolated-CODEX_HOME work (absorbs the prior
-state-lock diagnostics + lock-message rework): a fresh/free home preflights
-clean, a database held by another connection is reported ``locked``, and a
-stopped (job-control-suspended) holder produces a distinct, actionable
-remediation message.
-"""
+"""Focused tests for read-only Codex SQLite holder diagnostics."""
 
 from __future__ import annotations
 
+import errno
+import os
+import select
+import signal
 import sqlite3
-import threading
+import subprocess
+import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
+from tokenpak.companion.codex import session_home as sh
 from tokenpak.companion.codex import state_lock as sl
 
 
@@ -29,177 +29,867 @@ def codex_home(monkeypatch, tmp_path):
     return home
 
 
-def _make_state_db(home: Path) -> Path:
-    db = home / sl.STATE_DB_NAME
-    conn = sqlite3.connect(str(db))
-    conn.execute("CREATE TABLE IF NOT EXISTS t (id INTEGER)")
-    conn.commit()
-    conn.close()
+def _make_db(home: Path, name: str = sl.STATE_DB_NAME) -> Path:
+    db = home / name
+    connection = sqlite3.connect(db)
+    connection.execute("CREATE TABLE IF NOT EXISTS records (id INTEGER)")
+    connection.commit()
+    connection.close()
     return db
 
 
-def _make_log_db(home: Path) -> Path:
-    db = home / sl._LOG_DB_NAME
-    conn = sqlite3.connect(str(db))
-    conn.execute("CREATE TABLE IF NOT EXISTS logs (id INTEGER)")
-    conn.commit()
-    conn.close()
-    return db
+_HOLDER_SCRIPT = r"""
+import sqlite3
+import sys
+
+database, mode = sys.argv[1:]
+connection = sqlite3.connect(database, isolation_level=None)
+if mode == "wal":
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("BEGIN IMMEDIATE")
+else:
+    connection.execute("BEGIN EXCLUSIVE")
+print("ready", flush=True)
+sys.stdin.readline()
+connection.execute("ROLLBACK")
+connection.close()
+"""
 
 
-# ── absent / free database ────────────────────────────────────────────
+@contextmanager
+def _sqlite_holder(db: Path, mode: str = "exclusive"):
+    """Start and fully reap a test-owned SQLite holder process."""
+    process = subprocess.Popen(
+        [sys.executable, "-c", _HOLDER_SCRIPT, str(db), mode],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        readable, _, _ = select.select([process.stdout], [], [], 10)
+        if not readable:
+            stderr = process.stderr.read() if process.poll() is not None and process.stderr else ""
+            pytest.fail(f"SQLite holder did not become ready: {stderr}")
+        assert process.stdout.readline().strip() == "ready"
+        yield process
+    finally:
+        if process.poll() is None and sl._pid_stopped(process.pid):
+            os.kill(process.pid, signal.SIGCONT)
+        if process.poll() is None and process.stdin is not None:
+            try:
+                process.stdin.write("\n")
+                process.stdin.flush()
+            except BrokenPipeError:
+                pass
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.wait(timeout=10)
+        if process.stdin is not None:
+            process.stdin.close()
+        if process.stdout is not None:
+            process.stdout.close()
+        if process.stderr is not None:
+            process.stderr.close()
+
+
+def _wait_for_state(pid: int, *, stopped: bool) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if sl._pid_stopped(pid) is stopped:
+            return
+        time.sleep(0.01)
+    pytest.fail(f"test holder PID {pid} did not reach expected stopped={stopped} state")
+
+
+def _write_synthetic_process(
+    proc_root: Path,
+    pid: int,
+    *,
+    uid: int,
+    state: str = "S",
+    name: str = "codex",
+    with_fd_dir: bool = True,
+) -> Path:
+    process = proc_root / str(pid)
+    process.mkdir(parents=True)
+    if with_fd_dir:
+        (process / "fd").mkdir()
+        (process / "fdinfo").mkdir()
+    (process / "status").write_text(
+        f"Name:\t{name}\nTgid:\t{pid}\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n"
+    )
+    fields = [state, *(["0"] * 18), "9001"]
+    (process / "stat").write_text(f"{pid} (fixture holder) {' '.join(fields)}\n")
+    (process / "comm").write_text(name + "\n")
+    (process / "cmdline").write_bytes(name.encode() + b"\0")
+    return process
+
+
+def _complete_empty_proc(tmp_path: Path) -> Path:
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    (proc_root / "locks").write_text("")
+    return proc_root
 
 
 def test_probe_absent_db_is_unlocked(codex_home):
     status = sl.probe(codex_home)
+
     assert status.exists is False
     assert status.locked is False
+    assert status.diagnostics_complete is True
     assert "uncontended" in status.detail
 
 
-def test_probe_free_db_is_unlocked(codex_home):
-    _make_state_db(codex_home)
-    status = sl.probe(codex_home)
+def test_probe_free_db_is_unlocked_without_sqlite_client(codex_home, tmp_path):
+    _make_db(codex_home)
+
+    status = sl.probe(codex_home, proc_root=_complete_empty_proc(tmp_path))
+
     assert status.exists is True
     assert status.locked is False
+    assert status.diagnostics_complete is True
+    assert "sqlite3" not in sl.__dict__
 
 
-def test_probe_defaults_to_codex_home_env(codex_home, monkeypatch):
+def test_missing_proc_fails_closed_when_database_exists(codex_home, tmp_path):
+    db = _make_db(codex_home)
+
+    status = sl.probe(codex_home, proc_root=tmp_path / "missing-proc")
+
+    assert status.exists is True
+    assert status.db_path == db
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.holder_pids == []
+    assert "/proc holder inspection is incomplete" in status.detail
+    assert "refusing unsafe access" in status.detail
+
+
+def test_unreadable_database_discovery_fails_closed(codex_home, tmp_path, monkeypatch):
+    _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    original_iterdir = Path.iterdir
+
+    def guarded_iterdir(path):
+        if path == codex_home:
+            raise PermissionError("fixture denies database discovery")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.exists is True
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "database discovery is incomplete" in status.detail
+    assert "refusing unsafe access" in status.detail
+
+
+def test_unreadable_database_sidecar_target_fails_closed(codex_home, tmp_path, monkeypatch):
+    db = _make_db(codex_home)
+    shm = Path(f"{db}-shm")
+    shm.write_bytes(b"\0" * 256)
+    proc_root = _complete_empty_proc(tmp_path)
+    original_stat = Path.stat
+
+    def guarded_stat(path, *args, **kwargs):
+        if path == shm:
+            raise PermissionError("fixture denies sidecar inspection")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", guarded_stat)
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.exists is True
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "database target inspection is incomplete" in status.detail
+    assert "refusing unsafe access" in status.detail
+
+
+def test_same_owner_unreadable_fd_scan_fails_closed(codex_home, tmp_path):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(
+        proc_root,
+        4243,
+        uid=db.stat().st_uid,
+        with_fd_dir=False,
+    )
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.holder_pids == []
+    assert "refusing unsafe access" in status.detail
+
+
+def test_foreign_owner_unreadable_fd_scan_does_not_fail_closed(codex_home, tmp_path):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(
+        proc_root,
+        4244,
+        uid=db.stat().st_uid + 1,
+        with_fd_dir=False,
+    )
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is False
+    assert status.diagnostics_complete is True
+
+
+def test_same_owner_known_non_codex_unreadable_fd_is_ignored(codex_home, tmp_path):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    process = _write_synthetic_process(
+        proc_root,
+        4245,
+        uid=db.stat().st_uid,
+        name="(sd-pam)",
+    )
+    fd_dir = process / "fd"
+    fd_dir.chmod(0)
+    try:
+        status = sl.probe(codex_home, proc_root=proc_root)
+    finally:
+        fd_dir.chmod(0o700)
+
+    assert status.locked is False
+    assert status.diagnostics_complete is True
+
+
+def test_same_owner_benign_process_nonpermission_fd_error_fails_closed(
+    codex_home, tmp_path, monkeypatch
+):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    process = _write_synthetic_process(
+        proc_root,
+        4248,
+        uid=db.stat().st_uid,
+        name="(sd-pam)",
+    )
+    original = sl._bounded_directory_entries
+
+    def fail_fd(path, **kwargs):
+        if path == process / "fd":
+            return [], OSError(5, "fixture I/O failure")
+        return original(path, **kwargs)
+
+    monkeypatch.setattr(sl, "_bounded_directory_entries", fail_fd)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "proc_inspection_incomplete" in status.incomplete_reasons
+
+
+@pytest.mark.parametrize("name", ["node", "python", "sh", "env", "npx", "arbitrary-helper"])
+def test_same_owner_unreadable_wrapper_process_fails_closed(codex_home, tmp_path, name):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(
+        proc_root,
+        4247,
+        uid=db.stat().st_uid,
+        name=name,
+        with_fd_dir=False,
+    )
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+
+
+@pytest.mark.parametrize("state", ["Z", "X", "x"])
+def test_known_dead_codex_process_does_not_make_scan_incomplete(codex_home, tmp_path, state):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(
+        proc_root,
+        4246,
+        uid=db.stat().st_uid,
+        state=state,
+        with_fd_dir=False,
+    )
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is False
+    assert status.diagnostics_complete is True
+
+
+def test_probe_defaults_to_codex_home_env(codex_home, monkeypatch, tmp_path):
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
-    _make_state_db(codex_home)
-    status = sl.probe()  # no arg → reads $CODEX_HOME
+    _make_db(codex_home)
+
+    status = sl.probe(proc_root=_complete_empty_proc(tmp_path))
+
     assert status.home == codex_home
     assert status.locked is False
 
 
-# ── contended database ────────────────────────────────────────────────
+@pytest.mark.skipif(not Path("/proc/locks").exists(), reason="requires Linux /proc")
+def test_dynamic_state_database_reports_running_holder_pid(codex_home):
+    db = _make_db(codex_home, "state_99.sqlite")
 
-
-def test_probe_detects_locked_db(codex_home):
-    db = _make_state_db(codex_home)
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")  # hold an exclusive lock
-    try:
+    with _sqlite_holder(db) as holder:
         status = sl.probe(codex_home)
+
         assert status.locked is True
-        assert status.exists is True
-        assert "locked" in status.detail.lower()
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
+        assert status.db_path == db
+        assert status.holder_pids == [holder.pid]
+        assert status.running_pids == [holder.pid]
+        assert status.stopped_pids == []
+        assert f"PID {holder.pid} (running)" in status.detail
+        assert "holder PID unavailable" not in status.detail
 
 
-def test_probe_detects_locked_log_db(codex_home):
-    """Regression: Codex can fail state init because logs_2.sqlite is locked."""
-    _make_state_db(codex_home)
-    log_db = _make_log_db(codex_home)
-    holder = sqlite3.connect(str(log_db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")  # hold an exclusive lock on logs_2.sqlite
-    try:
+@pytest.mark.skipif(not Path("/proc/locks").exists(), reason="requires Linux /proc")
+def test_dynamic_log_database_reports_running_holder_pid(codex_home):
+    _make_db(codex_home, "state_12.sqlite")
+    db = _make_db(codex_home, "logs_17.sqlite")
+
+    with _sqlite_holder(db) as holder:
         status = sl.probe(codex_home)
+
         assert status.locked is True
-        assert status.db_path == log_db
-        assert sl._LOG_DB_NAME in status.detail
-        assert str(log_db) in sl.remediation_hint(status)
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
+        assert status.db_path == db
+        assert status.holder_pids == [holder.pid]
+        assert f"PID {holder.pid} (running)" in status.detail
+        assert str(db) in sl.remediation_hint(status)
 
 
-def test_locked_status_with_no_holder_pid_still_locked(codex_home):
-    db = _make_state_db(codex_home)
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")
-    try:
+@pytest.mark.skipif(not Path("/proc/locks").exists(), reason="requires Linux /proc")
+def test_stopped_test_holder_is_named_and_classified(codex_home):
+    db = _make_db(codex_home)
+
+    with _sqlite_holder(db) as holder:
+        os.kill(holder.pid, signal.SIGSTOP)
+        _wait_for_state(holder.pid, stopped=True)
         status = sl.probe(codex_home)
-        # no codex.pid sentinel written → holder_pids empty, but locked holds
+
         assert status.locked is True
-        assert status.holder_pids == []
-        assert "holder PID unavailable" in status.detail
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
-
-
-# ── holder PID context + remediation message ──────────────────────────
-
-
-def test_remediation_hint_for_locked_shared_home(codex_home):
-    db = _make_state_db(codex_home)
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")
-    try:
-        status = sl.probe(codex_home)
+        assert status.holder_pids == [holder.pid]
+        assert status.running_pids == []
+        assert status.stopped_pids == [holder.pid]
+        assert f"PID {holder.pid} (stopped)" in status.detail
         hint = sl.remediation_hint(status)
-        assert str(db) in hint
-        # message points the user at the isolation escape hatch
-        assert "TOKENPAK_CODEX_SESSION_MODE=workspace" in hint
-        assert "isolated" in hint
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
+        assert "resumed and exited normally" in hint
+        assert "kill" not in hint.lower()
+
+        os.kill(holder.pid, signal.SIGCONT)
+        _wait_for_state(holder.pid, stopped=False)
 
 
-def test_locked_with_live_holder_pid_names_it(codex_home, monkeypatch):
-    import os
+@pytest.mark.skipif(not Path("/proc/locks").exists(), reason="requires Linux /proc")
+def test_wal_shm_attachment_is_detected(codex_home):
+    db = _make_db(codex_home)
 
-    db = _make_state_db(codex_home)
-    # record our own (live) PID as the holder
+    with _sqlite_holder(db, mode="wal") as holder:
+        assert Path(f"{db}-shm").exists()
+        status = sl.probe(codex_home)
+
+        assert status.locked is True
+        assert status.holder_pids == [holder.pid]
+        assert f"PID {holder.pid} (running)" in status.detail
+
+
+def test_sqlite_main_and_shm_lock_byte_ranges(codex_home):
+    db = _make_db(codex_home)
+    shm = Path(f"{db}-shm")
+    shm.touch()
+    targets = {target.role: target for target in sl._target_files(db)[0]}
+
+    def lock_for(role: str, start: int, end: int):
+        target = targets[role]
+        major, minor = target.proc_device
+        return sl._ProcLock(123, major, minor, target.inode, start, end)
+
+    assert sl._lock_targets_file(
+        lock_for("main", sl._SQLITE_PENDING_BYTE, sl._SQLITE_PENDING_BYTE),
+        targets["main"],
+    )
+    assert sl._lock_targets_file(lock_for("shm", 120, 127), targets["shm"])
+    assert sl._lock_targets_file(lock_for("shm", 128, 128), targets["shm"])
+    assert not sl._lock_targets_file(lock_for("main", 0, 100), targets["main"])
+    assert not sl._lock_targets_file(lock_for("shm", 0, 100), targets["shm"])
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_running", "expected_stopped"),
+    [("S", [4242], []), ("T", [], [4242])],
+)
+def test_synthetic_proc_shm_only_lock_names_holder_state(
+    codex_home, tmp_path, state, expected_running, expected_stopped
+):
+    """Prove SHM-byte attribution without a main-database descriptor."""
+    db = _make_db(codex_home, "logs_88.sqlite")
+    shm = Path(f"{db}-shm")
+    shm.write_bytes(b"\0" * 256)
+    target = next(item for item in sl._target_files(db)[0] if item.role == "shm")
+    major, minor = target.proc_device
+
+    proc_root = tmp_path / "proc"
+    process = _write_synthetic_process(
+        proc_root,
+        4242,
+        uid=db.stat().st_uid,
+        state=state,
+    )
+    (process / "fd" / "7").symlink_to(shm)
+    lock_row = f"9: POSIX ADVISORY WRITE 4242 {major:02x}:{minor:02x}:{target.inode} 120 127"
+    (process / "fdinfo" / "7").write_text(f"lock:\t{lock_row}\n")
+    (proc_root / "locks").write_text(lock_row + "\n")
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.db_path == db
+    assert status.holder_pids == [4242]
+    assert status.diagnostics_complete is True
+    assert status.running_pids == expected_running
+    assert status.stopped_pids == expected_stopped
+    assert f"PID 4242 ({'stopped' if state == 'T' else 'running'})" in status.detail
+
+
+def test_proc_lock_parser_accepts_global_and_fdinfo_rows():
+    global_row = "7: POSIX ADVISORY READ 4321 08:02:99 120 127"
+    fdinfo_row = "lock:\t7: POSIX ADVISORY WRITE 4321 08:02:99 128 128"
+
+    global_lock = sl._parse_proc_lock_line(global_row)
+    fdinfo_lock = sl._parse_proc_lock_line(fdinfo_row)
+
+    assert global_lock == sl._ProcLock(4321, 8, 2, 99, 120, 127)
+    assert fdinfo_lock == sl._ProcLock(4321, 8, 2, 99, 128, 128)
+
+
+def test_codex_pid_file_is_not_trusted_as_lock_attribution(codex_home, tmp_path):
+    _make_db(codex_home)
     (codex_home / "codex.pid").write_text(f"{os.getpid()}\n")
-    # ensure our PID is not classified as stopped
-    monkeypatch.setattr(sl, "_pid_stopped", lambda pid: False)
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")
-    try:
-        status = sl.probe(codex_home)
-        assert status.locked is True
-        assert os.getpid() in status.holder_pids
-        assert "active Codex process" in status.detail
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
 
+    status = sl.probe(codex_home, proc_root=_complete_empty_proc(tmp_path))
 
-def test_locked_with_stopped_holder_pid_distinct_message(codex_home, monkeypatch):
-    import os
-
-    db = _make_state_db(codex_home)
-    pid = os.getpid()
-    (codex_home / "codex.pid").write_text(f"{pid}\n")
-    # force the stopped classification
-    monkeypatch.setattr(sl, "_pid_stopped", lambda p: True)
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")
-    try:
-        status = sl.probe(codex_home)
-        assert status.locked is True
-        assert pid in status.stopped_pids
-        assert "stopped Codex process" in status.detail
-        hint = sl.remediation_hint(status)
-        assert "kill -CONT" in hint
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
-
-
-def test_dead_holder_pid_dropped_from_candidates(codex_home):
-    db = _make_state_db(codex_home)
-    (codex_home / "codex.pid").write_text("2147480000\n")  # implausible/dead
-    holder = sqlite3.connect(str(db), isolation_level=None)
-    holder.execute("BEGIN EXCLUSIVE")
-    try:
-        status = sl.probe(codex_home)
-        assert status.locked is True
-        assert status.holder_pids == []  # dead PID filtered out
-    finally:
-        holder.execute("ROLLBACK")
-        holder.close()
-
-
-# ── non-database / malformed file is not a lock ───────────────────────
-
-
-def test_malformed_state_file_is_not_a_lock(codex_home):
-    (codex_home / sl.STATE_DB_NAME).write_text("not a sqlite db at all")
-    status = sl.probe(codex_home)
     assert status.locked is False
+    assert status.holder_pids == []
+
+
+def test_malformed_state_file_without_attachment_is_not_locked(codex_home, tmp_path):
+    (codex_home / "state_42.sqlite").write_text("not a SQLite database")
+
+    status = sl.probe(codex_home, proc_root=_complete_empty_proc(tmp_path))
+
+    assert status.exists is True
+    assert status.locked is False
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+def test_portable_shared_existing_database_is_functional_when_no_codex_process(
+    codex_home, monkeypatch, platform_id
+):
+    _make_db(codex_home)
+    monkeypatch.setattr(sl, "_portable_codex_processes", lambda *_args: ([], True))
+
+    status = sl.probe(codex_home, platform_id=platform_id)
+
+    assert status.exists is True
+    assert status.locked is False
+    assert status.diagnostics_complete is True
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+@pytest.mark.parametrize("state", ["S", "T"])
+def test_portable_shared_conservatively_names_codex_process(
+    codex_home, monkeypatch, platform_id, state
+):
+    _make_db(codex_home)
+    candidate = sl._ProcessInfo(pid=8123, uid=-1, state=state, start_time=99)
+    monkeypatch.setattr(
+        sl,
+        "_portable_codex_processes",
+        lambda *_args: ([candidate], True),
+    )
+
+    status = sl.probe(codex_home, platform_id=platform_id)
+
+    assert status.locked is True
+    assert status.holder_pids == [8123]
+    expected = "stopped" if state == "T" else "running"
+    assert f"PID 8123 ({expected})" in status.detail
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+def test_portable_shared_inspection_failure_is_explicit_fail_closed(
+    codex_home, monkeypatch, platform_id
+):
+    _make_db(codex_home)
+
+    def incomplete(_platform, budget):
+        budget.add("portable_inspection_incomplete")
+        return [], False
+
+    monkeypatch.setattr(sl, "_portable_codex_processes", incomplete)
+    status = sl.probe(codex_home, platform_id=platform_id)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.incomplete_reasons == ["portable_inspection_incomplete"]
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+def test_portable_shared_unknown_sentinel_identity_is_explicit_fail_closed(
+    codex_home, monkeypatch, platform_id
+):
+    _make_db(codex_home)
+    sentinel = sh.PidSentinel(
+        schema="tokenpak.codex.pid.v1",
+        pid=8124,
+        start_time_ticks=99,
+        session_id="portable-unknown",
+        mode="shared",
+        home=str(codex_home.resolve()),
+    )
+    path = codex_home / "codex.pid"
+    path.write_bytes(sh._sentinel_payload(sentinel))
+    path.chmod(0o600)
+    monkeypatch.setattr(
+        sh,
+        "_sentinel_liveness",
+        lambda *_a, **_k: sh._PROCESS_UNKNOWN,
+    )
+    monkeypatch.setattr(sl, "_portable_codex_processes", lambda *_args: ([], True))
+
+    status = sl.probe(codex_home, platform_id=platform_id)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.incomplete_reasons == ["portable_inspection_incomplete"]
+
+
+def test_multiple_databases_scan_processes_once(codex_home, tmp_path, monkeypatch):
+    _make_db(codex_home, "state_5.sqlite")
+    _make_db(codex_home, "logs_2.sqlite")
+    proc_root = _complete_empty_proc(tmp_path)
+    calls = 0
+    original = sl._scan_fd_holders
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(sl, "_scan_fd_holders", counted)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is False
+    assert calls == 1
+
+
+def test_target_inode_replacement_is_explicit_fail_closed(codex_home, tmp_path, monkeypatch):
+    db = _make_db(codex_home)
+    replacement = codex_home / "replacement.tmp"
+    replacement.write_bytes(b"replacement")
+    proc_root = _complete_empty_proc(tmp_path)
+    original = sl._scan_fd_holders
+
+    def replace_target(*args, **kwargs):
+        result = original(*args, **kwargs)
+        os.replace(replacement, db)
+        return result
+
+    monkeypatch.setattr(sl, "_scan_fd_holders", replace_target)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "target_inode_replaced" in status.incomplete_reasons
+
+
+def test_new_database_during_probe_is_explicit_fail_closed(codex_home, tmp_path, monkeypatch):
+    _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    original = sl._scan_fd_holders
+
+    def add_database(*args, **kwargs):
+        result = original(*args, **kwargs)
+        (codex_home / "logs_99.sqlite").write_bytes(b"new")
+        return result
+
+    monkeypatch.setattr(sl, "_scan_fd_holders", add_database)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert "database_set_changed" in status.incomplete_reasons
+
+
+def test_pid_reuse_during_holder_revalidation_is_explicit(monkeypatch, tmp_path):
+    observed = sl._ProcessInfo(pid=9000, uid=os.getuid(), state="S", start_time=10)
+    scan = sl._FdScan(attachments={9000: (observed, {(1, 2)})})
+    budget = sl._ProbeBudget(deadline=10, clock=lambda: 0)
+    monkeypatch.setattr(
+        sl,
+        "_read_process_info",
+        lambda *_args, **_kwargs: sl._ProcessInfo(9000, os.getuid(), "S", 11),
+    )
+
+    holders = sl._revalidate_attachments(
+        scan,
+        proc_root=tmp_path,
+        budget=budget,
+    )
+
+    assert holders == {}
+    assert budget.reasons == ["pid_reuse"]
+
+
+def test_probe_deadline_and_database_limit_fail_closed(codex_home, tmp_path, monkeypatch):
+    _make_db(codex_home, "state_1.sqlite")
+    status = sl.probe(
+        codex_home,
+        proc_root=_complete_empty_proc(tmp_path),
+        deadline=0,
+        clock=lambda: 0,
+    )
+    assert status.locked is True
+    assert status.incomplete_reasons == ["probe_timeout"]
+
+    monkeypatch.setattr(sl, "_MAX_DATABASES", 1)
+    _make_db(codex_home, "logs_1.sqlite")
+    second = tmp_path / "second"
+    second.mkdir()
+    status = sl.probe(codex_home, proc_root=_complete_empty_proc(second))
+    assert status.locked is True
+    assert "database_limit" in status.incomplete_reasons
+
+
+def test_process_and_fd_limits_are_explicit_fail_closed(codex_home, tmp_path, monkeypatch):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    process = _write_synthetic_process(
+        proc_root,
+        9300,
+        uid=db.stat().st_uid,
+        name="codex",
+    )
+    first = process / "fd" / "1"
+    second = process / "fd" / "2"
+    first.symlink_to(db)
+    second.symlink_to(db)
+
+    monkeypatch.setattr(sl, "_MAX_FDS_PER_PROCESS", 1)
+    status = sl.probe(codex_home, proc_root=proc_root)
+    assert status.locked is True
+    assert "fd_limit" in status.incomplete_reasons
+
+    monkeypatch.setattr(sl, "_MAX_FDS_PER_PROCESS", 10)
+    monkeypatch.setattr(sl, "_MAX_PROCESSES", 1)
+    status = sl.probe(codex_home, proc_root=proc_root)
+    assert status.locked is True
+    assert "process_limit" in status.incomplete_reasons
+
+
+def test_deadline_expiring_after_snapshot_fails_closed_during_classification(
+    codex_home, tmp_path, monkeypatch
+):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    process = _write_synthetic_process(
+        proc_root,
+        9400,
+        uid=db.stat().st_uid,
+    )
+    (process / "fd" / "7").symlink_to(db)
+    now = [0.0]
+    original = sl._revalidate_database_snapshot
+
+    def expire_after_snapshot(*args, **kwargs):
+        original(*args, **kwargs)
+        now[0] = 2.0
+
+    monkeypatch.setattr(sl, "_revalidate_database_snapshot", expire_after_snapshot)
+    status = sl.probe(
+        codex_home,
+        proc_root=proc_root,
+        deadline=1.0,
+        clock=lambda: now[0],
+    )
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "probe_timeout" in status.incomplete_reasons
+
+
+def test_pid_reuse_during_unreadable_fd_scan_is_explicit_fail_closed(
+    codex_home, tmp_path, monkeypatch
+):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    process = _write_synthetic_process(
+        proc_root,
+        9401,
+        uid=db.stat().st_uid,
+    )
+    original_entries = sl._bounded_directory_entries
+    original_info = sl._read_process_info
+    reads = 0
+
+    def unreadable_fd(path, **kwargs):
+        if path == process / "fd":
+            return [], PermissionError(errno.EACCES, "fixture permission denied")
+        return original_entries(path, **kwargs)
+
+    def reused_pid(pid, root=sl._PROC_ROOT):
+        nonlocal reads
+        info = original_info(pid, root)
+        if pid == 9401 and info is not None:
+            reads += 1
+            if reads > 1:
+                return sl._ProcessInfo(info.pid, info.uid, info.state, info.start_time + 1)
+        return info
+
+    monkeypatch.setattr(sl, "_bounded_directory_entries", unreadable_fd)
+    monkeypatch.setattr(sl, "_read_process_info", reused_pid)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert "pid_reuse" in status.incomplete_reasons
+
+
+def test_proc_lock_pid_is_attributed_without_fd_row(codex_home, tmp_path):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(proc_root, 9402, uid=db.stat().st_uid)
+    target = next(item for item in sl._target_files(db)[0] if item.role == "main")
+    major, minor = target.proc_device
+    (proc_root / "locks").write_text(
+        f"7: POSIX ADVISORY WRITE 9402 {major:02x}:{minor:02x}:"
+        f"{target.inode} {sl._SQLITE_PENDING_BYTE} {sl._SQLITE_PENDING_BYTE}\n"
+    )
+
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is True
+    assert status.holder_pids == [9402]
+    assert "PID 9402 (running)" in status.detail
+
+
+def test_proc_lock_pid_reuse_is_explicit_fail_closed(codex_home, tmp_path, monkeypatch):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(proc_root, 9403, uid=db.stat().st_uid)
+    target = next(item for item in sl._target_files(db)[0] if item.role == "main")
+    major, minor = target.proc_device
+    (proc_root / "locks").write_text(
+        f"7: POSIX ADVISORY WRITE 9403 {major:02x}:{minor:02x}:"
+        f"{target.inode} {sl._SQLITE_PENDING_BYTE} {sl._SQLITE_PENDING_BYTE}\n"
+    )
+    original = sl._read_process_info
+    reads = 0
+
+    def reused(pid, root=sl._PROC_ROOT):
+        nonlocal reads
+        info = original(pid, root)
+        if pid == 9403 and info is not None:
+            reads += 1
+            if reads > 2:
+                return sl._ProcessInfo(info.pid, info.uid, info.state, info.start_time + 1)
+        return info
+
+    monkeypatch.setattr(sl, "_read_process_info", reused)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.holder_pids == []
+    assert "pid_reuse" in status.incomplete_reasons
+
+
+def test_proc_lock_pid_reuse_during_fd_scan_is_explicit_fail_closed(
+    codex_home, tmp_path, monkeypatch
+):
+    db = _make_db(codex_home)
+    proc_root = _complete_empty_proc(tmp_path)
+    _write_synthetic_process(proc_root, 9500, uid=db.stat().st_uid)
+    target = next(item for item in sl._target_files(db)[0] if item.role == "main")
+    major, minor = target.proc_device
+    (proc_root / "locks").write_text(
+        f"7: POSIX ADVISORY WRITE 9500 {major:02x}:{minor:02x}:"
+        f"{target.inode} {sl._SQLITE_PENDING_BYTE} {sl._SQLITE_PENDING_BYTE}\n"
+    )
+    original_read = sl._read_process_info
+    original_scan = sl._scan_fd_holders
+    scan_finished = False
+
+    def reused_after_scan(pid, root=sl._PROC_ROOT):
+        info = original_read(pid, root)
+        if pid == 9500 and info is not None and scan_finished:
+            return sl._ProcessInfo(info.pid, info.uid, info.state, info.start_time + 1)
+        return info
+
+    def finish_scan(*args, **kwargs):
+        nonlocal scan_finished
+        result = original_scan(*args, **kwargs)
+        scan_finished = True
+        return result
+
+    monkeypatch.setattr(sl, "_read_process_info", reused_after_scan)
+    monkeypatch.setattr(sl, "_scan_fd_holders", finish_scan)
+    status = sl.probe(codex_home, proc_root=proc_root)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert status.holder_pids == []
+    assert "pid_reuse" in status.incomplete_reasons
+
+
+def test_toolhelp_eof_is_distinct_from_enumeration_failure():
+    assert sl._toolhelp_has_entry(True, 0) is True
+    assert sl._toolhelp_has_entry(False, sl._ERROR_NO_MORE_FILES) is False
+    with pytest.raises(OSError, match="Toolhelp process enumeration failed"):
+        sl._toolhelp_has_entry(False, errno.EIO)
+
+
+@pytest.mark.parametrize("platform_id", ["darwin", "win32"])
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        ("inode", "target_inode_replaced"),
+        ("database", "database_set_changed"),
+        ("shm", "target_inode_replaced"),
+    ],
+)
+def test_portable_probe_revalidates_database_targets(
+    codex_home, monkeypatch, platform_id, change, reason
+):
+    db = _make_db(codex_home)
+
+    def mutate_during_snapshot(*_args):
+        if change == "inode":
+            replacement = codex_home / "replacement.tmp"
+            replacement.write_bytes(b"replacement")
+            os.replace(replacement, db)
+        elif change == "database":
+            (codex_home / "logs_99.sqlite").write_bytes(b"new")
+        else:
+            Path(f"{db}-shm").write_bytes(b"new")
+        return [], True
+
+    monkeypatch.setattr(sl, "_portable_codex_processes", mutate_during_snapshot)
+    status = sl.probe(codex_home, platform_id=platform_id)
+
+    assert status.locked is True
+    assert status.diagnostics_complete is False
+    assert reason in status.incomplete_reasons

--- a/tests/proxy/spend_guard/test_classifier.py
+++ b/tests/proxy/spend_guard/test_classifier.py
@@ -1,0 +1,110 @@
+"""Traffic-classifier contract tests.
+
+Fixture policy: agent-name fixture values in this module are neutral
+placeholder identifiers (``agent-a``, ``worker-1``, ...) and must match
+``_NEUTRAL_IDENTIFIER`` below — never real deployment or operator names.
+A regression guard at the bottom of this module enforces the pattern.
+"""
+
+import re
+from pathlib import Path
+
+from tokenpak.proxy.spend_guard import classifier as c
+
+
+def test_precedence_and_classes():
+    assert c.classify({"X-Tokenpak-Agent": "agent-a"}) == c.Classification(
+        c.MANAGED, c.HEADER_AGENT, "agent-a"
+    )
+    marked = c.classify({"X-Tokenpak-Managed": "1"})
+    assert marked.request_class == c.MANAGED
+    assert marked.reason == c.HEADER_MANAGED
+    assert c.classify({"User-Agent": "claude-cli/1"}).request_class == c.RAW_CLAUDE_OBSERVED
+    assert c.classify({"User-Agent": "curl"}).request_class == c.EXTERNAL_UNTAGGED
+
+
+def test_managed_marker_grammar_is_exact():
+    # Only the exact documented marker value counts; alternate truthy-looking
+    # tokens do not mark a request managed.
+    for value in ("true", "yes", "on", "TRUE", "On", "0", "false", "", "2", "11"):
+        result = c.classify({"X-Tokenpak-Managed": value})
+        assert result.request_class == c.EXTERNAL_UNTAGGED, value
+    # Surrounding whitespace is tolerated (header values are stripped).
+    assert c.classify({"X-Tokenpak-Managed": " 1 "}).request_class == c.MANAGED
+
+
+def test_undocumented_env_marker_header_is_not_consumed():
+    # No alternate marker header exists in the ratified grammar; a request
+    # carrying only this header is unmarked traffic.
+    assert c.classify({"X-Tokenpak-Managed-Env": "1"}).request_class == c.EXTERNAL_UNTAGGED
+    assert c.classify({"X-Tokenpak-Managed-Env": "1"}).reason == c.NO_MARKER
+
+
+def test_higher_precedence_wins_and_false_marker_is_external():
+    result = c.classify(
+        {"X-Tokenpak-Agent": "worker-1", "X-Tokenpak-Managed": "1", "User-Agent": "claude-cli"}
+    )
+    assert result.reason == c.HEADER_AGENT
+    assert result.agent_attribution == "worker-1"
+    assert c.classify({"X-Tokenpak-Managed": "0"}).request_class == c.EXTERNAL_UNTAGGED
+
+
+def test_case_insensitive_and_read_only():
+    headers = {"x-tokenpak-agent": "Agent-B", "User-Agent": "claude-cli"}
+    before = dict(headers)
+    assert c.classify(headers).agent_attribution == "agent-b"
+    assert headers == before
+
+
+def test_strip_internal_headers_only():
+    headers = {
+        "X-Tokenpak-Agent": "agent-a",
+        "x-tokenpak-managed": "1",
+        "X-Tpk-Trace-Id": "trace-1",
+        "Authorization": "x",
+    }
+    removed = c.strip_managed_headers(headers)
+    assert headers == {"Authorization": "x"}
+    assert set(removed) == {"X-Tokenpak-Agent", "x-tokenpak-managed", "X-Tpk-Trace-Id"}
+
+
+def test_internal_namespace_predicate():
+    assert c.is_internal_header("X-Tokenpak-Managed")
+    assert c.is_internal_header("x-tokenpak-agent")
+    assert c.is_internal_header("X-TPK-ANYTHING")
+    assert not c.is_internal_header("Authorization")
+    assert not c.is_internal_header("anthropic-version")
+    assert not c.is_internal_header("x-token")  # prefix must match exactly
+
+
+def test_empty_headers_and_noop_strip():
+    assert c.classify(None).reason == c.NO_MARKER
+    headers = {"Authorization": "x"}
+    assert c.strip_managed_headers(headers) == []
+
+
+# ---------------------------------------------------------------------------
+# Fixture-identifier regression guard
+# ---------------------------------------------------------------------------
+
+_NEUTRAL_IDENTIFIER = re.compile(r"^(agent|worker|client)-[a-z0-9]+$", re.IGNORECASE)
+
+_AGENT_FIXTURE_VALUE = re.compile(
+    r"""[Xx]-[Tt]okenpak-[Aa]gent["']\s*:\s*["']([^"']+)["']"""
+)
+
+
+def test_agent_fixture_identifiers_are_neutral():
+    """Agent-name fixture values in this module must be neutral placeholders.
+
+    Guards against reintroducing non-neutral identifiers into the
+    ``X-Tokenpak-Agent`` fixtures used by this test module.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    values = _AGENT_FIXTURE_VALUE.findall(source)
+    assert values, "expected X-Tokenpak-Agent fixtures in this module"
+    for value in values:
+        assert _NEUTRAL_IDENTIFIER.match(value), (
+            f"non-neutral agent fixture identifier: {value!r} — use a neutral "
+            "placeholder matching ^(agent|worker|client)-[a-z0-9]+$"
+        )

--- a/tests/proxy/spend_guard/test_fail_closed_wrapper.py
+++ b/tests/proxy/spend_guard/test_fail_closed_wrapper.py
@@ -33,9 +33,21 @@ def test_internal_guard_error_blocks_before_provider_send(monkeypatch, caplog):
 
     payload = json.loads(outcome.response_body.decode("utf-8"))
     assert payload["error"]["type"] == "tokenpak_spend_guard_blocked"
-    assert payload["error"]["reason"] == "spend_guard_internal_error"
+    assert payload["error"]["reason"] == "spend_guard_state_unavailable"
+    assert payload["error"]["failure_kind"] == "spend_guard_internal_error"
     assert payload["error"]["threshold_hit"] == "internal_error:DatabaseError"
+    assert payload["error"]["pending_id"] is None
+    assert payload["error"]["approval_prompt"] is None
+    assert payload["error"]["approval_prompt_available"] is False
+    assert payload["error"]["auto_proceed_available"] is False
+    assert payload["error"]["continuum_auto_proceed_available"] is False
+    assert payload["error"]["continuum_status"] == "not_active"
     assert payload["error"]["recovery_status"] == "operator_action_required"
+    assert payload["error"]["recovery_actions"] == [
+        "run tokenpak doctor",
+        "repair or restore the local Spend Guard state store",
+        "restart the TokenPak proxy after repair",
+    ]
     assert payload["error"]["retryable"] is False
     assert "file is not a database" not in outcome.response_body.decode("utf-8")
     assert "internal error (fail closed): DatabaseError" in caplog.text

--- a/tests/proxy/test_connection_pool_socket_bound.py
+++ b/tests/proxy/test_connection_pool_socket_bound.py
@@ -1,0 +1,239 @@
+"""Linux loopback proof that session churn cannot grow half-closed sockets.
+
+The stub deliberately half-closes otherwise keep-alive upstream connections.
+That puts every still-owned client socket into CLOSE-WAIT without contacting a
+real provider. Churning beyond the session-client cap must close each displaced
+client promptly, so both CLOSE-WAIT and FD counts plateau instead of growing
+one-for-one with requests.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from tests.proxy._proxy_subprocess import ProxyProc
+
+pytestmark = [
+    pytest.mark.needs_proxy,
+    pytest.mark.timeout(120),
+    pytest.mark.skipif(
+        not Path("/proc/self/fd").is_dir(),
+        reason="socket ownership assertion requires Linux procfs",
+    ),
+]
+
+_CAP = 32
+_ROUNDS = 3
+
+
+class _HalfCloseUpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        with self.server.connections_lock:  # type: ignore[attr-defined]
+            self.server.connections.add(self.connection)  # type: ignore[attr-defined]
+        body = json.dumps(
+            {
+                "id": "msg_loopback",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+                "model": "claude-sonnet-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+
+
+def _post(proxy: ProxyProc, index: int) -> int:
+    body = json.dumps(
+        {
+            "model": "claude-sonnet-4-5",
+            "max_tokens": 8,
+            "messages": [{"role": "user", "content": f"loopback-{index}"}],
+        }
+    ).encode()
+    conn = http.client.HTTPConnection("127.0.0.1", proxy.port, timeout=15)
+    try:
+        conn.putrequest("POST", "/v1/messages")
+        conn.putheader("Content-Type", "application/json")
+        conn.putheader("x-api-key", "offline-test-key")
+        conn.putheader("x-tokenpak-session-id", f"half-close-{index}")
+        conn.putheader("Content-Length", str(len(body)))
+        conn.endheaders(body)
+        response = conn.getresponse()
+        response.read()
+        return response.status
+    finally:
+        conn.close()
+
+
+def _half_close_all(server: ThreadingHTTPServer) -> None:
+    with server.connections_lock:  # type: ignore[attr-defined]
+        connections = list(server.connections)  # type: ignore[attr-defined]
+    for connection in connections:
+        try:
+            connection.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def _owned_tcp_states(pid: int, remote_port: int | None = None) -> dict[str, int]:
+    socket_inodes: set[str] = set()
+    for fd in Path(f"/proc/{pid}/fd").iterdir():
+        try:
+            target = os.readlink(fd)
+        except OSError:
+            continue
+        if target.startswith("socket:["):
+            socket_inodes.add(target[8:-1])
+
+    states: dict[str, int] = {}
+    for raw in Path(f"/proc/{pid}/net/tcp").read_text().splitlines()[1:]:
+        fields = raw.split()
+        if len(fields) < 10 or fields[9] not in socket_inodes:
+            continue
+        if remote_port is not None:
+            observed_port = int(fields[2].rsplit(":", 1)[1], 16)
+            if observed_port != remote_port:
+                continue
+        state = fields[3]
+        states[state] = states.get(state, 0) + 1
+    return states
+
+
+def _health(proxy: ProxyProc) -> dict:
+    conn = http.client.HTTPConnection("127.0.0.1", proxy.port, timeout=3)
+    try:
+        conn.request("GET", "/health")
+        response = conn.getresponse()
+        assert response.status == 200
+        return json.loads(response.read())
+    finally:
+        conn.close()
+
+
+def _wait_for_close_wait(pid: int, remote_port: int, maximum: int, timeout: float = 2.0) -> int:
+    deadline = time.monotonic() + timeout
+    count = 0
+    while time.monotonic() < deadline:
+        count = _owned_tcp_states(pid, remote_port).get("08", 0)  # Linux TCP_CLOSE_WAIT
+        if 0 < count <= maximum:
+            return count
+        time.sleep(0.01)
+    return count
+
+
+def _wait_for_live_drain(proxy: ProxyProc, remote_port: int, timeout: float = 5.0) -> dict:
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        health = _health(proxy)
+        metrics = health.get("connection_pool", health.get("pool", {}))
+        close_wait = _owned_tcp_states(proxy.proc.pid, remote_port).get("08", 0)
+        last = {
+            "close_wait": close_wait,
+            "cleanup_pending_close": metrics.get("cleanup_pending_close"),
+            "retired_pending_close": metrics.get("retired_pending_close"),
+        }
+        if last == {
+            "close_wait": 0,
+            "cleanup_pending_close": 0,
+            "retired_pending_close": 0,
+        }:
+            return health
+        time.sleep(0.02)
+    pytest.fail(f"proxy did not drain half-closed sockets while live: {last}")
+
+
+def test_half_closed_upstream_sockets_and_fds_plateau_at_session_cap():
+    upstream = ThreadingHTTPServer(("127.0.0.1", 0), _HalfCloseUpstreamHandler)
+    upstream.connections = set()  # type: ignore[attr-defined]
+    upstream.connections_lock = threading.Lock()  # type: ignore[attr-defined]
+    upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    upstream_thread.start()
+    stub_url = f"http://127.0.0.1:{upstream.server_port}"
+    assert stub_url.startswith("http://127.0.0.1:")
+
+    proxy = ProxyProc(stub_url)
+    samples: list[tuple[int, int]] = []
+    try:
+        proxy.wait_ready()
+        baseline_fds = len(list(Path(f"/proc/{proxy.proc.pid}/fd").iterdir()))
+
+        for round_index in range(_ROUNDS):
+            start = round_index * _CAP
+            statuses = [_post(proxy, index) for index in range(start, start + _CAP)]
+            assert statuses == [200] * _CAP
+            _half_close_all(upstream)
+            close_wait = _wait_for_close_wait(proxy.proc.pid, upstream.server_port, _CAP)
+            fds = len(list(Path(f"/proc/{proxy.proc.pid}/fd").iterdir()))
+            samples.append((close_wait, fds))
+
+        close_wait_counts = [sample[0] for sample in samples]
+        fd_counts = [sample[1] for sample in samples]
+        assert all(0 < count <= _CAP for count in close_wait_counts), samples
+        assert max(close_wait_counts) - min(close_wait_counts) <= 1, samples
+        assert max(fd_counts) - min(fd_counts) <= 2, samples
+        # Session sockets plus the monitor DB's WAL/SHM descriptors. The
+        # plateau assertion above is the primary leak guard; this absolute
+        # ceiling prevents a stable but unexpectedly large offset.
+        assert max(fd_counts) <= baseline_fds + _CAP + 4, samples
+
+        health = _health(proxy)
+        metrics = health.get("connection_pool", health.get("pool", {}))
+        assert metrics["retired_pending_close"] == 0
+        assert metrics["cleanup_pending_close"] == 0
+        assert metrics["client_slots_used"] == _CAP
+        assert metrics["client_capacity_rejections_total"] == 0
+
+        # Keep the proxy alive and replace the entire final half-closed
+        # generation with fresh sessions. Do not half-close these replacements:
+        # LRU cleanup must make both kernel CLOSE-WAIT and user-space pending
+        # ownership converge to zero without relying on process termination.
+        drain_start = _ROUNDS * _CAP
+        drain_statuses = [_post(proxy, index) for index in range(drain_start, drain_start + _CAP)]
+        assert drain_statuses == [200] * _CAP
+        drained_health = _wait_for_live_drain(proxy, upstream.server_port)
+        assert proxy.proc.poll() is None
+        assert drained_health["status"] == "ok"
+        drained_metrics = drained_health.get("connection_pool", drained_health.get("pool", {}))
+        assert drained_metrics["client_slots_used"] == _CAP
+
+        started = time.monotonic()
+        proxy.proc.terminate()
+        assert proxy.proc.wait(timeout=5) == 0
+        assert time.monotonic() - started < 5.0
+    finally:
+        proxy.cleanup()
+        with upstream.connections_lock:  # type: ignore[attr-defined]
+            connections = list(upstream.connections)  # type: ignore[attr-defined]
+        for connection in connections:
+            try:
+                connection.close()
+            except OSError:
+                pass
+        upstream.shutdown()
+        upstream.server_close()
+        upstream_thread.join(timeout=2)

--- a/tests/proxy/test_listener_admission.py
+++ b/tests/proxy/test_listener_admission.py
@@ -1,0 +1,216 @@
+import json
+import socket
+import threading
+
+import pytest
+
+from tokenpak.proxy.server import _ADMISSION_REJECT_RESPONSE, _ThreadedHTTPServer
+
+
+class _Proxy:
+    def __init__(self):
+        self._admission = threading.BoundedSemaphore(1)
+        self._admission_rejected = 0
+
+
+def _server(proxy):
+    server = _ThreadedHTTPServer.__new__(_ThreadedHTTPServer)
+    server.proxy_server = proxy
+    server.shutdown_request = lambda request: request.close()
+    return server
+
+
+class _ScriptedRequest:
+    """Deterministic socket stand-in.
+
+    ``recv(..., MSG_PEEK)`` returns the scripted snapshots in order,
+    repeating the final snapshot once the script is exhausted — exactly the
+    observable behavior of a peeking recv on a socket whose bytes arrive in
+    fragments. No real sockets, timers, or sleeps are involved.
+    """
+
+    def __init__(self, snapshots):
+        self._snapshots = list(snapshots)
+        self.sent = b""
+        self.closed = False
+
+    def settimeout(self, value):  # accepted and ignored — deterministic stand-in
+        pass
+
+    def recv(self, bufsize, flags=0):
+        assert flags == socket.MSG_PEEK
+        if len(self._snapshots) > 1:
+            return self._snapshots.pop(0)
+        return self._snapshots[0]
+
+    def sendall(self, data):
+        self.sent += data
+
+    def close(self):
+        self.closed = True
+
+
+def test_model_admission_rejects_before_worker_creation():
+    proxy = _Proxy()
+    assert proxy._admission.acquire(False)
+    server = _server(proxy)
+    client, request = socket.socketpair()
+    try:
+        client.sendall(b"POST /v1/messages HTTP/1.1\r\nX-Tokenpak-Managed: 1\r\n\r\n")
+        server.process_request(request, ("local", 0))
+        response = client.recv(512)
+        assert b"503 Service Unavailable" in response
+        assert b"managed_admission_capacity" in response
+        assert proxy._admission_rejected == 1
+    finally:
+        client.close()
+        proxy._admission.release()
+
+
+def test_overload_response_wire_framing_is_exact():
+    """The complete wire response must parse, and the declared Content-Length
+    must equal the actual body byte count."""
+    proxy = _Proxy()
+    assert proxy._admission.acquire(False)
+    server = _server(proxy)
+    client, request = socket.socketpair()
+    try:
+        client.sendall(b"POST /v1/messages HTTP/1.1\r\nX-Tokenpak-Managed: 1\r\n\r\n")
+        server.process_request(request, ("local", 0))
+        chunks = []
+        while True:
+            try:
+                chunk = client.recv(4096)
+            except (ConnectionResetError, OSError):
+                # The server closes its side without consuming the peeked
+                # request bytes, which surfaces as a reset once the response
+                # has been read — treat it as end-of-stream.
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+        response = b"".join(chunks)
+        # Complete response bytes, exactly as built.
+        assert response == _ADMISSION_REJECT_RESPONSE
+        head, sep, body = response.partition(b"\r\n\r\n")
+        assert sep == b"\r\n\r\n"
+        status_line, *header_lines = head.split(b"\r\n")
+        assert status_line == b"HTTP/1.1 503 Service Unavailable"
+        headers = {}
+        for line in header_lines:
+            name, _, value = line.partition(b":")
+            headers[name.strip().lower()] = value.strip()
+        # Declared framing matches actual body bytes.
+        assert int(headers[b"content-length"]) == len(body)
+        assert headers[b"content-type"] == b"application/json"
+        assert headers[b"connection"] == b"close"
+        # Body parses to the expected JSON error.
+        assert json.loads(body.decode("utf-8")) == {"error": "managed_admission_capacity"}
+    finally:
+        client.close()
+        proxy._admission.release()
+
+
+def test_fragmented_managed_marker_is_classified_before_worker_creation(monkeypatch):
+    """A managed marker arriving in a later fragment than the request line
+    must still be admission-gated: at saturated capacity the request is
+    rejected with zero worker threads created and exactly one rejection."""
+    fragment_one = b"POST /v1/messages HTTP/1.1\r\nHost: local\r\n"
+    full_head = fragment_one + b"X-Tokenpak-Managed: 1\r\n\r\n"
+    request = _ScriptedRequest([fragment_one, full_head])
+
+    proxy = _Proxy()
+    assert proxy._admission.acquire(False)  # saturate managed capacity
+    server = _server(proxy)
+
+    created_threads = []
+
+    def _spy_thread(*args, **kwargs):
+        created_threads.append((args, kwargs))
+        raise AssertionError("no worker thread may be created for a rejected request")
+
+    monkeypatch.setattr(threading, "Thread", _spy_thread)
+    try:
+        server.process_request(request, ("local", 0))
+        assert created_threads == []  # zero worker threads
+        assert proxy._admission_rejected == 1  # exactly one rejection
+        assert request.sent == _ADMISSION_REJECT_RESPONSE
+        assert request.closed
+    finally:
+        proxy._admission.release()
+
+
+def test_lease_released_and_socket_closed_when_thread_construction_fails(monkeypatch):
+    proxy = _Proxy()
+    server = _server(proxy)
+    client, request = socket.socketpair()
+
+    def _construction_fails(*args, **kwargs):
+        raise RuntimeError("thread construction failed")
+
+    monkeypatch.setattr(threading, "Thread", _construction_fails)
+    try:
+        client.sendall(b"POST /v1/messages HTTP/1.1\r\nX-Tokenpak-Managed: 1\r\n\r\n")
+        with pytest.raises(RuntimeError, match="thread construction failed"):
+            server.process_request(request, ("local", 0))
+        # The admission lease must have been released...
+        assert proxy._admission.acquire(False)
+        proxy._admission.release()
+        # ...and the accepted socket closed.
+        assert request.fileno() == -1
+    finally:
+        client.close()
+
+
+def test_lease_released_and_socket_closed_when_thread_start_fails(monkeypatch):
+    proxy = _Proxy()
+    server = _server(proxy)
+    client, request = socket.socketpair()
+
+    class _StartFails:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(threading, "Thread", _StartFails)
+    try:
+        client.sendall(b"POST /v1/messages HTTP/1.1\r\nX-Tokenpak-Managed: 1\r\n\r\n")
+        with pytest.raises(RuntimeError, match="thread start failed"):
+            server.process_request(request, ("local", 0))
+        assert proxy._admission.acquire(False)
+        proxy._admission.release()
+        assert request.fileno() == -1
+    finally:
+        client.close()
+
+
+def test_control_plane_is_not_admission_gated():
+    proxy = _Proxy()
+    assert proxy._admission.acquire(False)
+    server = _server(proxy)
+    client, request = socket.socketpair()
+    try:
+        # The worker will fail harmlessly because this is only an admission test;
+        # importantly, it is not rejected with the overload response.
+        client.sendall(b"GET /health HTTP/1.1\r\nHost: local\r\n\r\n")
+        server.process_request(request, ("local", 0))
+        client.settimeout(0.5)
+        try:
+            client.recv(512)
+        except (ConnectionResetError, OSError):
+            pass
+        assert proxy._admission_rejected == 0
+    finally:
+        client.close()
+        proxy._admission.release()
+
+
+def test_admission_recovers_after_capacity_is_released():
+    proxy = _Proxy()
+    assert proxy._admission.acquire(False)
+    assert not proxy._admission.acquire(False)
+    proxy._admission.release()
+    assert proxy._admission.acquire(False)
+    proxy._admission.release()

--- a/tests/proxy/test_session_client_refcount.py
+++ b/tests/proxy/test_session_client_refcount.py
@@ -7,7 +7,7 @@ per-chunk read timeout alone is 300s) can look "idle" while it is mid-flight.
 These tests pin the lease semantics that keep live clients safe:
 
 - a checked-out (leased) client survives the idle reap pass
-- an idle, unleased client is still reaped (retired)
+- an idle, unleased client is closed promptly instead of grace-retired
 - LRU overflow with every pooled client leased hands out a temporary
   overflow client instead of evicting a live one; the overflow client is
   closed on release
@@ -17,6 +17,7 @@ These tests pin the lease semantics that keep live clients safe:
 
 from __future__ import annotations
 
+import time
 from typing import Iterator
 
 import httpx
@@ -62,9 +63,17 @@ def _refs(pool: ConnectionPool, client: httpx.Client) -> int:
     return pool._session_client_refs.get(client, 0)
 
 
+def _wait_closed(pool: ConnectionPool, client: httpx.Client, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not client.is_closed and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert client.is_closed is True
+
+
 # ---------------------------------------------------------------------------
 # Reap pass vs leases
 # ---------------------------------------------------------------------------
+
 
 def test_leased_client_survives_idle_reap_pass():
     """A client mid-request must not be reaped even when it looks idle."""
@@ -73,32 +82,98 @@ def test_leased_client_survives_idle_reap_pass():
     assert _refs(pool, held) == 1
 
     # Any later checkout triggers the idle reap pass (idle window is 0).
-    pool._get_session_client(NETLOC, "sess-other", checkout=True)
+    other = pool._get_session_client(NETLOC, "sess-other", checkout=True)
 
     assert (NETLOC, "sess-live") in pool._session_clients
     assert pool._session_clients[(NETLOC, "sess-live")][0] is held
     assert held.is_closed is False
+    pool._release_session_client(NETLOC, "sess-live", held)
+    pool._release_session_client(NETLOC, "sess-other", other)
     pool.close()
 
 
-def test_idle_unleased_client_is_reaped():
+def test_idle_unleased_client_is_closed_promptly():
     pool = _pool(_ok_transport(), session_client_idle_seconds=0.0)
     client = pool._get_session_client(NETLOC, "sess-idle", checkout=True)
     pool._release_session_client(NETLOC, "sess-idle", client)
     assert _refs(pool, client) == 0
 
-    pool._get_session_client(NETLOC, "sess-trigger", checkout=True)
+    trigger = pool._get_session_client(NETLOC, "sess-trigger", checkout=True)
 
     assert (NETLOC, "sess-idle") not in pool._session_clients
-    # Reaped clients are retired (grace-closed), not closed inline.
-    assert pool.metrics()["retired_pending_close"] >= 1
+    _wait_closed(pool, client)
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool._release_session_client(NETLOC, "sess-trigger", trigger)
     pool.close()
-    assert client.is_closed is True
+
+
+def test_idle_retirement_churn_does_not_accumulate_pending_clients():
+    """Regression: idle session churn must not recreate CLOSE-WAIT growth."""
+    pool = _pool(
+        _ok_transport(),
+        session_client_idle_seconds=0.0,
+        retire_close_grace_seconds=3600.0,
+    )
+    clients = []
+
+    for index in range(32):
+        client = pool._get_session_client(NETLOC, f"sess-{index}", checkout=True)
+        pool._release_session_client(NETLOC, f"sess-{index}", client)
+        clients.append(client)
+        if index:
+            _wait_closed(pool, clients[-2])
+        assert pool.metrics()["retired_pending_close"] == 0
+
+    assert all(client.is_closed for client in clients[:-1])
+    assert clients[-1].is_closed is False
+    pool.close()
+    _wait_closed(pool, clients[-1])
+
+
+def test_expired_retired_client_with_active_lease_is_not_reaped():
+    """Regression: the grace reaper must never close a live stream lease."""
+    pool = _pool(_ok_transport(), retire_close_grace_seconds=0.0)
+    held = pool._get_session_client(NETLOC, "sess-live", checkout=True)
+
+    assert pool._evict_client(NETLOC, "sess-live", held) is True
+    assert _refs(pool, held) == 1
+    assert held.is_closed is False
+    assert pool.metrics()["retired_pending_close"] == 1
+
+    pool._reap_retired()
+    assert held.is_closed is False
+    assert pool.metrics()["retired_pending_close"] == 1
+
+    pool._release_session_client(NETLOC, "sess-live", held)
+    _wait_closed(pool, held)
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool.close()
+
+
+def test_entered_stream_survives_retire_reap_until_context_exit():
+    """Regression: retire/reap cannot close an entered streaming lease."""
+    pool = _pool(_ok_transport(), retire_close_grace_seconds=0.0)
+
+    with pool.stream("POST", URL, content=b"{}", session_key="sess-live") as response:
+        held = pool._session_clients[(NETLOC, "sess-live")][0]
+        assert _refs(pool, held) == 1
+        assert pool._evict_client(NETLOC, "sess-live", held) is True
+
+        pool._reap_retired()
+        assert held.is_closed is False
+        assert pool.metrics()["retired_pending_close"] == 1
+        response.read()
+
+    assert _refs(pool, held) == 0
+    _wait_closed(pool, held)
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool.close()
 
 
 # ---------------------------------------------------------------------------
 # LRU cap vs leases
 # ---------------------------------------------------------------------------
+
 
 def test_lru_overflow_with_all_leased_does_not_close_live_clients():
     pool = _pool(_ok_transport(), session_client_max=2)
@@ -116,7 +191,7 @@ def test_lru_overflow_with_all_leased_does_not_close_live_clients():
 
     # Overflow client is create-and-close-after-use.
     pool._release_session_client(NETLOC, "sess-c", c)
-    assert c.is_closed is True
+    _wait_closed(pool, c)
     assert pool.session_client_snapshot()["overflow_active"] == 0
 
     # Pooled clients stay cached (open) after release.
@@ -132,18 +207,23 @@ def test_lru_evicts_unleased_entry_when_available():
     pool._release_session_client(NETLOC, "sess-a", a)  # unleased → evictable
     b = pool._get_session_client(NETLOC, "sess-b", checkout=True)
 
-    pool._get_session_client(NETLOC, "sess-c", checkout=True)
+    c = pool._get_session_client(NETLOC, "sess-c", checkout=True)
 
     assert (NETLOC, "sess-a") not in pool._session_clients
     assert (NETLOC, "sess-b") in pool._session_clients
     assert (NETLOC, "sess-c") in pool._session_clients
+    _wait_closed(pool, a)
     assert b.is_closed is False
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool._release_session_client(NETLOC, "sess-b", b)
+    pool._release_session_client(NETLOC, "sess-c", c)
     pool.close()
 
 
 # ---------------------------------------------------------------------------
 # Release semantics
 # ---------------------------------------------------------------------------
+
 
 def test_release_restamps_last_used():
     pool = _pool(_ok_transport())
@@ -174,6 +254,7 @@ def test_nested_leases_release_pairwise():
 # request()/stream() bracket the lease on all exit paths
 # ---------------------------------------------------------------------------
 
+
 def test_request_releases_lease_on_success():
     pool = _pool(_ok_transport())
     resp = pool.request("POST", URL, content=b"{}", session_key="sess-1")
@@ -187,6 +268,20 @@ def test_request_releases_lease_on_transport_error():
     with pytest.raises(httpx.ReadError):
         pool.request("POST", URL, content=b"{}", session_key="sess-1")
     assert pool._session_client_refs == {}
+    pool.close()
+
+
+def test_request_transport_error_closes_retired_client_after_release():
+    pool = _pool(_FailingTransport(), retire_close_grace_seconds=3600.0)
+    client = pool._get_session_client(NETLOC, "sess-1")
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}", session_key="sess-1")
+
+    assert pool._session_client_refs == {}
+    assert (NETLOC, "sess-1") not in pool._session_clients
+    _wait_closed(pool, client)
+    assert pool.metrics()["retired_pending_close"] == 0
     pool.close()
 
 
@@ -207,6 +302,22 @@ def test_stream_releases_lease_on_exit_and_midstream_error():
     failing.close()
 
 
+def test_stream_transport_error_closes_retired_client_after_release():
+    pool = _pool(_MidStreamFailTransport(), retire_close_grace_seconds=3600.0)
+    client = pool._get_session_client(NETLOC, "sess-1")
+
+    with pytest.raises(httpx.ReadError):
+        with pool.stream("POST", URL, content=b"{}", session_key="sess-1") as resp:
+            for _ in resp.iter_bytes(chunk_size=8):
+                pass
+
+    assert pool._session_client_refs == {}
+    assert (NETLOC, "sess-1") not in pool._session_clients
+    _wait_closed(pool, client)
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool.close()
+
+
 def test_stream_releases_lease_when_enter_fails():
     pool = _pool(_FailingTransport())
     with pytest.raises(httpx.ReadError):
@@ -216,13 +327,19 @@ def test_stream_releases_lease_when_enter_fails():
     pool.close()
 
 
-def test_close_clears_leases_and_overflow():
+def test_close_defers_active_leases_until_final_release():
     pool = _pool(_ok_transport(), session_client_max=1)
     a = pool._get_session_client(NETLOC, "sess-a", checkout=True)
     overflow = pool._get_session_client(NETLOC, "sess-b", checkout=True)
     pool.close()
-    assert a.is_closed is True
-    assert overflow.is_closed is True
+    assert a.is_closed is False
+    assert overflow.is_closed is False
+    assert _refs(pool, a) == 1
+    assert _refs(pool, overflow) == 1
+    pool._release_session_client(NETLOC, "sess-a", a)
+    pool._release_session_client(NETLOC, "sess-b", overflow)
+    _wait_closed(pool, a)
+    _wait_closed(pool, overflow)
     assert pool._session_client_refs == {}
     assert pool._overflow_clients == set()
 
@@ -252,4 +369,5 @@ def test_stream_construction_failure_releases_lease_exactly_once(monkeypatch):
     # prematurely closed.
     assert _refs(pool, held) == 1
     assert held.is_closed is False
+    pool._release_session_client(NETLOC, "sess-1", held)
     pool.close()

--- a/tests/proxy/test_shutdown_pool_close_order.py
+++ b/tests/proxy/test_shutdown_pool_close_order.py
@@ -19,6 +19,7 @@ import threading
 import time
 from unittest.mock import MagicMock
 
+from tokenpak.proxy.connection_pool import ConnectionPool, PoolConfig
 from tokenpak.proxy.server import ProxyServer
 
 
@@ -129,3 +130,36 @@ def test_stop_twice_is_safe():
 
     assert order.count("drain") == 1
     assert order.count("pool_close") == 2
+
+
+def test_stop_reaches_server_shutdown_when_pool_client_close_hangs():
+    """A wedged transport close cannot consume the server-stop step."""
+    ps = _make_server(shutdown_timeout=0.1)
+    server = MagicMock()
+    ps._server = server
+    ps._flush_telemetry = MagicMock()  # type: ignore[method-assign]
+    ps._connection_pool = ConnectionPool(PoolConfig(http2=False, close_timeout_seconds=0.05))
+    close_started = threading.Event()
+    release_close = threading.Event()
+    close_finished = threading.Event()
+
+    class _BlockingCloseClient:
+        def close(self):
+            close_started.set()
+            release_close.wait()
+            close_finished.set()
+
+    ps._connection_pool._clients["upstream.test"] = _BlockingCloseClient()  # type: ignore[assignment]
+
+    try:
+        started = time.monotonic()
+        ps.stop()
+        elapsed = time.monotonic() - started
+
+        assert close_started.is_set()
+        assert elapsed < 0.5
+        server.shutdown.assert_called_once_with()
+        assert ps._server is None
+    finally:
+        release_close.set()
+        assert close_finished.wait(timeout=1.0)

--- a/tests/proxy/test_upstream_header_forwarding.py
+++ b/tests/proxy/test_upstream_header_forwarding.py
@@ -1,0 +1,143 @@
+"""Upstream forwarding boundary: internal headers must never leave the proxy.
+
+Negative integration tests over every header-forwarding strategy the proxy
+uses to build the upstream request:
+
+- ``forward_all``  — client-auth pure relay (Claude Code client-auth route)
+- ``allowlist``    — Claude Code allowlist, OpenClaw allowlist, legacy allowlist
+- ``sanitize``     — SDK / unknown / custom-provider fallback
+
+Whatever the route or provider, headers in the TokenPak-internal namespace
+(``x-tokenpak-*`` / ``x-tpk-*``) must be absent from the upstream header set.
+The OpenClaw allowlist route must additionally remain byte-for-byte identical
+to its historical output: its allowlist never contained internal names, so
+the no-forward rule must not change that route's output at all.
+
+Fixture policy: agent-name fixture values are neutral placeholder
+identifiers, never real deployment or operator names. All tests are offline
+and deterministic — no live network, no live provider.
+"""
+
+import pytest
+
+from tokenpak.proxy.headers import (
+    CLAUDE_CODE_HEADER_ALLOWLIST,
+    OPENCLAW_HEADER_ALLOWLIST,
+    forward_headers,
+    sanitize_headers,
+)
+from tokenpak.proxy.passthrough import LEGACY_HEADER_ALLOWLIST
+from tokenpak.proxy.request import ROUTE_CLAUDE_CODE, ROUTE_OPENCLAW, ROUTE_SDK
+from tokenpak.proxy.spend_guard.classifier import is_internal_header, strip_managed_headers
+
+# Internal-namespace headers as a client might (incorrectly) send them:
+# mixed case, marker headers, and arbitrary internal-namespace names.
+INTERNAL_HEADERS = {
+    "X-Tokenpak-Managed": "1",
+    "X-Tokenpak-Agent": "agent-a",
+    "X-TOKENPAK-MANAGED-ENV": "1",
+    "x-tokenpak-bypass": "1",
+    "X-Tpk-Trace-Id": "trace-1",
+}
+
+# Representative legitimate client headers across the routed providers.
+BASE_HEADERS = {
+    "Authorization": "Bearer test-token",
+    "x-api-key": "test-key",
+    "Content-Type": "application/json",
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "prompt-caching-2024-07-31",
+    "User-Agent": "client/1.0",
+    "Accept": "application/json",
+}
+
+
+def _request_headers():
+    headers = dict(BASE_HEADERS)
+    headers.update(INTERNAL_HEADERS)
+    return headers
+
+
+def _internal_names_in(result):
+    return sorted(k for k in result if is_internal_header(k))
+
+
+# ---------------------------------------------------------------------------
+# Route / strategy matrix — no internal header may survive any of them
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("route", "client_has_auth"),
+    [
+        pytest.param(ROUTE_CLAUDE_CODE, True, id="claude-client-auth-relay"),
+        pytest.param(ROUTE_CLAUDE_CODE, False, id="claude-code-allowlist"),
+        pytest.param(ROUTE_OPENCLAW, False, id="openclaw-allowlist"),
+        pytest.param(ROUTE_SDK, False, id="sdk-sanitize"),
+        pytest.param("custom-provider", False, id="custom-provider-sanitize"),
+        pytest.param("", False, id="unknown-route-sanitize"),
+    ],
+)
+def test_no_internal_header_reaches_upstream_on_any_route(route, client_has_auth):
+    result = forward_headers(_request_headers(), route, client_has_auth=client_has_auth)
+    assert _internal_names_in(result) == [], (
+        f"internal headers leaked upstream on route {route!r}: {_internal_names_in(result)}"
+    )
+
+
+def test_sanitize_headers_strips_internal_namespace_directly():
+    result = sanitize_headers(_request_headers())
+    assert _internal_names_in(result) == []
+    # Legitimate client headers survive the sanitize strategy.
+    for name in ("Authorization", "x-api-key", "Content-Type", "User-Agent"):
+        assert name in result
+
+
+def test_client_auth_relay_still_forwards_client_headers():
+    result = forward_headers(_request_headers(), ROUTE_CLAUDE_CODE, client_has_auth=True)
+    assert _internal_names_in(result) == []
+    # The relay behavior for legitimate headers is unchanged.
+    for name in ("Authorization", "x-api-key", "anthropic-version", "User-Agent"):
+        assert name in result
+
+
+def test_openclaw_route_output_is_bit_for_bit_unchanged():
+    """The OpenClaw allowlist never contained internal names; the no-forward
+    rule must therefore not alter that route's output in any way."""
+    raw = _request_headers()
+    expected = {
+        k.lower(): v for k, v in raw.items() if k.lower() in OPENCLAW_HEADER_ALLOWLIST
+    }
+    assert forward_headers(raw, ROUTE_OPENCLAW) == expected
+    assert _internal_names_in(expected) == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlist invariants — no allowlist may ever gain an internal name
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("allowlist_name", "allowlist"),
+    [
+        ("OPENCLAW_HEADER_ALLOWLIST", OPENCLAW_HEADER_ALLOWLIST),
+        ("CLAUDE_CODE_HEADER_ALLOWLIST", CLAUDE_CODE_HEADER_ALLOWLIST),
+        ("LEGACY_HEADER_ALLOWLIST", frozenset(LEGACY_HEADER_ALLOWLIST)),
+    ],
+)
+def test_allowlists_contain_no_internal_namespace_names(allowlist_name, allowlist):
+    leaked = sorted(name for name in allowlist if is_internal_header(name))
+    assert leaked == [], f"{allowlist_name} must never contain internal names: {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# Alignment — the forwarding strip set and the classifier helper agree
+# ---------------------------------------------------------------------------
+
+def test_forwarding_strip_set_aligns_with_classifier_helper():
+    """The strip helper and the forwarding boundary share one namespace
+    predicate; both must remove exactly the internal fixture headers."""
+    headers = _request_headers()
+    removed = strip_managed_headers(headers)
+    assert {name.lower() for name in removed} == {name.lower() for name in INTERNAL_HEADERS}
+    # After the strip, nothing internal remains and client headers are intact.
+    assert _internal_names_in(headers) == []
+    assert headers == BASE_HEADERS

--- a/tests/proxy/test_vault_bridge_memory_bound.py
+++ b/tests/proxy/test_vault_bridge_memory_bound.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tokenpak.proxy import vault_bridge
+
+
+def _write_index(root: Path, documents: dict[str, tuple[str, str]]) -> Path:
+    blocks_dir = root / "blocks"
+    blocks_dir.mkdir(exist_ok=True)
+    metadata = {}
+    for block_id, (source_path, content) in documents.items():
+        (blocks_dir / f"{block_id}.txt").write_text(content, encoding="utf-8")
+        metadata[block_id] = {
+            "source_path": source_path,
+            "content_hash": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+            "raw_tokens": len(content.split()),
+        }
+
+    index_path = root / "index.json"
+    index_path.write_text(json.dumps({"blocks": metadata}), encoding="utf-8")
+    return index_path
+
+
+def _load_index(root: Path) -> vault_bridge.VaultIndex:
+    index_path = root / "index.json"
+    index = vault_bridge.VaultIndex(str(root))
+    index._load(index_path, index_path.stat().st_mtime)
+    return index
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_compact_index_preserves_query_expansion_search_and_injection(tmp_path, monkeypatch):
+    """Regression: compact postings preserve proxy query expansion and result bytes."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(
+        tmp_path,
+        {
+            "b1": ("docs/auth.md", "authentication authorization token auth"),
+            "b2": ("docs/config.md", "configuration database settings config"),
+            "b3": ("docs/request.md", "authentication authentication request message"),
+            "b4": ("docs/misc.md", "garden flowers unrelated"),
+        },
+    )
+    index = _load_index(tmp_path)
+
+    assert vault_bridge._bm25_tokenize_query("auth") == [
+        "auth",
+        "authentication",
+        "authentic",
+        "authorization",
+        "authoriz",
+        "authenticate",
+    ]
+    assert vault_bridge._bm25_tokenize_query("authentication request") == [
+        "authentication",
+        "authentic",
+        "auth",
+        "request",
+        "req",
+    ]
+
+    auth_results = index.search("auth", top_k=4, min_score=0)
+    assert [block["block_id"] for block, _ in auth_results] == ["b1"]
+    assert [score for _, score in auth_results] == pytest.approx([3.010769698264], rel=1e-12)
+    assert auth_results[0][0] == {
+        "block_id": "b1",
+        "source_path": "docs/auth.md",
+        "risk_class": "narrative",
+        "must_keep": False,
+        "raw_tokens": 4,
+        "source_type": "filesystem",
+        "claude_transcript": None,
+        "content": "authentication authorization token auth",
+    }
+
+    phrase_results = index.search("authentication request", top_k=4, min_score=0)
+    assert [block["block_id"] for block, _ in phrase_results] == ["b3", "b1"]
+    assert [score for _, score in phrase_results] == pytest.approx(
+        [2.138342251436, 1.841864062996], rel=1e-12
+    )
+
+    injection_text, tokens_used, source_refs = index.compile_injection(
+        "authentication request", budget=1000, top_k=4, min_score=0
+    )
+    assert injection_text == (
+        "\n\n## Retrieved Context\n"
+        "--- [docs/request.md] (relevance: 2.1) ---\n"
+        "authentication authentication request message\n\n"
+        "--- [docs/auth.md] (relevance: 1.8) ---\n"
+        "authentication authorization token auth"
+    )
+    assert tokens_used == vault_bridge.count_tokens(injection_text)
+    assert source_refs == ["docs/request.md", "docs/auth.md"]
+    assert all("content" not in block for block in index.blocks.values())
+
+
+def test_content_hydration_lru_is_strictly_byte_bounded(tmp_path, monkeypatch):
+    """Regression: selected block bytes never grow beyond the configured cache cap."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 96)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    documents = {
+        "b1": ("docs/one.md", "needle_one " + "x" * 60),
+        "b2": ("docs/two.md", "needle_two " + "y" * 60),
+        "b3": ("docs/huge.md", "needle_huge " + "z" * 120),
+    }
+    _write_index(tmp_path, documents)
+    index = _load_index(tmp_path)
+
+    assert index._cache_bytes == 0
+    first_result = index.search("needle_one", top_k=1, min_score=0)
+    assert first_result[0][0]["content"] == documents["b1"][1]
+    assert index._cache_bytes <= 96
+    second_result = index.search("needle_two", top_k=1, min_score=0)
+    assert second_result[0][0]["content"] == documents["b2"][1]
+    assert index._cache_bytes <= 96
+    assert len(index._content_cache) == 1
+    assert index.cache_stats["vault_cache_evictions"] == 1
+
+    # Rehydrate the evicted block to prove disk fallback stays correct.
+    assert index.search("needle_one", top_k=1, min_score=0)[0][0]["content"] == documents["b1"][1]
+    assert index._cache_bytes <= 96
+    assert index.cache_stats["vault_cache_evictions"] == 2
+    assert index._max_cache_bytes == 96
+
+    # A single block larger than the cap is served only as a bounded prefix.
+    huge_result = index.search("needle_huge", top_k=1, min_score=0)
+    huge_block = huge_result[0][0]
+    assert huge_block["content"] == documents["b3"][1][:96]
+    assert huge_block["content_truncated"] is True
+    assert huge_block["content_bytes_total"] == len(documents["b3"][1])
+    assert huge_block["content_bytes_loaded"] == 96
+    assert index._cache_bytes == 96
+
+
+def test_reload_replaces_postings_and_invalidates_cached_content(tmp_path, monkeypatch):
+    """Regression: a new index generation cannot serve stale postings or content."""
+    monkeypatch.setattr(vault_bridge, "VAULT_INDEX_RELOAD_INTERVAL", 0)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 1)
+    index_path = _write_index(tmp_path, {"b1": ("docs/item.md", "alpha old_marker")})
+
+    index = vault_bridge.VaultIndex(str(tmp_path))
+    index.maybe_reload()
+    assert index.search("alpha", top_k=1, min_score=0)[0][0]["content"] == "alpha old_marker"
+    first_postings = index._postings
+    first_cache = index._content_cache
+    first_mtime = index._last_mtime
+
+    _write_index(tmp_path, {"b1": ("docs/item.md", "beta new_marker")})
+    next_mtime = max(time.time() + 2, first_mtime + 2)
+    os.utime(index_path, (next_mtime, next_mtime))
+    os.utime(tmp_path / "blocks" / "b1.txt", (next_mtime, next_mtime))
+    index.maybe_reload()
+
+    assert index._last_mtime == next_mtime
+    assert index._postings is not first_postings
+    assert index._content_cache is not first_cache
+    assert index.search("alpha", top_k=1, min_score=0) == []
+    beta_results = index.search("beta", top_k=1, min_score=0)
+    assert beta_results[0][0]["content"] == "beta new_marker"
+
+
+def test_stale_metadata_hash_indexes_and_pins_stable_block_bytes(tmp_path, monkeypatch):
+    """One stale index hash cannot take the whole retrieval generation offline."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    index_path = _write_index(tmp_path, {"b1": ("docs/item.md", "needle stable")})
+    metadata = json.loads(index_path.read_text(encoding="utf-8"))
+    metadata["blocks"]["b1"]["content_hash"] = "0" * 64
+    index_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    index = _load_index(tmp_path)
+
+    results = index.search("needle", top_k=1, min_score=0)
+    assert index.available
+    assert results[0][0]["content"] == "needle stable"
+    assert index.cache_stats["vault_index_stale_content_hashes"] == 1
+    assert (
+        index._snapshot_generation().content_records["b1"].content_hash
+        == hashlib.sha256(b"needle stable").hexdigest()
+    )
+
+
+def test_missing_block_is_quarantined_without_hiding_healthy_siblings(tmp_path, monkeypatch):
+    """One unreadable index entry cannot take the complete generation offline."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(
+        tmp_path,
+        {
+            "healthy": ("docs/healthy.md", "needle healthy content"),
+            "missing": ("docs/missing.md", "needle missing content"),
+        },
+    )
+    (tmp_path / "blocks" / "missing.txt").unlink()
+
+    index = _load_index(tmp_path)
+
+    assert index.available
+    assert index._doc_count == 1
+    assert index.cache_stats["vault_index_skipped_blocks"] == 1
+    results = index.search("healthy", top_k=5, min_score=0)
+    assert [block["block_id"] for block, _ in results] == ["healthy"]
+    assert results[0][0]["content"] == "needle healthy content"
+
+
+def test_oversized_block_is_quarantined_without_hiding_healthy_siblings(tmp_path, monkeypatch):
+    """Loader allocation is bounded by the canonical vault walker file limit."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_BLOCK_MAX_BYTES", 32)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(
+        tmp_path,
+        {
+            "healthy": ("docs/healthy.md", "needle healthy"),
+            "oversized": ("docs/oversized.md", "needle " + "x" * 64),
+        },
+    )
+
+    index = _load_index(tmp_path)
+
+    assert index.available
+    assert index._doc_count == 1
+    assert index.cache_stats["vault_index_skipped_blocks"] == 1
+    assert index.cache_stats["vault_index_oversized_blocks"] == 1
+    results = index.search("healthy", top_k=5, min_score=0)
+    assert [block["block_id"] for block, _ in results] == ["healthy"]
+
+
+def test_stale_raw_tokens_use_actual_content_for_injection_budget(tmp_path, monkeypatch):
+    """Stale metadata cannot admit a full oversized block under a small budget."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 64 * 1024)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    content = "needle " + "x " * 1000
+    index_path = _write_index(tmp_path, {"b1": ("docs/stale.md", content)})
+    metadata = json.loads(index_path.read_text(encoding="utf-8"))
+    metadata["blocks"]["b1"]["content_hash"] = "0" * 64
+    metadata["blocks"]["b1"]["raw_tokens"] = 1
+    index_path.write_text(json.dumps(metadata), encoding="utf-8")
+    index = _load_index(tmp_path)
+
+    result = index.search("needle", top_k=1, min_score=0)[0][0]
+    injection, tokens_used, refs = index.compile_injection(
+        "needle", budget=150, top_k=1, min_score=0
+    )
+
+    assert result["content"] == content
+    assert not any(key.startswith("_content_") for key in result)
+    assert index._snapshot_generation().content_records[
+        "b1"
+    ].actual_tokens == vault_bridge.count_tokens(content)
+    assert len(injection) < len(content)
+    assert tokens_used <= 150
+    assert tokens_used < vault_bridge.count_tokens(content)
+    assert refs == ["docs/stale.md"]
+
+
+def test_coherent_token_dense_content_obeys_hard_injection_budget(tmp_path, monkeypatch):
+    """Accurate metadata still cannot omit rendered header tokens from the budget."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    content = "needle " + "x " * 1000
+    _write_index(tmp_path, {"b1": ("docs/coherent.md", content)})
+    index = _load_index(tmp_path)
+
+    injection, tokens_used, refs = index.compile_injection(
+        "needle", budget=150, top_k=1, min_score=0
+    )
+
+    assert injection
+    assert tokens_used == vault_bridge.count_tokens(injection)
+    assert tokens_used <= 150
+    assert refs == ["docs/coherent.md"]
+
+
+def test_complete_stale_result_does_not_suppress_later_in_budget_result(tmp_path, monkeypatch):
+    """A fully fitting stale block continues through the ranked result list."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    index_path = _write_index(
+        tmp_path,
+        {
+            "b1": ("docs/a.md", "needle first context"),
+            "b2": ("docs/b.md", "needle second context"),
+        },
+    )
+    metadata = json.loads(index_path.read_text(encoding="utf-8"))
+    metadata["blocks"]["b1"]["content_hash"] = "0" * 64
+    index_path.write_text(json.dumps(metadata), encoding="utf-8")
+    index = _load_index(tmp_path)
+
+    injection, tokens_used, refs = index.compile_injection(
+        "needle", budget=1000, top_k=2, min_score=0
+    )
+
+    assert refs == ["docs/a.md", "docs/b.md"]
+    assert "needle first context" in injection
+    assert "needle second context" in injection
+    assert tokens_used == vault_bridge.count_tokens(injection)
+    assert tokens_used <= 1000
+
+
+def test_search_keeps_one_generation_across_reload(tmp_path, monkeypatch):
+    """A reload cannot mix old IDs with new postings or pollute the new cache."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    index_path = _write_index(tmp_path, {"b1": ("docs/old.md", "alpha old_marker")})
+    index = _load_index(tmp_path)
+    old_generation = index._snapshot_generation()
+
+    generation_captured = threading.Event()
+    resume_search = threading.Event()
+    original_snapshot = index._snapshot_generation
+    results: list[list[tuple[dict, float]]] = []
+    errors: list[BaseException] = []
+    search_thread: threading.Thread
+
+    def paused_snapshot():
+        generation = original_snapshot()
+        if threading.current_thread() is search_thread:
+            generation_captured.set()
+            if not resume_search.wait(timeout=5):
+                raise TimeoutError("reload did not resume the paused search")
+        return generation
+
+    monkeypatch.setattr(index, "_snapshot_generation", paused_snapshot)
+
+    def run_search() -> None:
+        try:
+            results.append(index.search("alpha", top_k=1, min_score=0))
+        except BaseException as exc:
+            errors.append(exc)
+
+    search_thread = threading.Thread(target=run_search)
+    search_thread.start()
+    assert generation_captured.wait(timeout=5)
+
+    _write_index(
+        tmp_path,
+        {
+            "b2": ("docs/new-one.md", "beta new_marker"),
+            "b3": ("docs/new-two.md", "beta second_marker"),
+        },
+    )
+    index._load(index_path, index_path.stat().st_mtime)
+    new_generation = original_snapshot()
+    assert new_generation.generation_id == old_generation.generation_id + 1
+    assert new_generation.block_ids == ("b2", "b3")
+
+    resume_search.set()
+    search_thread.join(timeout=5)
+
+    assert not search_thread.is_alive()
+    assert not errors
+    assert results[0][0][0]["block_id"] == "b1"
+    assert results[0][0][0]["content"] == "alpha old_marker"
+    assert tuple(index._content_cache) == ()
+
+
+def test_hydration_rejects_content_from_a_different_generation(tmp_path, monkeypatch):
+    """Old BM25 scores never pair with bytes written after that generation."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, {"b1": ("docs/item.md", "alpha old_marker")})
+    index = _load_index(tmp_path)
+    generation = index._snapshot_generation()
+
+    block_path = tmp_path / "blocks" / "b1.txt"
+    block_path.write_text("beta replacement_marker", encoding="utf-8")
+    changed_mtime_ns = max(
+        time.time_ns() + 2_000_000_000,
+        (generation.content_records["b1"].mtime_ns or 0) + 2_000_000_000,
+    )
+    os.utime(block_path, ns=(changed_mtime_ns, changed_mtime_ns))
+
+    results = index.search("alpha", top_k=1, min_score=0)
+
+    assert results[0][0]["block_id"] == "b1"
+    assert results[0][0]["content"] == vault_bridge._CONTENT_GENERATION_MISMATCH
+    assert "replacement_marker" not in results[0][0]["content"]
+    assert results[0][0]["content_bytes_total"] == len("alpha old_marker")
+    assert results[0][0]["content_bytes_loaded"] == 0
+    assert results[0][0]["content_bytes_loaded"] <= results[0][0]["content_bytes_total"]
+    assert tuple(index._content_cache) == ()
+
+
+def test_bounded_reader_stops_on_a_utf8_boundary(tmp_path, monkeypatch):
+    """A byte cap inside a code point yields a valid prefix, never replacement bytes."""
+    prefix = "needle "
+    content = prefix + "€-tail"
+    cap = len(prefix.encode("utf-8")) + 1
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", cap)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, {"b1": ("docs/utf8.md", content)})
+    index = _load_index(tmp_path)
+
+    def forbidden_read_text(*args, **kwargs):
+        raise AssertionError("hydration must use a bounded binary read")
+
+    monkeypatch.setattr(Path, "read_text", forbidden_read_text)
+    block = index.search("needle", top_k=1, min_score=0)[0][0]
+
+    assert block["content"] == prefix
+    assert "�" not in block["content"]
+    assert len(block["content"].encode("utf-8")) <= cap
+    assert block["content_truncated"] is True
+    assert block["content_bytes_total"] == len(content.encode("utf-8"))
+    assert block["content_bytes_loaded"] == len(prefix.encode("utf-8"))
+    assert index._cache_bytes == block["content_bytes_loaded"]
+
+
+def test_search_aggregate_content_is_capped_without_ranking_changes(tmp_path, monkeypatch):
+    """Ranked IDs and scores survive rank-priority clipping across top-k."""
+    documents = {
+        "b1": ("docs/a.md", "needle " + "a" * 30),
+        "b2": ("docs/b.md", "needle " + "b" * 30),
+        "b3": ("docs/c.md", "needle " + "c" * 30),
+    }
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, documents)
+
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 4096)
+    high_cap = _load_index(tmp_path)
+    high_results = high_cap.search("needle", top_k=3, min_score=0)
+
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 50)
+    low_cap = _load_index(tmp_path)
+    low_results = low_cap.search("needle", top_k=3, min_score=0)
+
+    assert [block["block_id"] for block, _ in low_results] == [
+        block["block_id"] for block, _ in high_results
+    ]
+    assert [score for _, score in low_results] == pytest.approx(
+        [score for _, score in high_results]
+    )
+    assert sum(len(block["content"].encode("utf-8")) for block, _ in low_results) == 50
+    assert low_results[0][0]["content"] == documents["b1"][1]
+    assert "content_truncated" not in low_results[0][0]
+    assert low_results[1][0]["content"] == documents["b2"][1][:13]
+    assert low_results[1][0]["content_bytes_loaded"] == 13
+    assert low_results[2][0]["content"] == ""
+    assert low_results[2][0]["content_bytes_loaded"] == 0
+    assert low_cap.cache_stats["vault_cache_physical_reads"] == 2
+
+
+def test_same_block_concurrent_miss_is_generation_singleflight(tmp_path, monkeypatch):
+    """Concurrent misses share one physical read and one cache charge."""
+    worker_count = 16
+    content = "needle shared concurrent content"
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 256)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, {"b1": ("docs/shared.md", content)})
+    index = _load_index(tmp_path)
+
+    original_reader = index._read_pinned_prefix
+    read_started = threading.Event()
+    release_read = threading.Event()
+    read_calls = 0
+    read_lock = threading.Lock()
+
+    def stalled_reader(record, byte_limit):
+        nonlocal read_calls
+        with read_lock:
+            read_calls += 1
+        read_started.set()
+        if not release_read.wait(timeout=5):
+            raise TimeoutError("singleflight read was not released")
+        return original_reader(record, byte_limit)
+
+    monkeypatch.setattr(index, "_read_pinned_prefix", stalled_reader)
+    start = threading.Barrier(worker_count + 1)
+    results: list[list[tuple[dict, float]]] = []
+    errors: list[BaseException] = []
+
+    def search_once() -> None:
+        try:
+            start.wait(timeout=5)
+            results.append(index.search("needle", top_k=1, min_score=0))
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=search_once) for _ in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    assert read_started.wait(timeout=5)
+    _wait_until(lambda: index.cache_stats["vault_cache_coalesced_hydrations"] == worker_count - 1)
+    release_read.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    assert read_calls == 1
+    assert len(results) == worker_count
+    assert {result[0][0]["content"] for result in results} == {content}
+    assert len({id(result[0][0]["content"]) for result in results}) == 1
+    assert index._cache_bytes == len(content.encode("utf-8"))
+    assert index.cache_stats["vault_cache_physical_reads"] == 1
+    assert index._hydration_reserved_bytes == 0
+    assert index._hydration_flights == {}
+
+
+def test_distinct_concurrent_misses_respect_combined_managed_budget(tmp_path, monkeypatch):
+    """Distinct physical reads serialize admission when reservations would exceed max."""
+    cap = 80
+    documents = {
+        "b1": ("docs/one.md", "needle_one " + "a" * 55),
+        "b2": ("docs/two.md", "needle_two " + "b" * 55),
+    }
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", cap)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, documents)
+    index = _load_index(tmp_path)
+
+    original_reader = index._read_pinned_prefix
+    first_read_started = threading.Event()
+    release_first_read = threading.Event()
+    read_count = 0
+    read_lock = threading.Lock()
+
+    def sequenced_reader(record, byte_limit):
+        nonlocal read_count
+        with read_lock:
+            read_count += 1
+            ordinal = read_count
+        if ordinal == 1:
+            first_read_started.set()
+            if not release_first_read.wait(timeout=5):
+                raise TimeoutError("first distinct read was not released")
+        return original_reader(record, byte_limit)
+
+    monkeypatch.setattr(index, "_read_pinned_prefix", sequenced_reader)
+    start = threading.Barrier(3)
+    results: list[list[tuple[dict, float]]] = []
+
+    def search_once(query: str) -> None:
+        start.wait(timeout=5)
+        results.append(index.search(query, top_k=1, min_score=0))
+
+    threads = [
+        threading.Thread(target=search_once, args=("needle_one",)),
+        threading.Thread(target=search_once, args=("needle_two",)),
+    ]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    assert first_read_started.wait(timeout=5)
+    _wait_until(lambda: len(index._hydration_flights) == 2)
+    assert index._cache_bytes + index._hydration_reserved_bytes <= cap
+    release_first_read.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert read_count == 2
+    assert len(results) == 2
+    assert index._max_managed_content_bytes <= cap
+    assert index._cache_bytes + index._hydration_reserved_bytes <= cap
+    assert index._hydration_reserved_bytes == 0
+    assert index._hydration_flights == {}
+
+
+def test_singleflight_failure_wakes_waiters_and_next_call_retries(tmp_path, monkeypatch):
+    """A failed owner always releases reservations and leaves the key retryable."""
+    worker_count = 8
+    content = "needle retry succeeds"
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 256)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    _write_index(tmp_path, {"b1": ("docs/retry.md", content)})
+    index = _load_index(tmp_path)
+
+    original_reader = index._read_pinned_prefix
+    failed_read_started = threading.Event()
+    release_failure = threading.Event()
+    read_calls = 0
+    read_lock = threading.Lock()
+
+    def flaky_reader(record, byte_limit):
+        nonlocal read_calls
+        with read_lock:
+            read_calls += 1
+            call = read_calls
+        if call == 1:
+            failed_read_started.set()
+            if not release_failure.wait(timeout=5):
+                raise TimeoutError("failed read was not released")
+            raise OSError("synthetic hydration failure")
+        return original_reader(record, byte_limit)
+
+    monkeypatch.setattr(index, "_read_pinned_prefix", flaky_reader)
+    start = threading.Barrier(worker_count + 1)
+    results: list[list[tuple[dict, float]]] = []
+
+    def search_once() -> None:
+        start.wait(timeout=5)
+        results.append(index.search("needle", top_k=1, min_score=0))
+
+    threads = [threading.Thread(target=search_once) for _ in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    assert failed_read_started.wait(timeout=5)
+    _wait_until(lambda: index.cache_stats["vault_cache_coalesced_hydrations"] == worker_count - 1)
+    release_failure.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(results) == worker_count
+    assert all(
+        result[0][0]["content"] == vault_bridge._CONTENT_GENERATION_MISMATCH for result in results
+    )
+    assert index._hydration_reserved_bytes == 0
+    assert index._hydration_flights == {}
+    assert index.cache_stats["vault_cache_hydration_failures"] == 1
+
+    retry = index.search("needle", top_k=1, min_score=0)
+    assert retry[0][0]["content"] == content
+    assert read_calls == 2
+    assert index.cache_stats["vault_cache_physical_reads"] == 2
+
+
+def test_reload_during_hydration_never_publishes_old_generation(tmp_path, monkeypatch):
+    """An old-generation owner may finish for its caller but cannot enter the new cache."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 256)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    index_path = _write_index(tmp_path, {"b1": ("docs/old.md", "alpha old_marker")})
+    index = _load_index(tmp_path)
+    old_generation = index._snapshot_generation()
+
+    original_reader = index._read_pinned_prefix
+    read_started = threading.Event()
+    release_read = threading.Event()
+
+    def stalled_reader(record, byte_limit):
+        read_started.set()
+        if not release_read.wait(timeout=5):
+            raise TimeoutError("old hydration was not released")
+        return original_reader(record, byte_limit)
+
+    monkeypatch.setattr(index, "_read_pinned_prefix", stalled_reader)
+    results: list[list[tuple[dict, float]]] = []
+    search_thread = threading.Thread(
+        target=lambda: results.append(index.search("alpha", top_k=1, min_score=0))
+    )
+    search_thread.start()
+    assert read_started.wait(timeout=5)
+
+    _write_index(tmp_path, {"b2": ("docs/new.md", "beta new_marker")})
+    index._load(index_path, index_path.stat().st_mtime)
+    new_generation = index._snapshot_generation()
+    assert new_generation.generation_id == old_generation.generation_id + 1
+    release_read.set()
+    search_thread.join(timeout=5)
+
+    assert not search_thread.is_alive()
+    assert results[0][0][0]["content"] == "alpha old_marker"
+    assert all(key[0] == new_generation.generation_id for key in index._content_cache)
+    assert index._hydration_reserved_bytes == 0
+    assert index._hydration_flights == {}
+
+
+def test_zero_cap_returns_rank_only_without_physical_reads(tmp_path, monkeypatch):
+    """A zero managed-content budget preserves ranking and performs no hydration I/O."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 0)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    content = "needle zero-cap content"
+    _write_index(tmp_path, {"b1": ("docs/zero.md", content)})
+    index = _load_index(tmp_path)
+
+    results = index.search("needle", top_k=1, min_score=0)
+
+    assert results[0][0]["block_id"] == "b1"
+    assert results[0][0]["content"] == ""
+    assert results[0][0]["content_truncated"] is True
+    assert results[0][0]["content_bytes_total"] == len(content.encode("utf-8"))
+    assert results[0][0]["content_bytes_loaded"] == 0
+    assert index.cache_stats["vault_cache_physical_reads"] == 0
+    assert index._cache_bytes == 0
+    assert index._hydration_reserved_bytes == 0
+    assert index.compile_injection("needle", top_k=1, min_score=0) == ("", 0, [])
+
+
+def test_truncated_injection_counts_loaded_content_not_full_document(tmp_path, monkeypatch):
+    """Full-document raw_tokens cannot suppress a useful bounded prefix."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_MAX_BYTES", 32)
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    content = "needle usable bounded context " + "x" * 200
+    index_path = _write_index(tmp_path, {"b1": ("docs/injection.md", content)})
+    metadata = json.loads(index_path.read_text(encoding="utf-8"))
+    metadata["blocks"]["b1"]["raw_tokens"] = 100_000
+    index_path.write_text(json.dumps(metadata), encoding="utf-8")
+    index = _load_index(tmp_path)
+
+    injection, tokens_used, source_refs = index.compile_injection(
+        "needle", budget=150, top_k=1, min_score=0
+    )
+
+    assert "needle usable bounded context" in injection
+    assert tokens_used == vault_bridge.count_tokens(injection)
+    assert source_refs == ["docs/injection.md"]
+
+
+def _deep_size(value: Any, seen: set[int] | None = None) -> int:
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return 0
+    seen.add(value_id)
+
+    size = sys.getsizeof(value)
+    if isinstance(value, dict):
+        size += sum(_deep_size(key, seen) + _deep_size(item, seen) for key, item in value.items())
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        size += sum(_deep_size(item, seen) for item in value)
+    elif is_dataclass(value):
+        size += sum(_deep_size(getattr(value, field.name), seen) for field in fields(value))
+    return size
+
+
+def _legacy_state(documents: dict[str, tuple[str, str]]) -> tuple[Any, ...]:
+    blocks = {}
+    document_frequencies: dict[str, int] = {}
+    block_term_frequencies: dict[str, dict[str, int]] = {}
+    block_lengths = {}
+    inverted: dict[str, set[str]] = {}
+
+    for block_id, (source_path, content) in documents.items():
+        blocks[block_id] = {
+            "block_id": block_id,
+            "source_path": source_path,
+            "raw_tokens": len(content.split()),
+            "content": content,
+        }
+        terms = vault_bridge._bm25_tokenize.__wrapped__(content)
+        term_frequencies: dict[str, int] = {}
+        for term in terms:
+            term_frequencies[term] = term_frequencies.get(term, 0) + 1
+        block_term_frequencies[block_id] = term_frequencies
+        block_lengths[block_id] = len(terms)
+        for term in set(terms):
+            document_frequencies[term] = document_frequencies.get(term, 0) + 1
+        for term in term_frequencies:
+            inverted.setdefault(term, set()).add(block_id)
+
+    return blocks, document_frequencies, block_term_frequencies, block_lengths, inverted
+
+
+def test_compact_state_is_materially_smaller_than_legacy_shape(tmp_path, monkeypatch):
+    """Regression: the resident BM25 shape stays compact on repeated-term corpora."""
+    monkeypatch.setattr(vault_bridge, "_VAULT_CACHE_PRELOAD", 0)
+    common_terms = [f"common_{term}" for term in range(80)]
+    documents = {}
+    for doc_index in range(200):
+        unique_terms = [f"unique_{doc_index}_{term}" for term in range(40)]
+        content = " ".join(common_terms + unique_terms)
+        documents[f"b{doc_index:04d}"] = (f"docs/{doc_index:04d}.md", content)
+
+    _write_index(tmp_path, documents)
+    index = _load_index(tmp_path)
+    compact_bytes = _deep_size(
+        (
+            index.blocks,
+            index._snapshot_generation().content_records,
+            index._block_ids,
+            index._postings,
+            index._block_dl,
+            index._content_cache,
+        )
+    )
+    legacy_bytes = _deep_size(_legacy_state(documents))
+    ratio = compact_bytes / legacy_bytes
+
+    print(
+        f"memory-shape compact_bytes={compact_bytes} legacy_bytes={legacy_bytes} ratio={ratio:.3f}"
+    )
+    assert not hasattr(index, "_block_tfs")
+    assert not hasattr(index, "_inverted")
+    assert all(posting.typecode == "Q" for posting in index._postings.values())
+    assert ratio < 0.50

--- a/tests/test_connection_pool_eviction.py
+++ b/tests/test_connection_pool_eviction.py
@@ -18,6 +18,8 @@ Covers:
 from __future__ import annotations
 
 import os
+import threading
+import time
 from typing import Iterator
 from unittest.mock import patch
 
@@ -71,9 +73,24 @@ def _pool_with_transport(transport: httpx.BaseTransport, **cfg_kwargs) -> Connec
     return pool
 
 
+def _wait_closed(pool: ConnectionPool, client: httpx.Client, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not client.is_closed and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert client.is_closed is True
+
+
+def _wait_pending(pool: ConnectionPool, expected: int = 0, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while pool.metrics()["retired_pending_close"] != expected and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert pool.metrics()["retired_pending_close"] == expected
+
+
 # ---------------------------------------------------------------------------
 # request() path
 # ---------------------------------------------------------------------------
+
 
 def test_request_transport_error_evicts_client():
     transport = _FlakyTransport(fail_times=1)
@@ -171,11 +188,58 @@ def test_stale_reference_does_not_evict_replacement():
     pool.close()
 
 
+def test_close_cannot_miss_concurrent_client_retirement(monkeypatch):
+    """Regression: shutdown and eviction cannot strand a post-close retire."""
+    pool = _pool_with_transport(
+        _FlakyTransport(fail_times=0),
+        retire_close_grace_seconds=3600.0,
+    )
+    client = pool._get_client(NETLOC)
+    retire_entered = threading.Event()
+    allow_retire = threading.Event()
+    original_retire = pool._retire
+
+    def paused_retire(retired_client):
+        retire_entered.set()
+        allow_retire.wait()
+        original_retire(retired_client)
+
+    monkeypatch.setattr(pool, "_retire", paused_retire)
+    evicter = threading.Thread(
+        target=pool._evict_client,
+        args=(NETLOC, None, client),
+        daemon=True,
+    )
+    closer = None
+    try:
+        evicter.start()
+        assert retire_entered.wait(timeout=1.0)
+
+        closer = threading.Thread(target=pool.close, daemon=True)
+        closer.start()
+        closer.join(timeout=0.05)
+        allow_retire.set()
+        evicter.join(timeout=1.0)
+        closer.join(timeout=1.0)
+    finally:
+        allow_retire.set()
+        evicter.join(timeout=1.0)
+        if closer is not None:
+            closer.join(timeout=1.0)
+
+    assert evicter.is_alive() is False
+    assert closer is not None
+    assert closer.is_alive() is False
+    assert client.is_closed is True
+    assert pool.metrics()["retired_pending_close"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Retire/close lifecycle
 # ---------------------------------------------------------------------------
 
-def test_retired_client_kept_open_during_grace_then_closed():
+
+def test_zero_ref_shared_client_closes_without_waiting_for_grace():
     transport = _FlakyTransport(fail_times=1)
     pool = _pool_with_transport(transport, retire_close_grace_seconds=3600.0)
     first = pool._get_client(NETLOC)
@@ -183,33 +247,31 @@ def test_retired_client_kept_open_during_grace_then_closed():
     with pytest.raises(httpx.ReadError):
         pool.request("POST", URL, content=b"{}")
 
-    assert first.is_closed is False, "in-flight grace: evicted client stays open"
+    _wait_closed(pool, first)
+    assert pool.metrics()["retired_pending_close"] == 0
+    pool.close()
+
+
+def test_shared_client_with_active_lease_survives_reap_until_release():
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(transport, retire_close_grace_seconds=0.0)
+    first = pool._get_client(NETLOC, checkout=True)
+
+    assert pool._evict_client(NETLOC, None, first) is True
+    pool._reap_retired()
+    assert first.is_closed is False
     assert pool.metrics()["retired_pending_close"] == 1
 
-    pool.close()
-    assert first.is_closed is True
+    pool._release_client(first)
+    _wait_closed(pool, first)
     assert pool.metrics()["retired_pending_close"] == 0
-
-
-def test_retired_client_closed_after_grace_expiry():
-    transport = _FlakyTransport(fail_times=2)
-    pool = _pool_with_transport(transport, retire_close_grace_seconds=0.0)
-    first = pool._get_client(NETLOC)
-
-    with pytest.raises(httpx.ReadError):
-        pool.request("POST", URL, content=b"{}")
-
-    # Grace of 0: the next reap (triggered by the next eviction) closes it.
-    with pytest.raises(httpx.ReadError):
-        pool.request("POST", URL, content=b"{}")
-
-    assert first.is_closed is True
     pool.close()
 
 
 # ---------------------------------------------------------------------------
 # Streaming path
 # ---------------------------------------------------------------------------
+
 
 def test_streaming_connect_failure_evicts():
     transport = _FlakyTransport(fail_times=1)
@@ -267,13 +329,32 @@ def test_streaming_downstream_error_does_not_evict():
     pool.close()
 
 
+def test_non_session_entered_stream_survives_evict_reap_until_exit():
+    """Shared clients take the same lease protection as session clients."""
+    transport = _FlakyTransport(fail_times=0)
+    pool = _pool_with_transport(transport, retire_close_grace_seconds=0.0)
+
+    with pool.stream("POST", URL, content=b"{}") as response:
+        held = pool._clients[NETLOC]
+        assert pool._session_client_refs[held] == 1
+        assert pool._evict_client(NETLOC, None, held) is True
+        pool._reap_retired()
+        assert held.is_closed is False
+        assert pool.metrics()["retired_pending_close"] == 1
+        response.read()
+
+    _wait_closed(pool, held)
+    _wait_pending(pool)
+    pool.close()
+
+
 # ---------------------------------------------------------------------------
 # Session reaper / LRU disposal safety
 # ---------------------------------------------------------------------------
 
-def test_idle_reap_retires_instead_of_closing():
-    """An idle-looking session client may be mid-way through a long stream
-    (last_used is a checkout stamp) — the reaper must retire, not close."""
+
+def test_idle_reap_closes_zero_reference_client_promptly():
+    """An idle client with no active lease must not wait for retire grace."""
     transport = _FlakyTransport(fail_times=0)
     pool = _pool_with_transport(
         transport, session_client_idle_seconds=0.0, retire_close_grace_seconds=3600.0
@@ -284,24 +365,318 @@ def test_idle_reap_retires_instead_of_closing():
     pool._get_session_client(NETLOC, "sess-new")
 
     assert (NETLOC, "sess-old") not in pool._session_clients
-    assert first.is_closed is False, "reaped client must stay open for in-flights"
-    assert pool.metrics()["retired_pending_close"] >= 1
+    _wait_closed(pool, first)
+    assert pool.metrics()["retired_pending_close"] == 0
     pool.close()
-    assert first.is_closed is True
 
 
-def test_lru_eviction_retires_instead_of_closing():
+def test_lru_eviction_closes_zero_reference_client_promptly():
     transport = _FlakyTransport(fail_times=0)
-    pool = _pool_with_transport(
-        transport, session_client_max=1, retire_close_grace_seconds=3600.0
-    )
+    pool = _pool_with_transport(transport, session_client_max=1, retire_close_grace_seconds=3600.0)
     first = pool._get_session_client(NETLOC, "sess-a")
     pool._get_session_client(NETLOC, "sess-b")  # cap 1 → LRU-evicts sess-a
 
     assert (NETLOC, "sess-a") not in pool._session_clients
-    assert first.is_closed is False
+    _wait_closed(pool, first)
+    assert pool.metrics()["retired_pending_close"] == 0
     pool.close()
-    assert first.is_closed is True
+
+
+def test_blocking_idle_close_never_blocks_replacement_checkout():
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _BlockingCloseClient:
+        is_closed = False
+
+        def close(self):
+            entered.set()
+            release.wait(timeout=5.0)
+            self.is_closed = True
+
+    blocking = _BlockingCloseClient()
+    replacement = httpx.Client(transport=_FlakyTransport(fail_times=0))
+    clients = iter([blocking, replacement])
+    pool = ConnectionPool(
+        PoolConfig(http2=False, session_client_max=1, session_client_idle_seconds=0.0)
+    )
+    pool._make_client = lambda: next(clients)  # type: ignore[method-assign]
+
+    pool._get_session_client(NETLOC, "old")
+    started = time.monotonic()
+    got = pool._get_session_client(NETLOC, "new")
+    elapsed = time.monotonic() - started
+
+    try:
+        assert got is replacement
+        assert entered.wait(timeout=1.0)
+        assert elapsed < 0.1
+        assert pool.metrics()["cleanup_in_progress"] == 1
+    finally:
+        release.set()
+        _wait_pending(pool)
+        pool.close()
+
+
+def test_fixed_cleanup_workers_and_hard_slots_bound_blocked_close_churn():
+    release = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    class _BlockingCloseClient:
+        is_closed = False
+
+        def close(self):
+            nonlocal entered
+            with entered_lock:
+                entered += 1
+            release.wait(timeout=5.0)
+            self.is_closed = True
+
+    pool = ConnectionPool(
+        PoolConfig(http2=False, session_client_max=2, session_client_idle_seconds=0.0)
+    )
+    pool._make_client = _BlockingCloseClient  # type: ignore[method-assign]
+
+    # Eight hard slots: one current client plus seven cleanup-owned clients.
+    for index in range(8):
+        pool._get_session_client(NETLOC, f"session-{index}")
+    with pytest.raises(httpx.PoolTimeout):
+        pool._get_session_client(NETLOC, "capacity-rejected")
+
+    metrics = pool.metrics()
+    assert metrics["client_slots_used"] == metrics["client_slots_max"] == 8
+    assert metrics["retired_pending_close"] == 8
+    assert metrics["cleanup_workers_alive"] == 4
+    assert metrics["cleanup_in_progress"] <= 4
+    assert metrics["client_capacity_rejections_total"] == 1
+    assert metrics["cleanup_saturated"] is True
+
+    release.set()
+    _wait_pending(pool, timeout=2.0)
+    replacement = pool._get_session_client(NETLOC, "capacity-restored")
+    assert replacement is not None
+    pool.close()
+
+
+def test_cleanup_failure_remains_visible_and_retries_to_success():
+    class _FailOnceCloseClient:
+        is_closed = False
+        attempts = 0
+
+        def close(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient close failure")
+            self.is_closed = True
+
+    failing = _FailOnceCloseClient()
+    replacement = httpx.Client(transport=_FlakyTransport(fail_times=0))
+    clients = iter([failing, replacement])
+    pool = ConnectionPool(
+        PoolConfig(http2=False, session_client_max=1, session_client_idle_seconds=0.0)
+    )
+    pool._make_client = lambda: next(clients)  # type: ignore[method-assign]
+
+    pool._get_session_client(NETLOC, "old")
+    pool._get_session_client(NETLOC, "new")
+    _wait_closed(pool, failing)
+    _wait_pending(pool)
+
+    metrics = pool.metrics()
+    assert failing.attempts == 2
+    assert metrics["cleanup_failures_total"] == 1
+    assert metrics["client_slots_used"] == 1
+    pool.close()
+
+
+def test_duplicate_cleanup_submission_closes_exactly_once():
+    class _CountingCloseClient:
+        is_closed = False
+        closes = 0
+
+        def close(self):
+            self.closes += 1
+            self.is_closed = True
+
+    client = _CountingCloseClient()
+    pool = ConnectionPool(PoolConfig(http2=False))
+    assert pool._schedule_close(client) is True
+    assert pool._schedule_close(client) is True
+    _wait_pending(pool)
+    assert client.closes == 1
+    pool.close()
+
+
+def test_health_metrics_recovers_pending_close_after_worker_start_failure(monkeypatch):
+    real_start = threading.Thread.start
+    failed_once = False
+
+    def _fail_first_cleanup_start(thread):
+        nonlocal failed_once
+        if thread.name.startswith("tokenpak-connection-close-") and not failed_once:
+            failed_once = True
+            raise RuntimeError("transient thread capacity exhaustion")
+        return real_start(thread)
+
+    pool = _pool_with_transport(
+        _FlakyTransport(fail_times=1),
+        close_timeout_seconds=0.5,
+    )
+    client = pool._get_client(NETLOC)
+    monkeypatch.setattr(threading.Thread, "start", _fail_first_cleanup_start)
+
+    with pytest.raises(httpx.ReadError):
+        pool.request("POST", URL, content=b"{}")
+
+    # Inspect directly while starts are still failing: metrics() is itself a
+    # normal-operation recovery kick and must be called only after capacity is
+    # restored.
+    with pool._close_cv:
+        assert len(pool._close_pending) == 1
+        assert pool._close_backlog
+        assert not pool._close_workers
+
+    monkeypatch.setattr(threading.Thread, "start", real_start)
+    metrics = pool.metrics()
+    assert metrics["cleanup_worker_start_failures_total"] == 1
+    _wait_closed(pool, client)
+    _wait_pending(pool)
+    pool.close()
+
+
+def test_dead_cleanup_worker_records_are_replaced():
+    class _CountingCloseClient:
+        is_closed = False
+        closes = 0
+
+        def close(self):
+            self.closes += 1
+            self.is_closed = True
+
+    dead = threading.Thread(target=lambda: None)
+    dead.start()
+    dead.join(timeout=1.0)
+    assert dead.is_alive() is False
+
+    pool = ConnectionPool(PoolConfig(http2=False))
+    with pool._close_cv:
+        pool._close_workers = [dead] * 4
+
+    client = _CountingCloseClient()
+    pool._schedule_close(client)
+    _wait_pending(pool)
+    assert client.closes == 1
+    assert client.is_closed is True
+    pool.close()
+
+
+def test_final_release_cannot_stop_workers_before_close_handoff_completes():
+    pool = _pool_with_transport(
+        _FlakyTransport(fail_times=0),
+        close_timeout_seconds=1.0,
+    )
+    client = pool._get_session_client(NETLOC, "leased", checkout=True)
+
+    # Start idle cleanup workers so the regression covers the exact failure:
+    # a final release used to tell these workers to exit before close() could
+    # detach and enqueue the still-cached client.
+    with pool._close_cv:
+        pool._ensure_cleanup_workers_locked()
+        assert len(pool._close_workers) == 4
+
+    close_done = threading.Event()
+    close_errors = []
+
+    def _close_pool():
+        try:
+            pool.close()
+        except BaseException as exc:  # pragma: no cover - assertion aid
+            close_errors.append(exc)
+        finally:
+            close_done.set()
+
+    pool._lock.acquire()
+    closer = threading.Thread(target=_close_pool)
+    closer.start()
+    try:
+        deadline = time.monotonic() + 1.0
+        while not pool._closed and time.monotonic() < deadline:
+            time.sleep(0.001)
+        assert pool._closed is True
+
+        pool._release_session_client(NETLOC, "leased", client)
+        with pool._close_cv:
+            assert pool._cleanup_handoff_complete is False
+            assert pool._cleanup_shutdown is False
+    finally:
+        pool._lock.release()
+
+    assert close_done.wait(timeout=2.0)
+    closer.join(timeout=1.0)
+    assert close_errors == []
+    _wait_closed(pool, client)
+    _wait_pending(pool)
+    metrics = pool.metrics()
+    assert metrics["client_slots_used"] == 0
+
+
+def test_close_returns_within_configured_bound_when_client_close_hangs():
+    """Regression: pool shutdown must not inherit a stuck transport close."""
+    entered = threading.Event()
+    release = threading.Event()
+    blocking_done = threading.Event()
+    blocking_close_was_daemon = []
+
+    class _BlockingCloseClient:
+        def close(self):
+            blocking_close_was_daemon.append(threading.current_thread().daemon)
+            entered.set()
+            release.wait(timeout=5.0)
+            blocking_done.set()
+
+    class _FastCloseClient:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    pool = ConnectionPool(PoolConfig(http2=False, close_timeout_seconds=0.05))
+    pool._clients[NETLOC] = _BlockingCloseClient()  # type: ignore[assignment]
+    fast = _FastCloseClient()
+    pool._clients["other.test"] = fast  # type: ignore[assignment]
+    session_lock_acquired = []
+
+    class _SessionLockProbeClient:
+        def close(self):
+            acquired = pool._session_lock.acquire(timeout=0.1)
+            session_lock_acquired.append(acquired)
+            if acquired:
+                pool._session_lock.release()
+
+    probe = _SessionLockProbeClient()
+    pool._session_clients[(NETLOC, "probe")] = (probe, time.monotonic())  # type: ignore[assignment]
+
+    try:
+        started = time.monotonic()
+        pool.close()
+        elapsed = time.monotonic() - started
+
+        assert entered.is_set()
+        assert elapsed < 0.5
+        assert fast.closed is True, "one stuck client must not starve other closes"
+        assert blocking_close_was_daemon == [True]
+        assert session_lock_acquired == [True]
+        assert pool._clients == {}
+        assert pool._lock.acquire(timeout=0.1)
+        pool._lock.release()
+        assert pool._session_lock.acquire(timeout=0.1)
+        pool._session_lock.release()
+        assert pool._retired_lock.acquire(timeout=0.1)
+        pool._retired_lock.release()
+    finally:
+        release.set()
+        assert blocking_done.wait(timeout=1.0)
 
 
 def test_request_completion_restamps_session_last_used():
@@ -325,12 +700,14 @@ def test_request_completion_restamps_session_last_used():
 # Config / metrics surface
 # ---------------------------------------------------------------------------
 
+
 def test_from_env_parses_new_vars():
     env = {
         "TOKENPAK_POOL_CONNECT_TIMEOUT": "5",
         "TOKENPAK_POOL_READ_TIMEOUT": "120",
         "TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR": "0",
         "TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS": "60",
+        "TOKENPAK_POOL_CLOSE_TIMEOUT_SECS": "1.5",
     }
     with patch.dict(os.environ, env):
         cfg = PoolConfig.from_env()
@@ -338,6 +715,7 @@ def test_from_env_parses_new_vars():
     assert cfg.read_timeout == 120.0
     assert cfg.evict_on_transport_error is False
     assert cfg.retire_close_grace_seconds == 60.0
+    assert cfg.close_timeout_seconds == 1.5
 
 
 def test_from_env_defaults_for_new_vars():
@@ -348,6 +726,7 @@ def test_from_env_defaults_for_new_vars():
             "TOKENPAK_POOL_READ_TIMEOUT",
             "TOKENPAK_POOL_EVICT_ON_TRANSPORT_ERROR",
             "TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS",
+            "TOKENPAK_POOL_CLOSE_TIMEOUT_SECS",
         )
     }
     try:
@@ -356,6 +735,7 @@ def test_from_env_defaults_for_new_vars():
         assert cfg.read_timeout == 300.0
         assert cfg.evict_on_transport_error is True
         assert cfg.retire_close_grace_seconds == 900.0
+        assert cfg.close_timeout_seconds == 1.0
     finally:
         for k, v in saved.items():
             if v is not None:

--- a/tokenpak/_cli_core.py
+++ b/tokenpak/_cli_core.py
@@ -2534,7 +2534,7 @@ def _build_codex_parser(sub):
             "  tokenpak codex\n"
             "  tokenpak codex --install-only    # set up without launching Codex\n"
             "  tokenpak codex doctor            # verify installation\n"
-            "  tokenpak codex uninstall         # reverse installation\n"
+            "  tokenpak codex uninstall         # clean selected home; preserve shared skills in use\n"
             "  tokenpak codex --budget 5.00\n"
             '  tokenpak codex "Fix the login bug"\n'
             "  tokenpak codex --model o3 -s workspace-write"

--- a/tokenpak/cli/commands/uninstall.py
+++ b/tokenpak/cli/commands/uninstall.py
@@ -197,11 +197,11 @@ def _teardown_codex() -> "tuple[str, str]":
     idempotent. It prints its own report; we capture the return code.
     """
     try:
-        from ...companion.codex.uninstall import run as codex_run
+        from ...companion.codex.uninstall import _run_global as codex_uninstall
     except Exception as exc:
         return _OUTCOME_NOOP, f"codex companion not present ({exc.__class__.__name__})"
     try:
-        rc = codex_run()
+        rc = codex_uninstall()
     except Exception as exc:
         return _OUTCOME_FAIL, f"codex teardown error: {exc}"
     if rc == 0:

--- a/tokenpak/companion/codex/agents_md.py
+++ b/tokenpak/companion/codex/agents_md.py
@@ -2,7 +2,7 @@
 """Generate and install AGENTS.md for durable TokenPak behavior in Codex.
 
 AGENTS.md is Codex's mechanism for persistent behavioral guidance.  It's
-loaded before each session and merged from global (~/.codex/AGENTS.md) to
+loaded before each session and merged from global ($CODEX_HOME/AGENTS.md) to
 project (<repo>/AGENTS.md) scope.
 
 The companion installs a global AGENTS.md with rules for:
@@ -14,6 +14,7 @@ The companion installs a global AGENTS.md with rules for:
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 _AGENTS_CONTENT = """\
@@ -80,12 +81,26 @@ def generate_agents_md() -> str:
     return _AGENTS_CONTENT
 
 
+def _selected_codex_home(codex_home: Path | None = None) -> Path:
+    """Resolve the active Codex home at call time."""
+    if codex_home is not None:
+        return Path(codex_home).expanduser()
+    configured = os.environ.get("CODEX_HOME")
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
 def install_agents_md(target: str = "global") -> Path:
+    """Write AGENTS.md using the active public Codex configuration."""
+    return _install_agents_md(target)
+
+
+def _install_agents_md(target: str = "global", *, codex_home: Path | None = None) -> Path:
     """Write AGENTS.md to the appropriate Codex config directory.
 
     Args:
-        target: "global" for ~/.codex/AGENTS.md, or a repo path for
+        target: "global" for $CODEX_HOME/AGENTS.md, or a repo path for
                 <repo>/AGENTS.md.
+        codex_home: Internal explicit selected Codex home for a global install.
 
     Returns:
         Path to the written AGENTS.md file.
@@ -95,7 +110,7 @@ def install_agents_md(target: str = "global") -> Path:
     any other content.
     """
     if target == "global":
-        agents_path = Path.home() / ".codex" / "AGENTS.md"
+        agents_path = _selected_codex_home(codex_home) / "AGENTS.md"
     else:
         agents_path = Path(target) / "AGENTS.md"
 

--- a/tokenpak/companion/codex/doctor.py
+++ b/tokenpak/companion/codex/doctor.py
@@ -13,18 +13,28 @@ so adding a check is "define function, append to CHECKS list".
 
 from __future__ import annotations
 
+import contextvars
 import json
+import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING as _TYPE_CHECKING
 from typing import Callable
 
 from ..config import CompanionConfig
 from .mcp_config import SERVER_NAME
 from .rates_snapshot import DEFAULT_SNAPSHOT_PATH
 from .rates_snapshot import count as rates_count
-from .skills_installer import bundled_skill_names
+from .skills_installer import (
+    _configured_skill_paths,
+    _default_skills_root,
+    bundled_skill_names,
+)
+
+if _TYPE_CHECKING:
+    from .session_home import SessionPaths
 
 CheckFn = Callable[[], "tuple[bool | str, str]"]
 
@@ -32,6 +42,32 @@ CheckFn = Callable[[], "tuple[bool | str, str]"]
 # WARN row.  Underscore-private so it stays out of the released public-API
 # snapshot; ``run`` normalizes it to the "WARN" status.
 _WARN = "WARN"
+
+_ACTIVE_CODEX_HOME: contextvars.ContextVar[Path | None] = contextvars.ContextVar(
+    "tokenpak_codex_doctor_home", default=None
+)
+_ACTIVE_SESSION_MODE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "tokenpak_codex_doctor_mode", default="shared"
+)
+_ACTIVE_RETENTION_REPORT: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "tokenpak_codex_doctor_retention", default=None
+)
+
+
+def _selected_codex_home(explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    active = _ACTIVE_CODEX_HOME.get()
+    if active is not None:
+        return active
+    configured = os.environ.get("CODEX_HOME")
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
+def _codex_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(_selected_codex_home())
+    return env
 
 
 def _status_of(raw: "bool | str") -> str:
@@ -48,14 +84,13 @@ def _status_of(raw: "bool | str") -> str:
 
 # ── Individual checks ────────────────────────────────────────────────
 
+
 def check_codex_binary() -> "tuple[bool, str]":
     path = shutil.which("codex")
     if not path:
         return False, "codex not on PATH"
     try:
-        result = subprocess.run(
-            ["codex", "--version"], capture_output=True, text=True, timeout=5
-        )
+        result = subprocess.run(["codex", "--version"], capture_output=True, text=True, timeout=5)
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return False, f"codex --version failed: {exc}"
     return result.returncode == 0, result.stdout.strip() or result.stderr.strip()
@@ -64,7 +99,11 @@ def check_codex_binary() -> "tuple[bool, str]":
 def check_hooks_feature() -> "tuple[bool, str]":
     try:
         result = subprocess.run(
-            ["codex", "features", "list"], capture_output=True, text=True, timeout=10
+            ["codex", "features", "list"],
+            capture_output=True,
+            env=_codex_env(),
+            text=True,
+            timeout=10,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return False, f"codex features list failed: {exc}"
@@ -82,6 +121,7 @@ def check_mcp_registered() -> "tuple[bool, str]":
         result = subprocess.run(
             ["codex", "mcp", "get", SERVER_NAME],
             capture_output=True,
+            env=_codex_env(),
             text=True,
             timeout=10,
         )
@@ -93,7 +133,7 @@ def check_mcp_registered() -> "tuple[bool, str]":
 
 
 def check_hooks_json() -> "tuple[bool, str]":
-    path = Path.home() / ".codex" / "hooks.json"
+    path = _selected_codex_home() / "hooks.json"
     if not path.exists():
         return False, f"{path} missing"
     try:
@@ -125,7 +165,7 @@ def check_hooks_json() -> "tuple[bool, str]":
 
 
 def check_agents_md() -> "tuple[bool, str]":
-    path = Path.home() / ".codex" / "AGENTS.md"
+    path = _selected_codex_home() / "AGENTS.md"
     if not path.exists():
         return False, f"{path} missing"
     content = path.read_text()
@@ -137,7 +177,7 @@ def check_agents_md() -> "tuple[bool, str]":
 def check_skills_installed() -> "tuple[bool, str]":
     # Canonical user-scope skill-discovery path Codex actually scans:
     # ``$HOME/.agents/skills`` — not the pre-L3 ``~/.codex/skills`` location.
-    target = Path.home() / ".agents" / "skills"
+    target = _default_skills_root()
     if not target.exists():
         return False, f"{target} missing"
     bundled = bundled_skill_names()
@@ -145,6 +185,28 @@ def check_skills_installed() -> "tuple[bool, str]":
     if missing:
         return False, f"missing skills at {target}: {missing}"
     return True, f"{len(bundled)} skills present at {target}"
+
+
+def _check_skills_config() -> "tuple[bool, str]":
+    """Verify the selected home explicitly references every bundled skill."""
+    if _ACTIVE_SESSION_MODE.get() == "shared":
+        return True, "shared mode uses Codex's canonical user skill discovery root"
+    config_path = _selected_codex_home() / "config.toml"
+    if not config_path.exists():
+        return False, f"{config_path} missing"
+    expected = {
+        _default_skills_root() / name
+        for name in bundled_skill_names()
+        if (_default_skills_root() / name / "SKILL.md").is_file()
+    }
+    try:
+        configured = set(_configured_skill_paths(config_path))
+    except (OSError, ValueError) as exc:
+        return False, f"{config_path} skill config invalid: {exc}"
+    missing = sorted(str(path) for path in expected - configured)
+    if missing:
+        return False, f"selected config missing skill paths: {missing}"
+    return True, f"{len(expected)} skill paths referenced by {config_path}"
 
 
 def _check_skills_legacy_orphans() -> "tuple[bool | str, str]":
@@ -165,6 +227,49 @@ def _check_skills_legacy_orphans() -> "tuple[bool | str, str]":
         f"legacy skills at ~/.codex/skills: {orphans} — remove them or run "
         "`tokenpak codex --install-only` then delete the old copies"
     )
+
+
+def _retention_report():
+    from .session_home import inspect_isolated_homes
+
+    cached = _ACTIVE_RETENTION_REPORT.get()
+    if cached is None:
+        cached = inspect_isolated_homes()
+        _ACTIVE_RETENTION_REPORT.set(cached)
+    return cached
+
+
+def _check_orphaned_codex_homes() -> "tuple[bool | str, str]":
+    report = _retention_report()
+    detail = (
+        f"total={len(report.homes)}, active={len(report.active)}, "
+        f"orphaned={len(report.orphaned)}, protected={len(report.unsafe)}, "
+        f"quarantined={len(report.quarantines)}, "
+        f"inventory={'complete' if report.inventory_complete else 'incomplete'} at {report.root}"
+    )
+    if report.orphaned or report.unsafe or report.quarantines or not report.inventory_complete:
+        return _WARN, detail
+    return True, detail
+
+
+def _check_codex_home_disk_usage() -> "tuple[bool | str, str]":
+    from .session_home import (
+        RETENTION_MAX_AGE_S,
+        RETENTION_MAX_HOMES,
+        RETENTION_MAX_TOTAL_BYTES,
+    )
+
+    report = _retention_report()
+    used_mb = report.total_bytes / (1024 * 1024)
+    cap_mb = RETENTION_MAX_TOTAL_BYTES / (1024 * 1024)
+    detail = (
+        f"{used_mb:.1f}/{cap_mb:.0f} MB, {len(report.homes)}/{RETENTION_MAX_HOMES} homes, "
+        f"age cap={RETENTION_MAX_AGE_S // 86400} days, "
+        f"inventory={'complete' if report.inventory_complete else 'incomplete'}"
+    )
+    if report.over_size or report.over_count or report.over_age or not report.inventory_complete:
+        return _WARN, detail
+    return True, detail
 
 
 def check_databases() -> "tuple[bool, str]":
@@ -257,7 +362,10 @@ CHECKS: list["tuple[str, CheckFn]"] = [
     ("hooks.json schema", check_hooks_json),
     ("AGENTS.md", check_agents_md),
     ("skills installed", check_skills_installed),
+    ("skills selected config", _check_skills_config),
     ("skills legacy orphans", _check_skills_legacy_orphans),
+    ("orphaned codex homes", _check_orphaned_codex_homes),
+    ("codex home disk usage", _check_codex_home_disk_usage),
     ("storage dbs", check_databases),
     ("rates snapshot", check_rates_snapshot),
     ("MCP import", check_mcp_import),
@@ -265,21 +373,57 @@ CHECKS: list["tuple[str, CheckFn]"] = [
 ]
 
 
-def run(refresh_rates: bool = False) -> int:
-    """Run all checks, print a report, return an exit code."""
+def _run_selected(
+    refresh_rates: bool = False,
+    *,
+    paths: "SessionPaths | None" = None,
+    codex_home: Path | None = None,
+    session_mode: str | None = None,
+    workspace_dir: Path | None = None,
+) -> int:
+    """Internal selected-home doctor runner."""
+    if paths is None:
+        from .session_home import InvalidSessionMode, current_paths, select_paths
+
+        try:
+            if codex_home is not None:
+                paths = select_paths(
+                    session_mode,
+                    workspace_dir=workspace_dir,
+                    selected_home=codex_home,
+                )
+            else:
+                paths = current_paths(session_mode, workspace_dir=workspace_dir)
+        except (InvalidSessionMode, ValueError) as exc:
+            print(f"tokenpak codex doctor: {exc}", file=sys.stderr)
+            return 2
+
     if refresh_rates:
         from .rates_snapshot import refresh
 
         path = refresh()
         print(f"refreshed rates snapshot: {path}")
 
+    print("selected Codex paths:")
+    for label, value in paths.report_rows():
+        print(f"  {label}: {value}")
+    print()
+
     results: list["tuple[str, str, str]"] = []
-    for name, fn in CHECKS:
-        try:
-            raw, detail = fn()
-        except Exception as exc:
-            raw, detail = False, f"check raised: {exc.__class__.__name__}: {exc}"
-        results.append((name, _status_of(raw), detail))
+    active = _ACTIVE_CODEX_HOME.set(paths.home)
+    active_mode = _ACTIVE_SESSION_MODE.set(paths.mode)
+    retention = _ACTIVE_RETENTION_REPORT.set(None)
+    try:
+        for name, fn in CHECKS:
+            try:
+                raw, detail = fn()
+            except Exception as exc:
+                raw, detail = False, f"check raised: {exc.__class__.__name__}: {exc}"
+            results.append((name, _status_of(raw), detail))
+    finally:
+        _ACTIVE_SESSION_MODE.reset(active_mode)
+        _ACTIVE_CODEX_HOME.reset(active)
+        _ACTIVE_RETENTION_REPORT.reset(retention)
 
     name_width = max(len(n) for n, _, _ in results)
     any_fail = False
@@ -300,6 +444,11 @@ def run(refresh_rates: bool = False) -> int:
     print()
     print(", ".join(parts))
     return 1 if any_fail else 0
+
+
+def run(refresh_rates: bool = False) -> int:
+    """Run all checks, print a report, return an exit code."""
+    return _run_selected(refresh_rates)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tokenpak/companion/codex/hooks.py
+++ b/tokenpak/companion/codex/hooks.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Generate and install Codex hooks.json for the tokenpak companion.
 
-Codex hooks are configured via ``~/.codex/hooks.json`` (global) or
+Codex hooks are configured via ``$CODEX_HOME/hooks.json`` (global) or
 ``<repo>/.codex/hooks.json`` (project-level).  The companion installs
 five hooks (5 of 6 Codex stable lifecycle events; PermissionRequest is
 deferred to L5 — see L1 audit delta hooks #10):
@@ -25,6 +25,7 @@ inside a function body.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -114,12 +115,32 @@ def generate_hooks_json() -> dict:
     return {"hooks": {event: [group] for event, group in _TOKENPAK_HOOK_EVENTS.items()}}
 
 
+def _selected_codex_home(codex_home: Path | None = None) -> Path:
+    """Resolve the active Codex home at call time."""
+    if codex_home is not None:
+        return Path(codex_home).expanduser()
+    configured = os.environ.get("CODEX_HOME")
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
+def _codex_env(codex_home: Path | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(_selected_codex_home(codex_home))
+    return env
+
+
 def install_hooks(target: str = "global") -> Path:
+    """Write hooks.json using the active public Codex configuration."""
+    return _install_hooks(target)
+
+
+def _install_hooks(target: str = "global", *, codex_home: Path | None = None) -> Path:
     """Write hooks.json to the appropriate Codex config directory.
 
     Args:
-        target: ``"global"`` for ``~/.codex/hooks.json``, or a repo path
+        target: ``"global"`` for ``$CODEX_HOME/hooks.json``, or a repo path
                 for ``<repo>/.codex/hooks.json``.
+        codex_home: Internal explicit selected Codex home for a global install.
 
     Returns:
         Path to the written hooks.json file.
@@ -128,7 +149,7 @@ def install_hooks(target: str = "global") -> Path:
     replaced idempotently.
     """
     if target == "global":
-        hooks_dir = Path.home() / ".codex"
+        hooks_dir = _selected_codex_home(codex_home)
     else:
         hooks_dir = Path(target) / ".codex"
 
@@ -197,6 +218,11 @@ def _merge_hooks(existing: dict, new: dict) -> dict:
 
 
 def ensure_hooks_feature_enabled() -> bool:
+    """Enable hooks using the active public Codex configuration."""
+    return _ensure_hooks_feature_enabled()
+
+
+def _ensure_hooks_feature_enabled(codex_home: Path | None = None) -> bool:
     """Enable the ``hooks`` feature via ``codex features enable``.
 
     Uses the Codex-native command rather than hand-writing config.toml,
@@ -210,6 +236,7 @@ def ensure_hooks_feature_enabled() -> bool:
         result = subprocess.run(
             ["codex", "features", "enable", "hooks"],
             capture_output=True,
+            env=_codex_env(codex_home),
             text=True,
             timeout=10,
         )
@@ -223,17 +250,20 @@ def ensure_hooks_feature_enabled() -> bool:
         )
         return False
 
-    _suppress_unstable_warning()
+    if codex_home is None:
+        _suppress_unstable_warning()
+    else:
+        _suppress_unstable_warning(codex_home)
     return True
 
 
-def _suppress_unstable_warning() -> None:
-    """Add ``suppress_unstable_features_warning = true`` to ~/.codex/config.toml.
+def _suppress_unstable_warning(codex_home: Path | None = None) -> None:
+    """Add the warning suppression to the selected ``config.toml``.
 
     Best-effort: if the file can't be read/written we stay silent rather
     than fail the install. The warning is cosmetic.
     """
-    config_path = Path.home() / ".codex" / "config.toml"
+    config_path = _selected_codex_home(codex_home) / "config.toml"
     try:
         content = config_path.read_text() if config_path.exists() else ""
     except OSError:

--- a/tokenpak/companion/codex/launcher.py
+++ b/tokenpak/companion/codex/launcher.py
@@ -1,15 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Launcher for ``tokenpak codex`` — thin bootstrap for Codex with companion.
 
-Does setup (rate snapshot, MCP registration, hooks install, AGENTS.md,
-skills) and either exec-replaces into ``codex`` (default) or exits
-after install (``--install-only``).
+Selects and safely provisions a Codex home, installs the companion into that
+home, then supervises the Codex child so the validated ``codex.pid`` lifecycle
+sentinel can always be removed after a normal exit. ``--install-only`` performs
+the same selected-home safety preflight and setup without spawning Codex.
 
-Before exec-ing a real launch it preflights Codex's own local SQLite
-databases (``state_5.sqlite`` / ``logs_2.sqlite``) so a shared ``~/.codex``
-that is locked by another (or a suspended) Codex process surfaces an
-actionable wait/retry instead of Codex dying on a raw "database is
-locked" error. ``--install-only`` skips the preflight — it never exec-s.
+Before any selected-home mutation it inspects Codex's local SQLite files using
+read-only kernel metadata. A home attached to another live or suspended Codex
+process surfaces an actionable wait/retry instead of a raw lock failure.
 
 Companion features work without the launcher if the user manually
 configures MCP, hooks, and AGENTS.md — the launcher is convenience.
@@ -18,10 +17,18 @@ configures MCP, hooks, and AGENTS.md — the launcher is convenience.
 from __future__ import annotations
 
 import contextlib
+import errno
+import json
 import os
+import queue
+import signal
 import subprocess
 import sys
+import threading
 import time
+from pathlib import Path
+from typing import TYPE_CHECKING as _TYPE_CHECKING
+from typing import Callable as _Callable
 
 from ..config import CompanionConfig
 from .accounting import (
@@ -33,6 +40,9 @@ from .accounting import (
     write_receipt,
 )
 
+if _TYPE_CHECKING:
+    from .session_home import SessionPaths
+
 _TEAL = "\033[38;2;0;180;170m"
 _DIM = "\033[2m"
 _RESET = "\033[0m"
@@ -42,6 +52,7 @@ _TOKENPAK_CHATGPT_BASE_URL = "http://127.0.0.1:8766/v1"
 _BYPASS_FLAG = "--dangerously-bypass-approvals-and-sandbox"
 _BYPASS_ENV_VAR = "TOKENPAK_CODEX_BYPASS_APPROVALS_AND_SANDBOX"
 _TRUTHY = {"1", "true", "yes"}
+_STORAGE_PRESSURE_ERRNOS = {errno.ENOSPC, getattr(errno, "EDQUOT", errno.ENOSPC)}
 
 
 def _bypass_env_enabled(env: dict[str, str] | None = None) -> bool:
@@ -166,6 +177,7 @@ def _drain_esc_pressed() -> bool:
 
 def _preflight_state_lock(
     *,
+    home: Path | str | None = None,
     prober=None,
     interactive: bool | None = None,
     timeout_s: float = _LOCK_WAIT_TIMEOUT_S,
@@ -173,6 +185,7 @@ def _preflight_state_lock(
     esc_pressed=None,
     sleep=None,
     monotonic=None,
+    deadline: float | None = None,
 ) -> "int | None":
     """Preflight Codex-owned SQLite databases before exec.
 
@@ -195,16 +208,78 @@ def _preflight_state_lock(
     """
     from . import state_lock
 
-    prober = prober or state_lock.probe
     esc_pressed = esc_pressed or _drain_esc_pressed
     sleep = sleep or time.sleep
     monotonic = monotonic or time.monotonic
+    deadline = deadline if deadline is not None else monotonic() + timeout_s
     if interactive is None:
         interactive = _stdin_is_tty()
 
-    status = prober()
+    def invoke_probe():
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return state_lock.LockStatus(
+                home=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex"),
+                db_path=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+                / state_lock.STATE_DB_NAME,
+                exists=True,
+                locked=True,
+                detail="holder inspection wall-time limit is incomplete; refusing unsafe access",
+                diagnostics_complete=False,
+                incomplete_reasons=["probe_timeout"],
+            )
+
+        results: "queue.SimpleQueue[tuple[bool, object]]" = queue.SimpleQueue()
+
+        def run_probe() -> None:
+            try:
+                value = (
+                    state_lock.probe(home, deadline=deadline, clock=monotonic)
+                    if prober is None
+                    else prober()
+                )
+                results.put((True, value))
+            except BaseException as exc:  # fail closed; surfaced below
+                results.put((False, exc))
+
+        worker = threading.Thread(
+            target=run_probe,
+            name="tokenpak-codex-lock-probe",
+            daemon=True,
+        )
+        worker.start()
+        worker.join(timeout=max(0.0, remaining))
+        if worker.is_alive():
+            return state_lock.LockStatus(
+                home=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex"),
+                db_path=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+                / state_lock.STATE_DB_NAME,
+                exists=True,
+                locked=True,
+                detail="holder inspection wall-time limit is incomplete; refusing unsafe access",
+                diagnostics_complete=False,
+                incomplete_reasons=["probe_timeout"],
+            )
+        ok, value = results.get()
+        if ok:
+            return value
+        return state_lock.LockStatus(
+            home=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex"),
+            db_path=Path(home or os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+            / state_lock.STATE_DB_NAME,
+            exists=True,
+            locked=True,
+            detail=(f"holder inspection raised {value.__class__.__name__}; refusing unsafe access"),
+            diagnostics_complete=False,
+            incomplete_reasons=["proc_inspection_incomplete"],
+        )
+
+    status = invoke_probe()
     if not status.locked:
         return None
+    if not getattr(status, "diagnostics_complete", True):
+        print(state_lock.remediation_hint(status), file=sys.stderr)
+        return 1
 
     # A stopped/suspended holder never releases the lock — waiting is
     # futile, so surface direct remediation immediately.
@@ -214,19 +289,17 @@ def _preflight_state_lock(
 
     if interactive:
         print(
-            "tokenpak: SQLite database is busy. Waiting to connect... "
-            "Press Esc to cancel.",
+            "tokenpak: SQLite database is busy. Waiting to connect... Press Esc to cancel.",
             file=sys.stderr,
         )
     else:
         print(
             "tokenpak: Codex local database is busy; waiting up to "
             f"{int(timeout_s)}s for the holder to release "
-            "(set a fresh CODEX_HOME to skip)...",
+            "(use TOKENPAK_CODEX_SESSION_MODE=isolated for a fresh home)...",
             file=sys.stderr,
         )
 
-    deadline = monotonic() + timeout_s
     while monotonic() < deadline:
         if interactive and esc_pressed():
             print(
@@ -235,10 +308,15 @@ def _preflight_state_lock(
             )
             print(state_lock.remediation_hint(status), file=sys.stderr)
             return 130
-        sleep(poll_interval_s)
-        status = prober()
+        sleep(min(poll_interval_s, max(0.0, deadline - monotonic())))
+        if monotonic() >= deadline:
+            break
+        status = invoke_probe()
         if not status.locked:
             return None
+        if not getattr(status, "diagnostics_complete", True):
+            print(state_lock.remediation_hint(status), file=sys.stderr)
+            return 1
         if status.stopped_pids:
             print(state_lock.remediation_hint(status), file=sys.stderr)
             return 1
@@ -257,37 +335,206 @@ def _preflight_state_lock(
 
 
 def _run_codex_process(
-    codex_args: list[str], env: dict[str, str]
+    codex_args: list[str],
+    env: dict[str, str],
+    *,
+    on_start: _Callable[[int], None] | None = None,
 ) -> tuple[int, dict[str, int | None]]:
-    """Run Codex for explicit receipt mode, teeing JSONL while extracting usage."""
-    usage = empty_usage()
-    if "--json" not in codex_args:
-        completed = subprocess.run(codex_args, env=env)
-        return completed.returncode, usage
+    """Supervise Codex, optionally teeing JSONL and extracting usage.
 
+    The launcher never signals or terminates the child.  Terminal-generated
+    interrupts reach both foreground processes naturally; the parent keeps
+    waiting until Codex exits so lifecycle cleanup cannot race a live child.
+    """
+    usage = empty_usage()
+    json_mode = "--json" in codex_args
     proc = subprocess.Popen(
         codex_args,
         env=env,
-        stdout=subprocess.PIPE,
+        stdout=subprocess.PIPE if json_mode else None,
         stderr=None,
         text=True,
         bufsize=1,
     )
-    assert proc.stdout is not None
-    for line in proc.stdout:
-        sys.stdout.write(line)
-        sys.stdout.flush()
-        usage = merge_usage(usage, usage_from_json_line(line))
-    return proc.wait(), usage
+    # The terminal delivers Ctrl-C to the whole foreground process group.
+    # Codex may consume SIGINT as an operation cancel and continue running;
+    # the supervisory parent therefore ignores SIGINT after the child has
+    # inherited the caller's original disposition, then trusts the child's
+    # eventual exit status.  This also prevents a PIPE-drain interruption
+    # from deadlocking JSON mode.
+    previous_sigint = None
+    return_code: int | None = None
+    start_error: BaseException | None = None
+    try:
+        try:
+            previous_sigint = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (AttributeError, OSError, ValueError):
+            previous_sigint = None
+
+        if on_start is not None:
+            try:
+                on_start(proc.pid)
+            except BaseException as exc:
+                # A very fast command can exit before /proc identity transfer.
+                # In that case the parent-owned lease remains valid until this
+                # function returns, and the real child result wins.
+                poll = getattr(proc, "poll", lambda: None)
+                if poll() is None:
+                    start_error = exc
+                    print(
+                        "tokenpak: PID sentinel transfer failed "
+                        f"({exc}); continuing supervised launch",
+                        file=sys.stderr,
+                    )
+
+        if json_mode:
+            assert proc.stdout is not None
+            forward_output = True
+            while True:
+                try:
+                    line = proc.stdout.readline()
+                except KeyboardInterrupt:
+                    continue
+                except BaseException:
+                    # Closing our read end does not terminate the child.  It
+                    # merely gives a still-writing child normal pipe-closure
+                    # semantics; the finally block below still waits/reaps.
+                    with contextlib.suppress(Exception):
+                        proc.stdout.close()
+                    break
+                if not line:
+                    break
+                if forward_output:
+                    try:
+                        sys.stdout.write(line)
+                        sys.stdout.flush()
+                    except (BrokenPipeError, OSError, UnicodeError, KeyboardInterrupt):
+                        # Continue draining so a downstream `head` cannot
+                        # strand Codex behind a full PIPE while the lifecycle
+                        # lease is released.
+                        forward_output = False
+                try:
+                    usage = merge_usage(usage, usage_from_json_line(line))
+                except (ValueError, TypeError, json.JSONDecodeError):
+                    pass
+
+        while True:
+            try:
+                return_code = proc.wait()
+                break
+            except KeyboardInterrupt:
+                continue
+    finally:
+        # Every path after a successful Popen reaps the child before the
+        # caller's `with lease` can remove codex.pid.
+        if return_code is None:
+            while True:
+                try:
+                    return_code = proc.wait()
+                    break
+                except KeyboardInterrupt:
+                    continue
+        if previous_sigint is not None:
+            with contextlib.suppress(OSError, ValueError):
+                signal.signal(signal.SIGINT, previous_sigint)
+    if start_error is not None:
+        raise start_error
+    assert return_code is not None
+    if return_code < 0:
+        return 128 + abs(return_code), usage
+    return return_code, usage
+
+
+def _print_session_paths(paths: "SessionPaths") -> None:
+    """Print the complete selected-home routing map at startup."""
+    print("tokenpak: Codex session paths", file=sys.stderr)
+    for label, value in paths.report_rows():
+        print(f"  {label}: {value}", file=sys.stderr)
+
+
+def _is_storage_pressure(exc: BaseException) -> bool:
+    """Recognize nested ENOSPC/EDQUOT without retrying unrelated failures."""
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, OSError) and current.errno in _STORAGE_PRESSURE_ERRNOS:
+            return True
+        for linked in (current.__cause__, current.__context__):
+            if isinstance(linked, BaseException):
+                pending.append(linked)
+    return False
+
+
+def _run_isolated_retention(
+    session_home,
+    paths: "SessionPaths",
+    *,
+    phase: str,
+    preserve_home: Path | None,
+    remove_all_orphans: bool = False,
+) -> object | None:
+    """Run the receipt-governed engine without masking launch results."""
+    tokenpak_home = session_home._generated_tokenpak_root(paths.home)
+    try:
+        cleanup = session_home.cleanup_isolated_homes(
+            tokenpak_home,
+            preserve_home=preserve_home,
+            remove_all_orphans=remove_all_orphans,
+            orphan_cleanup_reason="storage-pressure" if remove_all_orphans else phase,
+        )
+    except Exception as exc:
+        print(
+            f"tokenpak: isolated-home retention {phase} preserved all homes ({exc})",
+            file=sys.stderr,
+        )
+        return None
+    if cleanup.removed:
+        print(
+            f"tokenpak: isolated-home retention {phase} removed "
+            f"{len(cleanup.removed)} orphan(s)",
+            file=sys.stderr,
+        )
+    if cleanup.errors:
+        print(
+            f"tokenpak: isolated-home retention {phase} preserved uncertain home(s): "
+            + "; ".join(cleanup.errors),
+            file=sys.stderr,
+        )
+    return cleanup
+
+
+@contextlib.contextmanager
+def _lease_with_post_retention(lease, session_home, paths: "SessionPaths"):
+    """Release the exact lease before the final isolated-home sweep."""
+    try:
+        yield lease
+    finally:
+        try:
+            lease.release()
+        except Exception as exc:
+            # A failed exact-owner unlink leaves the sentinel/artifact in
+            # place, which retention treats as protected.  Do not replace an
+            # already-known child result with a cleanup-only exception.
+            print(
+                f"tokenpak: PID sentinel cleanup preserved for inspection ({exc})",
+                file=sys.stderr,
+            )
+        if paths.mode == session_home.MODE_ISOLATED:
+            _run_isolated_retention(
+                session_home,
+                paths,
+                phase="post-session",
+                preserve_home=None,
+            )
 
 
 def _vanilla_receipt_env() -> dict[str, str]:
     """Return a child environment with TokenPak companion state stripped."""
-    return {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("TOKENPAK_")
-    }
+    return {key: value for key, value in os.environ.items() if not key.startswith("TOKENPAK_")}
 
 
 def _receipt_only_setup_metadata() -> dict[str, object]:
@@ -348,216 +595,79 @@ def main(
     """Entry point for ``tokenpak codex``."""
     args = list(args if args is not None else sys.argv[1:])
 
-    install_only = False
-    receipt_only = False
-    if "--install-only" in args:
-        install_only = True
-        args = [a for a in args if a != "--install-only"]
-    if "--receipt-only" in args:
-        receipt_only = True
-        args = [a for a in args if a != "--receipt-only"]
+    install_only = "--install-only" in args
+    receipt_only = "--receipt-only" in args
+    args = [a for a in args if a not in {"--install-only", "--receipt-only"}]
 
-    if receipt_only:
-        if not (receipt_out and run_id):
-            print(
-                "tokenpak: --receipt-only requires --receipt-out and --run-id",
-                file=sys.stderr,
-            )
-            return 2
-        if install_only:
-            print(
-                "tokenpak: --receipt-only cannot be combined with --install-only",
-                file=sys.stderr,
-            )
-            return 2
-        setup = _receipt_only_setup_metadata()
-        lock_exit = _preflight_state_lock()
-        if lock_exit is not None:
-            started_at = utc_now()
-            start_monotonic = time.monotonic()
-            try:
-                _write_accounting_receipt(
-                    receipt_out=receipt_out,
-                    run_id=run_id,
-                    codex_args=args,
-                    setup=setup,
-                    started_at=started_at,
-                    start_monotonic=start_monotonic,
-                    exit_code=lock_exit,
-                    status="blocked",
-                    missing_evidence=[
-                        "codex_process_not_launched_preflight_block"
-                    ],
-                )
-            except OSError as exc:
-                print(
-                    f"tokenpak: failed to write accounting receipt: {exc}",
-                    file=sys.stderr,
-                )
-                return 1
-            return lock_exit
-
-        env = _vanilla_receipt_env()
-        env["TOKENPAK_CODEX_RECEIPT_OUT"] = receipt_out
-        env["TOKENPAK_CODEX_RUN_ID"] = run_id
-        codex_args = ["codex", *args]
-        started_at = utc_now()
-        start_monotonic = time.monotonic()
-        usage = empty_usage()
-        status = "failed"
-        try:
-            exit_code, usage = _run_codex_process(codex_args, env)
-            status = "completed" if exit_code == 0 else "failed"
-        except KeyboardInterrupt:
-            exit_code = 130
-            status = "interrupted"
-        except OSError as exc:
-            exit_code = 1
-            status = "launch_failed"
-            print(f"tokenpak: failed to launch codex: {exc}", file=sys.stderr)
-        try:
-            _write_accounting_receipt(
-                receipt_out=receipt_out,
-                run_id=run_id,
-                codex_args=args,
-                setup=setup,
-                started_at=started_at,
-                start_monotonic=start_monotonic,
-                exit_code=exit_code,
-                status=status,
-                usage=usage,
-            )
-        except OSError as exc:
-            print(
-                f"tokenpak: failed to write accounting receipt: {exc}",
-                file=sys.stderr,
-            )
-            return 1
-        return exit_code
-
-    config = CompanionConfig.from_env()
-    config.profile_overrides()
-
-    config.journal_dir.mkdir(parents=True, exist_ok=True)
-
-    # ── Step 0: Refresh model-rate snapshot for shell hooks ──
-    from .rates_snapshot import refresh as refresh_rates
-
-    rates_path = refresh_rates()
-    print(f"tokenpak: rates snapshot refreshed ({rates_path})", file=sys.stderr)
-
-    # ── Step 1: Register MCP server ──────────────────────────
-    from .mcp_config import get_env_vars, register
-
-    env_vars = get_env_vars(config)
-    mcp_registered = register(env_vars=env_vars)
-    if mcp_registered:
-        print("tokenpak: MCP server registered", file=sys.stderr)
-    else:
-        print("tokenpak: MCP registration failed (continuing)", file=sys.stderr)
-
-    # ── Step 2: Install hooks ────────────────────────────────
-    hooks_installed = False
-    if config.hooks_enabled:
-        from .hooks import ensure_hooks_feature_enabled, install_hooks
-
-        if ensure_hooks_feature_enabled():
-            hooks_path = install_hooks(target="global")
-            hooks_installed = True
-            print(f"tokenpak: hooks installed ({hooks_path})", file=sys.stderr)
-        else:
-            print(
-                "tokenpak: hooks feature could not be enabled",
-                file=sys.stderr,
-            )
-
-    # ── Step 3: Install AGENTS.md ────────────────────────────
-    from .agents_md import install_agents_md
-
-    agents_path = install_agents_md(target="global")
-    print(f"tokenpak: AGENTS.md installed ({agents_path})", file=sys.stderr)
-
-    # ── Step 4: Install skills ───────────────────────────────
-    from .skills_installer import install_skills
-
-    installed = install_skills()
-    if installed:
-        print(f"tokenpak: {len(installed)} skills installed", file=sys.stderr)
-
-    setup = {
-        "setup_completed": True,
-        "profile": config.profile,
-        "budget_daily_usd": config.budget_daily_usd,
-        "rates_snapshot_refreshed": True,
-        "mcp_registered": bool(mcp_registered),
-        "hooks_enabled": bool(config.hooks_enabled),
-        "hooks_installed": hooks_installed,
-        "agents_md_installed": True,
-        "skills_installed_count": len(installed),
-    }
-
-    # ── Step 5: Banner ───────────────────────────────────────
-    budget_phrase = (
-        f"budget ${config.budget_daily_usd:.2f}/day"
-        if config.budget_daily_usd > 0
-        else "no budget cap"
-    )
-    print(
-        f"tokenpak: companion ready for codex ({config.profile}, {budget_phrase})",
-        file=sys.stderr,
-    )
-
-    if install_only:
-        if receipt_out and run_id:
-            started_at = utc_now()
-            start_monotonic = time.monotonic()
-            try:
-                _write_accounting_receipt(
-                    receipt_out=receipt_out,
-                    run_id=run_id,
-                    codex_args=[],
-                    setup=setup,
-                    started_at=started_at,
-                    start_monotonic=start_monotonic,
-                    exit_code=0,
-                    status="setup_only",
-                    missing_evidence=["codex_process_not_launched_install_only"],
-                )
-            except OSError as exc:
-                print(
-                    f"tokenpak: failed to write accounting receipt: {exc}",
-                    file=sys.stderr,
-                )
-                return 1
+    if receipt_only and not (receipt_out and run_id):
         print(
-            "tokenpak: setup complete — run `tokenpak codex doctor` to verify",
+            "tokenpak: --receipt-only requires --receipt-out and --run-id",
             file=sys.stderr,
         )
-        return 0
+        return 2
+    if receipt_only and install_only:
+        print(
+            "tokenpak: --receipt-only cannot be combined with --install-only",
+            file=sys.stderr,
+        )
+        return 2
 
-    # ── Step 5.5: Preflight Codex local-database lock ────────
-    # Only for real launches (install-only returned above): a shared
-    # ~/.codex whose state/log SQLite is held by another — or a suspended
-    # — Codex process would otherwise fail Codex on a raw "database is
-    # locked" error at startup.
-    lock_exit = _preflight_state_lock()
+    # Resolve and expose every path before any selected-home write.  Unknown
+    # modes fail closed; a typo must never fall back to shared state.
+    from . import session_home
+
+    try:
+        paths = session_home.select_paths(workspace_dir=Path.cwd())
+    except (session_home.InvalidSessionMode, ValueError) as exc:
+        print(f"tokenpak: {exc}", file=sys.stderr)
+        return 2
+    _print_session_paths(paths)
+
+    # This sweep is deliberately before preflight, lease acquisition, and
+    # selected-home creation.  It therefore remains reachable after switching
+    # to shared/workspace mode and can recover receipt-proven quarantines even
+    # when the selected launch later blocks or runs out of storage.
+    _run_isolated_retention(
+        session_home,
+        paths,
+        phase="pre-launch",
+        preserve_home=paths.home,
+    )
+
+    # Kernel-only inspection happens before provisioning, MCP registration,
+    # hooks, AGENTS.md, skills config, or the lifecycle sentinel is written.
+    # Linux can attribute native Codex attachments through procfs before the
+    # TokenPak lifecycle lease exists.  On other platforms, deterministic
+    # workspace homes rely on that exclusive lifecycle lease; shared mode
+    # still fails closed through the diagnostic surface when databases exist.
+    needs_kernel_preflight = paths.mode == session_home.MODE_SHARED or sys.platform.startswith(
+        "linux"
+    )
+    lock_exit = _preflight_state_lock(home=paths.home) if needs_kernel_preflight else None
     if lock_exit is not None:
         if receipt_out and run_id:
-            started_at = utc_now()
-            start_monotonic = time.monotonic()
+            setup = (
+                _receipt_only_setup_metadata()
+                if receipt_only
+                else {
+                    "setup_completed": False,
+                    "session_mode": paths.mode,
+                    "codex_home": str(paths.home),
+                }
+            )
             try:
                 _write_accounting_receipt(
                     receipt_out=receipt_out,
                     run_id=run_id,
                     codex_args=args,
                     setup=setup,
-                    started_at=started_at,
-                    start_monotonic=start_monotonic,
+                    started_at=utc_now(),
+                    start_monotonic=time.monotonic(),
                     exit_code=lock_exit,
                     status="blocked",
                     missing_evidence=["codex_process_not_launched_preflight_block"],
                 )
-            except OSError as exc:
+            except (OSError, RuntimeError) as exc:
                 print(
                     f"tokenpak: failed to write accounting receipt: {exc}",
                     file=sys.stderr,
@@ -565,62 +675,302 @@ def main(
                 return 1
         return lock_exit
 
-    # ── Step 6: Exec into codex ──────────────────────────────
-    if config.budget_daily_usd > 0:
-        os.environ["TOKENPAK_COMPANION_BUDGET"] = str(config.budget_daily_usd)
-
-    env = os.environ.copy()
-    if config.profile != "balanced":
-        env["TOKENPAK_COMPANION_PROFILE"] = config.profile
-    default_journal_dir = str(config.journal_dir.__class__.home() / ".tokenpak" / "companion")
-    if str(config.journal_dir) != default_journal_dir:
-        env["TOKENPAK_COMPANION_JOURNAL_DIR"] = str(config.journal_dir)
-    if receipt_out and run_id:
-        env["TOKENPAK_CODEX_RECEIPT_OUT"] = receipt_out
-        env["TOKENPAK_CODEX_RUN_ID"] = run_id
-
-    fleet = _fleet_state_enabled()
-    forwarded = _maybe_inject_bypass_flag(args, env, fleet=fleet)
-    banner = _fleet_banner(env, fleet=fleet)
-    if banner:
-        print(banner, file=sys.stderr)
-    codex_args = ["codex", *forwarded]
-    if receipt_out and run_id:
-        started_at = utc_now()
-        start_monotonic = time.monotonic()
-        usage = empty_usage()
-        status = "failed"
+    try:
         try:
-            exit_code, usage = _run_codex_process(codex_args, env)
-            status = "completed" if exit_code == 0 else "failed"
-        except KeyboardInterrupt:
-            exit_code = 130
-            status = "interrupted"
-        except OSError as exc:
-            exit_code = 1
-            status = "launch_failed"
-            print(f"tokenpak: failed to launch codex: {exc}", file=sys.stderr)
-        try:
-            _write_accounting_receipt(
-                receipt_out=receipt_out,
-                run_id=run_id,
-                codex_args=forwarded,
-                setup=setup,
-                started_at=started_at,
-                start_monotonic=start_monotonic,
-                exit_code=exit_code,
-                status=status,
-                usage=usage,
+            lease = session_home.SessionLease.acquire(paths)
+        except (OSError, RuntimeError) as exc:
+            if not _is_storage_pressure(exc):
+                raise
+            _run_isolated_retention(
+                session_home,
+                paths,
+                phase="storage-pressure",
+                preserve_home=paths.home,
+                remove_all_orphans=True,
             )
-        except OSError as exc:
+            lease = session_home.SessionLease.acquire(paths)
+    except (OSError, RuntimeError) as exc:
+        print(f"tokenpak: selected-home setup refused: {exc}", file=sys.stderr)
+        return 1
+
+    with _lease_with_post_retention(lease, session_home, paths):
+
+        def reusable_home_is_clear() -> bool:
+            if paths.mode == session_home.MODE_ISOLATED:
+                return True
+            if paths.mode == session_home.MODE_WORKSPACE and not sys.platform.startswith("linux"):
+                return True
+            lease.assert_home_binding()
+            return _preflight_state_lock(home=paths.home) is None
+
+        # Close the preflight-to-lease race for reusable homes.  A native
+        # Codex process does not participate in our sentinel guard, so sample
+        # kernel attachment state once more while this launcher owns the
+        # TokenPak lease and before companion setup starts subprocesses.
+        if not reusable_home_is_clear():
+            return 1
+
+        try:
+            try:
+                lease.assert_home_binding()
+                provisioned = session_home.provision(paths, home_fd=lease.home_fd)
+                lease.assert_home_binding()
+            except (OSError, RuntimeError) as exc:
+                if not _is_storage_pressure(exc):
+                    raise
+                _run_isolated_retention(
+                    session_home,
+                    paths,
+                    phase="storage-pressure",
+                    preserve_home=paths.home,
+                    remove_all_orphans=True,
+                )
+                lease.assert_home_binding()
+                provisioned = session_home.provision(paths, home_fd=lease.home_fd)
+                lease.assert_home_binding()
+        except (OSError, RuntimeError) as exc:
+            print(f"tokenpak: selected-home provisioning refused: {exc}", file=sys.stderr)
+            return 1
+
+        if provisioned.seeded:
             print(
-                f"tokenpak: failed to write accounting receipt: {exc}",
+                f"tokenpak: safe config seeded ({', '.join(provisioned.seeded)})",
                 file=sys.stderr,
             )
+        if provisioned.linked_credentials:
+            print(
+                "tokenpak: credential link installed "
+                f"({', '.join(provisioned.linked_credentials)})",
+                file=sys.stderr,
+            )
+
+        if paths.mode == session_home.MODE_ISOLATED:
+            _run_isolated_retention(
+                session_home,
+                paths,
+                phase="post-provision",
+                preserve_home=paths.home,
+            )
+
+        if receipt_only:
+            assert receipt_out is not None and run_id is not None
+            setup = _receipt_only_setup_metadata()
+            setup.update({"session_mode": paths.mode, "codex_home": str(paths.home)})
+            env = paths.environment(_vanilla_receipt_env())
+            env["TOKENPAK_CODEX_RECEIPT_OUT"] = receipt_out
+            env["TOKENPAK_CODEX_RUN_ID"] = run_id
+            codex_args = ["codex", *args]
+            started_at = utc_now()
+            start_monotonic = time.monotonic()
+            try:
+                lease.assert_home_binding()
+                if not reusable_home_is_clear():
+                    return 1
+                lease.begin_transfer()
+                exit_code, usage = _run_codex_process(codex_args, env, on_start=lease.transfer_to)
+                status = (
+                    "completed"
+                    if exit_code == 0
+                    else "interrupted"
+                    if exit_code == 130
+                    else "failed"
+                )
+            except (OSError, RuntimeError) as exc:
+                exit_code = 1
+                usage = empty_usage()
+                status = "launch_failed"
+                print(f"tokenpak: failed to launch codex: {exc}", file=sys.stderr)
+            try:
+                _write_accounting_receipt(
+                    receipt_out=receipt_out,
+                    run_id=run_id,
+                    codex_args=args,
+                    setup=setup,
+                    started_at=started_at,
+                    start_monotonic=start_monotonic,
+                    exit_code=exit_code,
+                    status=status,
+                    usage=usage,
+                )
+            except OSError as exc:
+                print(
+                    f"tokenpak: failed to write accounting receipt: {exc}",
+                    file=sys.stderr,
+                )
+                return 1
+            return exit_code
+
+        config = CompanionConfig.from_env()
+        config.profile_overrides()
+        config.journal_dir.mkdir(parents=True, exist_ok=True)
+
+        from .rates_snapshot import refresh as refresh_rates
+
+        rates_path = refresh_rates()
+        print(f"tokenpak: rates snapshot refreshed ({rates_path})", file=sys.stderr)
+
+        from .mcp_config import _register, get_env_vars
+
+        env_vars = get_env_vars(config)
+        lease.assert_home_binding()
+        if not reusable_home_is_clear():
             return 1
+        mcp_registered = _register(env_vars=env_vars, codex_home=paths.home)
+        lease.assert_home_binding()
+        print(
+            "tokenpak: MCP server registered"
+            if mcp_registered
+            else "tokenpak: MCP registration failed (continuing)",
+            file=sys.stderr,
+        )
+
+        hooks_installed = False
+        if config.hooks_enabled:
+            from .hooks import _ensure_hooks_feature_enabled, _install_hooks
+
+            lease.assert_home_binding()
+            if not reusable_home_is_clear():
+                return 1
+            if _ensure_hooks_feature_enabled(codex_home=paths.home):
+                if not reusable_home_is_clear():
+                    return 1
+                hooks_path = _install_hooks(target="global", codex_home=paths.home)
+                lease.assert_home_binding()
+                hooks_installed = True
+                print(f"tokenpak: hooks installed ({hooks_path})", file=sys.stderr)
+            else:
+                print(
+                    "tokenpak: hooks feature could not be enabled",
+                    file=sys.stderr,
+                )
+
+        from .agents_md import _install_agents_md
+
+        lease.assert_home_binding()
+        if not reusable_home_is_clear():
+            return 1
+        agents_path = _install_agents_md(target="global", codex_home=paths.home)
+        lease.assert_home_binding()
+        print(f"tokenpak: AGENTS.md installed ({agents_path})", file=sys.stderr)
+
+        from .skills_installer import _configure_skills, install_skills
+
+        installed = install_skills(target_dir=paths.skills_root)
+        configured = []
+        if paths.mode != session_home.MODE_SHARED:
+            lease.assert_home_binding()
+            configured = _configure_skills(paths.config, skills_root=paths.skills_root)
+            lease.assert_home_binding()
+        if installed:
+            print(
+                f"tokenpak: {len(installed)} skills installed and "
+                f"{len(configured)} configured ({paths.skills_root})",
+                file=sys.stderr,
+            )
+
+        setup: dict[str, object] = {
+            "setup_completed": True,
+            "profile": config.profile,
+            "budget_daily_usd": config.budget_daily_usd,
+            "session_mode": paths.mode,
+            "codex_home": str(paths.home),
+            "config_path": str(paths.config),
+            "mcp_config_path": str(paths.mcp_config),
+            "hooks_path": str(paths.hooks),
+            "agents_md_path": str(paths.agents),
+            "skills_root": str(paths.skills_root),
+            "pid_sentinel_path": str(paths.pid_sentinel),
+            "rates_snapshot_refreshed": True,
+            "mcp_registered": bool(mcp_registered),
+            "hooks_enabled": bool(config.hooks_enabled),
+            "hooks_installed": hooks_installed,
+            "agents_md_installed": True,
+            "skills_installed_count": len(installed),
+            "skills_configured_count": len(configured),
+        }
+
+        budget_phrase = (
+            f"budget ${config.budget_daily_usd:.2f}/day"
+            if config.budget_daily_usd > 0
+            else "no budget cap"
+        )
+        print(
+            f"tokenpak: companion ready for codex ({config.profile}, {budget_phrase})",
+            file=sys.stderr,
+        )
+
+        if install_only:
+            if receipt_out and run_id:
+                try:
+                    _write_accounting_receipt(
+                        receipt_out=receipt_out,
+                        run_id=run_id,
+                        codex_args=[],
+                        setup=setup,
+                        started_at=utc_now(),
+                        start_monotonic=time.monotonic(),
+                        exit_code=0,
+                        status="setup_only",
+                        missing_evidence=["codex_process_not_launched_install_only"],
+                    )
+                except OSError as exc:
+                    print(
+                        f"tokenpak: failed to write accounting receipt: {exc}",
+                        file=sys.stderr,
+                    )
+                    return 1
+            print(
+                "tokenpak: setup complete — run `tokenpak codex doctor` to verify",
+                file=sys.stderr,
+            )
+            return 0
+
+        env = paths.environment(os.environ.copy())
+        env.update(env_vars)
+        if receipt_out and run_id:
+            env["TOKENPAK_CODEX_RECEIPT_OUT"] = receipt_out
+            env["TOKENPAK_CODEX_RUN_ID"] = run_id
+
+        fleet = _fleet_state_enabled()
+        forwarded = _maybe_inject_bypass_flag(args, env, fleet=fleet)
+        banner = _fleet_banner(env, fleet=fleet)
+        if banner:
+            print(banner, file=sys.stderr)
+        codex_args = ["codex", *forwarded]
+        started_at = utc_now()
+        start_monotonic = time.monotonic()
+        try:
+            lease.assert_home_binding()
+            if not reusable_home_is_clear():
+                return 1
+            lease.begin_transfer()
+            exit_code, usage = _run_codex_process(codex_args, env, on_start=lease.transfer_to)
+            status = (
+                "completed" if exit_code == 0 else "interrupted" if exit_code == 130 else "failed"
+            )
+        except (OSError, RuntimeError) as exc:
+            exit_code = 1
+            usage = empty_usage()
+            status = "launch_failed"
+            print(f"tokenpak: failed to launch codex: {exc}", file=sys.stderr)
+
+        if receipt_out and run_id:
+            try:
+                _write_accounting_receipt(
+                    receipt_out=receipt_out,
+                    run_id=run_id,
+                    codex_args=forwarded,
+                    setup=setup,
+                    started_at=started_at,
+                    start_monotonic=start_monotonic,
+                    exit_code=exit_code,
+                    status=status,
+                    usage=usage,
+                )
+            except OSError as exc:
+                print(
+                    f"tokenpak: failed to write accounting receipt: {exc}",
+                    file=sys.stderr,
+                )
+                return 1
         return exit_code
-
-    os.execvpe("codex", codex_args, env)
-
-    print("tokenpak: failed to launch codex", file=sys.stderr)
-    return 1

--- a/tokenpak/companion/codex/mcp_config.py
+++ b/tokenpak/companion/codex/mcp_config.py
@@ -2,7 +2,7 @@
 """Register / unregister the tokenpak companion MCP server with Codex.
 
 Uses ``codex mcp add`` / ``codex mcp remove`` so the config lives in
-Codex's own config store (~/.codex/config.toml) and is visible to
+Codex's own config store (``$CODEX_HOME/config.toml``) and is visible to
 ``codex mcp list``.
 
 The MCP server binary is the same stdio JSON-RPC server used by Claude Code
@@ -12,8 +12,10 @@ mechanism differs.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -22,12 +24,26 @@ if TYPE_CHECKING:
 SERVER_NAME = "tokenpak-companion"
 
 
+def _codex_env(codex_home: Path | None = None) -> dict[str, str]:
+    """Return an environment scoped to the selected Codex home."""
+    env = os.environ.copy()
+    if codex_home is not None:
+        env["CODEX_HOME"] = str(codex_home)
+    return env
+
+
 def is_registered() -> bool:
+    """Check registration using the active public Codex configuration."""
+    return _is_registered()
+
+
+def _is_registered(codex_home: Path | None = None) -> bool:
     """Check whether the companion MCP server is already registered."""
     try:
         result = subprocess.run(
             ["codex", "mcp", "get", SERVER_NAME],
             capture_output=True,
+            env=_codex_env(codex_home),
             text=True,
             timeout=10,
         )
@@ -39,17 +55,31 @@ def is_registered() -> bool:
 def register(
     env_vars: Optional[dict[str, str]] = None,
 ) -> bool:
+    """Register using the active public Codex configuration."""
+    return _register(env_vars)
+
+
+def _register(
+    env_vars: Optional[dict[str, str]] = None,
+    *,
+    codex_home: Path | None = None,
+) -> bool:
     """Register the companion MCP server via ``codex mcp add``.
 
     Returns True if registration succeeded (or was already registered).
     """
-    if is_registered():
+    if _is_registered(codex_home):
         return True
 
     cmd = [
-        "codex", "mcp", "add", SERVER_NAME,
+        "codex",
+        "mcp",
+        "add",
+        SERVER_NAME,
         "--",
-        sys.executable, "-m", "tokenpak.companion.mcp.server",
+        sys.executable,
+        "-m",
+        "tokenpak.companion.mcp.server",
     ]
 
     # Pass companion env vars to the MCP server process.
@@ -64,6 +94,7 @@ def register(
         result = subprocess.run(
             cmd,
             capture_output=True,
+            env=_codex_env(codex_home),
             text=True,
             timeout=15,
         )
@@ -80,14 +111,20 @@ def register(
 
 
 def unregister() -> bool:
+    """Remove registration using the active public Codex configuration."""
+    return _unregister()
+
+
+def _unregister(codex_home: Path | None = None) -> bool:
     """Remove the companion MCP server registration."""
-    if not is_registered():
+    if not _is_registered(codex_home):
         return True
 
     try:
         result = subprocess.run(
             ["codex", "mcp", "remove", SERVER_NAME],
             capture_output=True,
+            env=_codex_env(codex_home),
             text=True,
             timeout=10,
         )
@@ -104,6 +141,8 @@ def get_env_vars(config: "CompanionConfig") -> dict[str, str]:
         env["TOKENPAK_COMPANION_BUDGET"] = str(config.budget_daily_usd)
     if config.profile != "balanced":
         env["TOKENPAK_COMPANION_PROFILE"] = config.profile
-    if str(config.journal_dir) != str(config.journal_dir.__class__.home() / ".tokenpak" / "companion"):
+    if str(config.journal_dir) != str(
+        config.journal_dir.__class__.home() / ".tokenpak" / "companion"
+    ):
         env["TOKENPAK_COMPANION_JOURNAL_DIR"] = str(config.journal_dir)
     return env

--- a/tokenpak/companion/codex/session_home.py
+++ b/tokenpak/companion/codex/session_home.py
@@ -1,0 +1,2610 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve and provision Codex homes for parallel launcher sessions.
+
+``TOKENPAK_CODEX_SESSION_MODE`` accepts exactly three values:
+
+``shared``
+    Use the existing user Codex home.  This preserves the pre-isolation
+    behavior and is intentionally single-session when local state is in use.
+``workspace``
+    Use a deterministic home derived from the resolved project directory.
+``isolated``
+    Use a fresh, unique home for each launcher invocation.
+
+Provisioning is allowlist-only.  It never walks or copies the source Codex
+home.  A new home may receive a private copy of ``config.toml`` and a symlink
+to the externally refreshed ``auth.json`` credential; databases, WAL/SHM
+sidecars, history, logs, sessions, and every other runtime file stay behind.
+
+The ``codex.pid`` file is a lifecycle lease, not lock-attribution evidence.
+Actual SQLite holders are discovered from kernel lock and file-descriptor
+state by :mod:`tokenpak.companion.codex.state_lock`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 backport
+    import tomli as tomllib  # type: ignore[no-redef]
+
+# Launcher-internal implementation.  Keeping the module out of ``import *``
+# also keeps these lifecycle helpers out of the released API snapshot.
+__all__: list[str] = []
+
+MODE_SHARED = "shared"
+MODE_WORKSPACE = "workspace"
+MODE_ISOLATED = "isolated"
+VALID_MODES = (MODE_SHARED, MODE_WORKSPACE, MODE_ISOLATED)
+
+ENV_SESSION_MODE = "TOKENPAK_CODEX_SESSION_MODE"
+ENV_CODEX_HOME = "CODEX_HOME"
+
+PID_SENTINEL_NAME = "codex.pid"
+_LEASE_GUARD_NAME = ".tokenpak-codex-home.lock"
+_SENTINEL_SCHEMA = "tokenpak.codex.pid.v1"
+
+# Closed seed allowlist.  Adding a filename here is a security-sensitive
+# decision; provisioning deliberately has no glob or recursive-copy path.
+SAFE_CONFIG_FILES = ("config.toml",)
+SAFE_CREDENTIAL_LINKS = ("auth.json",)
+_ISOLATION_BREAKING_CONFIG_KEYS = ("sqlite_home", "log_dir")
+
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_THREAD_LEASE_LOCK = threading.RLock()
+_GUARD_LOCK_TIMEOUT_S = 5.0
+_MAX_SEED_BYTES = 4 * 1024 * 1024
+_MAX_SENTINEL_BYTES = 16 * 1024
+_SENTINEL_TEMP_RE = re.compile(
+    rf"^\.{re.escape(PID_SENTINEL_NAME)}\.(acquire|transfer)\.([0-9a-f]{{32}})\.tmp$"
+)
+_PROCESS_LIVE = "live"
+_PROCESS_DEAD = "dead-or-reused"
+_PROCESS_UNKNOWN = "unknown"
+_PROCESS_OBSERVED = "observed"
+
+RETENTION_MAX_HOMES = 5
+RETENTION_MAX_AGE_S = 7 * 24 * 60 * 60
+RETENTION_MAX_TOTAL_BYTES = 500 * 1024 * 1024
+_RETENTION_CREATION_GRACE_S = 60.0
+_RETENTION_SCAN_TIMEOUT_S = 30.0
+_RETENTION_MAX_ENTRIES = 4096
+_RETENTION_MAX_NODES = 200000
+_RETENTION_GUARD_NAME = ".tokenpak-retention.lock"
+_RETENTION_RECEIPT_NAME = ".tokenpak-retention.jsonl"
+_RETENTION_QUARANTINE_PREFIX = ".tokenpak-quarantine."
+_RETENTION_QUARANTINE_RE = re.compile(rf"^{re.escape(_RETENTION_QUARANTINE_PREFIX)}[0-9a-f]{{32}}$")
+_RETENTION_MAX_RECEIPT_BYTES = 16 * 1024 * 1024
+
+
+def _is_sentinel_temp_candidate(name: str) -> bool:
+    """Recognize the full wildcard family, including unusual filenames."""
+    return any(
+        name.startswith(f".{PID_SENTINEL_NAME}.{phase}.") and name.endswith(".tmp")
+        for phase in ("acquire", "transfer")
+    )
+
+
+class InvalidSessionMode(ValueError):
+    """Raised when the session-mode environment value is not supported."""
+
+
+class HomeInUseError(RuntimeError):
+    """Raised when a validated live lease already owns a selected home."""
+
+
+@dataclass(frozen=True)
+class _IsolatedHomeInfo:
+    path: Path
+    device: int
+    inode: int
+    mtime: float
+    age_s: float
+    size_bytes: int
+    size_complete: bool
+    state: str
+    pid: int | None = None
+
+    @property
+    def orphaned(self) -> bool:
+        return self.state in {"orphan-absent", "orphan-stale"}
+
+    @property
+    def protected(self) -> bool:
+        return not self.orphaned or not self.size_complete
+
+
+@dataclass(frozen=True)
+class _RetentionReport:
+    root: Path
+    homes: tuple[_IsolatedHomeInfo, ...]
+    total_bytes: int
+    inventory_complete: bool
+    quarantines: tuple[str, ...] = ()
+
+    @property
+    def orphaned(self) -> tuple[_IsolatedHomeInfo, ...]:
+        return tuple(home for home in self.homes if home.orphaned)
+
+    @property
+    def active(self) -> tuple[_IsolatedHomeInfo, ...]:
+        return tuple(home for home in self.homes if home.state == "active")
+
+    @property
+    def unsafe(self) -> tuple[_IsolatedHomeInfo, ...]:
+        return tuple(
+            home for home in self.homes if home.state in {"unsafe", "creating", "handoff"}
+        )
+
+    @property
+    def over_count(self) -> bool:
+        return len(self.homes) > RETENTION_MAX_HOMES
+
+    @property
+    def over_age(self) -> bool:
+        return any(home.age_s > RETENTION_MAX_AGE_S for home in self.homes)
+
+    @property
+    def over_size(self) -> bool:
+        return self.total_bytes > RETENTION_MAX_TOTAL_BYTES
+
+
+@dataclass(frozen=True)
+class _CleanupResult:
+    before: _RetentionReport
+    after: _RetentionReport
+    removed: tuple[Path, ...]
+    planned: tuple[Path, ...]
+    errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SessionPaths:
+    """Every path selected for one Codex launcher invocation."""
+
+    mode: str
+    home: Path
+    source_home: Path
+    workspace: Path
+    config: Path
+    auth: Path
+    mcp_config: Path
+    hooks: Path
+    agents: Path
+    skills_root: Path
+    pid_sentinel: Path
+
+    def environment(self, base: dict[str, str] | None = None) -> dict[str, str]:
+        """Return a child environment pointing Codex at this home."""
+        env = dict(os.environ if base is None else base)
+        env[ENV_CODEX_HOME] = str(self.home)
+        env[ENV_SESSION_MODE] = self.mode
+        return env
+
+    def report_rows(self) -> list[tuple[str, str]]:
+        """Return stable labels used by launcher and doctor output."""
+        return [
+            ("session mode", self.mode),
+            ("workspace", str(self.workspace)),
+            ("CODEX_HOME", str(self.home)),
+            ("source home", str(self.source_home)),
+            ("config", str(self.config)),
+            ("auth", str(self.auth)),
+            ("MCP config", str(self.mcp_config)),
+            ("hooks", str(self.hooks)),
+            ("AGENTS.md", str(self.agents)),
+            ("skills", str(self.skills_root)),
+            ("PID sentinel", str(self.pid_sentinel)),
+        ]
+
+
+@dataclass(frozen=True)
+class ProvisionedHome:
+    """Result of allowlist-only home provisioning."""
+
+    paths: SessionPaths
+    created: bool
+    seeded: tuple[str, ...]
+    linked_credentials: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PidSentinel:
+    """Validated lifecycle lease stored in ``codex.pid``."""
+
+    schema: str
+    pid: int
+    start_time_ticks: int
+    session_id: str
+    mode: str
+    home: str
+
+
+@dataclass(frozen=True)
+class _SentinelArtifactInspection:
+    """Fail-closed retention view of lifecycle publication artifacts."""
+
+    state: str | None = None
+    pid: int | None = None
+    complete: bool = True
+
+
+def resolve_mode(raw: str | None = None) -> str:
+    """Return an exact advertised mode token, failing closed on bad input."""
+    value = raw if raw is not None else os.environ.get(ENV_SESSION_MODE, MODE_SHARED)
+    if value not in VALID_MODES:
+        allowed = "|".join(VALID_MODES)
+        shown = value or "<empty>"
+        raise InvalidSessionMode(f"invalid {ENV_SESSION_MODE}={shown!r}; expected {allowed}")
+    return value
+
+
+def canonical_codex_home() -> Path:
+    """Return the source-of-truth user Codex home."""
+    return Path.home() / ".codex"
+
+
+def _tokenpak_home() -> Path:
+    from tokenpak import _paths
+
+    return _paths.home()
+
+
+def sessions_root(tokenpak_home: Path | None = None) -> Path:
+    """Root containing unique per-session Codex homes."""
+    return (tokenpak_home or _tokenpak_home()) / "companion" / "codex" / "sessions"
+
+
+def workspaces_root(tokenpak_home: Path | None = None) -> Path:
+    """Root containing deterministic per-project Codex homes."""
+    return (tokenpak_home or _tokenpak_home()) / "companion" / "codex" / "workspaces"
+
+
+def codex_root(tokenpak_home: Path | None = None) -> Path:
+    """Private boundary containing TokenPak-managed Codex homes."""
+    return (tokenpak_home or _tokenpak_home()) / "companion" / "codex"
+
+
+def _generated_tokenpak_root(home: Path) -> Path | None:
+    parents = home.parents
+    if (
+        len(parents) >= 4
+        and parents[0].name in {"sessions", "workspaces"}
+        and parents[1].name == "codex"
+        and parents[2].name == "companion"
+    ):
+        return parents[3]
+    return None
+
+
+def workspace_hash(workspace_dir: Path | str) -> str:
+    """Return a stable short digest for an equivalent resolved directory."""
+    resolved = str(Path(workspace_dir).expanduser().resolve())
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:20]
+
+
+def project_root(workspace_dir: Path | str) -> Path:
+    """Resolve a stable project root, using the nearest Git boundary."""
+    resolved = Path(workspace_dir).expanduser().resolve()
+    start = resolved if resolved.is_dir() else resolved.parent
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return start
+
+
+def _validated_session_id(session_id: str | None) -> str:
+    value = session_id or uuid.uuid4().hex
+    if not _SESSION_ID_RE.fullmatch(value):
+        raise ValueError("session_id must be a safe filename component")
+    return value
+
+
+def select_paths(
+    mode: str | None = None,
+    *,
+    workspace_dir: Path | str | None = None,
+    session_id: str | None = None,
+    tokenpak_home: Path | None = None,
+    source_home: Path | None = None,
+    selected_home: Path | None = None,
+) -> SessionPaths:
+    """Resolve all paths without creating or modifying the filesystem.
+
+    ``selected_home`` is intended for doctor/uninstall inspection of an
+    already-running isolated session.  Normal launcher calls omit it so an
+    ``isolated`` mode invocation always receives a new UUID home.
+    """
+    resolved_mode = resolve_mode(mode)
+    workspace = project_root(workspace_dir or Path.cwd())
+    source = Path(
+        source_home or os.environ.get(ENV_CODEX_HOME) or canonical_codex_home()
+    ).expanduser()
+
+    if selected_home is not None:
+        home = Path(selected_home).expanduser()
+    elif resolved_mode == MODE_SHARED:
+        home = Path(os.environ.get(ENV_CODEX_HOME) or source).expanduser()
+    elif resolved_mode == MODE_WORKSPACE:
+        home = workspaces_root(tokenpak_home) / workspace_hash(workspace)
+    else:
+        home = sessions_root(tokenpak_home) / _validated_session_id(session_id)
+
+    return SessionPaths(
+        mode=resolved_mode,
+        home=home,
+        source_home=source,
+        workspace=workspace,
+        config=home / "config.toml",
+        auth=home / "auth.json",
+        mcp_config=home / "config.toml",
+        hooks=home / "hooks.json",
+        agents=home / "AGENTS.md",
+        # User skills remain at Codex's documented user discovery root.  The
+        # selected config records explicit per-skill entries separately.
+        skills_root=Path.home() / ".agents" / "skills",
+        pid_sentinel=home / PID_SENTINEL_NAME,
+    )
+
+
+def current_paths(
+    mode: str | None = None,
+    *,
+    workspace_dir: Path | str | None = None,
+    tokenpak_home: Path | None = None,
+    source_home: Path | None = None,
+) -> SessionPaths:
+    """Resolve the active home for doctor/uninstall without creating one."""
+    resolved_mode = resolve_mode(mode)
+    selected = os.environ.get(ENV_CODEX_HOME)
+    if resolved_mode == MODE_ISOLATED and not selected:
+        raise InvalidSessionMode(
+            "isolated mode has no selected home outside a launch; set CODEX_HOME "
+            "to the session home before running doctor or uninstall"
+        )
+    if resolved_mode == MODE_ISOLATED and selected:
+        selected_path = Path(selected).expanduser().resolve()
+        expected_parent = sessions_root(tokenpak_home).resolve()
+        if selected_path.parent != expected_parent:
+            raise InvalidSessionMode(
+                "isolated CODEX_HOME is outside the TokenPak sessions root; "
+                "refusing unsafe inspection or cleanup"
+            )
+    return select_paths(
+        resolved_mode,
+        workspace_dir=workspace_dir,
+        tokenpak_home=tokenpak_home,
+        source_home=source_home,
+        # A workspace home is a deterministic function of the project.  An
+        # inherited CODEX_HOME must not silently redirect it.  Isolated mode,
+        # by contrast, can only be inspected when its selected home is passed
+        # through the environment by the launcher.
+        selected_home=(
+            Path(selected) if selected and resolved_mode in {MODE_SHARED, MODE_ISOLATED} else None
+        ),
+    )
+
+
+def _entry_stat(name: str, dir_fd: int) -> os.stat_result | None:
+    """Return an entry's no-follow stat relative to a validated home."""
+    try:
+        return os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+
+
+def _owned_directory(fd: int, path: Path, *, allowed_modes: set[int]) -> os.stat_result:
+    current = os.fstat(fd)
+    getuid = getattr(os, "geteuid", None)
+    mode = stat.S_IMODE(current.st_mode)
+    if (
+        not stat.S_ISDIR(current.st_mode)
+        or (getuid is not None and current.st_uid != getuid())
+        or mode not in allowed_modes
+    ):
+        expected = "/".join(f"{value:04o}" for value in sorted(allowed_modes))
+        raise HomeInUseError(
+            f"selected CODEX_HOME ancestor is not an owned {expected} directory: {path}"
+        )
+    return current
+
+
+def _mkdir_open_owned_at(
+    parent_fd: int,
+    name: str,
+    path: Path,
+    *,
+    existing_modes: set[int],
+) -> int:
+    created = False
+    try:
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+        created = True
+    except FileExistsError:
+        pass
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(name, flags, dir_fd=parent_fd)
+    except OSError as exc:
+        raise HomeInUseError(f"selected CODEX_HOME ancestor is unsafe: {path}") from exc
+    try:
+        if created:
+            os.fchmod(fd, 0o700)
+            allowed = {0o700}
+        else:
+            allowed = existing_modes
+        _owned_directory(fd, path, allowed_modes=allowed)
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _open_selected_home(paths: SessionPaths) -> int | None:
+    """Create/open the selected home and pin its directory inode.
+
+    Non-shared homes are TokenPak-owned private runtime directories.  Their
+    immediate container and leaf are therefore forced to 0700 before any
+    credential link or configuration is installed.  ``O_NOFOLLOW`` closes
+    the leaf-symlink race; callers retain the returned descriptor for the
+    entire lease so sentinel operations stay bound to this exact inode.
+    """
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    if paths.mode == MODE_SHARED:
+        paths.home.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name == "nt":  # Windows CRT cannot open directory descriptors.
+            entry = paths.home.lstat()
+            if not stat.S_ISDIR(entry.st_mode) or paths.home.is_symlink():
+                raise HomeInUseError(f"selected CODEX_HOME is not a directory: {paths.home}")
+            return None
+        fd = os.open(str(paths.home), directory_flags)
+    else:
+        # Normal generated homes have this shape:
+        # <tokenpak-home>/companion/codex/{sessions,workspaces}/<id>.  Create
+        # the TokenPak-owned chain one component at a time and pin every
+        # component with O_NOFOLLOW before creating the next.  Tests and
+        # explicit internal callers with another shape use the immediate
+        # parent as their private root.
+        parents = paths.home.parents
+        generated = _generated_tokenpak_root(paths.home) is not None
+        private_root = parents[3] if generated else paths.home.parent
+        root_created = not private_root.exists()
+        private_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        current_fd = os.open(
+            str(private_root),
+            directory_flags | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            if root_created:
+                os.fchmod(current_fd, 0o700)
+            _owned_directory(current_fd, private_root, allowed_modes={0o700})
+
+            relative_parent = paths.home.parent.relative_to(private_root)
+            for index, component in enumerate(relative_parent.parts):
+                component_path = private_root / Path(*relative_parent.parts[: index + 1])
+                allowed_modes = (
+                    {0o700, 0o775} if generated and component == "companion" else {0o700}
+                )
+                next_fd = _mkdir_open_owned_at(
+                    current_fd,
+                    component,
+                    component_path,
+                    existing_modes=allowed_modes,
+                )
+                os.close(current_fd)
+                current_fd = next_fd
+            fd = _mkdir_open_owned_at(
+                current_fd,
+                paths.home.name,
+                paths.home,
+                existing_modes={0o700},
+            )
+        finally:
+            os.close(current_fd)
+    try:
+        pinned = os.fstat(fd)
+        current = os.stat(paths.home, follow_symlinks=paths.mode == MODE_SHARED)
+        if not stat.S_ISDIR(pinned.st_mode) or (pinned.st_dev, pinned.st_ino) != (
+            current.st_dev,
+            current.st_ino,
+        ):
+            raise HomeInUseError(f"selected CODEX_HOME changed during validation: {paths.home}")
+        if paths.mode != MODE_SHARED and pinned.st_mode & 0o077:
+            raise HomeInUseError(f"selected CODEX_HOME is not private (0700): {paths.home}")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _read_bounded_regular(
+    path: Path,
+    *,
+    dir_fd: int | None = None,
+    private: bool = False,
+    max_bytes: int = _MAX_SEED_BYTES,
+) -> bytes | None:
+    """Read a bounded regular file without following its final symlink."""
+    if dir_fd is None and path.is_symlink():
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path.name if dir_fd is not None else str(path), flags, dir_fd=dir_fd)
+    except OSError:
+        return None
+    try:
+        source_stat = os.fstat(fd)
+        if not stat.S_ISREG(source_stat.st_mode) or source_stat.st_size > max_bytes:
+            return None
+        if private:
+            getuid = getattr(os, "geteuid", None)
+            if getuid is not None and source_stat.st_uid != getuid():
+                return None
+            if source_stat.st_mode & 0o077:
+                return None
+        chunks: list[bytes] = []
+        total = 0
+        while chunk := os.read(fd, min(1024 * 1024, max_bytes + 1 - total)):
+            total += len(chunk)
+            if total > max_bytes:
+                return None
+            chunks.append(chunk)
+        return b"".join(chunks)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+def _sanitized_config(data: bytes) -> bytes | None:
+    """Validate one TOML config and remove isolation-breaking root keys."""
+    try:
+        text = data.decode("utf-8")
+        tomllib.loads(text)
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+
+    lines = text.splitlines()
+    top_level_end = next(
+        (index for index, line in enumerate(lines) if re.match(r"^\s*\[", line)),
+        len(lines),
+    )
+    key_pattern = re.compile(
+        r"^\s*(?:"
+        + "|".join(
+            rf"(?:{re.escape(key)}|\"{re.escape(key)}\"|'{re.escape(key)}')"
+            for key in _ISOLATION_BREAKING_CONFIG_KEYS
+        )
+        + r")\s*="
+    )
+    filtered = [
+        line
+        for index, line in enumerate(lines)
+        if not (index < top_level_end and key_pattern.match(line))
+    ]
+    sanitized = "\n".join(filtered)
+    if text.endswith("\n"):
+        sanitized += "\n"
+    try:
+        parsed = tomllib.loads(sanitized)
+    except tomllib.TOMLDecodeError:
+        return None
+    if any(key in parsed for key in _ISOLATION_BREAKING_CONFIG_KEYS):
+        return None
+    return sanitized.encode("utf-8")
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte, treating a zero-length write as an I/O failure."""
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise OSError("short write while persisting Codex session metadata")
+        view = view[written:]
+
+
+def _replace_private_at(dir_fd: int, name: str, data: bytes) -> None:
+    """Atomically replace one regular file inside a pinned directory."""
+    tmp_name = f".{name}.{uuid.uuid4().hex}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(tmp_name, flags, 0o600, dir_fd=dir_fd)
+    try:
+        os.fchmod(fd, 0o600)
+        _write_all(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        os.replace(tmp_name, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name, dir_fd=dir_fd)
+
+
+def _provision_config(src: Path, dir_fd: int, name: str) -> bool:
+    """Seed or revalidate the selected home's private config."""
+    existing = _entry_stat(name, dir_fd)
+    if existing is None:
+        source = _read_bounded_regular(src)
+        if source is None:
+            return False
+        sanitized = _sanitized_config(source)
+        if sanitized is None:
+            return False
+        _replace_private_at(dir_fd, name, sanitized)
+        return True
+
+    getuid = getattr(os, "geteuid", None)
+    if (
+        not stat.S_ISREG(existing.st_mode)
+        or existing.st_nlink != 1
+        or (getuid is not None and existing.st_uid != getuid())
+    ):
+        raise RuntimeError(f"selected config is not a regular file: {name}")
+    current = _read_bounded_regular(Path(name), dir_fd=dir_fd)
+    if current is None:
+        raise RuntimeError(f"selected config is unreadable or oversized: {name}")
+    sanitized = _sanitized_config(current)
+    if sanitized is None:
+        raise RuntimeError(f"selected config is not safe UTF-8 TOML: {name}")
+    if sanitized != current or existing.st_mode & 0o777 != 0o600:
+        _replace_private_at(dir_fd, name, sanitized)
+    return False
+
+
+def _safe_credential_source(src: Path) -> Path | None:
+    """Validate an externally refreshed credential without copying it."""
+    raw = _read_bounded_regular(src, private=True)
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return Path(os.path.abspath(src))
+
+
+def _link_credential_once(src: Path, dir_fd: int, name: str) -> bool:
+    """Install or validate one exact allowlisted credential symlink."""
+    safe_source = _safe_credential_source(src)
+    existing = _entry_stat(name, dir_fd)
+    if existing is not None:
+        if not stat.S_ISLNK(existing.st_mode):
+            raise RuntimeError(f"selected credential is not a managed symlink: {name}")
+        try:
+            target = os.readlink(name, dir_fd=dir_fd)
+        except OSError as exc:
+            raise RuntimeError(f"selected credential link is unreadable: {name}") from exc
+        if safe_source is None or target != str(safe_source):
+            raise RuntimeError(f"selected credential link has an unsafe target: {name}")
+        return False
+    if safe_source is None:
+        return False
+    os.symlink(str(safe_source), name, dir_fd=dir_fd)
+    return True
+
+
+def _validate_selected_entries(dir_fd: int) -> None:
+    """Reject redirectable managed files and aliased runtime databases."""
+    for name in ("hooks.json", "AGENTS.md"):
+        entry = _entry_stat(name, dir_fd)
+        if entry is None:
+            continue
+        getuid = getattr(os, "geteuid", None)
+        if (
+            not stat.S_ISREG(entry.st_mode)
+            or entry.st_nlink != 1
+            or entry.st_size > _MAX_SEED_BYTES
+            or (getuid is not None and entry.st_uid != getuid())
+        ):
+            raise RuntimeError(f"selected managed file is unsafe: {name}")
+
+    runtime_pattern = re.compile(r"^(?:state|logs)_[^/]+\.sqlite(?:-(?:wal|wal2|shm|journal))?$")
+    for name in os.listdir(dir_fd):
+        if not runtime_pattern.fullmatch(name):
+            continue
+        entry = _entry_stat(name, dir_fd)
+        if entry is None:
+            continue
+        getuid = getattr(os, "geteuid", None)
+        if (
+            not stat.S_ISREG(entry.st_mode)
+            or entry.st_nlink != 1
+            or (getuid is not None and entry.st_uid != getuid())
+        ):
+            raise RuntimeError(f"selected runtime database is aliased or unsafe: {name}")
+
+
+def provision(paths: SessionPaths, *, home_fd: int | None = None) -> ProvisionedHome:
+    """Create ``paths.home`` and seed only the closed safe-file allowlist."""
+    if paths.mode == MODE_SHARED:
+        return ProvisionedHome(paths, False, (), ())
+    created = not paths.home.exists()
+    owned_fd = home_fd is None
+    fd = _open_selected_home(paths) if home_fd is None else home_fd
+    if fd is None:
+        raise RuntimeError("non-shared selected home requires directory-descriptor support")
+
+    seeded: list[str] = []
+    linked: list[str] = []
+    try:
+        _validate_selected_entries(fd)
+        for name in SAFE_CONFIG_FILES:
+            if _provision_config(paths.source_home / name, fd, name):
+                seeded.append(name)
+        for name in SAFE_CREDENTIAL_LINKS:
+            if _link_credential_once(paths.source_home / name, fd, name):
+                linked.append(name)
+        return ProvisionedHome(paths, created, tuple(seeded), tuple(linked))
+    finally:
+        if owned_fd:
+            os.close(fd)
+
+
+def _portable_process_identity(pid: int) -> tuple[str, int] | None:
+    """Best-effort process incarnation identity when Linux procfs is absent."""
+    if os.name == "posix":
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=,lstart=", "-p", str(pid)],
+                capture_output=True,
+                env={**os.environ, "LC_ALL": "C"},
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        row = result.stdout.strip()
+        if result.returncode != 0 or not row:
+            return None
+        fields = row.split(maxsplit=1)
+        if len(fields) != 2:
+            return None
+        fingerprint = int.from_bytes(hashlib.sha256(fields[1].encode("utf-8")).digest()[:8], "big")
+        return fields[0][0], fingerprint or 1
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        import ctypes
+        from ctypes import wintypes
+
+        class FILETIME(ctypes.Structure):
+            _fields_ = (("low", wintypes.DWORD), ("high", wintypes.DWORD))
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+        kernel32.GetProcessTimes.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(FILETIME),
+            ctypes.POINTER(FILETIME),
+            ctypes.POINTER(FILETIME),
+            ctypes.POINTER(FILETIME),
+        )
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        handle = kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return None
+        try:
+            exit_code = wintypes.DWORD()
+            created, exited, kernel, user = FILETIME(), FILETIME(), FILETIME(), FILETIME()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return None
+            if exit_code.value != 259:  # STILL_ACTIVE
+                return None
+            if not kernel32.GetProcessTimes(
+                handle,
+                ctypes.byref(created),
+                ctypes.byref(exited),
+                ctypes.byref(kernel),
+                ctypes.byref(user),
+            ):
+                return None
+            return "R", (created.high << 32) | created.low
+        finally:
+            kernel32.CloseHandle(handle)
+    return None
+
+
+def _proc_identity(pid: int, proc_root: Path = Path("/proc")) -> tuple[str, int] | None:
+    """Return ``(state, start-time ticks)`` for one process incarnation."""
+    if pid <= 0:
+        return None
+    try:
+        raw = (proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+    except OSError:
+        if proc_root == Path("/proc") and not sys.platform.startswith("linux"):
+            return _portable_process_identity(pid)
+        return None
+    return _parse_proc_stat_identity(raw)
+
+
+def _parse_proc_stat_identity(raw: str) -> tuple[str, int] | None:
+    """Parse one Linux proc stat row without performing fallback I/O."""
+    rparen = raw.rfind(")")
+    if rparen < 0:
+        return None
+    fields = raw[rparen + 1 :].split()
+    if len(fields) <= 19:
+        return None
+    try:
+        return fields[0], int(fields[19])
+    except ValueError:
+        return None
+
+
+def _sentinel_from_data(data: object) -> PidSentinel | None:
+    if not isinstance(data, dict):
+        return None
+    try:
+        sentinel = PidSentinel(
+            schema=str(data["schema"]),
+            pid=int(data["pid"]),
+            start_time_ticks=int(data["start_time_ticks"]),
+            session_id=str(data["session_id"]),
+            mode=str(data["mode"]),
+            home=str(data["home"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+    if (
+        sentinel.schema != _SENTINEL_SCHEMA
+        or sentinel.pid <= 0
+        or sentinel.start_time_ticks <= 0
+        or sentinel.mode not in VALID_MODES
+        or not _SESSION_ID_RE.fullmatch(sentinel.session_id)
+    ):
+        return None
+    return sentinel
+
+
+def read_pid_sentinel(path: Path, *, dir_fd: int | None = None) -> PidSentinel | None:
+    """Parse a bounded private regular sentinel without following links."""
+    raw = _read_bounded_regular(
+        path,
+        dir_fd=dir_fd,
+        private=True,
+        max_bytes=_MAX_SENTINEL_BYTES,
+    )
+    if raw is None:
+        return None
+    try:
+        return _sentinel_from_data(json.loads(raw))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _process_identity_evidence(
+    pid: int,
+    *,
+    proc_root: Path = Path("/proc"),
+) -> tuple[str, tuple[str, int] | None]:
+    """Separate proven absence from incomplete process inspection."""
+    if pid <= 0:
+        return _PROCESS_DEAD, None
+    use_proc = proc_root != Path("/proc") or sys.platform.startswith("linux")
+    if use_proc:
+        try:
+            root_info = proc_root.stat()
+        except OSError:
+            return _PROCESS_UNKNOWN, None
+        if not stat.S_ISDIR(root_info.st_mode):
+            return _PROCESS_UNKNOWN, None
+        stat_path = proc_root / str(pid) / "stat"
+        try:
+            stat_path.stat()
+        except FileNotFoundError:
+            # Distinguish a proven-absent PID from procfs disappearing or
+            # becoming unreadable between the root and PID observations.
+            try:
+                if not stat.S_ISDIR(proc_root.stat().st_mode):
+                    return _PROCESS_UNKNOWN, None
+            except OSError:
+                return _PROCESS_UNKNOWN, None
+            return _PROCESS_DEAD, None
+        except OSError:
+            return _PROCESS_UNKNOWN, None
+        try:
+            raw = stat_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return _PROCESS_UNKNOWN, None
+        except OSError:
+            return _PROCESS_UNKNOWN, None
+        identity = _parse_proc_stat_identity(raw)
+    else:
+        identity = _proc_identity(pid, proc_root)
+    if identity is None:
+        return _PROCESS_UNKNOWN, None
+    return _PROCESS_OBSERVED, identity
+
+
+def _sentinel_liveness(
+    sentinel: PidSentinel,
+    *,
+    expected_home: Path | None = None,
+    proc_root: Path = Path("/proc"),
+) -> str:
+    """Return live, proven-dead/reused, or unknown incarnation evidence."""
+    if expected_home is not None:
+        try:
+            if Path(sentinel.home).resolve() != expected_home.resolve():
+                return _PROCESS_UNKNOWN
+        except OSError:
+            return _PROCESS_UNKNOWN
+    evidence, identity = _process_identity_evidence(sentinel.pid, proc_root=proc_root)
+    if evidence != _PROCESS_OBSERVED or identity is None:
+        return evidence
+    state, start_ticks = identity
+    if state in {"Z", "X", "x"} or start_ticks != sentinel.start_time_ticks:
+        return _PROCESS_DEAD
+    return _PROCESS_LIVE
+
+
+def sentinel_is_live(
+    sentinel: PidSentinel,
+    *,
+    expected_home: Path | None = None,
+    proc_root: Path = Path("/proc"),
+) -> bool:
+    """Validate process incarnation and selected-home binding."""
+    return (
+        _sentinel_liveness(
+            sentinel,
+            expected_home=expected_home,
+            proc_root=proc_root,
+        )
+        == _PROCESS_LIVE
+    )
+
+
+def _open_managed_sessions_root(
+    tokenpak_home: Path | None = None,
+    *,
+    create: bool = False,
+) -> tuple[Path, int] | None:
+    """Open the sessions root through its pinned, no-follow chain.
+
+    Inspection callers leave ``create`` false so doctor remains read-only.
+    Isolated-session publication sets it true to create only the managed
+    ancestors; the leaf is created later while holding the retention guard.
+    """
+    tokenpak_root = tokenpak_home or _tokenpak_home()
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    if create:
+        root_created = not tokenpak_root.exists()
+        tokenpak_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    else:
+        root_created = False
+    try:
+        current_fd = os.open(str(tokenpak_root), flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise HomeInUseError(f"unsafe TokenPak home: {tokenpak_root}") from exc
+    current_path = tokenpak_root
+    try:
+        if root_created:
+            os.fchmod(current_fd, 0o700)
+        _owned_directory(current_fd, current_path, allowed_modes={0o700})
+        for component, modes in (
+            ("companion", {0o700, 0o775}),
+            ("codex", {0o700}),
+            ("sessions", {0o700}),
+        ):
+            current_path = current_path / component
+            if create:
+                next_fd = _mkdir_open_owned_at(
+                    current_fd,
+                    component,
+                    current_path,
+                    existing_modes=modes,
+                )
+            else:
+                try:
+                    next_fd = os.open(component, flags, dir_fd=current_fd)
+                except FileNotFoundError:
+                    os.close(current_fd)
+                    return None
+                except OSError as exc:
+                    raise HomeInUseError(f"unsafe managed Codex path: {current_path}") from exc
+            os.close(current_fd)
+            current_fd = next_fd
+            if not create:
+                _owned_directory(current_fd, current_path, allowed_modes=modes)
+        pinned = os.fstat(current_fd)
+        named = os.stat(current_path, follow_symlinks=False)
+        if (pinned.st_dev, pinned.st_ino) != (named.st_dev, named.st_ino):
+            raise HomeInUseError("isolated homes root changed during inspection")
+        return current_path, current_fd
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(current_fd)
+        raise
+
+
+def _open_isolated_leaf_at(paths: SessionPaths, root_fd: int) -> int:
+    """Create/open and pin one isolated leaf beneath a guarded sessions root."""
+    fd = _mkdir_open_owned_at(
+        root_fd,
+        paths.home.name,
+        paths.home,
+        existing_modes={0o700},
+    )
+    try:
+        pinned = os.fstat(fd)
+        named = os.stat(paths.home.name, dir_fd=root_fd, follow_symlinks=False)
+        if not stat.S_ISDIR(pinned.st_mode) or (pinned.st_dev, pinned.st_ino) != (
+            named.st_dev,
+            named.st_ino,
+        ):
+            raise HomeInUseError(f"selected CODEX_HOME changed during validation: {paths.home}")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _tree_allocated_size(
+    directory_fd: int,
+    *,
+    root_device: int,
+    owner_uid: int | None,
+    deadline: float,
+) -> tuple[int, bool]:
+    """Count allocated bytes without following links, mounts, or duplicate inodes."""
+    seen: set[tuple[int, int]] = set()
+    nodes = 0
+
+    def walk(fd: int) -> tuple[int, bool]:
+        nonlocal nodes
+        total = 0
+        complete = True
+        try:
+            with os.scandir(fd) as entries:
+                for entry in entries:
+                    if time.monotonic() >= deadline:
+                        return total, False
+                    nodes += 1
+                    if nodes > _RETENTION_MAX_NODES:
+                        return total, False
+                    try:
+                        info = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
+                    except OSError:
+                        complete = False
+                        continue
+                    if info.st_dev != root_device:
+                        complete = False
+                        continue
+                    if owner_uid is not None and info.st_uid != owner_uid:
+                        complete = False
+                    key = (info.st_dev, info.st_ino)
+                    if key not in seen:
+                        seen.add(key)
+                        total += max(0, getattr(info, "st_blocks", 0) * 512)
+                    if stat.S_ISDIR(info.st_mode):
+                        try:
+                            child_fd = os.open(
+                                entry.name,
+                                os.O_RDONLY
+                                | getattr(os, "O_DIRECTORY", 0)
+                                | getattr(os, "O_NOFOLLOW", 0),
+                                dir_fd=fd,
+                            )
+                        except OSError:
+                            complete = False
+                            continue
+                        try:
+                            pinned = os.fstat(child_fd)
+                            if (pinned.st_dev, pinned.st_ino) != (info.st_dev, info.st_ino):
+                                complete = False
+                                continue
+                            child_total, child_complete = walk(child_fd)
+                            total += child_total
+                            complete = complete and child_complete
+                        finally:
+                            os.close(child_fd)
+                    elif not (stat.S_ISREG(info.st_mode) or stat.S_ISLNK(info.st_mode)):
+                        complete = False
+        except OSError:
+            return total, False
+        return total, complete
+
+    return walk(directory_fd)
+
+
+def _inspect_sentinel_temp_artifacts(
+    home_fd: int,
+    path: Path,
+    *,
+    deadline: float,
+    proc_root: Path,
+) -> _SentinelArtifactInspection:
+    """Inspect every acquire/transfer temp; ambiguity always protects."""
+    getuid = getattr(os, "geteuid", None)
+    artifacts = 0
+    live_pid: int | None = None
+    handoff = False
+    unsafe = False
+    try:
+        with os.scandir(home_fd) as entries:
+            for entry_count, entry in enumerate(entries, start=1):
+                if time.monotonic() >= deadline or entry_count > _RETENTION_MAX_ENTRIES:
+                    return _SentinelArtifactInspection("unsafe", None, False)
+                name = entry.name
+                if not _is_sentinel_temp_candidate(name):
+                    continue
+                artifacts += 1
+                match = _SENTINEL_TEMP_RE.fullmatch(name)
+                if match is None:
+                    unsafe = True
+                    continue
+                try:
+                    info = os.stat(name, dir_fd=home_fd, follow_symlinks=False)
+                except OSError:
+                    unsafe = True
+                    continue
+                if (
+                    not stat.S_ISREG(info.st_mode)
+                    or info.st_nlink != 1
+                    or stat.S_IMODE(info.st_mode) != 0o600
+                    or (getuid is not None and info.st_uid != getuid())
+                ):
+                    unsafe = True
+                    continue
+                candidate = read_pid_sentinel(Path(name), dir_fd=home_fd)
+                if candidate is None or candidate.mode != MODE_ISOLATED:
+                    unsafe = True
+                    continue
+                liveness = _sentinel_liveness(
+                    candidate,
+                    expected_home=path,
+                    proc_root=proc_root,
+                )
+                if liveness == _PROCESS_UNKNOWN:
+                    unsafe = True
+                elif liveness == _PROCESS_LIVE:
+                    if live_pid is not None and live_pid != candidate.pid:
+                        unsafe = True
+                    live_pid = candidate.pid
+                elif match.group(1) == "transfer":
+                    # A complete but interrupted transfer is still a handoff,
+                    # not proof that no child inherited this home.
+                    handoff = True
+    except OSError:
+        return _SentinelArtifactInspection("unsafe", None, False)
+
+    if artifacts > 1:
+        unsafe = True
+    if unsafe:
+        return _SentinelArtifactInspection("unsafe", live_pid, False)
+    if live_pid is not None:
+        return _SentinelArtifactInspection("active", live_pid, True)
+    if handoff:
+        return _SentinelArtifactInspection("handoff", None, True)
+    return _SentinelArtifactInspection()
+
+
+def _inspect_isolated_home_at(
+    root_fd: int,
+    root: Path,
+    name: str,
+    *,
+    now: float,
+    deadline: float,
+    proc_root: Path = Path("/proc"),
+) -> _IsolatedHomeInfo:
+    getuid = getattr(os, "geteuid", None)
+    owner_uid = getuid() if getuid is not None else None
+    path = root / name
+    try:
+        entry = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
+    except OSError:
+        return _IsolatedHomeInfo(path, -1, -1, now, 0.0, 0, False, "unsafe")
+    age = max(0.0, now - entry.st_mtime)
+    if (
+        not stat.S_ISDIR(entry.st_mode)
+        or stat.S_IMODE(entry.st_mode) != 0o700
+        or (owner_uid is not None and entry.st_uid != owner_uid)
+        or entry.st_dev != os.fstat(root_fd).st_dev
+    ):
+        return _IsolatedHomeInfo(
+            path, entry.st_dev, entry.st_ino, entry.st_mtime, age, 0, False, "unsafe"
+        )
+    try:
+        home_fd = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=root_fd,
+        )
+    except OSError:
+        return _IsolatedHomeInfo(
+            path, entry.st_dev, entry.st_ino, entry.st_mtime, age, 0, False, "unsafe"
+        )
+    try:
+        pinned = os.fstat(home_fd)
+        if (pinned.st_dev, pinned.st_ino) != (entry.st_dev, entry.st_ino):
+            return _IsolatedHomeInfo(
+                path, entry.st_dev, entry.st_ino, entry.st_mtime, age, 0, False, "unsafe"
+            )
+        size, size_complete = _tree_allocated_size(
+            home_fd,
+            root_device=entry.st_dev,
+            owner_uid=owner_uid,
+            deadline=deadline,
+        )
+        artifacts = _inspect_sentinel_temp_artifacts(
+            home_fd,
+            path,
+            deadline=deadline,
+            proc_root=proc_root,
+        )
+        if artifacts.state is not None:
+            return _IsolatedHomeInfo(
+                path,
+                entry.st_dev,
+                entry.st_ino,
+                entry.st_mtime,
+                age,
+                size,
+                size_complete and artifacts.complete,
+                artifacts.state,
+                artifacts.pid,
+            )
+        sentinel_entry = _entry_stat(PID_SENTINEL_NAME, home_fd)
+        if sentinel_entry is None:
+            state = "creating" if age < _RETENTION_CREATION_GRACE_S else "orphan-absent"
+            return _IsolatedHomeInfo(
+                path,
+                entry.st_dev,
+                entry.st_ino,
+                entry.st_mtime,
+                age,
+                size,
+                size_complete,
+                state,
+            )
+        sentinel = read_pid_sentinel(Path(PID_SENTINEL_NAME), dir_fd=home_fd)
+        if sentinel is None:
+            state = "unsafe"
+            pid = None
+        else:
+            liveness = _sentinel_liveness(sentinel, expected_home=path, proc_root=proc_root)
+            if liveness == _PROCESS_LIVE:
+                state = "active"
+            elif liveness == _PROCESS_DEAD:
+                state = "orphan-stale"
+            else:
+                state = "unsafe"
+            pid = sentinel.pid
+        return _IsolatedHomeInfo(
+            path,
+            entry.st_dev,
+            entry.st_ino,
+            entry.st_mtime,
+            age,
+            size,
+            size_complete,
+            state,
+            pid,
+        )
+    finally:
+        os.close(home_fd)
+
+
+def inspect_isolated_homes(
+    tokenpak_home: Path | None = None,
+    *,
+    now: float | None = None,
+    deadline: float | None = None,
+    proc_root: Path = Path("/proc"),
+) -> _RetentionReport:
+    """Read-only isolated-home inventory for doctor and retention planning."""
+    root = sessions_root(tokenpak_home)
+    opened = _open_managed_sessions_root(tokenpak_home)
+    if opened is None:
+        return _RetentionReport(root, (), 0, True)
+    root, root_fd = opened
+    now = time.time() if now is None else now
+    deadline = time.monotonic() + _RETENTION_SCAN_TIMEOUT_S if deadline is None else deadline
+    homes: list[_IsolatedHomeInfo] = []
+    quarantines: list[str] = []
+    total = 0
+    complete = True
+    try:
+        try:
+            with os.scandir(root_fd) as entries:
+                for entry_count, entry in enumerate(entries, start=1):
+                    if time.monotonic() >= deadline or entry_count > _RETENTION_MAX_ENTRIES:
+                        complete = False
+                        break
+                    name = entry.name
+                    if name in {
+                        _RETENTION_GUARD_NAME,
+                        _RETENTION_RECEIPT_NAME,
+                    }:
+                        continue
+                    if name.startswith(_RETENTION_QUARANTINE_PREFIX):
+                        quarantines.append(name)
+                        quarantine_info = _inspect_isolated_home_at(
+                            root_fd,
+                            root,
+                            name,
+                            now=now,
+                            deadline=deadline,
+                            proc_root=proc_root,
+                        )
+                        total += quarantine_info.size_bytes
+                        complete = False
+                        continue
+                    info = _inspect_isolated_home_at(
+                        root_fd,
+                        root,
+                        name,
+                        now=now,
+                        deadline=deadline,
+                        proc_root=proc_root,
+                    )
+                    homes.append(info)
+                    total += info.size_bytes
+                    complete = (
+                        complete
+                        and info.size_complete
+                        and info.state not in {"unsafe", "handoff"}
+                    )
+        except OSError:
+            complete = False
+    finally:
+        os.close(root_fd)
+    homes.sort(key=lambda item: (item.mtime, item.path.name))
+    return _RetentionReport(
+        root=root,
+        homes=tuple(homes),
+        total_bytes=total,
+        inventory_complete=complete,
+        quarantines=tuple(sorted(quarantines)),
+    )
+
+
+@contextlib.contextmanager
+def _interprocess_file_lock(fd: int, *, deadline: float) -> Iterator[None]:
+    """Hold one process-shared lock on POSIX or Windows."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - exercised on Windows CI
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        while True:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                break
+            except OSError as exc:
+                if exc.errno not in {errno.EACCES, errno.EAGAIN} or time.monotonic() >= deadline:
+                    raise HomeInUseError("timed out acquiring selected-home lease guard") from exc
+                time.sleep(0.01)
+        try:
+            yield
+        finally:
+            os.lseek(fd, 0, os.SEEK_SET)
+            with contextlib.suppress(OSError):
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        return
+
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except OSError as exc:
+            if exc.errno not in {errno.EACCES, errno.EAGAIN} or time.monotonic() >= deadline:
+                raise HomeInUseError("timed out acquiring Codex lifecycle guard") from exc
+            time.sleep(0.01)
+    try:
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def _bounded_guard_lock(fd: int) -> Iterator[None]:
+    """Bound both in-process and kernel guard acquisition by one deadline."""
+    deadline = time.monotonic() + _GUARD_LOCK_TIMEOUT_S
+    acquired = _THREAD_LEASE_LOCK.acquire(timeout=max(0.0, deadline - time.monotonic()))
+    if not acquired:
+        raise HomeInUseError("timed out acquiring Codex lifecycle thread guard")
+    try:
+        with _interprocess_file_lock(fd, deadline=deadline):
+            yield
+    finally:
+        _THREAD_LEASE_LOCK.release()
+
+
+@contextlib.contextmanager
+def _lease_guard(home: Path, *, home_fd: int | None = None) -> Iterator[None]:
+    """Serialize lease mutation without deleting or signalling processes."""
+    guard = home / _LEASE_GUARD_NAME
+    guard_stat = _entry_stat(_LEASE_GUARD_NAME, home_fd) if home_fd is not None else None
+    if home_fd is None and guard.is_symlink():
+        raise HomeInUseError(f"invalid lease guard: {guard}")
+    if guard_stat is not None and not stat.S_ISREG(guard_stat.st_mode):
+        raise HomeInUseError(f"invalid lease guard: {guard}")
+    fd = os.open(
+        _LEASE_GUARD_NAME if home_fd is not None else str(guard),
+        os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=home_fd,
+    )
+    guard_info = os.fstat(fd)
+    getuid = getattr(os, "geteuid", None)
+    if guard_stat is None:
+        os.fchmod(fd, 0o600)
+        guard_info = os.fstat(fd)
+    if (
+        not stat.S_ISREG(guard_info.st_mode)
+        or guard_info.st_nlink != 1
+        or stat.S_IMODE(guard_info.st_mode) != 0o600
+        or (getuid is not None and guard_info.st_uid != getuid())
+    ):
+        os.close(fd)
+        raise HomeInUseError(f"invalid lease guard: {guard}")
+    if guard_stat is not None and (guard_stat.st_dev, guard_stat.st_ino) != (
+        guard_info.st_dev,
+        guard_info.st_ino,
+    ):
+        os.close(fd)
+        raise HomeInUseError(f"lease guard changed during validation: {guard}")
+    if home_fd is None:
+        named = guard.lstat()
+        if stat.S_ISLNK(named.st_mode) or (named.st_dev, named.st_ino) != (
+            guard_info.st_dev,
+            guard_info.st_ino,
+        ):
+            os.close(fd)
+            raise HomeInUseError(f"invalid lease guard: {guard}")
+    if guard_info.st_size == 0:
+        _write_all(fd, b"\0")
+        os.fsync(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+    try:
+        with _bounded_guard_lock(fd):
+            yield
+    finally:
+        os.close(fd)
+
+
+@contextlib.contextmanager
+def _existing_lease_guard(home: Path, *, home_fd: int) -> Iterator[None]:
+    """Join an existing home lease without creating state in a bare orphan."""
+    if _entry_stat(_LEASE_GUARD_NAME, home_fd) is None:
+        yield
+        return
+    with _lease_guard(home, home_fd=home_fd):
+        yield
+
+
+@contextlib.contextmanager
+def _retention_guard(root: Path, root_fd: int) -> Iterator[None]:
+    """Serialize isolated-home publication and cleanup across processes."""
+    entry = _entry_stat(_RETENTION_GUARD_NAME, root_fd)
+    if entry is not None and (
+        not stat.S_ISREG(entry.st_mode)
+        or entry.st_nlink != 1
+        or stat.S_IMODE(entry.st_mode) != 0o600
+    ):
+        raise HomeInUseError(f"unsafe retention guard: {root / _RETENTION_GUARD_NAME}")
+    fd = os.open(
+        _RETENTION_GUARD_NAME,
+        os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=root_fd,
+    )
+    try:
+        info = os.fstat(fd)
+        getuid = getattr(os, "geteuid", None)
+        if entry is None:
+            os.fchmod(fd, 0o600)
+            info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_nlink != 1
+            or stat.S_IMODE(info.st_mode) != 0o600
+            or (getuid is not None and info.st_uid != getuid())
+        ):
+            raise HomeInUseError(f"unsafe retention guard: {root / _RETENTION_GUARD_NAME}")
+        if entry is not None and (entry.st_dev, entry.st_ino) != (info.st_dev, info.st_ino):
+            raise HomeInUseError(
+                f"retention guard changed during validation: {root / _RETENTION_GUARD_NAME}"
+            )
+        if info.st_size == 0:
+            _write_all(fd, b"\0")
+            os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+        with _bounded_guard_lock(fd):
+            yield
+    finally:
+        os.close(fd)
+
+
+def _append_retention_receipt(root_fd: int, payload: dict[str, object]) -> None:
+    getuid = getattr(os, "geteuid", None)
+    entry = _entry_stat(_RETENTION_RECEIPT_NAME, root_fd)
+    if entry is not None and (
+        not stat.S_ISREG(entry.st_mode)
+        or entry.st_nlink != 1
+        or stat.S_IMODE(entry.st_mode) != 0o600
+        or (getuid is not None and entry.st_uid != getuid())
+    ):
+        raise HomeInUseError("unsafe retention receipt file")
+    fd = os.open(
+        _RETENTION_RECEIPT_NAME,
+        os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=root_fd,
+    )
+    try:
+        info = os.fstat(fd)
+        if entry is None:
+            os.fchmod(fd, 0o600)
+            info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_nlink != 1
+            or stat.S_IMODE(info.st_mode) != 0o600
+            or (getuid is not None and info.st_uid != getuid())
+        ):
+            raise HomeInUseError("unsafe retention receipt file")
+        if entry is not None and (entry.st_dev, entry.st_ino) != (info.st_dev, info.st_ino):
+            raise HomeInUseError("retention receipt changed during validation")
+        _write_all(fd, (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    _fsync_directory(root_fd)
+
+
+def _read_retention_receipts(root_fd: int) -> tuple[dict[str, object], ...]:
+    """Read and validate the bounded append-only quarantine ledger."""
+    entry = _entry_stat(_RETENTION_RECEIPT_NAME, root_fd)
+    if entry is None:
+        return ()
+    getuid = getattr(os, "geteuid", None)
+    if (
+        not stat.S_ISREG(entry.st_mode)
+        or entry.st_nlink != 1
+        or stat.S_IMODE(entry.st_mode) != 0o600
+        or entry.st_size > _RETENTION_MAX_RECEIPT_BYTES
+        or (getuid is not None and entry.st_uid != getuid())
+    ):
+        raise HomeInUseError("unsafe retention receipt file")
+    raw = _read_bounded_regular(
+        Path(_RETENTION_RECEIPT_NAME),
+        dir_fd=root_fd,
+        private=True,
+        max_bytes=_RETENTION_MAX_RECEIPT_BYTES,
+    )
+    if raw is None:
+        raise HomeInUseError("unreadable retention receipt file")
+
+    records: list[dict[str, object]] = []
+    for line_number, line in enumerate(raw.splitlines(), start=1):
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HomeInUseError(f"invalid retention receipt at line {line_number}") from exc
+        if not isinstance(record, dict):
+            raise HomeInUseError(f"invalid retention receipt at line {line_number}")
+        quarantine = record.get("quarantine")
+        home = record.get("home")
+        device = record.get("device")
+        inode = record.get("inode")
+        size_bytes = record.get("size_bytes")
+        timestamp_ns = record.get("timestamp_ns")
+        reason = record.get("reason")
+        if (
+            record.get("schema") != "tokenpak.codex.retention.v1"
+            or record.get("action") not in {"planned", "completed"}
+            or not isinstance(quarantine, str)
+            or _RETENTION_QUARANTINE_RE.fullmatch(quarantine) is None
+            or not isinstance(home, str)
+            or _SESSION_ID_RE.fullmatch(home) is None
+            or not isinstance(device, int)
+            or isinstance(device, bool)
+            or device < 0
+            or not isinstance(inode, int)
+            or isinstance(inode, bool)
+            or inode <= 0
+            or not isinstance(size_bytes, int)
+            or isinstance(size_bytes, bool)
+            or size_bytes < 0
+            or not isinstance(timestamp_ns, int)
+            or isinstance(timestamp_ns, bool)
+            or timestamp_ns <= 0
+            or not isinstance(reason, str)
+            or _SESSION_ID_RE.fullmatch(reason) is None
+        ):
+            raise HomeInUseError(f"invalid retention receipt at line {line_number}")
+        records.append(record)
+    return tuple(records)
+
+
+def _remove_tree_contents_at(
+    directory_fd: int,
+    *,
+    root_device: int,
+    deadline: float,
+    counter: list[int],
+) -> None:
+    """Delete a quarantined tree through pinned descriptors only."""
+    try:
+        names: list[str] = []
+        with os.scandir(directory_fd) as entries:
+            for entry in entries:
+                if time.monotonic() >= deadline:
+                    raise HomeInUseError("quarantined isolated-home cleanup timed out")
+                if len(names) + counter[0] >= _RETENTION_MAX_NODES:
+                    raise HomeInUseError("quarantined isolated home exceeds cleanup node limit")
+                names.append(entry.name)
+    except OSError as exc:
+        raise HomeInUseError("cannot enumerate quarantined isolated home") from exc
+    for name in names:
+        if time.monotonic() >= deadline:
+            raise HomeInUseError("quarantined isolated-home cleanup timed out")
+        counter[0] += 1
+        info = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if info.st_dev != root_device:
+            raise HomeInUseError("refusing to cross a mount during isolated-home cleanup")
+        if stat.S_ISDIR(info.st_mode):
+            child_fd = os.open(
+                name,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=directory_fd,
+            )
+            try:
+                pinned = os.fstat(child_fd)
+                if (pinned.st_dev, pinned.st_ino) != (info.st_dev, info.st_ino):
+                    raise HomeInUseError("directory changed during isolated-home cleanup")
+                _remove_tree_contents_at(
+                    child_fd,
+                    root_device=root_device,
+                    deadline=deadline,
+                    counter=counter,
+                )
+            finally:
+                os.close(child_fd)
+            current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            if (current.st_dev, current.st_ino) != (info.st_dev, info.st_ino):
+                raise HomeInUseError("directory changed before isolated-home removal")
+            os.rmdir(name, dir_fd=directory_fd)
+        else:
+            os.unlink(name, dir_fd=directory_fd)
+
+
+def _purge_quarantine_at(
+    root_fd: int,
+    quarantine: str,
+    *,
+    expected_device: int,
+    expected_inode: int,
+    deadline: float,
+) -> None:
+    """Delete one receipt-proven quarantine through pinned descriptors."""
+    if _RETENTION_QUARANTINE_RE.fullmatch(quarantine) is None:
+        raise HomeInUseError("invalid isolated-home quarantine name")
+    entry = _entry_stat(quarantine, root_fd)
+    getuid = getattr(os, "geteuid", None)
+    if (
+        entry is None
+        or not stat.S_ISDIR(entry.st_mode)
+        or stat.S_IMODE(entry.st_mode) != 0o700
+        or (getuid is not None and entry.st_uid != getuid())
+        or (entry.st_dev, entry.st_ino) != (expected_device, expected_inode)
+    ):
+        raise HomeInUseError("quarantine does not match its retention receipt")
+    quarantine_fd = os.open(
+        quarantine,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=root_fd,
+    )
+    try:
+        pinned = os.fstat(quarantine_fd)
+        if (
+            not stat.S_ISDIR(pinned.st_mode)
+            or stat.S_IMODE(pinned.st_mode) != 0o700
+            or (getuid is not None and pinned.st_uid != getuid())
+            or (pinned.st_dev, pinned.st_ino) != (expected_device, expected_inode)
+        ):
+            raise HomeInUseError("quarantine inode does not match its retention receipt")
+        _remove_tree_contents_at(
+            quarantine_fd,
+            root_device=expected_device,
+            deadline=deadline,
+            counter=[0],
+        )
+    finally:
+        os.close(quarantine_fd)
+    current = os.stat(quarantine, dir_fd=root_fd, follow_symlinks=False)
+    if (current.st_dev, current.st_ino) != (expected_device, expected_inode):
+        raise HomeInUseError("quarantine changed before final removal")
+    os.rmdir(quarantine, dir_fd=root_fd)
+    _fsync_directory(root_fd)
+
+
+def _recover_quarantines_at(
+    root: Path,
+    root_fd: int,
+    *,
+    deadline: float,
+) -> tuple[tuple[Path, ...], tuple[str, ...]]:
+    """Resume receipt-proven quarantines; preserve and report all others."""
+    names: list[str] = []
+    try:
+        with os.scandir(root_fd) as entries:
+            for entry_count, entry in enumerate(entries, start=1):
+                if time.monotonic() >= deadline:
+                    return (), ("quarantine recovery wall-time limit reached",)
+                if entry_count > _RETENTION_MAX_ENTRIES:
+                    return (), ("quarantine inventory exceeds retention entry limit",)
+                if entry.name.startswith(_RETENTION_QUARANTINE_PREFIX):
+                    names.append(entry.name)
+    except OSError as exc:
+        return (), (f"cannot inspect quarantine inventory: {exc}",)
+    names.sort()
+    if not names:
+        return (), ()
+    if len(names) > _RETENTION_MAX_ENTRIES:
+        return (), ("quarantine inventory exceeds retention entry limit",)
+    try:
+        records = _read_retention_receipts(root_fd)
+    except (OSError, RuntimeError) as exc:
+        return (), (str(exc),)
+
+    planned: dict[str, dict[str, object]] = {}
+    completed: set[str] = set()
+    conflicted: set[str] = set()
+    errors: list[str] = []
+    for record in records:
+        quarantine = str(record["quarantine"])
+        if record["action"] == "completed":
+            completed.add(quarantine)
+            continue
+        prior = planned.get(quarantine)
+        if prior is not None and any(
+            prior[field] != record[field]
+            for field in ("home", "device", "inode", "size_bytes", "reason")
+        ):
+            errors.append(f"{quarantine}: conflicting planned retention receipts")
+            conflicted.add(quarantine)
+            planned.pop(quarantine, None)
+            continue
+        if quarantine in conflicted:
+            continue
+        planned[quarantine] = record
+
+    removed: list[Path] = []
+    for quarantine in names:
+        if time.monotonic() >= deadline:
+            errors.append("quarantine recovery wall-time limit reached")
+            break
+        if quarantine in conflicted:
+            continue
+        receipt = planned.get(quarantine)
+        if receipt is None:
+            errors.append(f"{quarantine}: no planned retention receipt")
+            continue
+        if quarantine in completed:
+            errors.append(f"{quarantine}: completed receipt still has a quarantine")
+            continue
+        try:
+            _purge_quarantine_at(
+                root_fd,
+                quarantine,
+                expected_device=int(receipt["device"]),
+                expected_inode=int(receipt["inode"]),
+                deadline=deadline,
+            )
+            _append_retention_receipt(
+                root_fd,
+                {
+                    **receipt,
+                    "action": "completed",
+                    "timestamp_ns": time.time_ns(),
+                },
+            )
+            removed.append(root / str(receipt["home"]))
+        except (OSError, RuntimeError) as exc:
+            errors.append(f"{quarantine}: {exc}")
+    return tuple(removed), tuple(errors)
+
+
+def _retire_isolated_home_at(
+    root: Path,
+    root_fd: int,
+    expected: _IsolatedHomeInfo,
+    *,
+    reason: str,
+    deadline: float,
+    proc_root: Path = Path("/proc"),
+) -> Path:
+    """Revalidate, receipt, quarantine, and delete exactly one orphan."""
+    home_fd = os.open(
+        expected.path.name,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=root_fd,
+    )
+    try:
+        pinned = os.fstat(home_fd)
+        if (pinned.st_dev, pinned.st_ino) != (expected.device, expected.inode):
+            raise HomeInUseError(f"isolated home changed before cleanup: {expected.path}")
+        # cleanup already holds the root retention guard.  Joining any
+        # pre-existing home guard closes races with older launchers that did
+        # not yet coordinate transfer publication through the root guard.
+        with _existing_lease_guard(expected.path, home_fd=home_fd):
+            current = _inspect_isolated_home_at(
+                root_fd,
+                root,
+                expected.path.name,
+                now=time.time(),
+                deadline=deadline,
+                proc_root=proc_root,
+            )
+            if (
+                not current.orphaned
+                or not current.size_complete
+                or (current.device, current.inode) != (expected.device, expected.inode)
+            ):
+                raise HomeInUseError(f"isolated home changed before cleanup: {expected.path}")
+
+            from . import state_lock
+
+            status = state_lock.probe(
+                current.path,
+                deadline=deadline,
+            )
+            if status.locked or not status.diagnostics_complete:
+                raise HomeInUseError(
+                    f"isolated home has live or incomplete holder evidence: {current.path}"
+                )
+            final = _inspect_isolated_home_at(
+                root_fd,
+                root,
+                expected.path.name,
+                now=time.time(),
+                deadline=deadline,
+                proc_root=proc_root,
+            )
+            stable_fields = (
+                "device",
+                "inode",
+                "mtime",
+                "size_bytes",
+                "size_complete",
+                "state",
+                "pid",
+            )
+            if not final.orphaned or any(
+                getattr(final, field) != getattr(current, field) for field in stable_fields
+            ):
+                raise HomeInUseError(
+                    f"isolated home changed after holder inspection: {expected.path}"
+                )
+            quarantine = f"{_RETENTION_QUARANTINE_PREFIX}{uuid.uuid4().hex}"
+            receipt = {
+                "schema": "tokenpak.codex.retention.v1",
+                "action": "planned",
+                "home": current.path.name,
+                "device": current.device,
+                "inode": current.inode,
+                "size_bytes": current.size_bytes,
+                "reason": reason,
+                "quarantine": quarantine,
+                "timestamp_ns": time.time_ns(),
+            }
+            _append_retention_receipt(root_fd, receipt)
+            os.rename(current.path.name, quarantine, src_dir_fd=root_fd, dst_dir_fd=root_fd)
+            _fsync_directory(root_fd)
+    finally:
+        os.close(home_fd)
+    _purge_quarantine_at(
+        root_fd,
+        quarantine,
+        expected_device=current.device,
+        expected_inode=current.inode,
+        deadline=deadline,
+    )
+    _append_retention_receipt(
+        root_fd,
+        {
+            **receipt,
+            "action": "completed",
+            "timestamp_ns": time.time_ns(),
+        },
+    )
+    return current.path
+
+
+def _retention_plan(
+    report: _RetentionReport,
+    *,
+    preserve_home: Path | None,
+    remove_all_orphans: bool,
+    remove_all_reason: str = "explicit-orphan-cleanup",
+) -> list[tuple[_IsolatedHomeInfo, str]]:
+    preserve = str(preserve_home.resolve()) if preserve_home is not None else None
+    eligible = [
+        home
+        for home in report.homes
+        if home.orphaned
+        and home.size_complete
+        and (preserve is None or str(home.path.resolve()) != preserve)
+    ]
+    eligible.sort(key=lambda home: (home.mtime, home.path.name))
+    if remove_all_orphans:
+        return [(home, remove_all_reason) for home in eligible]
+
+    planned: list[tuple[_IsolatedHomeInfo, str]] = []
+    selected: set[Path] = set()
+    for home in eligible:
+        if home.age_s > RETENTION_MAX_AGE_S:
+            planned.append((home, "age"))
+            selected.add(home.path)
+
+    remaining_count = len(report.homes) - len(selected)
+    for home in eligible:
+        if remaining_count <= RETENTION_MAX_HOMES:
+            break
+        if home.path in selected:
+            continue
+        planned.append((home, "count"))
+        selected.add(home.path)
+        remaining_count -= 1
+
+    remaining_bytes = report.total_bytes - sum(
+        home.size_bytes for home in eligible if home.path in selected
+    )
+    for home in eligible:
+        if remaining_bytes <= RETENTION_MAX_TOTAL_BYTES:
+            break
+        if home.path in selected:
+            continue
+        planned.append((home, "size"))
+        selected.add(home.path)
+        remaining_bytes -= home.size_bytes
+    return planned
+
+
+def cleanup_isolated_homes(
+    tokenpak_home: Path | None = None,
+    *,
+    preserve_home: Path | None = None,
+    remove_all_orphans: bool = False,
+    dry_run: bool = False,
+    orphan_cleanup_reason: str = "explicit-orphan-cleanup",
+    proc_root: Path = Path("/proc"),
+) -> _CleanupResult:
+    """Apply the isolated-home policy without touching live/unknown homes."""
+    if tokenpak_home is None and preserve_home is not None:
+        tokenpak_home = _generated_tokenpak_root(preserve_home)
+    opened = _open_managed_sessions_root(tokenpak_home)
+    if opened is None:
+        empty = inspect_isolated_homes(tokenpak_home, proc_root=proc_root)
+        return _CleanupResult(empty, empty, (), (), ())
+    root, root_fd = opened
+    removed: list[Path] = []
+    errors: list[str] = []
+    deadline = time.monotonic() + _RETENTION_SCAN_TIMEOUT_S
+    try:
+        with _retention_guard(root, root_fd):
+            if not dry_run:
+                recovered, recovery_errors = _recover_quarantines_at(
+                    root,
+                    root_fd,
+                    deadline=deadline,
+                )
+                removed.extend(recovered)
+                errors.extend(recovery_errors)
+            before = inspect_isolated_homes(
+                tokenpak_home,
+                deadline=deadline,
+                proc_root=proc_root,
+            )
+            if not before.inventory_complete:
+                errors.append("isolated-home inventory incomplete; preserving all ordinary homes")
+                plan: list[tuple[_IsolatedHomeInfo, str]] = []
+            else:
+                plan = _retention_plan(
+                    before,
+                    preserve_home=preserve_home,
+                    remove_all_orphans=remove_all_orphans,
+                    remove_all_reason=orphan_cleanup_reason,
+                )
+            if not dry_run:
+                for home, reason in plan:
+                    if time.monotonic() >= deadline:
+                        errors.append("retention cleanup wall-time limit reached")
+                        break
+                    try:
+                        removed.append(
+                            _retire_isolated_home_at(
+                                root,
+                                root_fd,
+                                home,
+                                reason=reason,
+                                deadline=deadline,
+                                proc_root=proc_root,
+                            )
+                        )
+                    except (OSError, RuntimeError) as exc:
+                        errors.append(f"{home.path.name}: {exc}")
+            after = (
+                before
+                if dry_run
+                else inspect_isolated_homes(
+                    tokenpak_home,
+                    deadline=deadline,
+                    proc_root=proc_root,
+                )
+            )
+            return _CleanupResult(
+                before=before,
+                after=after,
+                removed=tuple(removed),
+                planned=tuple(home.path for home, _reason in plan),
+                errors=tuple(errors),
+            )
+    finally:
+        os.close(root_fd)
+
+
+def _fsync_directory(dir_fd: int) -> None:
+    """Persist directory-entry publication on platforms that support it."""
+    try:
+        os.fsync(dir_fd)
+    except OSError as exc:  # pragma: no cover - Windows directory handles
+        if exc.errno not in {errno.EINVAL, errno.EBADF}:
+            raise
+
+
+def _sentinel_payload(sentinel: PidSentinel) -> bytes:
+    return (json.dumps(asdict(sentinel), sort_keys=True) + "\n").encode("utf-8")
+
+
+def _create_sentinel_temp(
+    path: Path,
+    sentinel: PidSentinel,
+    *,
+    dir_fd: int | None,
+    phase: str,
+) -> tuple[str, tuple[int, int]]:
+    """Durably create and verify one private lifecycle temp artifact."""
+    if phase not in {"acquire", "transfer"}:
+        raise ValueError("invalid sentinel publication phase")
+    payload = _sentinel_payload(sentinel)
+    tmp_name = f".{PID_SENTINEL_NAME}.{phase}.{uuid.uuid4().hex}.tmp"
+    tmp_target = tmp_name if dir_fd is not None else str(path.parent / tmp_name)
+    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(tmp_target, flags, 0o600, dir_fd=dir_fd)
+    try:
+        os.fchmod(fd, 0o600)
+        _write_all(fd, payload)
+        os.fsync(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        persisted = os.read(fd, _MAX_SENTINEL_BYTES + 1)
+        try:
+            parsed = _sentinel_from_data(json.loads(persisted))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            parsed = None
+        info = os.fstat(fd)
+        if parsed != sentinel:
+            raise OSError("sentinel verification failed before publication")
+        identity = (info.st_dev, info.st_ino)
+        os.close(fd)
+        fd = -1
+        if dir_fd is not None:
+            _fsync_directory(dir_fd)
+        return tmp_name, identity
+    except BaseException:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(OSError):
+            if dir_fd is None:
+                os.unlink(path.parent / tmp_name)
+            else:
+                os.unlink(tmp_name, dir_fd=dir_fd)
+                with contextlib.suppress(OSError):
+                    _fsync_directory(dir_fd)
+        raise
+
+
+def _write_sentinel_atomic(
+    path: Path,
+    sentinel: PidSentinel,
+    *,
+    dir_fd: int | None,
+    phase: str,
+    replace_existing: bool,
+) -> None:
+    """Publish a complete private sentinel with fsync + atomic rename."""
+    tmp_name, _identity = _create_sentinel_temp(
+        path,
+        sentinel,
+        dir_fd=dir_fd,
+        phase=phase,
+    )
+    published = False
+    try:
+        existing = (
+            _entry_stat(PID_SENTINEL_NAME, dir_fd)
+            if dir_fd is not None
+            else path.lstat()
+            if path.exists() or path.is_symlink()
+            else None
+        )
+        if not replace_existing and existing is not None:
+            raise FileExistsError(PID_SENTINEL_NAME)
+        if dir_fd is None:
+            os.replace(path.parent / tmp_name, path)
+            published = True
+        else:
+            os.replace(
+                tmp_name,
+                PID_SENTINEL_NAME,
+                src_dir_fd=dir_fd,
+                dst_dir_fd=dir_fd,
+            )
+            published = True
+            _fsync_directory(dir_fd)
+    except BaseException:
+        # Initial publication has no predecessor to restore.  If durability
+        # confirmation fails after rename, remove only the exact record just
+        # written so a bounded ENOSPC/EDQUOT retry cannot collide with itself.
+        if published and not replace_existing:
+            current = read_pid_sentinel(path, dir_fd=dir_fd)
+            if current == sentinel:
+                with contextlib.suppress(OSError):
+                    _unlink_sentinel(path, dir_fd)
+        raise
+    finally:
+        with contextlib.suppress(OSError):
+            if dir_fd is None:
+                os.unlink(path.parent / tmp_name)
+            else:
+                os.unlink(tmp_name, dir_fd=dir_fd)
+
+
+def _unlink_owned_sentinel_temp(
+    path: Path,
+    *,
+    name: str,
+    expected_identity: tuple[int, int],
+    expected_sentinel: PidSentinel,
+    dir_fd: int | None,
+) -> None:
+    """Remove only the exact durable handoff marker this lease created."""
+    entry = (
+        _entry_stat(name, dir_fd)
+        if dir_fd is not None
+        else (path.parent / name).lstat()
+        if (path.parent / name).exists() or (path.parent / name).is_symlink()
+        else None
+    )
+    if entry is None:
+        return
+    if (
+        not stat.S_ISREG(entry.st_mode)
+        or entry.st_nlink != 1
+        or stat.S_IMODE(entry.st_mode) != 0o600
+        or (entry.st_dev, entry.st_ino) != expected_identity
+    ):
+        raise HomeInUseError(f"handoff marker changed during launch: {path.parent / name}")
+    current = read_pid_sentinel(
+        Path(name) if dir_fd is not None else path.parent / name,
+        dir_fd=dir_fd,
+    )
+    if current != expected_sentinel:
+        raise HomeInUseError(f"handoff marker content changed during launch: {path.parent / name}")
+    if dir_fd is None:
+        os.unlink(path.parent / name)
+    else:
+        os.unlink(name, dir_fd=dir_fd)
+        _fsync_directory(dir_fd)
+
+
+def _recover_sentinel_temps(
+    path: Path,
+    *,
+    dir_fd: int | None,
+    proc_root: Path,
+) -> None:
+    """Recover only positively identified crash artifacts under the guard."""
+    getuid = getattr(os, "geteuid", None)
+    location = dir_fd if dir_fd is not None else path.parent
+    try:
+        entries = os.scandir(location)
+    except OSError as exc:
+        raise HomeInUseError(f"cannot inspect sentinel recovery artifacts: {path.parent}") from exc
+    with entries:
+        names: list[str] = []
+        for entry_count, entry in enumerate(entries, start=1):
+            if entry_count > _RETENTION_MAX_ENTRIES:
+                raise HomeInUseError("sentinel recovery artifact inventory exceeds limit")
+            if _is_sentinel_temp_candidate(entry.name):
+                names.append(entry.name)
+    for name in names:
+        match = _SENTINEL_TEMP_RE.fullmatch(name)
+        if match is None:
+            raise HomeInUseError(f"unsafe sentinel recovery artifact: {path.parent / name}")
+        if dir_fd is not None:
+            entry = _entry_stat(name, dir_fd)
+        else:
+            try:
+                entry = (path.parent / name).lstat()
+            except FileNotFoundError:
+                entry = None
+        if entry is None:
+            continue
+        if (
+            not stat.S_ISREG(entry.st_mode)
+            or entry.st_nlink != 1
+            or stat.S_IMODE(entry.st_mode) != 0o600
+            or (getuid is not None and entry.st_uid != getuid())
+        ):
+            raise HomeInUseError(f"unsafe sentinel recovery artifact: {path.parent / name}")
+        candidate = read_pid_sentinel(
+            Path(name) if dir_fd is not None else path.parent / name,
+            dir_fd=dir_fd,
+        )
+        phase = match.group(1)
+        if candidate is None:
+            if phase == "transfer":
+                raise HomeInUseError(
+                    f"partial transfer sentinel requires manual inspection: {path.parent / name}"
+                )
+            os.unlink(name if dir_fd is not None else path.parent / name, dir_fd=dir_fd)
+            if dir_fd is not None:
+                _fsync_directory(dir_fd)
+            continue
+        liveness = _sentinel_liveness(
+            candidate,
+            expected_home=path.parent,
+            proc_root=proc_root,
+        )
+        if liveness == _PROCESS_LIVE:
+            raise HomeInUseError(
+                f"live sentinel recovery artifact claims PID {candidate.pid}: {path.parent / name}"
+            )
+        if liveness == _PROCESS_UNKNOWN:
+            raise HomeInUseError(
+                f"incomplete sentinel recovery evidence for PID {candidate.pid}: "
+                f"{path.parent / name}"
+            )
+        if phase == "transfer":
+            raise HomeInUseError(
+                f"interrupted transfer sentinel requires manual inspection: {path.parent / name}"
+            )
+        os.unlink(name if dir_fd is not None else path.parent / name, dir_fd=dir_fd)
+        if dir_fd is not None:
+            _fsync_directory(dir_fd)
+
+
+def _write_sentinel_exclusive(
+    path: Path, sentinel: PidSentinel, *, dir_fd: int | None = None
+) -> None:
+    """Compatibility wrapper for guarded initial atomic publication."""
+    _write_sentinel_atomic(
+        path,
+        sentinel,
+        dir_fd=dir_fd,
+        phase="acquire",
+        replace_existing=False,
+    )
+
+
+def _sentinel_stat(path: Path, home_fd: int | None) -> os.stat_result | None:
+    if home_fd is not None:
+        return _entry_stat(PID_SENTINEL_NAME, home_fd)
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def _unlink_sentinel(path: Path, home_fd: int | None) -> None:
+    if home_fd is None:
+        path.unlink()
+    else:
+        os.unlink(PID_SENTINEL_NAME, dir_fd=home_fd)
+        _fsync_directory(home_fd)
+
+
+class SessionLease:
+    """Owner-checked ``codex.pid`` lifecycle lease."""
+
+    def __init__(
+        self,
+        paths: SessionPaths,
+        sentinel: PidSentinel,
+        *,
+        proc_root: Path = Path("/proc"),
+        home_fd: int | None,
+    ) -> None:
+        self.paths = paths
+        self.sentinel = sentinel
+        self.proc_root = proc_root
+        self.home_fd = home_fd
+        self._released = False
+        self._handoff_temp: tuple[str, tuple[int, int], PidSentinel] | None = None
+
+    def assert_home_binding(self) -> None:
+        """Fail if the selected pathname no longer names the pinned home."""
+        if self.paths.mode == MODE_SHARED:
+            return
+        try:
+            current = os.stat(self.paths.home, follow_symlinks=False)
+            pinned = os.fstat(self.home_fd)
+        except OSError as exc:
+            raise HomeInUseError("selected CODEX_HOME disappeared during launch") from exc
+        if not stat.S_ISDIR(current.st_mode) or (current.st_dev, current.st_ino) != (
+            pinned.st_dev,
+            pinned.st_ino,
+        ):
+            raise HomeInUseError("selected CODEX_HOME changed during launch")
+
+    @contextlib.contextmanager
+    def _mutation_guard(self) -> Iterator[None]:
+        """Serialize isolated lifecycle mutation in retention→home order."""
+        managed_root = _generated_tokenpak_root(self.paths.home)
+        if self.paths.mode != MODE_ISOLATED or managed_root is None:
+            with _lease_guard(self.paths.home, home_fd=self.home_fd):
+                yield
+            return
+        opened = _open_managed_sessions_root(managed_root)
+        if opened is None:
+            raise HomeInUseError("managed sessions root disappeared during launch")
+        root, root_fd = opened
+        try:
+            with _retention_guard(root, root_fd):
+                self.assert_home_binding()
+                with _lease_guard(self.paths.home, home_fd=self.home_fd):
+                    yield
+        finally:
+            os.close(root_fd)
+
+    @classmethod
+    def acquire(
+        cls,
+        paths: SessionPaths,
+        *,
+        pid: int | None = None,
+        session_id: str | None = None,
+        proc_root: Path = Path("/proc"),
+    ) -> "SessionLease":
+        home_fd: int | None = None
+        owner_pid = pid if pid is not None else os.getpid()
+        identity = _proc_identity(owner_pid, proc_root)
+        if identity is None:
+            raise RuntimeError(f"cannot validate launcher PID {owner_pid}")
+        state, start_ticks = identity
+        if state in {"Z", "X", "x"}:
+            raise RuntimeError(f"launcher PID {owner_pid} is not running")
+        validated_session_id = _validated_session_id(session_id)
+
+        def claim(sentinel: PidSentinel) -> None:
+            with _lease_guard(paths.home, home_fd=home_fd):
+                _recover_sentinel_temps(
+                    paths.pid_sentinel,
+                    dir_fd=home_fd,
+                    proc_root=proc_root,
+                )
+                if _sentinel_stat(paths.pid_sentinel, home_fd) is not None:
+                    existing = read_pid_sentinel(paths.pid_sentinel, dir_fd=home_fd)
+                    if existing is None:
+                        raise HomeInUseError(
+                            f"invalid {paths.pid_sentinel}; refusing unsafe replacement"
+                        )
+                    process_liveness = _sentinel_liveness(
+                        existing,
+                        proc_root=proc_root,
+                    )
+                    liveness = _sentinel_liveness(
+                        existing,
+                        expected_home=paths.home,
+                        proc_root=proc_root,
+                    )
+                    if process_liveness == _PROCESS_LIVE and liveness != _PROCESS_LIVE:
+                        raise HomeInUseError(
+                            f"live {paths.pid_sentinel} is bound to another home; "
+                            "refusing unsafe replacement"
+                        )
+                    if liveness == _PROCESS_LIVE:
+                        raise HomeInUseError(
+                            f"{paths.home} is already claimed by PID {existing.pid}"
+                        )
+                    if liveness == _PROCESS_UNKNOWN:
+                        raise HomeInUseError(
+                            f"incomplete {paths.pid_sentinel} process evidence; "
+                            "refusing unsafe replacement"
+                        )
+                    _unlink_sentinel(paths.pid_sentinel, home_fd)
+                _write_sentinel_exclusive(paths.pid_sentinel, sentinel, dir_fd=home_fd)
+
+        try:
+            managed_root = _generated_tokenpak_root(paths.home)
+            if paths.mode == MODE_ISOLATED and managed_root is not None:
+                root_opened = _open_managed_sessions_root(managed_root, create=True)
+                assert root_opened is not None
+                root_path, root_fd = root_opened
+                try:
+                    with _retention_guard(root_path, root_fd):
+                        # Publication ordering is deliberate: the isolated leaf
+                        # does not become visible until this process owns the
+                        # same coordinator used by retention cleanup, and the
+                        # guard remains held through the durable sentinel rename.
+                        home_fd = _open_isolated_leaf_at(paths, root_fd)
+                        sentinel = PidSentinel(
+                            schema=_SENTINEL_SCHEMA,
+                            pid=owner_pid,
+                            start_time_ticks=start_ticks,
+                            session_id=validated_session_id,
+                            mode=paths.mode,
+                            home=str(paths.home.resolve()),
+                        )
+                        claim(sentinel)
+                finally:
+                    os.close(root_fd)
+            else:
+                home_fd = _open_selected_home(paths)
+                sentinel = PidSentinel(
+                    schema=_SENTINEL_SCHEMA,
+                    pid=owner_pid,
+                    start_time_ticks=start_ticks,
+                    session_id=validated_session_id,
+                    mode=paths.mode,
+                    home=str(paths.home.resolve()),
+                )
+                claim(sentinel)
+            return cls(paths, sentinel, proc_root=proc_root, home_fd=home_fd)
+        except BaseException:
+            if home_fd is not None:
+                os.close(home_fd)
+            raise
+
+    def begin_transfer(self) -> None:
+        """Publish a durable handoff marker before spawning the child."""
+        if self._handoff_temp is not None:
+            raise HomeInUseError("PID sentinel handoff is already in progress")
+        with self._mutation_guard():
+            current = read_pid_sentinel(self.paths.pid_sentinel, dir_fd=self.home_fd)
+            if current != self.sentinel:
+                raise HomeInUseError("PID sentinel ownership changed before child launch")
+            name, identity = _create_sentinel_temp(
+                self.paths.pid_sentinel,
+                self.sentinel,
+                dir_fd=self.home_fd,
+                phase="transfer",
+            )
+            self._handoff_temp = (name, identity, self.sentinel)
+
+    def transfer_to(self, pid: int) -> None:
+        """Transfer the lease to the spawned child process incarnation."""
+        if self._handoff_temp is None:
+            # Compatibility for direct callers; the launcher calls
+            # begin_transfer() before Popen to close the spawn window.
+            self.begin_transfer()
+        identity = _proc_identity(pid, self.proc_root)
+        if identity is None:
+            raise RuntimeError(f"cannot validate Codex child PID {pid}")
+        state, start_ticks = identity
+        if state in {"Z", "X", "x"}:
+            raise RuntimeError(f"Codex child PID {pid} is not running")
+        replacement = PidSentinel(
+            schema=_SENTINEL_SCHEMA,
+            pid=pid,
+            start_time_ticks=start_ticks,
+            session_id=self.sentinel.session_id,
+            mode=self.sentinel.mode,
+            home=self.sentinel.home,
+        )
+        published = False
+        try:
+            with self._mutation_guard():
+                current = read_pid_sentinel(self.paths.pid_sentinel, dir_fd=self.home_fd)
+                if current != self.sentinel:
+                    raise HomeInUseError("PID sentinel ownership changed during launch")
+                revalidated = _proc_identity(pid, self.proc_root)
+                if revalidated != identity or revalidated is None or revalidated[0] in {
+                    "Z",
+                    "X",
+                    "x",
+                }:
+                    raise HomeInUseError("Codex child PID changed during handoff")
+                try:
+                    _write_sentinel_atomic(
+                        self.paths.pid_sentinel,
+                        replacement,
+                        dir_fd=self.home_fd,
+                        phase="transfer",
+                        replace_existing=True,
+                    )
+                except BaseException:
+                    # Rename may have succeeded before directory durability
+                    # reported ENOSPC/EDQUOT.  Bind this lease to the exact
+                    # replacement so supervised closeout can remove it later.
+                    if (
+                        read_pid_sentinel(self.paths.pid_sentinel, dir_fd=self.home_fd)
+                        == replacement
+                    ):
+                        published = True
+                        self.sentinel = replacement
+                    raise
+                published = True
+                self.sentinel = replacement
+                assert self._handoff_temp is not None
+                name, marker_identity, marker_sentinel = self._handoff_temp
+                _unlink_owned_sentinel_temp(
+                    self.paths.pid_sentinel,
+                    name=name,
+                    expected_identity=marker_identity,
+                    expected_sentinel=marker_sentinel,
+                    dir_fd=self.home_fd,
+                )
+                self._handoff_temp = None
+        finally:
+            if published:
+                self.sentinel = replacement
+
+    def release(self) -> bool:
+        """Remove only the still-matching sentinel owned by this session."""
+        if self._released:
+            return False
+        removed = False
+        try:
+            with self._mutation_guard():
+                if self._handoff_temp is not None:
+                    name, marker_identity, marker_sentinel = self._handoff_temp
+                    _unlink_owned_sentinel_temp(
+                        self.paths.pid_sentinel,
+                        name=name,
+                        expected_identity=marker_identity,
+                        expected_sentinel=marker_sentinel,
+                        dir_fd=self.home_fd,
+                    )
+                    self._handoff_temp = None
+                current = read_pid_sentinel(self.paths.pid_sentinel, dir_fd=self.home_fd)
+                if current == self.sentinel:
+                    with contextlib.suppress(FileNotFoundError):
+                        _unlink_sentinel(self.paths.pid_sentinel, self.home_fd)
+                    removed = True
+        finally:
+            self._released = True
+            if self.home_fd is not None:
+                os.close(self.home_fd)
+        return removed
+
+    def __enter__(self) -> "SessionLease":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb) -> None:
+        self.release()

--- a/tokenpak/companion/codex/skills_installer.py
+++ b/tokenpak/companion/codex/skills_installer.py
@@ -30,6 +30,7 @@ races a reader and old generations are never retained indefinitely.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import shutil
 import tempfile
@@ -39,10 +40,16 @@ from collections.abc import Iterator
 from pathlib import Path
 
 _BUNDLED_SKILLS = Path(__file__).parent / "skills"
-# Canonical user-scope path per Codex skill-discovery spec.
-_DEFAULT_TARGET = Path.home() / ".agents" / "skills"
-# Pre-L3 install path. Kept for defensive uninstall + doctor orphan reporting.
-_LEGACY_TARGET = Path.home() / ".codex" / "skills"
+
+# Tests may override these, but normal defaults are resolved at call time so a
+# changed HOME cannot leak an import-time path into another launcher session.
+_DEFAULT_TARGET: Path | None = None
+_LEGACY_TARGET: Path | None = None
+
+# The skill payloads live at the documented user discovery root, while every
+# selected CODEX_HOME gets explicit references in its own config.toml.
+_SKILLS_CONFIG_BEGIN = "# >>> tokenpak managed skills >>>"
+_SKILLS_CONFIG_END = "# <<< tokenpak managed skills <<<"
 
 # Transient dirs created during an atomic publish. Hidden + prefixed so
 # they are never mistaken for a skill (which must be a directory holding
@@ -66,6 +73,16 @@ _THREAD_LOCK = threading.RLock()
 _RECLAIM_MIN_AGE_S = 5.0
 
 
+def _default_skills_root() -> Path:
+    """Return Codex's canonical user-scope skills root."""
+    return _DEFAULT_TARGET or (Path.home() / ".agents" / "skills")
+
+
+def _legacy_skills_root() -> Path:
+    """Return the pre-L3 path used only for cleanup and diagnostics."""
+    return _LEGACY_TARGET or (Path.home() / ".codex" / "skills")
+
+
 def bundled_skill_names() -> list[str]:
     """Return the names of all skills shipped with this package.
 
@@ -75,9 +92,7 @@ def bundled_skill_names() -> list[str]:
     if not _BUNDLED_SKILLS.exists():
         return []
     return sorted(
-        p.name
-        for p in _BUNDLED_SKILLS.iterdir()
-        if p.is_dir() and (p / "SKILL.md").exists()
+        p.name for p in _BUNDLED_SKILLS.iterdir() if p.is_dir() and (p / "SKILL.md").exists()
     )
 
 
@@ -149,10 +164,7 @@ def _sweep_stale_temp(target: Path) -> None:
         except OSError:
             continue
         for entry in entries:
-            if not (
-                entry.name.startswith(_STAGE_PREFIX)
-                or entry.name.startswith(_BACKUP_PREFIX)
-            ):
+            if not (entry.name.startswith(_STAGE_PREFIX) or entry.name.startswith(_BACKUP_PREFIX)):
                 continue
             try:
                 age = now - entry.stat().st_mtime
@@ -227,7 +239,7 @@ def install_skills(target_dir: Path | None = None) -> list[Path]:
     sibling then swapped into place — so a reader never observes a
     half-copied or long-missing skill.
     """
-    target = target_dir or _DEFAULT_TARGET
+    target = target_dir or _default_skills_root()
     target.mkdir(parents=True, exist_ok=True)
 
     installed: list[Path] = []
@@ -243,7 +255,7 @@ def install_skills(target_dir: Path | None = None) -> list[Path]:
 
 def list_installed_skills(target_dir: Path | None = None) -> list[str]:
     """Return the bundled skills currently present in the target dir."""
-    target = target_dir or _DEFAULT_TARGET
+    target = target_dir or _default_skills_root()
     return [name for name in bundled_skill_names() if (target / name).exists()]
 
 
@@ -259,7 +271,7 @@ def uninstall_skills(target_dir: Path | None = None) -> list[str]:
     if target_dir is not None:
         targets = [target_dir]
     else:
-        targets = [_DEFAULT_TARGET, _LEGACY_TARGET]
+        targets = [_default_skills_root(), _legacy_skills_root()]
 
     removed: list[str] = []
     for name in bundled_skill_names():
@@ -285,4 +297,127 @@ def _orphaned_legacy_skills() -> list[str]:
     not part of the released public API surface recorded in
     ``_snapshots/public-api.json``.
     """
-    return [name for name in bundled_skill_names() if (_LEGACY_TARGET / name).exists()]
+    legacy = _legacy_skills_root()
+    return [name for name in bundled_skill_names() if (legacy / name).exists()]
+
+
+def _split_managed_skill_config(content: str) -> tuple[str, str | None]:
+    """Return config without our managed block and the prior block, if any.
+
+    A lone marker fails closed instead of risking damage to a user-owned TOML
+    file whose ownership boundary cannot be determined safely.
+    """
+    starts = content.count(_SKILLS_CONFIG_BEGIN)
+    ends = content.count(_SKILLS_CONFIG_END)
+    if starts != ends or starts > 1:
+        raise ValueError("malformed TokenPak skills config markers")
+    if starts == 0:
+        return content, None
+
+    start = content.index(_SKILLS_CONFIG_BEGIN)
+    end = content.index(_SKILLS_CONFIG_END, start) + len(_SKILLS_CONFIG_END)
+    # The installer owns exactly one separator newline before the marker and
+    # one terminator newline after it.  Keeping those bytes inside the managed
+    # region makes install -> uninstall restore user config byte-for-byte.
+    managed_start = start - 1 if start > 0 and content[start - 1] == "\n" else start
+    managed_end = end + 1 if content[end : end + 1] == "\n" else end
+    return content[:managed_start] + content[managed_end:], content[managed_start:managed_end]
+
+
+def _render_skill_config(skills_root: Path) -> str:
+    lines = [_SKILLS_CONFIG_BEGIN]
+    for name in bundled_skill_names():
+        skill_dir = skills_root / name
+        if not (skill_dir / "SKILL.md").is_file():
+            continue
+        lines.extend(
+            (
+                "[[skills.config]]",
+                f"path = {json.dumps(str(skill_dir))}",
+                "enabled = true",
+                "",
+            )
+        )
+    while lines[-1] == "":
+        lines.pop()
+    lines.append(_SKILLS_CONFIG_END)
+    return "\n".join(lines)
+
+
+def _write_private(path: Path, content: str) -> None:
+    """Replace one selected-home config atomically with private permissions."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+
+
+def _configure_skills(
+    config_path: Path,
+    *,
+    skills_root: Path | None = None,
+) -> list[Path]:
+    """Reference installed TokenPak skills from one selected CODEX_HOME.
+
+    Only an explicitly delimited ``[[skills.config]]`` block is owned. User
+    configuration outside that block is preserved byte-for-byte except for a
+    separating newline. The referenced paths are skill directories containing
+    ``SKILL.md``, as required by Codex's config schema.
+    """
+    root = skills_root or _default_skills_root()
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    _, prior = _split_managed_skill_config(existing)
+    block = _render_skill_config(root)
+    if prior is not None:
+        managed = (
+            ("\n" if prior.startswith("\n") else "")
+            + block
+            + ("\n" if prior.endswith("\n") else "")
+        )
+        content = existing.replace(prior, managed, 1)
+    else:
+        content = existing + ("\n" if existing else "") + block + "\n"
+    _write_private(config_path, content)
+    return [root / name for name in bundled_skill_names() if (root / name / "SKILL.md").is_file()]
+
+
+def _configured_skill_paths(config_path: Path) -> list[Path]:
+    """Return directory paths from TokenPak's managed config block."""
+    if not config_path.exists():
+        return []
+    _, block = _split_managed_skill_config(config_path.read_text(encoding="utf-8"))
+    if block is None:
+        return []
+    paths: list[Path] = []
+    for line in block.splitlines():
+        key, separator, value = line.partition("=")
+        if not separator or key.strip() != "path":
+            continue
+        try:
+            parsed = json.loads(value.strip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, str):
+            paths.append(Path(parsed))
+    return paths
+
+
+def _clean_skills_config(config_path: Path) -> bool:
+    """Remove only TokenPak's managed skill references from one config."""
+    if not config_path.exists():
+        return False
+    existing = config_path.read_text(encoding="utf-8")
+    base, block = _split_managed_skill_config(existing)
+    if block is None:
+        return False
+    _write_private(config_path, base)
+    return True

--- a/tokenpak/companion/codex/state_lock.py
+++ b/tokenpak/companion/codex/state_lock.py
@@ -1,68 +1,88 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Codex local-database lock diagnostics for ``CODEX_HOME``.
+"""Read-only Codex SQLite holder diagnostics for ``CODEX_HOME``.
 
-Codex keeps interactive session state and logs in SQLite databases under
-``CODEX_HOME`` (default ``~/.codex/``).  When two Codex processes share the
-same home they can contend over those databases, and a Codex process that
-is suspended by job control (``Tl`` — stopped via SIGTSTP) keeps the file
-descriptors open without releasing the lock.  The result is a zombie-style
-lock: the foreground process blocks on a database held by a process that
-will never make progress.
+The diagnostic path must not join, copy, checkpoint, or otherwise touch a
+Codex runtime database.  On Linux, the kernel already exposes the evidence we
+need: database file identities, open file descriptors, and advisory byte-range
+locks.  This module correlates those sources without importing ``sqlite3`` or
+opening a database file.
 
-This module gives the launcher a *preflight* read on that situation so it
-can refuse to start (or, in an isolated home, confirm the home is clean)
-with an actionable message instead of hanging on a contended database.
-
-Detection is deliberately dependency-free:
-
-* each known Codex-owned SQLite file is probed with an ``EXCLUSIVE``
-  ``BEGIN`` inside a short connection — if another connection holds the
-  database the probe raises ``sqlite3.OperationalError`` ("database is
-  locked"), which is the exact symptom we want to surface;
-* candidate holder PIDs are read from any sidecar ``*.lock`` / WAL files
-  and from a best-effort scan, then liveness-classified with
-  ``os.kill(pid, 0)`` and (on Linux) ``/proc`` so a stopped/zombie holder
-  is reported distinctly from a healthy concurrent session.
-
-No hard dependency on ``psutil`` — that keeps the launcher path importable
-on minimal installs.
+SQLite's rollback-mode locks live in the main database's pending/reserved/
+shared byte range.  WAL coordination locks live in bytes 120 through 127 of
+the ``-shm`` file, with byte 128 used for dead-man-switch coordination.  An
+open descriptor to a Codex database or sidecar is also treated as an unsafe
+shared-home attachment, even if the process happens to be between lock
+operations when sampled.
 """
 
 from __future__ import annotations
 
+import errno
+import hashlib
 import os
-import sqlite3
+import stat as stat_module
+import subprocess
+import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Callable
 
 # Companion-internal launcher helper (probe/remediation_hint are called by
-# launcher.py, not by end users): export nothing as released public API so
-# this module stays out of the public-API snapshot. Direct attribute access
-# (``state_lock.probe``) is unaffected — ``__all__`` only governs ``import *``
-# and the release-gate API walker.
+# launcher.py, not by end users): export nothing as released public API.
 __all__: list[str] = []
 
-# Codex's interactive state/log database filenames under CODEX_HOME.
+# Retained for callers and older installations.  Discovery itself is dynamic.
 STATE_DB_NAME = "state_5.sqlite"
 _LOG_DB_NAME = "logs_2.sqlite"
-_CODEX_DB_NAMES = (STATE_DB_NAME, _LOG_DB_NAME)
 
-# How long the probe waits for the database before declaring it locked.
-# Kept short — this is a preflight, not a retry loop.
-_PROBE_TIMEOUT_S = 0.5
+_PROC_ROOT = Path("/proc")
+
+# SQLite locking bytes from sqlite3.h/os_unix.c.
+_SQLITE_PENDING_BYTE = 0x40000000
+_SQLITE_SHARED_FIRST = _SQLITE_PENDING_BYTE + 2
+_SQLITE_SHARED_SIZE = 510
+_SQLITE_MAIN_LOCK_LAST = _SQLITE_SHARED_FIRST + _SQLITE_SHARED_SIZE - 1
+_SQLITE_SHM_LOCK_FIRST = 120
+_SQLITE_SHM_LOCK_LAST = 127
+_SQLITE_SHM_DMS = 128
+
+_DEAD_STATES = frozenset({"X", "x", "Z"})
+_STOPPED_STATES = frozenset({"T", "t"})
+_BENIGN_UNREADABLE_PROCESSES = frozenset({"sd-pam"})
+
+# Every probe has structural and wall-clock limits.  The values are generous
+# for a developer workstation but finite so a hostile or damaged procfs/home
+# cannot turn the launcher's 30-second wait into unbounded work.
+_MAX_DATABASES = 128
+_MAX_HOME_ENTRIES = 4096
+_MAX_PROCESSES = 65536
+_MAX_FDS_PER_PROCESS = 65536
+_MAX_TOTAL_FDS = 262144
+_MAX_PROC_LOCK_ROWS = 262144
+_DEFAULT_PROBE_TIMEOUT_S = 5.0
+_ERROR_NO_MORE_FILES = 18
+
+_REASON_LABELS = {
+    "database_discovery_incomplete": "Codex database discovery",
+    "database_limit": "Codex database discovery limit",
+    "database_target_incomplete": "Codex database target inspection",
+    "database_set_changed": "Codex database set changed during inspection",
+    "target_inode_replaced": "Codex database target inode changed during inspection",
+    "proc_inspection_incomplete": "/proc holder inspection",
+    "process_limit": "/proc process inspection limit",
+    "fd_limit": "/proc file-descriptor inspection limit",
+    "pid_reuse": "PID reuse detected during holder inspection",
+    "process_changed": "process changed during holder inspection",
+    "proc_lock_limit": "/proc lock inspection limit",
+    "probe_timeout": "holder inspection wall-time limit",
+    "portable_inspection_incomplete": "portable SQLite lock inspection",
+}
 
 
 @dataclass
 class LockStatus:
-    """Result of a state-lock preflight on one ``CODEX_HOME``.
-
-    ``locked`` is the load-bearing field: ``True`` means another
-    connection currently holds a Codex local database and a fresh Codex
-    session in this home would contend.  ``holder_pids`` /
-    ``stopped_pids`` are best-effort context for the message — they may be
-    empty even when ``locked`` is ``True`` (e.g. the holder PID could not
-    be recovered) and that does not weaken the ``locked`` verdict.
-    """
+    """Result of a read-only state-lock preflight on one ``CODEX_HOME``."""
 
     home: Path
     db_path: Path
@@ -71,197 +91,1173 @@ class LockStatus:
     holder_pids: list[int] = field(default_factory=list)
     stopped_pids: list[int] = field(default_factory=list)
     detail: str = ""
+    running_pids: list[int] = field(default_factory=list)
+    diagnostics_complete: bool = True
+    incomplete_reasons: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _FileIdentity:
+    path: Path
+    device: int
+    inode: int
+    owner_uid: int
+    role: str
+    db_path: Path
+
+    @property
+    def proc_device(self) -> tuple[int, int]:
+        return os.major(self.device), os.minor(self.device)
+
+
+@dataclass(frozen=True)
+class _ProcLock:
+    pid: int
+    device_major: int
+    device_minor: int
+    inode: int
+    start: int
+    end: int | None
+
+
+@dataclass(frozen=True)
+class _ProcessInfo:
+    pid: int
+    uid: int
+    state: str
+    start_time: int
+
+    @property
+    def stopped(self) -> bool:
+        return self.state in _STOPPED_STATES
+
+
+@dataclass
+class _ProbeBudget:
+    deadline: float
+    clock: Callable[[], float]
+    reasons: list[str] = field(default_factory=list)
+
+    def add(self, reason: str) -> None:
+        if reason not in self.reasons:
+            self.reasons.append(reason)
+
+    def expired(self) -> bool:
+        if self.clock() < self.deadline:
+            return False
+        self.add("probe_timeout")
+        return True
+
+
+@dataclass
+class _FdScan:
+    attachments: dict[int, tuple[_ProcessInfo, set[tuple[int, int]]]] = field(default_factory=dict)
+    locks: list[_ProcLock] = field(default_factory=list)
+    complete: bool = True
+
+
+def _bounded_directory_entries(
+    path: Path,
+    *,
+    limit: int,
+    budget: _ProbeBudget | None,
+    limit_reason: str,
+) -> tuple[list[Path], OSError | None]:
+    """Materialize at most ``limit`` entries and surface iteration errors."""
+    entries: list[Path] = []
+    try:
+        with os.scandir(path) as iterator:
+            for entry in iterator:
+                if budget is not None and budget.expired():
+                    return entries, TimeoutError("probe deadline reached")
+                if len(entries) >= limit:
+                    if budget is not None:
+                        budget.add(limit_reason)
+                    return entries, OSError(f"{limit_reason} exceeded")
+                entries.append(path / entry.name)
+    except OSError as exc:
+        return entries, exc
+    return entries, None
 
 
 def _db_path(home: Path) -> Path:
+    """Compatibility fallback used when a home has no database yet."""
     return home / STATE_DB_NAME
 
 
-def _db_paths(home: Path) -> list[Path]:
-    """Known Codex local SQLite databases to preflight, in priority order."""
-    return [home / name for name in _CODEX_DB_NAMES]
-
-
-def _pid_alive(pid: int) -> bool:
-    """True if a process with ``pid`` exists and is signalable by us."""
-    if pid <= 0:
-        return False
+def _db_paths(home: Path, *, budget: _ProbeBudget | None = None) -> tuple[list[Path], bool]:
+    """Discover Codex databases without assuming a schema generation."""
     try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # Exists but owned by another user — count it as alive.
-        return True
+        entries: list[Path] = []
+        for entry_count, path in enumerate(home.iterdir(), start=1):
+            if budget is not None and budget.expired():
+                return [], False
+            if entry_count > _MAX_HOME_ENTRIES:
+                if budget is not None:
+                    budget.add("database_limit")
+                return [], False
+            entries.append(path)
+    except FileNotFoundError:
+        return [], True
     except OSError:
+        if budget is not None:
+            budget.add("database_discovery_incomplete")
+        return [], False
+    candidates = [
+        path
+        for path in entries
+        if path.name.endswith(".sqlite") and path.name.startswith(("state_", "logs_"))
+    ]
+    result: list[Path] = []
+    complete = True
+    for path in sorted(
+        candidates, key=lambda item: (not item.name.startswith("state_"), item.name)
+    ):
+        if budget is not None and budget.expired():
+            return result, False
+        if len(result) >= _MAX_DATABASES:
+            if budget is not None:
+                budget.add("database_limit")
+            return result, False
+        try:
+            mode = path.stat().st_mode
+        except FileNotFoundError:
+            continue
+        except OSError:
+            complete = False
+            if budget is not None:
+                budget.add("database_discovery_incomplete")
+            continue
+        if stat_module.S_ISREG(mode):
+            result.append(path)
+    return result, complete
+
+
+def _target_files(
+    db_path: Path, *, budget: _ProbeBudget | None = None
+) -> tuple[list[_FileIdentity], bool]:
+    targets: list[_FileIdentity] = []
+    complete = True
+    for path, role in (
+        (db_path, "main"),
+        (Path(f"{db_path}-wal"), "wal"),
+        (Path(f"{db_path}-shm"), "shm"),
+    ):
+        if budget is not None and budget.expired():
+            return targets, False
+        try:
+            st = path.stat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            complete = False
+            if budget is not None:
+                budget.add("database_target_incomplete")
+            continue
+        if stat_module.S_ISREG(st.st_mode):
+            targets.append(
+                _FileIdentity(
+                    path=path,
+                    device=st.st_dev,
+                    inode=st.st_ino,
+                    owner_uid=st.st_uid,
+                    role=role,
+                    db_path=db_path,
+                )
+            )
+    return targets, complete
+
+
+def _parse_proc_lock_line(line: str) -> _ProcLock | None:
+    """Parse one ``/proc/locks`` or ``fdinfo`` lock row."""
+    line = line.strip()
+    if line.startswith("lock:"):
+        line = line[5:].strip()
+    fields = line.split()
+    if len(fields) < 8:
+        return None
+    if len(fields) > 1 and fields[1] == "->":
+        fields.pop(1)
+    if len(fields) < 8:
+        return None
+    try:
+        pid = int(fields[4])
+        major_raw, minor_raw, inode_raw = fields[5].split(":", 2)
+        device_major = int(major_raw, 16)
+        device_minor = int(minor_raw, 16)
+        inode = int(inode_raw)
+        start = int(fields[6])
+        end = None if fields[7] == "EOF" else int(fields[7])
+    except (TypeError, ValueError):
+        return None
+    return _ProcLock(
+        pid=pid,
+        device_major=device_major,
+        device_minor=device_minor,
+        inode=inode,
+        start=start,
+        end=end,
+    )
+
+
+def _read_proc_locks(
+    proc_root: Path = _PROC_ROOT, *, budget: _ProbeBudget | None = None
+) -> tuple[list[_ProcLock], bool]:
+    try:
+        stream = (proc_root / "locks").open(errors="replace")
+    except OSError:
+        if budget is not None:
+            budget.add("proc_inspection_incomplete")
+        return [], False
+    locks: list[_ProcLock] = []
+    complete = True
+    try:
+        for row_count, row in enumerate(stream, start=1):
+            if budget is not None and budget.expired():
+                return locks, False
+            if row_count > _MAX_PROC_LOCK_ROWS:
+                complete = False
+                if budget is not None:
+                    budget.add("proc_lock_limit")
+                break
+            lock = _parse_proc_lock_line(row)
+            if lock is None:
+                if row.strip():
+                    complete = False
+                    if budget is not None:
+                        budget.add("proc_inspection_incomplete")
+                continue
+            locks.append(lock)
+    except OSError:
+        complete = False
+        if budget is not None:
+            budget.add("proc_inspection_incomplete")
+    finally:
+        stream.close()
+    return locks, complete
+
+
+def _read_process_info(pid: int, proc_root: Path = _PROC_ROOT) -> _ProcessInfo | None:
+    """Return a TGID-normalized process identity, resistant to PID reuse."""
+    if pid <= 0:
+        return None
+    process_dir = proc_root / str(pid)
+    try:
+        status = (process_dir / "status").read_text(errors="replace")
+        raw_stat = (process_dir / "stat").read_text(errors="replace")
+    except OSError:
+        return None
+
+    tgid: int | None = None
+    uid: int | None = None
+    for line in status.splitlines():
+        if line.startswith("Tgid:"):
+            try:
+                tgid = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return None
+        elif line.startswith("Uid:"):
+            try:
+                uid = int(line.split(":", 1)[1].split()[0])
+            except (IndexError, ValueError):
+                return None
+    if tgid is None or uid is None:
+        return None
+    if tgid != pid:
+        return _read_process_info(tgid, proc_root)
+
+    # /proc/<pid>/stat is ``pid (comm) state ...``.  comm may contain spaces
+    # and parentheses, so only the final right parenthesis is structural.
+    rparen = raw_stat.rfind(")")
+    if rparen < 0:
+        return None
+    tail = raw_stat[rparen + 1 :].split()
+    if len(tail) <= 19:
+        return None
+    state = tail[0]
+    try:
+        start_time = int(tail[19])  # field 22 in proc_pid_stat(5)
+    except ValueError:
+        return None
+    return _ProcessInfo(pid=tgid, uid=uid, state=state, start_time=start_time)
+
+
+def _revalidate_process(
+    info: _ProcessInfo, proc_root: Path = _PROC_ROOT
+) -> tuple[str, _ProcessInfo | None]:
+    """Distinguish a clean exit from PID reuse or unreadable identity."""
+    current = _read_process_info(info.pid, proc_root)
+    if current is not None:
+        if current.state in _DEAD_STATES:
+            return "dead", current
+        if current.start_time != info.start_time:
+            return "reused", current
+        return "same", current
+    try:
+        (proc_root / str(info.pid)).stat()
+    except FileNotFoundError:
+        return "exited", None
+    except OSError:
+        return "unreadable", None
+    return "unreadable", None
+
+
+def _identity_key(device: int, inode: int) -> tuple[int, int]:
+    return device, inode
+
+
+def _normalize_process_name(value: str) -> str:
+    """Normalize procfs ``comm`` and argv names for conservative matching.
+
+    Linux may expose kernel-style names such as ``(sd-pam)`` while cmdline
+    exposes ``sd-pam``.  Treating those spellings differently turned one
+    unreadable benign desktop process into an incomplete machine-wide scan.
+    """
+    normalized = value.strip()
+    while len(normalized) >= 2 and normalized.startswith("(") and normalized.endswith(")"):
+        normalized = normalized[1:-1].strip()
+    return Path(normalized).name.casefold()
+
+
+def _codex_process_kind(pid: int, proc_root: Path = _PROC_ROOT) -> bool | None:
+    """Classify Codex, explicitly benign, or unknown process wrappers."""
+    process_dir = proc_root / str(pid)
+    executable_names: list[str] = []
+    all_names: list[str] = []
+    try:
+        comm = (process_dir / "comm").read_text(errors="replace").strip()
+    except OSError:
+        comm = ""
+    if comm:
+        executable_names.append(comm)
+        all_names.append(comm)
+    try:
+        command = (process_dir / "cmdline").read_bytes()
+    except OSError:
+        command = b""
+    argv = [token.decode(errors="replace") for token in command.split(b"\0") if token]
+    if argv:
+        executable_names.append(argv[0])
+        all_names.extend(argv)
+    if not all_names:
+        return None
+    normalized_all = {name for value in all_names if (name := _normalize_process_name(value))}
+    if any("codex" in name for name in normalized_all):
+        return True
+    # Generic interpreters and arbitrary readable process names are not proof
+    # that the process cannot own a Codex database.  Only a deliberately tiny
+    # benign allowlist avoids the known non-dumpable desktop-session false
+    # blocker; every other readable name remains unknown and fails closed.
+    normalized_executables = {
+        name for value in executable_names if (name := _normalize_process_name(value))
+    }
+    if normalized_executables and normalized_executables <= _BENIGN_UNREADABLE_PROCESSES:
+        return False
+    return None
+
+
+def _inspection_failure_is_unsafe(
+    info: _ProcessInfo,
+    owner_uids: set[int],
+    proc_root: Path,
+    error: OSError,
+) -> tuple[bool, str | None]:
+    """Fail closed unless a permission error belongs to a known benign process."""
+    if info.uid not in owner_uids:
+        return False, None
+    outcome, current = _revalidate_process(info, proc_root)
+    if outcome in {"exited", "dead"}:
+        return False, None
+    if outcome == "reused":
+        return True, "pid_reuse"
+    if outcome == "unreadable" or current is None:
+        return True, "process_changed"
+    if current.uid not in owner_uids:
+        return True, "pid_reuse"
+    if error.errno not in {errno.EACCES, errno.EPERM}:
+        return True, "proc_inspection_incomplete"
+    unsafe = _codex_process_kind(current.pid, proc_root) is not False
+    return unsafe, "proc_inspection_incomplete" if unsafe else None
+
+
+def _scan_fd_holders(
+    targets: list[_FileIdentity],
+    proc_root: Path = _PROC_ROOT,
+    *,
+    budget: _ProbeBudget | None = None,
+) -> _FdScan:
+    """Scan every process at most once and correlate all target descriptors."""
+    identities = {_identity_key(target.device, target.inode) for target in targets}
+    owner_uids = {target.owner_uid for target in targets if target.role == "main"}
+    scan = _FdScan()
+    process_dirs, process_error = _bounded_directory_entries(
+        proc_root,
+        limit=_MAX_PROCESSES,
+        budget=budget,
+        limit_reason="process_limit",
+    )
+    if process_error is not None:
+        if budget is not None:
+            budget.add("proc_inspection_incomplete")
+        scan.complete = False
+        return scan
+
+    process_count = 0
+    total_fd_count = 0
+    for process_dir in process_dirs:
+        if not process_dir.name.isdigit():
+            continue
+        process_count += 1
+        if budget is not None and budget.expired():
+            scan.complete = False
+            break
+        info = _read_process_info(int(process_dir.name), proc_root)
+        if info is None:
+            # A same-owner process that remains present but cannot be parsed
+            # cannot safely be excluded from the holder scan.  Use the proc
+            # directory owner only as a fallback because status is unavailable.
+            try:
+                process_uid = process_dir.stat().st_uid
+            except FileNotFoundError:
+                continue
+            except OSError:
+                scan.complete = False
+                if budget is not None:
+                    budget.add("proc_inspection_incomplete")
+                continue
+            if process_uid in owner_uids and process_dir.exists():
+                scan.complete = False
+                if budget is not None:
+                    budget.add("proc_inspection_incomplete")
+            continue
+        if info.state in _DEAD_STATES:
+            continue
+        if info.pid in scan.attachments:
+            continue
+        fd_dir = proc_root / str(info.pid) / "fd"
+        descriptors, descriptor_error = _bounded_directory_entries(
+            fd_dir,
+            limit=_MAX_FDS_PER_PROCESS,
+            budget=budget,
+            limit_reason="fd_limit",
+        )
+        if descriptor_error is not None:
+            exc = descriptor_error
+            unsafe, reason = _inspection_failure_is_unsafe(info, owner_uids, proc_root, exc)
+            if unsafe:
+                scan.complete = False
+                if budget is not None:
+                    budget.add(reason or "proc_inspection_incomplete")
+            continue
+        total_fd_count += len(descriptors)
+        if total_fd_count > _MAX_TOTAL_FDS:
+            scan.complete = False
+            if budget is not None:
+                budget.add("fd_limit")
+            break
+        matching_fds: list[tuple[str, tuple[int, int]]] = []
+        fd_count = 0
+        for descriptor in descriptors:
+            fd_count += 1
+            if budget is not None and budget.expired():
+                scan.complete = False
+                break
+            try:
+                st = descriptor.stat()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                unsafe, reason = _inspection_failure_is_unsafe(info, owner_uids, proc_root, exc)
+                if unsafe:
+                    scan.complete = False
+                    if budget is not None:
+                        budget.add(reason or "proc_inspection_incomplete")
+                continue
+            identity = _identity_key(st.st_dev, st.st_ino)
+            if identity in identities:
+                matching_fds.append((descriptor.name, identity))
+        if budget is not None and budget.expired():
+            break
+        if not matching_fds:
+            continue
+
+        # Re-read stat after descriptor matching so a recycled PID cannot be
+        # attributed using observations from two different processes.
+        outcome, current = _revalidate_process(info, proc_root)
+        if outcome in {"exited", "dead"}:
+            continue
+        if outcome == "reused":
+            scan.complete = False
+            if budget is not None:
+                budget.add("pid_reuse")
+            continue
+        if outcome != "same" or current is None:
+            scan.complete = False
+            if budget is not None:
+                budget.add("process_changed")
+            continue
+        attached = {identity for _, identity in matching_fds}
+        scan.attachments[current.pid] = (current, attached)
+
+        for fd_name, _identity in matching_fds:
+            if budget is not None and budget.expired():
+                scan.complete = False
+                break
+            try:
+                rows = (
+                    (proc_root / str(current.pid) / "fdinfo" / fd_name)
+                    .read_text(errors="replace")
+                    .splitlines()
+                )
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                unsafe, reason = _inspection_failure_is_unsafe(current, owner_uids, proc_root, exc)
+                if unsafe:
+                    scan.complete = False
+                    if budget is not None:
+                        budget.add(reason or "proc_inspection_incomplete")
+                continue
+            for row in rows:
+                if not row.lstrip().startswith("lock:"):
+                    continue
+                lock = _parse_proc_lock_line(row)
+                if lock is not None:
+                    scan.locks.append(lock)
+
+    return scan
+
+
+def _ranges_overlap(
+    first_start: int, first_end: int | None, second_start: int, second_end: int
+) -> bool:
+    effective_end = (1 << 63) - 1 if first_end is None else first_end
+    return first_start <= second_end and effective_end >= second_start
+
+
+def _lock_targets_file(lock: _ProcLock, target: _FileIdentity) -> bool:
+    major, minor = target.proc_device
+    if (lock.device_major, lock.device_minor, lock.inode) != (major, minor, target.inode):
+        return False
+    if target.role == "main":
+        return _ranges_overlap(
+            lock.start,
+            lock.end,
+            _SQLITE_PENDING_BYTE,
+            _SQLITE_MAIN_LOCK_LAST,
+        )
+    if target.role == "shm":
+        return _ranges_overlap(
+            lock.start,
+            lock.end,
+            _SQLITE_SHM_LOCK_FIRST,
+            _SQLITE_SHM_DMS,
+        )
+    return False
+
+
+def _target_snapshot_key(target: _FileIdentity) -> tuple[str, int, int, int, str]:
+    return (
+        target.role,
+        target.device,
+        target.inode,
+        target.owner_uid,
+        str(target.path),
+    )
+
+
+def _targets_unchanged(
+    db_path: Path,
+    before: list[_FileIdentity],
+    *,
+    budget: _ProbeBudget,
+) -> bool:
+    """Re-stat main/WAL/SHM targets and reject replacement or appearance."""
+    after, complete = _target_files(db_path, budget=budget)
+    if not complete:
+        budget.add("database_target_incomplete")
+        return False
+    if {_target_snapshot_key(item) for item in before} != {
+        _target_snapshot_key(item) for item in after
+    }:
+        budget.add("target_inode_replaced")
         return False
     return True
 
 
+def _revalidate_database_snapshot(
+    home: Path,
+    dbs: list[Path],
+    targets_by_db: dict[Path, list[_FileIdentity]],
+    *,
+    budget: _ProbeBudget,
+) -> None:
+    """Fail closed if database names or target inodes changed during a probe."""
+    after_dbs, after_complete = _db_paths(home, budget=budget)
+    if not after_complete:
+        budget.add("database_discovery_incomplete")
+    elif [str(path) for path in after_dbs] != [str(path) for path in dbs]:
+        budget.add("database_set_changed")
+    for db_path, targets in targets_by_db.items():
+        if budget.expired():
+            return
+        _targets_unchanged(db_path, targets, budget=budget)
+
+
+def _revalidate_attachments(
+    scan: _FdScan,
+    *,
+    proc_root: Path,
+    budget: _ProbeBudget,
+) -> dict[int, tuple[_ProcessInfo, set[tuple[int, int]]]]:
+    """Revalidate every attached PID incarnation exactly once."""
+    validated: dict[int, tuple[_ProcessInfo, set[tuple[int, int]]]] = {}
+    for pid, (observed, attached) in scan.attachments.items():
+        if budget.expired():
+            break
+        outcome, current = _revalidate_process(observed, proc_root)
+        if outcome in {"exited", "dead"}:
+            continue
+        if outcome == "reused":
+            budget.add("pid_reuse")
+            continue
+        if outcome != "same" or current is None:
+            budget.add("process_changed")
+            continue
+        validated[pid] = (current, attached)
+    return validated
+
+
+def _darwin_codex_processes(budget: _ProbeBudget) -> tuple[list[_ProcessInfo], bool]:
+    """Return a locale-stable, bounded macOS process snapshot."""
+    remaining = budget.deadline - budget.clock()
+    if remaining <= 0:
+        budget.add("probe_timeout")
+        return [], False
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,state=,lstart=,comm="],
+            capture_output=True,
+            env={**os.environ, "LC_ALL": "C"},
+            text=True,
+            timeout=remaining,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        budget.add("portable_inspection_incomplete")
+        return [], False
+    if result.returncode != 0:
+        budget.add("portable_inspection_incomplete")
+        return [], False
+
+    processes: list[_ProcessInfo] = []
+    for row_count, row in enumerate(result.stdout.splitlines(), start=1):
+        if budget.expired():
+            return processes, False
+        if row_count > _MAX_PROCESSES:
+            budget.add("process_limit")
+            return processes, False
+        fields = row.split(maxsplit=7)
+        if len(fields) != 8:
+            if row.strip():
+                budget.add("portable_inspection_incomplete")
+                return processes, False
+            continue
+        try:
+            pid = int(fields[0])
+        except ValueError:
+            budget.add("portable_inspection_incomplete")
+            return processes, False
+        executable = _normalize_process_name(fields[7])
+        if "codex" not in executable:
+            continue
+        fingerprint = int.from_bytes(
+            hashlib.sha256(" ".join(fields[2:7]).encode()).digest()[:8], "big"
+        )
+        processes.append(
+            _ProcessInfo(
+                pid=pid,
+                uid=-1,
+                state=fields[1][0],
+                start_time=fingerprint or 1,
+            )
+        )
+    return processes, True
+
+
+def _toolhelp_has_entry(available: bool, error_code: int) -> bool:
+    """Distinguish Toolhelp EOF from an enumeration failure."""
+    if available:
+        return True
+    if error_code == _ERROR_NO_MORE_FILES:
+        return False
+    raise OSError(error_code, "Toolhelp process enumeration failed")
+
+
+def _windows_codex_processes(budget: _ProbeBudget) -> tuple[list[_ProcessInfo], bool]:
+    """Enumerate Windows executables with Toolhelp32, without dependencies."""
+    try:  # pragma: no cover - exercised on Windows CI
+        import ctypes
+        from ctypes import wintypes
+
+        class PROCESSENTRY32W(ctypes.Structure):
+            _fields_ = (
+                ("dwSize", wintypes.DWORD),
+                ("cntUsage", wintypes.DWORD),
+                ("th32ProcessID", wintypes.DWORD),
+                ("th32DefaultHeapID", ctypes.c_size_t),
+                ("th32ModuleID", wintypes.DWORD),
+                ("cntThreads", wintypes.DWORD),
+                ("th32ParentProcessID", wintypes.DWORD),
+                ("pcPriClassBase", ctypes.c_long),
+                ("dwFlags", wintypes.DWORD),
+                ("szExeFile", wintypes.WCHAR * 260),
+            )
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+        kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+        kernel32.Process32FirstW.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(PROCESSENTRY32W),
+        )
+        kernel32.Process32FirstW.restype = wintypes.BOOL
+        kernel32.Process32NextW.argtypes = (
+            wintypes.HANDLE,
+            ctypes.POINTER(PROCESSENTRY32W),
+        )
+        kernel32.Process32NextW.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        snapshot = kernel32.CreateToolhelp32Snapshot(0x00000002, 0)
+        invalid_handle = ctypes.c_void_p(-1).value
+        if snapshot == invalid_handle:
+            raise OSError(ctypes.get_last_error(), "CreateToolhelp32Snapshot failed")
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(entry)
+        first = kernel32.Process32FirstW
+        next_entry = kernel32.Process32NextW
+        processes: list[_ProcessInfo] = []
+        count = 0
+        try:
+            ctypes.set_last_error(0)
+            available = _toolhelp_has_entry(
+                bool(first(snapshot, ctypes.byref(entry))),
+                ctypes.get_last_error(),
+            )
+            while available:
+                if budget.expired():
+                    return processes, False
+                count += 1
+                if count > _MAX_PROCESSES:
+                    budget.add("process_limit")
+                    return processes, False
+                executable = _normalize_process_name(entry.szExeFile)
+                if "codex" in executable:
+                    from .session_home import _portable_process_identity
+
+                    identity = _portable_process_identity(int(entry.th32ProcessID))
+                    if identity is None:
+                        budget.add("portable_inspection_incomplete")
+                        return processes, False
+                    state, start_time = identity
+                    processes.append(
+                        _ProcessInfo(
+                            pid=int(entry.th32ProcessID),
+                            uid=-1,
+                            state=state,
+                            start_time=start_time,
+                        )
+                    )
+                ctypes.set_last_error(0)
+                available = _toolhelp_has_entry(
+                    bool(next_entry(snapshot, ctypes.byref(entry))),
+                    ctypes.get_last_error(),
+                )
+        finally:
+            kernel32.CloseHandle(snapshot)
+        return processes, True
+    except (ImportError, OSError, AttributeError):
+        budget.add("portable_inspection_incomplete")
+        return [], False
+
+
+def _portable_codex_processes(
+    platform_id: str, budget: _ProbeBudget
+) -> tuple[list[_ProcessInfo], bool]:
+    if platform_id == "darwin":
+        return _darwin_codex_processes(budget)
+    if platform_id.startswith("win"):
+        return _windows_codex_processes(budget)
+    budget.add("portable_inspection_incomplete")
+    return [], False
+
+
+def _pid_alive(pid: int) -> bool:
+    """Compatibility helper implemented as a read-only ``/proc`` lookup."""
+    info = _read_process_info(pid)
+    return bool(info and info.state not in _DEAD_STATES)
+
+
 def _pid_stopped(pid: int) -> bool:
-    """Best-effort: True if ``pid`` is in a stopped/traced state (Linux).
+    """Return whether a live process is stopped or being traced."""
+    info = _read_process_info(pid)
+    return bool(info and info.state not in _DEAD_STATES and info.stopped)
 
-    A stopped Codex process is the zombie-lock case the packet calls out:
-    it holds the database FD but will never release it without a SIGCONT
-    or kill.  Non-Linux platforms (no ``/proc``) return ``False`` — we
-    simply lose the stopped/running distinction there, not correctness.
-    """
-    stat = Path(f"/proc/{pid}/stat")
+
+def _incomplete_component(reasons: list[str]) -> str:
+    labels = [_REASON_LABELS.get(reason, reason.replace("_", " ")) for reason in reasons]
+    return ", ".join(labels)
+
+
+def _portable_probe(
+    home: Path,
+    dbs: list[Path],
+    targets_by_db: dict[Path, list[_FileIdentity]],
+    *,
+    platform_id: str,
+    budget: _ProbeBudget,
+) -> LockStatus:
+    """Conservatively gate non-Linux shared homes without relying on procfs."""
+    from .session_home import (
+        _PROCESS_LIVE,
+        _PROCESS_UNKNOWN,
+        _proc_identity,
+        _sentinel_liveness,
+        read_pid_sentinel,
+    )
+
+    db_path = dbs[0]
+    holders: dict[int, _ProcessInfo] = {}
+    sentinel_path = home / "codex.pid"
     try:
-        raw = stat.read_text()
-    except (OSError, ValueError):
-        return False
-    # /proc/<pid>/stat: "<pid> (<comm>) <state> ...".  comm may contain
-    # spaces/parens, so split on the LAST ')'.
-    rparen = raw.rfind(")")
-    if rparen == -1:
-        return False
-    fields = raw[rparen + 1 :].split()
-    if not fields:
-        return False
-    # State codes: T = stopped (job control), t = traced.
-    return fields[0] in ("T", "t")
+        sentinel_stat = sentinel_path.lstat()
+    except FileNotFoundError:
+        sentinel_stat = None
+    except OSError:
+        sentinel_stat = None
+        budget.add("portable_inspection_incomplete")
+    if sentinel_stat is not None:
+        sentinel = read_pid_sentinel(sentinel_path)
+        if sentinel is None:
+            budget.add("portable_inspection_incomplete")
+        elif sentinel.pid != os.getpid():
+            liveness = _sentinel_liveness(sentinel, expected_home=home)
+            if liveness == _PROCESS_UNKNOWN:
+                budget.add("portable_inspection_incomplete")
+            elif liveness == _PROCESS_LIVE:
+                identity = _proc_identity(sentinel.pid)
+                if identity is None:
+                    budget.add("portable_inspection_incomplete")
+                else:
+                    state, start_time = identity
+                    holders[sentinel.pid] = _ProcessInfo(
+                        pid=sentinel.pid,
+                        uid=-1,
+                        state=state,
+                        start_time=start_time,
+                    )
+
+    processes, complete = _portable_codex_processes(platform_id, budget)
+    for info in processes:
+        if info.state not in _DEAD_STATES:
+            holders[info.pid] = info
+    if not complete:
+        budget.add("portable_inspection_incomplete")
+
+    _revalidate_database_snapshot(home, dbs, targets_by_db, budget=budget)
+    budget.expired()
+
+    running = sorted(pid for pid, info in holders.items() if not info.stopped)
+    stopped = sorted(pid for pid, info in holders.items() if info.stopped)
+    reasons = list(budget.reasons)
+    diagnostics_complete = not reasons
+    if holders or reasons:
+        if holders:
+            states = [
+                *(f"PID {pid} (running)" for pid in running),
+                *(f"PID {pid} (stopped)" for pid in stopped),
+            ]
+            detail = (
+                f"{db_path.name} has conservative {platform_id} Codex process "
+                f"candidate(s): {', '.join(states)}"
+            )
+        else:
+            detail = f"{db_path.name} portable contention inspection did not complete"
+        if reasons:
+            detail += f"; {_incomplete_component(reasons)} is incomplete, refusing unsafe access"
+        return LockStatus(
+            home=home,
+            db_path=db_path,
+            exists=True,
+            locked=True,
+            holder_pids=sorted(holders),
+            stopped_pids=stopped,
+            running_pids=running,
+            detail=detail,
+            diagnostics_complete=diagnostics_complete,
+            incomplete_reasons=reasons,
+        )
+    return LockStatus(
+        home=home,
+        db_path=db_path,
+        exists=True,
+        locked=False,
+        detail=(
+            f"Codex local databases have no live portable Codex process candidates: "
+            f"{', '.join(db.name for db in dbs)}"
+        ),
+    )
 
 
-def _candidate_holder_pids(home: Path) -> list[int]:
-    """Collect candidate holder PIDs recorded in this home, best-effort.
-
-    The TokenPak session-home provisioner writes a ``codex.pid`` sentinel
-    when it launches a session into an isolated/workspace home; we read it
-    here so a contended home can name its holder.  We never trust the file
-    blindly — every PID is liveness-checked by the caller.
-    """
-    pids: list[int] = []
-    sentinel = home / "codex.pid"
-    try:
-        for line in sentinel.read_text().splitlines():
-            line = line.strip()
-            if line.isdigit():
-                pids.append(int(line))
-    except (OSError, ValueError):
-        pass
-    return pids
-
-
-def probe(home: "Path | str | None" = None) -> LockStatus:
-    """Preflight Codex-owned local databases under ``home``.
-
-    ``home`` defaults to ``$CODEX_HOME`` then ``~/.codex``.  Returns a
-    :class:`LockStatus`.  Never raises on a contended database — the lock
-    is reported via ``LockStatus.locked``, which is the whole point of a
-    preflight.
-    """
+def probe(
+    home: "Path | str | None" = None,
+    *,
+    proc_root: Path = _PROC_ROOT,
+    deadline: float | None = None,
+    timeout_s: float = _DEFAULT_PROBE_TIMEOUT_S,
+    clock: Callable[[], float] | None = None,
+    platform_id: str | None = None,
+) -> LockStatus:
+    """Inspect Codex database attachments once, within fixed work limits."""
     if home is None:
         home = os.environ.get("CODEX_HOME") or (Path.home() / ".codex")
     home = Path(home)
-    dbs = _db_paths(home)
-    state_db = _db_path(home)
-    existing = [db for db in dbs if db.exists()]
-
-    if not existing:
-        # No Codex database yet — a fresh home is by definition uncontended.
+    clock = clock or time.monotonic
+    budget = _ProbeBudget(
+        deadline=deadline if deadline is not None else clock() + max(0.0, timeout_s),
+        clock=clock,
+    )
+    dbs, discovery_complete = _db_paths(home, budget=budget)
+    fallback = _db_path(home)
+    if not dbs:
+        if not discovery_complete:
+            if not budget.reasons:
+                budget.add("database_discovery_incomplete")
+            reasons = list(budget.reasons)
+            return LockStatus(
+                home=home,
+                db_path=fallback,
+                exists=True,
+                locked=True,
+                detail=(f"{_incomplete_component(reasons)} is incomplete; refusing unsafe access"),
+                diagnostics_complete=False,
+                incomplete_reasons=reasons,
+            )
         return LockStatus(
             home=home,
-            db_path=state_db,
+            db_path=fallback,
             exists=False,
             locked=False,
             detail="no Codex local database yet (uncontended)",
         )
 
-    locked_db = next((db for db in existing if _is_locked(db)), None)
-    if locked_db is None:
-        names = ", ".join(db.name for db in existing)
+    targets_by_db: dict[Path, list[_FileIdentity]] = {}
+    for db_path in dbs:
+        targets, complete = _target_files(db_path, budget=budget)
+        targets_by_db[db_path] = targets
+        if not complete:
+            budget.add("database_target_incomplete")
+
+    resolved_platform = platform_id or sys.platform
+    if not resolved_platform.startswith("linux"):
+        return _portable_probe(
+            home,
+            dbs,
+            targets_by_db,
+            platform_id=resolved_platform,
+            budget=budget,
+        )
+
+    all_targets = [target for targets in targets_by_db.values() for target in targets]
+    targets_by_identity: dict[tuple[int, int], list[_FileIdentity]] = {}
+    targets_by_proc_identity: dict[tuple[int, int, int], list[_FileIdentity]] = {}
+    for target in all_targets:
+        targets_by_identity.setdefault(_identity_key(target.device, target.inode), []).append(
+            target
+        )
+        major, minor = target.proc_device
+        targets_by_proc_identity.setdefault((major, minor, target.inode), []).append(target)
+
+    proc_locks, locks_complete = _read_proc_locks(proc_root, budget=budget)
+    # Capture every relevant kernel lock-owner incarnation before the process
+    # scan.  Revalidating this exact snapshot later closes the PID-reuse window
+    # between reading /proc/locks and classifying its holder PID.
+    lock_owner_observations: dict[int, _ProcessInfo | None] = {}
+    for lock in proc_locks:
+        if budget.expired():
+            break
+        if lock.pid <= 0 or lock.pid in lock_owner_observations:
+            continue
+        candidates = targets_by_proc_identity.get(
+            (lock.device_major, lock.device_minor, lock.inode), ()
+        )
+        if not any(_lock_targets_file(lock, target) for target in candidates):
+            continue
+        observed = _read_process_info(lock.pid, proc_root)
+        if observed is None or observed.state in _DEAD_STATES:
+            budget.add("process_changed")
+            observed = None
+        lock_owner_observations[lock.pid] = observed
+
+    scan = _scan_fd_holders(all_targets, proc_root, budget=budget)
+    if not locks_complete or not scan.complete:
+        budget.add("proc_inspection_incomplete")
+
+    # Revalidate both the database set and every target inode after the single
+    # process scan.  A concurrent replacement or new WAL/SHM sidecar is not a
+    # clean result; it is an explicit fail-closed race outcome.
+    _revalidate_database_snapshot(home, dbs, targets_by_db, budget=budget)
+
+    validated = _revalidate_attachments(scan, proc_root=proc_root, budget=budget)
+
+    holders_by_db: dict[Path, dict[int, _ProcessInfo]] = {db_path: {} for db_path in dbs}
+    relevant_by_db: dict[Path, bool] = {db_path: False for db_path in dbs}
+    lock_owner_cache: dict[int, _ProcessInfo | None] = {}
+    for pid, (info, attached) in validated.items():
+        if budget.expired():
+            break
+        for identity in attached:
+            for target in targets_by_identity.get(identity, ()):
+                holders_by_db[target.db_path][pid] = info
+
+    for lock in (*proc_locks, *scan.locks):
+        if budget.expired():
+            break
+        candidates = targets_by_proc_identity.get(
+            (lock.device_major, lock.device_minor, lock.inode), ()
+        )
+        relevant_targets = [target for target in candidates if _lock_targets_file(lock, target)]
+        if not relevant_targets:
+            continue
+        for target in relevant_targets:
+            relevant_by_db[target.db_path] = True
+
+        # POSIX lock rows identify an owning PID directly.  Validate each
+        # unique incarnation once so a lock that races the FD snapshot still
+        # names its discoverable holder instead of degrading to "unavailable".
+        if lock.pid > 0:
+            if lock.pid not in lock_owner_cache:
+                observed = lock_owner_observations.get(lock.pid)
+                if lock.pid not in lock_owner_observations:
+                    attached = scan.attachments.get(lock.pid)
+                    observed = attached[0] if attached is not None else None
+                if observed is None:
+                    budget.add("process_changed")
+                    lock_owner_cache[lock.pid] = None
+                else:
+                    outcome, current = _revalidate_process(observed, proc_root)
+                    if outcome == "reused":
+                        budget.add("pid_reuse")
+                        current = None
+                    elif outcome != "same" or current is None:
+                        budget.add("process_changed")
+                        current = None
+                    lock_owner_cache[lock.pid] = current
+            current = lock_owner_cache[lock.pid]
+            if current is not None:
+                for target in relevant_targets:
+                    holders_by_db[target.db_path][current.pid] = current
+
+    budget.expired()
+    unsafe_by_db = {
+        db_path: (
+            holders_by_db[db_path],
+            bool(holders_by_db[db_path] or relevant_by_db[db_path]),
+        )
+        for db_path in dbs
+    }
+
+    reasons = list(budget.reasons)
+    diagnostics_complete = discovery_complete and not reasons
+    for db_path in dbs:
+        holders, unsafe = unsafe_by_db[db_path]
+        if not unsafe:
+            continue
+        running = sorted(pid for pid, info in holders.items() if not info.stopped)
+        stopped = sorted(pid for pid, info in holders.items() if info.stopped)
+        all_holders = sorted(holders)
         return LockStatus(
             home=home,
-            db_path=existing[0],
+            db_path=db_path,
             exists=True,
-            locked=False,
-            detail=f"Codex local databases are free: {names}",
+            locked=True,
+            holder_pids=all_holders,
+            stopped_pids=stopped,
+            running_pids=running,
+            detail=_format_lock_detail(
+                running,
+                stopped,
+                db_path.name,
+                diagnostics_complete=diagnostics_complete,
+                incomplete_component=_incomplete_component(reasons),
+            ),
+            diagnostics_complete=diagnostics_complete,
+            incomplete_reasons=reasons,
         )
 
-    # Locked — gather best-effort holder context for the message.
-    candidates = [p for p in _candidate_holder_pids(home) if _pid_alive(p)]
-    stopped = [p for p in candidates if _pid_stopped(p)]
-    detail = _format_lock_detail(candidates, stopped, locked_db.name)
+    if not diagnostics_complete:
+        return LockStatus(
+            home=home,
+            db_path=dbs[0],
+            exists=True,
+            locked=True,
+            detail=_format_lock_detail(
+                [],
+                [],
+                dbs[0].name,
+                diagnostics_complete=False,
+                incomplete_component=_incomplete_component(reasons),
+            ),
+            diagnostics_complete=False,
+            incomplete_reasons=reasons,
+        )
+
+    names = ", ".join(db.name for db in dbs)
     return LockStatus(
         home=home,
-        db_path=locked_db,
+        db_path=dbs[0],
         exists=True,
-        locked=True,
-        holder_pids=candidates,
-        stopped_pids=stopped,
-        detail=detail,
+        locked=False,
+        detail=f"Codex local databases have no live attachments: {names}",
     )
 
 
-def _is_locked(db: Path) -> bool:
-    """True if an EXCLUSIVE probe on ``db`` is denied within the timeout.
-
-    We open with a short busy-timeout and attempt ``BEGIN EXCLUSIVE``.  If
-    another connection holds the database the probe raises
-    ``OperationalError`` ("database is locked" / "database is busy") — that
-    is the contention we report.  A genuinely free database commits the
-    no-op transaction immediately.
-    """
-    conn = None
-    try:
-        conn = sqlite3.connect(str(db), timeout=_PROBE_TIMEOUT_S, isolation_level=None)
-        conn.execute("BEGIN EXCLUSIVE")
-        conn.execute("ROLLBACK")
-        return False
-    except sqlite3.OperationalError as exc:
-        msg = str(exc).lower()
-        if "lock" in msg or "busy" in msg:
-            return True
-        # Some other operational error (e.g. malformed) — not a lock; do
-        # not block the launcher on it.
-        return False
-    except sqlite3.DatabaseError:
-        # Not a valid SQLite database — not a lock condition.
-        return False
-    finally:
-        if conn is not None:
-            try:
-                conn.close()
-            except sqlite3.Error:
-                pass
-
-
-def _format_lock_detail(holders: list[int], stopped: list[int], db_name: str) -> str:
-    """Human-actionable description of who holds the lock and what to do."""
-    if not holders:
-        return f"{db_name} is locked by another Codex process (holder PID unavailable)"
-    if stopped:
-        s = ", ".join(str(p) for p in stopped)
-        return (
-            f"{db_name} is locked by a stopped Codex process (PID {s}); "
-            "a suspended session never releases the lock — resume it (fg) and "
-            "exit, or terminate it"
-        )
-    h = ", ".join(str(p) for p in holders)
-    return (
-        f"{db_name} is locked by an active Codex process (PID {h}); "
-        "finish or close that session, or use an isolated home"
-    )
+def _format_lock_detail(
+    running: list[int],
+    stopped: list[int],
+    db_name: str,
+    *,
+    diagnostics_complete: bool = True,
+    incomplete_component: str = "/proc holder inspection",
+) -> str:
+    """Describe every validated holder and its current process state."""
+    if not running and not stopped:
+        detail = f"{db_name} has SQLite lock evidence, but no holder passed /proc validation"
+    else:
+        states = [
+            *(f"PID {pid} (running)" for pid in running),
+            *(f"PID {pid} (stopped)" for pid in stopped),
+        ]
+        detail = f"{db_name} has live Codex database holder(s): {', '.join(states)}"
+    if not diagnostics_complete:
+        detail += f"; {incomplete_component} is incomplete, refusing unsafe access"
+    return detail
 
 
 def remediation_hint(status: LockStatus) -> str:
-    """Multi-line, mode-aware guidance for a locked shared home.
-
-    Shown by the launcher preflight so the user is not left guessing how
-    to escape a contended ``~/.codex`` without re-deriving the isolation
-    design themselves.
-    """
+    """Return mode-aware guidance for a contended shared home."""
     lines = [
         f"tokenpak: Codex local database is locked: {status.db_path}",
         f"          {status.detail}",
     ]
     if status.stopped_pids:
-        pids = " ".join(str(p) for p in status.stopped_pids)
         lines.append(
-            f"          resume the suspended session(s) then exit them: "
-            f"kill -CONT {pids} ; or terminate: kill {pids}"
+            "          a stopped holder must be resumed and exited normally "
+            "before this shared home is safe"
         )
+    elif status.running_pids:
+        lines.append("          finish or close the running session normally before retrying")
     lines.append(
         "          to run a parallel session without contention, set "
         "TOKENPAK_CODEX_SESSION_MODE=workspace (per-project home) or "

--- a/tokenpak/companion/codex/uninstall.py
+++ b/tokenpak/companion/codex/uninstall.py
@@ -11,19 +11,35 @@ Idempotent: running twice is safe.
 from __future__ import annotations
 
 import json
+import os
+import stat
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING as _TYPE_CHECKING
 
 from .hooks import TOKENPAK_HOOK_MARKER
 from .mcp_config import SERVER_NAME
 from .mcp_config import unregister as mcp_unregister
 from .rates_snapshot import DEFAULT_SNAPSHOT_PATH
-from .skills_installer import uninstall_skills
+from .skills_installer import _clean_skills_config, uninstall_skills
+
+if _TYPE_CHECKING:
+    from .session_home import SessionPaths
+
+
+def _selected_codex_home() -> Path:
+    configured = os.environ.get("CODEX_HOME")
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
 
 
 def remove_mcp() -> bool:
     """Remove the MCP registration from Codex. Returns True if gone."""
-    return mcp_unregister()
+    return _remove_mcp()
+
+
+def _remove_mcp(codex_home: Path | None = None) -> bool:
+    """Remove MCP registration from one internally selected Codex home."""
+    return mcp_unregister(codex_home)
 
 
 def clean_hooks_json(path: Path | None = None) -> "tuple[bool, str]":
@@ -31,7 +47,7 @@ def clean_hooks_json(path: Path | None = None) -> "tuple[bool, str]":
 
     Returns (changed, detail).
     """
-    path = path or (Path.home() / ".codex" / "hooks.json")
+    path = path or (_selected_codex_home() / "hooks.json")
     if not path.exists():
         return False, "hooks.json absent"
     try:
@@ -56,8 +72,7 @@ def clean_hooks_json(path: Path | None = None) -> "tuple[bool, str]":
             non_tokenpak = [
                 c
                 for c in commands
-                if isinstance(c, dict)
-                and TOKENPAK_HOOK_MARKER not in c.get("command", "")
+                if isinstance(c, dict) and TOKENPAK_HOOK_MARKER not in c.get("command", "")
             ]
             if len(non_tokenpak) != len(commands):
                 changed = True
@@ -82,7 +97,7 @@ def clean_agents_md(path: Path | None = None) -> "tuple[bool, str]":
     Uses the same section-boundary logic as :func:`agents_md._merge_agents`:
     everything from the marker heading up to the next top-level ``# `` heading.
     """
-    path = path or (Path.home() / ".codex" / "AGENTS.md")
+    path = path or (_selected_codex_home() / "AGENTS.md")
     if not path.exists():
         return False, "AGENTS.md absent"
 
@@ -122,40 +137,173 @@ def clean_rates_snapshot() -> "tuple[bool, str]":
     return False, "rates snapshot absent"
 
 
-def run() -> int:
-    """Execute uninstall and print a report. Returns 0 on clean run."""
+def _clean_selected_skills_config(path: Path) -> "tuple[bool, str]":
+    """Remove TokenPak skill references from one selected config."""
+    changed = _clean_skills_config(path)
+    if changed:
+        return True, f"removed TokenPak skill references from {path}"
+    return False, f"no TokenPak skill references in {path}"
+
+
+def _global_skill_removal_is_safe(paths: "SessionPaths") -> "tuple[bool, str]":
+    """Allow implicit removal only when a shared home has no managed peers."""
+    if paths.mode != "shared":
+        return False, "selected isolated/workspace home does not own global skills"
+
+    from .session_home import (
+        _RETENTION_GUARD_NAME,
+        _RETENTION_RECEIPT_NAME,
+        _tokenpak_home,
+    )
+
+    tokenpak_home = _tokenpak_home()
+    getuid = getattr(os, "geteuid", None)
+    owner_uid = getuid() if getuid is not None else None
+    chain = (
+        (tokenpak_home, {0o700}),
+        (tokenpak_home / "companion", {0o700, 0o775}),
+        (tokenpak_home / "companion" / "codex", {0o700}),
+    )
+    for directory, modes in chain:
+        try:
+            info = directory.lstat()
+        except FileNotFoundError:
+            return True, "no other managed Codex homes"
+        except OSError:
+            return False, f"cannot safely inspect managed homes at {directory}"
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or stat.S_IMODE(info.st_mode) not in modes
+            or (owner_uid is not None and info.st_uid != owner_uid)
+        ):
+            return False, f"managed-home boundary is unsafe at {directory}"
+    ignored = {_RETENTION_GUARD_NAME, _RETENTION_RECEIPT_NAME}
+    for namespace in ("sessions", "workspaces"):
+        root = tokenpak_home / "companion" / "codex" / namespace
+        try:
+            info = root.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return False, f"cannot safely inspect managed homes at {root}"
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or stat.S_IMODE(info.st_mode) != 0o700
+            or (owner_uid is not None and info.st_uid != owner_uid)
+        ):
+            return False, f"managed-home namespace is unsafe at {root}"
+        try:
+            with os.scandir(root) as entries:
+                if any(entry.name not in ignored for entry in entries):
+                    return False, f"global skills are referenced by another {namespace} home"
+        except OSError:
+            return False, f"cannot safely inspect managed homes at {root}"
+    return True, "no other managed Codex homes"
+
+
+def _run_selected(
+    *,
+    paths: "SessionPaths | None" = None,
+    codex_home: Path | None = None,
+    session_mode: str | None = None,
+    workspace_dir: Path | None = None,
+    remove_global_skills: bool | None = None,
+) -> int:
+    """Internal selected-home uninstall runner."""
+    if paths is None:
+        from .session_home import InvalidSessionMode, current_paths, select_paths
+
+        try:
+            if codex_home is not None:
+                paths = select_paths(
+                    session_mode,
+                    workspace_dir=workspace_dir,
+                    selected_home=codex_home,
+                )
+            else:
+                paths = current_paths(session_mode, workspace_dir=workspace_dir)
+        except (InvalidSessionMode, ValueError) as exc:
+            print(f"tokenpak codex uninstall: {exc}", file=sys.stderr)
+            return 2
+
+    from . import state_lock
+    from .session_home import HomeInUseError, SessionLease
+
+    status = state_lock.probe(paths.home)
+    if status.locked:
+        print(state_lock.remediation_hint(status), file=sys.stderr)
+        return 1
+
+    lease: SessionLease | None = None
+    if paths.home.exists():
+        try:
+            lease = SessionLease.acquire(paths)
+        except (OSError, RuntimeError, HomeInUseError) as exc:
+            print(
+                f"tokenpak codex uninstall: selected home is active or unsafe: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        # Native Codex does not participate in the lifecycle lease.  Sample
+        # attachments once more after acquiring it and immediately before any
+        # uninstall mutation to narrow the probe-to-cleanup race.
+        status = state_lock.probe(paths.home)
+        if status.locked:
+            lease.release()
+            print(state_lock.remediation_hint(status), file=sys.stderr)
+            return 1
+
     errors: list[str] = []
 
     print("tokenpak codex uninstall:")
+    for label, value in paths.report_rows():
+        print(f"  {label}: {value}")
+    print()
 
     try:
-        mcp_ok = remove_mcp()
-        print(f"  [{'ok' if mcp_ok else '—'}] MCP registration: {SERVER_NAME}")
-    except Exception as exc:
-        errors.append(f"MCP unregister: {exc}")
-        print(f"  [!!] MCP registration: {exc}")
-
-    for label, fn in (
-        ("hooks.json", clean_hooks_json),
-        ("AGENTS.md", clean_agents_md),
-        ("rates snapshot", clean_rates_snapshot),
-    ):
         try:
-            changed, detail = fn()
-            tag = "ok" if changed else "—"
-            print(f"  [{tag}] {label}: {detail}")
+            mcp_ok = _remove_mcp(paths.home)
+            print(f"  [{'ok' if mcp_ok else '—'}] MCP registration: {SERVER_NAME}")
         except Exception as exc:
-            errors.append(f"{label}: {exc}")
-            print(f"  [!!] {label}: {exc}")
+            errors.append(f"MCP unregister: {exc}")
+            print(f"  [!!] MCP registration: {exc}")
 
-    try:
-        removed = uninstall_skills()
-        detail = f"removed {len(removed)}" if removed else "nothing to remove"
-        tag = "ok" if removed else "—"
-        print(f"  [{tag}] skills: {detail}")
-    except Exception as exc:
-        errors.append(f"skills: {exc}")
-        print(f"  [!!] skills: {exc}")
+        cleaners = [
+            ("hooks.json", lambda: clean_hooks_json(paths.hooks)),
+            ("AGENTS.md", lambda: clean_agents_md(paths.agents)),
+        ]
+        if paths.mode != "shared":
+            cleaners.append(("skills config", lambda: _clean_selected_skills_config(paths.config)))
+        cleaners.append(("rates snapshot", clean_rates_snapshot))
+        for label, fn in cleaners:
+            try:
+                changed, detail = fn()
+                tag = "ok" if changed else "—"
+                print(f"  [{tag}] {label}: {detail}")
+            except Exception as exc:
+                errors.append(f"{label}: {exc}")
+                print(f"  [!!] {label}: {exc}")
+
+        removal_reason = "explicit top-level uninstall"
+        if remove_global_skills is None:
+            remove_global_skills, removal_reason = _global_skill_removal_is_safe(paths)
+        if remove_global_skills:
+            try:
+                removed = uninstall_skills()
+                detail = f"removed {len(removed)}" if removed else "nothing to remove"
+                tag = "ok" if removed else "—"
+                print(f"  [{tag}] global skills: {detail}")
+            except Exception as exc:
+                errors.append(f"global skills: {exc}")
+                print(f"  [!!] global skills: {exc}")
+        else:
+            print(
+                f"  [—] global skills: retained ({removal_reason}; "
+                "top-level tokenpak uninstall removes them explicitly)"
+            )
+    finally:
+        if lease is not None:
+            lease.release()
 
     print()
     print("journal.db + budget.db retained (user data)")
@@ -163,6 +311,16 @@ def run() -> int:
         print(f"{len(errors)} errors during uninstall", file=sys.stderr)
         return 1
     return 0
+
+
+def run() -> int:
+    """Execute uninstall and print a report. Returns 0 on clean run."""
+    return _run_selected()
+
+
+def _run_global() -> int:
+    """Reverse the global install as part of top-level TokenPak uninstall."""
+    return _run_selected(remove_global_skills=True)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tokenpak/proxy/connection_pool.py
+++ b/tokenpak/proxy/connection_pool.py
@@ -35,6 +35,8 @@ Env vars (all optional)
 ``TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS``
     Seconds an evicted client is kept open for in-flight requests before
     being closed (default: ``900``).
+``TOKENPAK_POOL_CLOSE_TIMEOUT_SECS``
+    Maximum seconds pool shutdown waits for client close calls (default: ``1``).
 
 Performance impact
 ------------------
@@ -51,13 +53,20 @@ With pooling (after first request):
 
 from __future__ import annotations
 
+import logging
+import math
 import os
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+_CLOSE_WORKER_COUNT = 4
 
 # ---------------------------------------------------------------------------
 # HTTP/2 availability check
@@ -88,9 +97,7 @@ _EVICT_EXCLUDED_ERRORS: tuple = (httpx.PoolTimeout,)
 
 def _is_evictable_transport_error(exc: BaseException) -> bool:
     """True when *exc* suggests the client's pooled connection(s) may be dead."""
-    return isinstance(exc, httpx.TransportError) and not isinstance(
-        exc, _EVICT_EXCLUDED_ERRORS
-    )
+    return isinstance(exc, httpx.TransportError) and not isinstance(exc, _EVICT_EXCLUDED_ERRORS)
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +131,8 @@ class PoolConfig:
     retire_close_grace_seconds : float
         How long an evicted client is retained (unclosed) so requests still
         in flight on it can finish before ``close()`` (default: 900).
+    close_timeout_seconds : float
+        Maximum time pool shutdown waits for client close calls (default: 1).
     """
 
     max_connections: int = 20
@@ -134,6 +143,7 @@ class PoolConfig:
     http2: bool = True
     evict_on_transport_error: bool = True
     retire_close_grace_seconds: float = 900.0
+    close_timeout_seconds: float = 1.0
     # Per-session upstream client pool — used when the caller passes a
     # session_key to stream()/request(). Each unique session_key gets its
     # own httpx.Client (and thus its own HTTP/2 connection to upstream),
@@ -160,6 +170,7 @@ class PoolConfig:
             retire_close_grace_seconds=float(
                 os.environ.get("TOKENPAK_POOL_RETIRE_CLOSE_GRACE_SECS", "900")
             ),
+            close_timeout_seconds=float(os.environ.get("TOKENPAK_POOL_CLOSE_TIMEOUT_SECS", "1")),
             session_client_max=int(os.environ.get("TOKENPAK_SESSION_CLIENTS_MAX", "32")),
             session_client_idle_seconds=float(
                 os.environ.get("TOKENPAK_SESSION_CLIENT_IDLE_SECS", "300")
@@ -247,8 +258,8 @@ class ConnectionPool:
         # but retired here and closed once the grace period has passed.
         self._retired_clients: List[Tuple[httpx.Client, float]] = []
         self._retired_lock = threading.Lock()
-        # In-use lease counts per session client (identity-keyed, guarded by
-        # _session_lock). last_used is only a checkout stamp, so a client
+        # In-use lease counts for every pooled client (identity-keyed, guarded
+        # by _session_lock). last_used is only a checkout stamp, so a client
         # mid-way through a long stream (per-chunk read timeout is 300s — a
         # legal stream can far exceed the idle window) looks idle to the
         # reaper. The lease count makes in-use clients visible: the reaper
@@ -261,6 +272,38 @@ class ConnectionPool:
         # on release (create-and-close-after-use) instead of closing a live
         # pooled client.
         self._overflow_clients: set = set()
+        # Client.close() is normally fast, but it is transport code and can
+        # wedge. Request handlers therefore enqueue closes onto a small fixed
+        # daemon-worker set instead of running them inline. The outstanding
+        # set is capped during normal operation; once saturated, checkout
+        # fails fast instead of creating more clients/FDs. Shutdown may enqueue
+        # every already-owned client, but never creates one thread per client.
+        self._close_cv = threading.Condition()
+        self._close_backlog: Deque[Any] = deque()
+        self._close_pending: Dict[int, Any] = {}
+        self._close_pending_since: Dict[int, float] = {}
+        self._close_in_progress: set[int] = set()
+        self._close_attempts: Dict[int, int] = {}
+        self._close_workers: List[threading.Thread] = []
+        self._close_completed = 0
+        self._close_failures = 0
+        self._cleanup_worker_start_failures = 0
+        self._cleanup_shutdown = False
+        # Worker shutdown is safe only after close() has detached every pool
+        # map and handed every zero-reference client to the cleanup queue.
+        # A final lease release can race with that handoff, so ``_closed``
+        # alone is not a sufficient terminal signal.
+        self._cleanup_handoff_complete = False
+        self._closed = False
+        # Every constructed client owns one hard slot until close succeeds.
+        # This bounds live + pooled + retired + cleanup-owned clients/FDs even
+        # if all cleanup workers wedge. The close queue therefore always has
+        # room to take ownership of an existing client and never drops one.
+        self._client_slot_limit = max(8, self._config.session_client_max * 2)
+        self._client_slots = threading.BoundedSemaphore(self._client_slot_limit)
+        self._client_slot_lock = threading.Lock()
+        self._client_slot_clients: Dict[int, Any] = {}
+        self._client_slot_rejections = 0
 
     # ------------------------------------------------------------------
     # Client management
@@ -291,24 +334,59 @@ class ConnectionPool:
             verify=True,  # enforce TLS certificate validation
         )
 
-    def _get_client(self, netloc: str) -> httpx.Client:
+    def _new_client(self) -> httpx.Client:
+        """Construct one client under the pool-wide hard resource bound."""
+        if not self._client_slots.acquire(blocking=False):
+            with self._client_slot_lock:
+                self._client_slot_rejections += 1
+            raise httpx.PoolTimeout("connection client-slot cap is saturated")
+        try:
+            client = self._make_client()
+        except Exception:
+            self._client_slots.release()
+            raise
+        with self._client_slot_lock:
+            client_id = id(client)
+            if client_id in self._client_slot_clients:
+                # Test doubles may deliberately return the same object more
+                # than once; one object owns exactly one permit.
+                self._client_slots.release()
+            else:
+                self._client_slot_clients[client_id] = client
+        return client
+
+    def _release_client_slot(self, client: Any) -> None:
+        """Release a constructed client's permit exactly once after close."""
+        with self._client_slot_lock:
+            if self._client_slot_clients.pop(id(client), None) is None:
+                return
+        self._client_slots.release()
+
+    def _get_client(self, netloc: str, checkout: bool = False) -> httpx.Client:
         """
         Return (or lazily create) the ``httpx.Client`` for *netloc*.
 
         Thread-safe — uses a double-checked lock pattern to avoid holding
         the global lock while constructing the client.
         """
-        # Fast path — client already exists
-        client = self._clients.get(netloc)
-        if client is not None:
-            return client
+        # Normal traffic is also the liveness path after transient cleanup
+        # worker-start exhaustion. Kick before taking any pool lock so cleanup
+        # never introduces a reverse lock edge.
+        self._kick_cleanup()
 
-        # Slow path — create under lock
+        # Keep lookup/create and lease acquisition atomic with eviction. An
+        # evicter cannot retire/reap the selected shared client between these
+        # steps.
         with self._lock:
-            # Re-check after acquiring lock (another thread may have created it)
+            if self._closed:
+                raise RuntimeError("connection pool is closed")
             if netloc not in self._clients:
-                self._clients[netloc] = self._make_client()
-            return self._clients[netloc]
+                self._clients[netloc] = self._new_client()
+            client = self._clients[netloc]
+            if checkout:
+                with self._session_lock:
+                    self._lease_locked(client)
+            return client
 
     def _get_session_client(
         self, netloc: str, session_key: str, checkout: bool = False
@@ -337,12 +415,21 @@ class ConnectionPool:
         cfg = self._config
         now = time.monotonic() if hasattr(time, "monotonic") else time.time()
         key = (netloc, session_key)
+        result: Optional[httpx.Client] = None
+        self._kick_cleanup()
         with self._session_lock:
-            # Reap idle clients. Retire instead of closing inline: last_used
-            # is a checkout stamp, so a client mid-way through a long stream
-            # can look idle — closing it here corrupts the live request.
-            # Leased clients are skipped outright: "idle" plus an active
-            # lease means a long-running request, not reclaimable garbage.
+            if self._closed:
+                raise RuntimeError("connection pool is closed")
+            # Retry any overflow close that previously hit the bounded cleanup
+            # cap. Keeping it tracked here prevents an FD from being dropped.
+            for client in list(self._overflow_clients):
+                if self._session_client_refs.get(client, 0) <= 0 and self._schedule_close(client):
+                    self._overflow_clients.discard(client)
+
+            # Reap idle clients. Leased clients are skipped outright:
+            # "idle" plus an active lease means a long-running request, not
+            # reclaimable garbage. A zero-reference client has no in-flight
+            # user, so close it now instead of accumulating it for 900 seconds.
             idle_cutoff = now - cfg.session_client_idle_seconds
             stale_keys = [
                 k
@@ -350,8 +437,9 @@ class ConnectionPool:
                 if last < idle_cutoff and self._session_client_refs.get(c, 0) <= 0
             ]
             for k in stale_keys:
-                client, _ = self._session_clients.pop(k)
-                self._retire(client)
+                client, _ = self._session_clients[k]
+                if self._schedule_close(client):
+                    self._session_clients.pop(k, None)
 
             entry = self._session_clients.get(key)
             if entry is not None:
@@ -359,46 +447,54 @@ class ConnectionPool:
                 self._session_clients[key] = (client, now)
                 if checkout:
                     self._lease_locked(client)
-                return client
+                result = client
+            else:
+                # Enforce cap — LRU-evict the oldest UNLEASED entry. Leased
+                # entries are never closed; the legacy peek fallback retires
+                # one behind the active-lease guard instead.
+                while len(self._session_clients) >= cfg.session_client_max:
+                    evictable = [
+                        (k, e)
+                        for k, e in self._session_clients.items()
+                        if self._session_client_refs.get(e[0], 0) <= 0
+                    ]
+                    if not evictable:
+                        if checkout:
+                            # Every pooled client is mid-request. Hand out a
+                            # temporary overflow client rather than closing a
+                            # live one; release closes the overflow client.
+                            if len(self._overflow_clients) >= cfg.session_client_max:
+                                raise httpx.PoolTimeout("session overflow client cap is saturated")
+                            result = self._new_client()
+                            self._overflow_clients.add(result)
+                            self._lease_locked(result)
+                            break
+                        # A non-leased private peek has no release callback and
+                        # therefore cannot safely displace a live client.
+                        raise httpx.PoolTimeout("all session clients are leased")
+                    oldest_key = min(evictable, key=lambda kv: kv[1][1])[0]
+                    client, _ = self._session_clients[oldest_key]
+                    if self._session_client_refs.get(client, 0) > 0:
+                        self._retire(client)
+                        self._session_clients.pop(oldest_key, None)
+                    else:
+                        if not self._schedule_close(client):
+                            raise httpx.PoolTimeout("connection cleanup unavailable")
+                        self._session_clients.pop(oldest_key, None)
 
-            # Enforce cap — LRU-evict the oldest UNLEASED entry (retired,
-            # same mid-flight hazard). Leased entries are never evicted.
-            while len(self._session_clients) >= cfg.session_client_max:
-                evictable = [
-                    (k, e)
-                    for k, e in self._session_clients.items()
-                    if self._session_client_refs.get(e[0], 0) <= 0
-                ]
-                if not evictable:
+                if result is None:
+                    result = self._new_client()
+                    self._session_clients[key] = (result, now)
                     if checkout:
-                        # Every pooled client is mid-request. Hand out a
-                        # temporary overflow client rather than closing a
-                        # live one; _release_session_client closes it.
-                        client = self._make_client()
-                        self._overflow_clients.add(client)
-                        self._lease_locked(client)
-                        return client
-                    # Legacy peek caller at cap with everything leased:
-                    # fall back to retiring the LRU entry (grace-close
-                    # still protects any in-flight request on it).
-                    evictable = list(self._session_clients.items())
-                oldest_key = min(evictable, key=lambda kv: kv[1][1])[0]
-                client, _ = self._session_clients.pop(oldest_key)
-                self._retire(client)
-
-            client = self._make_client()
-            self._session_clients[key] = (client, now)
-            if checkout:
-                self._lease_locked(client)
-            return client
+                        self._lease_locked(result)
+        assert result is not None
+        return result
 
     def _lease_locked(self, client: httpx.Client) -> None:
         """Increment *client*'s in-use lease count. Caller holds _session_lock."""
         self._session_client_refs[client] = self._session_client_refs.get(client, 0) + 1
 
-    def _release_session_client(
-        self, netloc: str, session_key: str, client: httpx.Client
-    ) -> None:
+    def _release_session_client(self, netloc: str, session_key: str, client: httpx.Client) -> None:
         """
         Release a lease taken by ``_get_session_client(..., checkout=True)``.
 
@@ -409,7 +505,7 @@ class ConnectionPool:
         evicted/retired clients are left to the retire/grace machinery.
         """
         key = (netloc, session_key)
-        close_now = False
+        close_retired_now = False
         with self._session_lock:
             refs = self._session_client_refs.get(client, 0) - 1
             if refs > 0:
@@ -420,13 +516,40 @@ class ConnectionPool:
             if entry is not None and entry[0] is client:
                 self._session_clients[key] = (client, time.monotonic())
             elif refs <= 0 and client in self._overflow_clients:
-                self._overflow_clients.discard(client)
-                close_now = True
-        if close_now:
-            try:
-                client.close()
-            except Exception:
-                pass
+                if self._schedule_close(client):
+                    self._overflow_clients.discard(client)
+            elif refs <= 0:
+                close_retired_now = True
+        if close_retired_now:
+            self._close_retired_client_now(client)
+        self._maybe_finish_cleanup_shutdown()
+
+    def _release_client(self, client: httpx.Client) -> None:
+        """Release a lease on a non-session shared client."""
+        close_retired_now = False
+        with self._session_lock:
+            refs = self._session_client_refs.get(client, 0) - 1
+            if refs > 0:
+                self._session_client_refs[client] = refs
+            else:
+                self._session_client_refs.pop(client, None)
+                close_retired_now = True
+        if close_retired_now:
+            self._close_retired_client_now(client)
+        self._maybe_finish_cleanup_shutdown()
+
+    def _maybe_finish_cleanup_shutdown(self) -> None:
+        """Let fixed workers exit once a closed pool has no live leases."""
+        if not self._closed:
+            return
+        with self._session_lock:
+            has_leases = any(refs > 0 for refs in self._session_client_refs.values())
+        if not has_leases:
+            with self._close_cv:
+                if not self._cleanup_handoff_complete:
+                    return
+                self._cleanup_shutdown = True
+                self._close_cv.notify_all()
 
     def _touch_session(self, netloc: str, session_key: str) -> None:
         """Re-stamp a session client's last_used after a request completes,
@@ -441,11 +564,130 @@ class ConnectionPool:
     def _retire(self, client: httpx.Client) -> None:
         """Queue *client* to be closed after the in-flight grace period."""
         with self._retired_lock:
-            self._retired_clients.append((client, time.monotonic()))
+            if not any(retired is client for retired, _ in self._retired_clients):
+                self._retired_clients.append((client, time.monotonic()))
 
-    def _evict_client(
-        self, netloc: str, session_key: Optional[str], client: httpx.Client
-    ) -> bool:
+    def _close_client(self, client: httpx.Client) -> bool:
+        """Close one client and report success without raising."""
+        try:
+            client.close()
+            return True
+        except Exception:
+            logger.warning("connection-pool client close failed", exc_info=True)
+            return False
+
+    def _ensure_cleanup_workers_locked(self) -> None:
+        """Start the fixed daemon cleanup set. Caller holds ``_close_cv``."""
+        # A worker removes itself under this same condition immediately before
+        # exit. Pruning is still required for unexpected thread termination and
+        # for historical dead entries created by older code/test doubles.
+        self._close_workers = [worker for worker in self._close_workers if worker.is_alive()]
+        target = min(_CLOSE_WORKER_COUNT, self._client_slot_limit)
+        while len(self._close_workers) < target:
+            index = len(self._close_workers)
+            worker = threading.Thread(
+                target=self._cleanup_worker,
+                name=f"tokenpak-connection-close-{index}",
+                daemon=True,
+            )
+            # Append before start while holding _close_cv. A newly started
+            # worker cannot enter its condition section until this lock is
+            # released, and a failed start is removed below.
+            self._close_workers.append(worker)
+            try:
+                worker.start()
+            except Exception:
+                self._close_workers.remove(worker)
+                self._cleanup_worker_start_failures += 1
+                logger.warning("connection-pool cleanup worker failed to start", exc_info=True)
+                break
+
+    def _kick_cleanup(self) -> None:
+        """Recover cleanup capacity whenever owned backlog is observable."""
+        with self._close_cv:
+            if not self._close_backlog:
+                return
+            self._ensure_cleanup_workers_locked()
+            self._close_cv.notify_all()
+
+    def _cleanup_worker(self) -> None:
+        """Drain client closes without ever occupying a request-handler thread."""
+        while True:
+            with self._close_cv:
+                while not self._close_backlog and not self._cleanup_shutdown:
+                    self._close_cv.wait()
+                if not self._close_backlog and self._cleanup_shutdown:
+                    current = threading.current_thread()
+                    if current in self._close_workers:
+                        self._close_workers.remove(current)
+                    self._close_cv.notify_all()
+                    return
+                client = self._close_backlog.popleft()
+                client_id = id(client)
+                self._close_in_progress.add(client_id)
+                attempt = self._close_attempts.get(client_id, 0) + 1
+                self._close_attempts[client_id] = attempt
+            succeeded = self._close_client(client)
+            with self._close_cv:
+                self._close_in_progress.discard(client_id)
+                if succeeded:
+                    self._close_pending.pop(client_id, None)
+                    self._close_pending_since.pop(client_id, None)
+                    self._close_attempts.pop(client_id, None)
+                    self._close_completed += 1
+                    self._release_client_slot(client)
+                else:
+                    self._close_failures += 1
+                self._close_cv.notify_all()
+            if not succeeded:
+                time.sleep(min(1.0, 0.01 * (2 ** min(attempt - 1, 7))))
+                with self._close_cv:
+                    if client_id in self._close_pending:
+                        self._close_backlog.append(client)
+                        self._close_cv.notify()
+
+    def _schedule_close(self, client: httpx.Client, *, force: bool = False) -> bool:
+        """Enqueue one idempotent close on fixed workers.
+
+        Every existing client already owns a hard construction permit, so the
+        deduplicated cleanup registry can always accept it. ``force`` remains
+        accepted for compatibility with the shutdown caller but does not alter
+        lease eligibility.
+        """
+        try:
+            if client.is_closed:
+                self._release_client_slot(client)
+                return True
+        except Exception:
+            pass
+        with self._close_cv:
+            client_id = id(client)
+            if client_id in self._close_pending:
+                # A prior start attempt may have failed during thread/resource
+                # exhaustion. Every duplicate handoff is a recovery kick.
+                self._ensure_cleanup_workers_locked()
+                self._close_cv.notify()
+                return True
+            self._close_pending[client_id] = client
+            self._close_pending_since[client_id] = time.monotonic()
+            self._close_backlog.append(client)
+            self._ensure_cleanup_workers_locked()
+            self._close_cv.notify()
+            return True
+
+    def _close_retired_client_now(self, client: httpx.Client) -> None:
+        """Close *client* immediately if it is retired and no longer leased."""
+        with self._retired_lock:
+            keep: List[Tuple[httpx.Client, float]] = []
+            for retired_client, retired_at in self._retired_clients:
+                if retired_client is client:
+                    if not self._schedule_close(client):
+                        keep.append((retired_client, retired_at))
+                else:
+                    keep.append((retired_client, retired_at))
+            self._retired_clients = keep
+
+    def _evict_client(self, netloc: str, session_key: Optional[str], client: httpx.Client) -> bool:
         """
         Remove *client* from the pool after a transport error so the next
         checkout builds a fresh client (and therefore fresh connections).
@@ -465,14 +707,15 @@ class ConnectionPool:
                 entry = self._session_clients.get(key)
                 if entry is not None and entry[0] is client:
                     self._session_clients.pop(key)
+                    self._retire(client)
                     evicted = True
         else:
             with self._lock:
                 if self._clients.get(netloc) is client:
                     self._clients.pop(netloc)
+                    self._retire(client)
                     evicted = True
         if evicted:
-            self._retire(client)
             with self._metrics_lock:
                 self._metrics.evicted_clients += 1
         self._reap_retired()
@@ -481,20 +724,17 @@ class ConnectionPool:
     def _reap_retired(self, force: bool = False) -> None:
         """Close retired clients whose in-flight grace period has passed."""
         cutoff = time.monotonic() - self._config.retire_close_grace_seconds
-        to_close: List[httpx.Client] = []
+        with self._session_lock:
+            leased = {client for client, refs in self._session_client_refs.items() if refs > 0}
         with self._retired_lock:
             keep: List[Tuple[httpx.Client, float]] = []
             for client, retired_at in self._retired_clients:
-                if force or retired_at <= cutoff:
-                    to_close.append(client)
+                if (force or retired_at <= cutoff) and client not in leased:
+                    if not self._schedule_close(client, force=force):
+                        keep.append((client, retired_at))
                 else:
                     keep.append((client, retired_at))
             self._retired_clients = keep
-        for client in to_close:
-            try:
-                client.close()
-            except Exception:
-                pass
 
     # ------------------------------------------------------------------
     # Public request interface
@@ -536,7 +776,7 @@ class ConnectionPool:
         client = (
             self._get_session_client(netloc, session_key, checkout=True)
             if session_key
-            else self._get_client(netloc)
+            else self._get_client(netloc, checkout=True)
         )
 
         with self._metrics_lock:
@@ -575,6 +815,8 @@ class ConnectionPool:
             # last_used (subsumes the success-path _touch_session call).
             if session_key:
                 self._release_session_client(netloc, session_key, client)
+            else:
+                self._release_client(client)
 
     def stream(
         self,
@@ -608,8 +850,10 @@ class ConnectionPool:
             def on_release() -> None:
                 self._release_session_client(netloc, session_key, client)
         else:
-            client = self._get_client(netloc)
-            on_release = None
+            client = self._get_client(netloc, checkout=True)
+
+            def on_release() -> None:
+                self._release_client(client)
 
         with self._metrics_lock:
             self._metrics.total_requests += 1
@@ -625,9 +869,7 @@ class ConnectionPool:
                 self._metrics_lock,
                 on_transport_error=lambda: self._evict_client(netloc, session_key, client),
                 on_complete=(
-                    (lambda: self._touch_session(netloc, session_key))
-                    if session_key
-                    else None
+                    (lambda: self._touch_session(netloc, session_key)) if session_key else None
                 ),
                 on_release=on_release,
             )
@@ -656,10 +898,51 @@ class ConnectionPool:
 
     def metrics(self) -> dict:
         """Return a copy of the current pool metrics."""
+        # /health calls this surface, making health polling a safe recovery
+        # kick after a transient inability to start cleanup workers.
+        self._kick_cleanup()
         with self._metrics_lock:
             data = self._metrics.to_dict()
         with self._retired_lock:
-            data["retired_pending_close"] = len(self._retired_clients)
+            retired = len(self._retired_clients)
+        now = time.monotonic()
+        with self._close_cv:
+            cleanup_pending = len(self._close_pending)
+            cleanup_queued = len(self._close_backlog)
+            cleanup_in_progress = len(self._close_in_progress)
+            oldest = (
+                max(0.0, now - min(self._close_pending_since.values()))
+                if self._close_pending_since
+                else 0.0
+            )
+            data.update(
+                {
+                    "cleanup_pending_close": cleanup_pending,
+                    "cleanup_queued": cleanup_queued,
+                    "cleanup_in_progress": cleanup_in_progress,
+                    "cleanup_retrying": max(
+                        0, cleanup_pending - cleanup_queued - cleanup_in_progress
+                    ),
+                    "cleanup_failures_total": self._close_failures,
+                    "cleanup_worker_start_failures_total": (self._cleanup_worker_start_failures),
+                    "cleanup_completed_total": self._close_completed,
+                    "cleanup_oldest_pending_seconds": round(oldest, 3),
+                    "cleanup_workers_alive": sum(
+                        worker.is_alive() for worker in self._close_workers
+                    ),
+                }
+            )
+        with self._client_slot_lock:
+            slots_used = len(self._client_slot_clients)
+            data.update(
+                {
+                    "client_slots_used": slots_used,
+                    "client_slots_max": self._client_slot_limit,
+                    "client_capacity_rejections_total": self._client_slot_rejections,
+                    "cleanup_saturated": slots_used >= self._client_slot_limit,
+                }
+            )
+        data["retired_pending_close"] = retired + cleanup_pending
         return data
 
     def reset_metrics(self) -> None:
@@ -672,29 +955,75 @@ class ConnectionPool:
     # ------------------------------------------------------------------
 
     def close(self) -> None:
-        """Close all pooled clients and release TCP/TLS resources."""
+        """Close all pooled clients within the configured shutdown bound."""
+        started = time.monotonic()
+        configured_timeout = self._config.close_timeout_seconds
+        timeout = (
+            configured_timeout
+            if math.isfinite(configured_timeout) and configured_timeout > 0.0
+            else 0.0
+        )
+        deadline = started + timeout
+        self._closed = True
+
+        clients: List[Any] = []
+        # Selection, lease visibility, and active retirement are atomic with
+        # every checkout path. Active requests/streams are never force-closed;
+        # their final release performs the cleanup handoff.
         with self._lock:
-            for client in self._clients.values():
-                try:
-                    client.close()
-                except Exception:
-                    pass
-            self._clients.clear()
-        with self._session_lock:
-            for client, _ in self._session_clients.values():
-                try:
-                    client.close()
-                except Exception:
-                    pass
-            self._session_clients.clear()
-            for client in self._overflow_clients:
-                try:
-                    client.close()
-                except Exception:
-                    pass
-            self._overflow_clients.clear()
-            self._session_client_refs.clear()
-        self._reap_retired(force=True)
+            with self._session_lock:
+                pooled = list(self._clients.values())
+                pooled.extend(client for client, _ in self._session_clients.values())
+                pooled.extend(self._overflow_clients)
+                leased = {client for client, refs in self._session_client_refs.items() if refs > 0}
+                for client in pooled:
+                    if client in leased:
+                        self._retire(client)
+                    else:
+                        clients.append(client)
+                self._clients.clear()
+                self._session_clients.clear()
+                self._overflow_clients.clear()
+
+        # Retired clients with no live lease move to cleanup; active ones stay
+        # visible until final release. Do not clear positive refcounts.
+        with self._retired_lock:
+            keep: List[Tuple[httpx.Client, float]] = []
+            for client, retired_at in self._retired_clients:
+                if client in leased:
+                    keep.append((client, retired_at))
+                else:
+                    clients.append(client)
+            self._retired_clients = keep
+
+        for client in {id(client): client for client in clients}.values():
+            self._schedule_close(client, force=True)
+
+        # Publish handoff completion only after all pool maps are detached and
+        # every eligible client is queued. A concurrent final lease release may
+        # observe _closed before this point, but cannot terminate idle cleanup
+        # workers until this flag becomes true.
+        with self._close_cv:
+            self._cleanup_handoff_complete = True
+            if self._close_pending:
+                self._ensure_cleanup_workers_locked()
+                self._close_cv.notify_all()
+
+        self._maybe_finish_cleanup_shutdown()
+        with self._close_cv:
+            while self._close_pending:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    break
+                self._close_cv.wait(timeout=remaining)
+            pending = len(self._close_pending)
+        if pending:
+            logger.warning(
+                "connection-pool close exceeded %.3fs for %d client(s); "
+                "fixed daemon cleanup continues",
+                timeout,
+                pending,
+            )
 
     def session_client_snapshot(self) -> Dict[str, Any]:
         """Return a diagnostic snapshot of the per-session client pool."""

--- a/tokenpak/proxy/headers.py
+++ b/tokenpak/proxy/headers.py
@@ -6,6 +6,13 @@ Each route classification maps to a header-forwarding strategy:
 - ``forward_all``: relay every client header (Claude Code client-auth pass-through)
 - ``allowlist``:   only forward headers on the route's allowlist (OpenClaw)
 - ``sanitize``:    strip known-bad hop-by-hop / dangerous headers (SDK, non-Anthropic)
+
+Whichever strategy builds the upstream header set, headers in the
+TokenPak-internal namespace (``x-tokenpak-*`` / ``x-tpk-*``) are stripped
+before the request leaves the proxy: they are internal plumbing and must
+never reach a provider upstream. The allowlist strategies exclude them by
+construction (no allowlist contains an internal name); the relay and
+sanitize strategies strip them explicitly.
 """
 from __future__ import annotations
 
@@ -75,6 +82,21 @@ BLOCKED_FORWARD_HEADERS: frozenset = frozenset((
 
 
 # ---------------------------------------------------------------------------
+# Internal-namespace strip (final upstream forwarding boundary)
+# ---------------------------------------------------------------------------
+
+def _is_internal_header(name: str) -> bool:
+    """True when *name* is a TokenPak-internal header (never forwarded).
+
+    Delegates to the single canonical namespace predicate so the forwarding
+    boundary and the traffic classifier can never disagree on the strip set.
+    """
+    from tokenpak.proxy.spend_guard.classifier import is_internal_header
+
+    return is_internal_header(name)
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -96,16 +118,21 @@ def forward_headers(
 
     Returns:
         A new header dict containing only the headers that should be
-        forwarded to the upstream provider.
+        forwarded to the upstream provider. TokenPak-internal headers
+        (``x-tokenpak-*`` / ``x-tpk-*``) are never included, whichever
+        strategy applies.
     """
     if route == ROUTE_CLAUDE_CODE and client_has_auth:
-        # Client-auth pass-through: forward ALL headers (like a pure relay).
+        # Client-auth pass-through: forward ALL headers (like a pure relay),
+        # except hop-by-hop and TokenPak-internal headers.
         return {
             k: v for k, v in raw_headers.items()
-            if k.lower() not in _HOP_BY_HOP_HEADERS
+            if k.lower() not in _HOP_BY_HOP_HEADERS and not _is_internal_header(k)
         }
 
     if route == ROUTE_CLAUDE_CODE:
+        # Allowlists never contain internal names, so the allowlist filter
+        # already excludes the internal namespace; output is unchanged.
         return {
             k.lower(): v for k, v in raw_headers.items()
             if k.lower() in CLAUDE_CODE_HEADER_ALLOWLIST
@@ -122,8 +149,8 @@ def forward_headers(
 
 
 def sanitize_headers(raw_headers: Dict[str, str]) -> Dict[str, str]:
-    """Strip hop-by-hop and dangerous headers (fallback strategy)."""
+    """Strip hop-by-hop, dangerous, and TokenPak-internal headers (fallback strategy)."""
     return {
         k: v for k, v in raw_headers.items()
-        if k.lower() not in BLOCKED_FORWARD_HEADERS
+        if k.lower() not in BLOCKED_FORWARD_HEADERS and not _is_internal_header(k)
     }

--- a/tokenpak/proxy/server.py
+++ b/tokenpak/proxy/server.py
@@ -468,23 +468,134 @@ def _is_app_endpoint_path(path: str) -> bool:
 # Threaded HTTP server
 # ---------------------------------------------------------------------------
 
+# The overload-rejection body is built exactly once; the Content-Length header
+# is computed from the actual body bytes so the wire framing is always exact.
+_ADMISSION_REJECT_BODY = b'{"error":"managed_admission_capacity"}'
+_ADMISSION_REJECT_RESPONSE = (
+    b"HTTP/1.1 503 Service Unavailable\r\n"
+    b"Content-Type: application/json\r\n"
+    b"Content-Length: " + str(len(_ADMISSION_REJECT_BODY)).encode("ascii") + b"\r\n"
+    b"Connection: close\r\n"
+    b"\r\n" + _ADMISSION_REJECT_BODY
+)
+
+# Bounds for the pre-worker request-head peek. A model request's header block
+# must fit within _ADMISSION_PEEK_MAX_BYTES and finish arriving within
+# _ADMISSION_PEEK_DEADLINE_S of the first peek; otherwise the request is
+# classified on whatever bytes arrived in time. A marker that does not arrive
+# within the bounds classifies the request as unmarked — the same handling as
+# any request without a marker (no admission lease, normal worker path).
+_ADMISSION_FIRST_PEEK_TIMEOUT_S = 0.25
+_ADMISSION_PEEK_DEADLINE_S = 1.0
+_ADMISSION_PEEK_MAX_BYTES = 8192
+_ADMISSION_PEEK_POLL_S = 0.005
+
+
 class _ThreadedHTTPServer(HTTPServer):
     """HTTP server that dispatches each request to a daemon thread."""
 
     proxy_server: "ProxyServer"  # injected after construction
 
-    def process_request(self, request, client_address):
-        t = threading.Thread(target=self._handle, args=(request, client_address))
-        t.daemon = True
-        t.start()
+    def _peek_request_head(self, request) -> bytes:
+        """Peek the request head without consuming bytes, under explicit bounds.
 
-    def _handle(self, request, client_address):
+        For model-endpoint paths the peek continues until the end of the
+        header block is visible, because a classification marker can arrive in
+        a later TCP segment than the request line. Both an explicit byte bound
+        and an explicit wall-time bound apply, so this never blocks
+        indefinitely. On bound exhaustion the partial head is returned and the
+        caller classifies the request on what actually arrived.
+        """
+        deadline = time.monotonic() + _ADMISSION_PEEK_DEADLINE_S
+        peeked = b""
+        try:
+            request.settimeout(_ADMISSION_FIRST_PEEK_TIMEOUT_S)
+            try:
+                peeked = request.recv(_ADMISSION_PEEK_MAX_BYTES, socket.MSG_PEEK)
+            except (OSError, ValueError):
+                return b""
+            if not peeked:
+                return b""
+            first_line = peeked.split(b"\r\n", 1)[0]
+            parts = first_line.split(b" ", 2)
+            path = parts[1].decode("latin-1", "ignore") if len(parts) > 1 else ""
+            if not path.startswith("/v1/messages"):
+                # Only model-endpoint requests are classified from the full
+                # header block; everything else needs just the request line.
+                return peeked
+            while (
+                b"\r\n\r\n" not in peeked
+                and len(peeked) < _ADMISSION_PEEK_MAX_BYTES
+                and time.monotonic() < deadline
+            ):
+                try:
+                    chunk = request.recv(_ADMISSION_PEEK_MAX_BYTES, socket.MSG_PEEK)
+                except (OSError, ValueError):
+                    break
+                if not chunk:
+                    break  # peer closed — nothing more will arrive
+                if len(chunk) <= len(peeked):
+                    # No new bytes yet — wait a bounded interval before the
+                    # next peek so the loop never busy-spins.
+                    time.sleep(_ADMISSION_PEEK_POLL_S)
+                peeked = chunk
+        finally:
+            try:
+                request.settimeout(None)
+            except (OSError, ValueError):
+                pass
+        return peeked
+
+    def process_request(self, request, client_address):
+        # Keep control-plane endpoints responsive while bounding model traffic.
+        # Admission happens before a worker thread is created, so overload cannot
+        # turn into an unbounded thread/socket population.
+        peeked = self._peek_request_head(request)
+        first_line = peeked.split(b"\r\n", 1)[0]
+        parts = first_line.split(b" ", 2)
+        path = parts[1].decode("latin-1", "ignore") if len(parts) > 1 else ""
+        control = path == "/health" or path.startswith("/health?") or path in {"/status", "/metrics"} or path.startswith("/tpk/v1/") or path.startswith("/pak/v1/")
+        managed = False
+        if not control and path.startswith("/v1/messages"):
+            from tokenpak.proxy.spend_guard.classifier import MANAGED, classify
+            headers = {}
+            for line in peeked.split(b"\r\n")[1:]:
+                if not line:
+                    break
+                key, sep, value = line.partition(b":")
+                if sep:
+                    headers[key.decode("latin-1")] = value.decode("latin-1").strip()
+            managed = classify(headers).request_class == MANAGED
+        admitted = managed and self.proxy_server._admission.acquire(blocking=False)
+        if managed and not admitted:
+            try:
+                request.sendall(_ADMISSION_REJECT_RESPONSE)
+            finally:
+                self.shutdown_request(request)
+            self.proxy_server._admission_rejected += 1
+            return
+        try:
+            t = threading.Thread(target=self._handle, args=(request, client_address, managed))
+            t.daemon = True
+            t.start()
+        except Exception:
+            # Worker creation failed after the admission decision: release the
+            # lease (if one was acquired) and close the accepted socket so
+            # neither leaks. Re-raise so the serving loop records the error.
+            if admitted:
+                self.proxy_server._admission.release()
+            self.shutdown_request(request)
+            raise
+
+    def _handle(self, request, client_address, managed=False):
         try:
             self.finish_request(request, client_address)
         except Exception:
             self.handle_error(request, client_address)
         finally:
             self.shutdown_request(request)
+            if managed:
+                self.proxy_server._admission.release()
 
 
 # ---------------------------------------------------------------------------
@@ -2948,6 +3059,9 @@ class ProxyServer:
         self._last_lock = threading.Lock()
         self._server: Optional[_ThreadedHTTPServer] = None
         self._server_thread: Optional[threading.Thread] = None
+        self._admission_limit = max(1, int(os.environ.get("TOKENPAK_MANAGED_ADMISSION", "16")))
+        self._admission = threading.BoundedSemaphore(self._admission_limit)
+        self._admission_rejected = 0
         # Rolling window of per-request compression ratios (last 100)
         self._compression_ratios: deque = deque(maxlen=100)
         self._compression_lock = threading.Lock()
@@ -3172,6 +3286,11 @@ class ProxyServer:
             "is_degraded": is_degraded,
             "is_shutting_down": is_shutting_down,
             "in_flight_requests": self.shutdown.in_flight_count(),
+            "admission": {
+                "limit": self._admission_limit,
+                "available": self._admission._value,
+                "rejected": self._admission_rejected,
+            },
             "timestamp": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "connection_pool": {
                 "http2_enabled": self._connection_pool.http2_enabled,

--- a/tokenpak/proxy/spend_guard/__init__.py
+++ b/tokenpak/proxy/spend_guard/__init__.py
@@ -72,20 +72,33 @@ def _fail_closed_outcome(exc: Exception) -> "GuardOutcome":
             "message": (
                 "Spend Guard could not verify this request because its local "
                 "guard state is unavailable. The request was blocked before "
-                "provider send."
+                "provider send. No allow/stop prompt is available because no "
+                "pending request could be recorded."
             ),
-            "reason": "spend_guard_internal_error",
+            "reason": "spend_guard_state_unavailable",
+            "failure_kind": "spend_guard_internal_error",
             "threshold_hit": f"internal_error:{type(exc).__name__}",
             "projected_input_tokens": None,
             "projected_output_tokens": None,
             "projected_cost_usd": None,
             "pending_id": None,
-            "approval_prompt": (
-                "Repair Spend Guard state, or explicitly disable Spend Guard "
-                "only as an operator-approved emergency."
-            ),
+            "approval_prompt": None,
+            "approval_prompt_available": False,
+            "auto_proceed_available": False,
+            "continuum_auto_proceed_available": False,
+            "continuum_status": "not_active",
             "retryable": False,
             "recovery_status": "operator_action_required",
+            "recovery_actions": [
+                "run tokenpak doctor",
+                "repair or restore the local Spend Guard state store",
+                "restart the TokenPak proxy after repair",
+            ],
+            "operator_note": (
+                "Disable Spend Guard only as an explicit operator-approved "
+                "emergency; auto-proceed is unsafe while spend cannot be "
+                "verified."
+            ),
         }
     }
     return GuardOutcome(

--- a/tokenpak/proxy/spend_guard/classifier.py
+++ b/tokenpak/proxy/spend_guard/classifier.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Internal request traffic classifier.
+
+Attributes every proxied request to exactly one of three canonical classes
+(``managed`` / ``raw_claude_observed`` / ``external_untagged``) using the
+strict detection precedence defined in :func:`classify`.
+
+The attributed class has exactly two consumers wired today:
+
+- the listener admission gate in ``tokenpak.proxy.server``, which bounds
+  managed model-endpoint requests with an admission lease before a worker
+  thread is created; and
+- the upstream forwarding boundary in ``tokenpak.proxy.headers``, which uses
+  :func:`is_internal_header` to keep internal markers from leaving the proxy.
+
+No other consumer (accounting, attribution, persistence) is wired to this
+classification in this tree.
+
+The classifier is read-only on the request: the only output is the attributed
+class + detection reason + agent attribution. It NEVER mutates the body, NEVER
+reads OS process env at request time, and NEVER infers the class from
+URL / port / remote IP.
+
+``__all__`` is intentionally empty: this is internal proxy plumbing, not released
+public API. Every consumer imports the specific name it needs function-locally so
+these helpers stay off the public API surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ── Canonical request classes. Stable string literals — no synonyms,
+#    no plurals, no aliasing. These three values are the canonical set.
+MANAGED = "managed"
+RAW_CLAUDE_OBSERVED = "raw_claude_observed"
+EXTERNAL_UNTAGGED = "external_untagged"
+
+REQUEST_CLASSES = frozenset({MANAGED, RAW_CLAUDE_OBSERVED, EXTERNAL_UNTAGGED})
+
+# ── Canonical detection reasons. Persisted alongside the class on audit rows
+#    for forensic reconstruction. No synonyms (``header-agent`` /
+#    ``agentHeader`` are forbidden). ``env_launcher`` is a reserved literal for
+#    the launcher-synthesised process-env marker; no header grammar for it is
+#    ratified in this tree, so :func:`classify` never returns it today.
+HEADER_AGENT = "header_agent"
+HEADER_MANAGED = "header_managed"
+ENV_LAUNCHER = "env_launcher"
+UA_CLAUDE_CODE = "ua_claude_code"
+NO_MARKER = "no_marker"
+
+DETECTION_REASONS = frozenset(
+    {HEADER_AGENT, HEADER_MANAGED, ENV_LAUNCHER, UA_CLAUDE_CODE, NO_MARKER}
+)
+
+# ── Header names (lowercase for case-insensitive matching).
+HEADER_NAME_AGENT = "x-tokenpak-agent"
+HEADER_NAME_MANAGED = "x-tokenpak-managed"
+
+# The managed marker grammar is exact: ``X-Tokenpak-Managed: 1``. No other
+# value (including truthy-looking tokens such as ``true`` / ``yes`` / ``on``)
+# marks a request managed. Surrounding whitespace is tolerated because header
+# values are stripped before comparison.
+MANAGED_MARKER_VALUE = "1"
+
+# TokenPak-internal header namespace. Any header whose name starts with one of
+# these prefixes is internal proxy plumbing and MUST be stripped before
+# upstream forwarding (re-synthesised at each hop, never passed through, even
+# to a TokenPak-managed downstream proxy).
+INTERNAL_HEADER_PREFIXES = ("x-tokenpak-", "x-tpk-")
+
+# Canonical Claude Code CLI User-Agent substring.
+# Matched case-insensitively, and ONLY after every higher-precedence marker has
+# failed. Single source of truth — do not duplicate this literal elsewhere.
+CLAUDE_CODE_UA_SUBSTRING = "claude-cli"
+
+# "managed marker present, but no agent name to attribute" sentinel.
+# Empty string, never fabricated.
+UNKNOWN_MANAGED_AGENT = ""
+
+# Intentionally empty — keeps every name above off the public-API snapshot.
+__all__: list[str] = []
+
+
+@dataclass(frozen=True)
+class Classification:
+    """Result of classifying one request — read-only attribution.
+
+    ``request_class`` is one of :data:`REQUEST_CLASSES`; ``reason`` is one of
+    :data:`DETECTION_REASONS`; ``agent_attribution`` is the lower-cased
+    ``X-Tokenpak-Agent`` value for ``header_agent`` matches, else ``""``.
+    """
+
+    request_class: str
+    reason: str
+    agent_attribution: str = ""
+
+
+def _header(headers, name: str) -> str:
+    """Case-insensitive header lookup → stripped string value (or "")."""
+    if not headers:
+        return ""
+    try:
+        items = headers.items()
+    except AttributeError:
+        return ""
+    target = name.lower()
+    for key, value in items:
+        if str(key).lower() == target:
+            return str(value).strip()
+    return ""
+
+
+def is_internal_header(name) -> bool:
+    """True when *name* is in the TokenPak-internal header namespace.
+
+    Internal headers MUST never be forwarded to a provider upstream — every
+    forwarding strategy strips them at the upstream boundary
+    (``tokenpak.proxy.headers``).
+    """
+    return str(name).lower().startswith(INTERNAL_HEADER_PREFIXES)
+
+
+def classify(headers) -> Classification:
+    """Attribute a request via the defined precedence chain.
+
+    Evaluates markers in strict order, returning on the first match:
+
+      1. ``X-Tokenpak-Agent: <name>``  → ``managed`` (reason ``header_agent``),
+         agent attribution = the lower-cased header value.
+      2. ``X-Tokenpak-Managed: 1``     → ``managed`` (reason ``header_managed``),
+         agent attribution = unknown-managed. The marker value must be exactly
+         ``1`` after whitespace stripping; no alternate values are recognised.
+      3. Claude Code UA substring      → ``raw_claude_observed`` (reason
+         ``ua_claude_code``) when no higher marker matched.
+      4. otherwise                     → ``external_untagged`` (reason
+         ``no_marker``).
+
+    Read-only: never mutates ``headers``, never consults ``os.environ``, never
+    infers from URL / port / remote IP.
+    """
+    agent = _header(headers, HEADER_NAME_AGENT)
+    if agent:
+        return Classification(MANAGED, HEADER_AGENT, agent.lower())
+
+    if _header(headers, HEADER_NAME_MANAGED) == MANAGED_MARKER_VALUE:
+        return Classification(MANAGED, HEADER_MANAGED, UNKNOWN_MANAGED_AGENT)
+
+    ua = _header(headers, "user-agent").lower()
+    if ua and CLAUDE_CODE_UA_SUBSTRING in ua:
+        return Classification(RAW_CLAUDE_OBSERVED, UA_CLAUDE_CODE, "")
+
+    return Classification(EXTERNAL_UNTAGGED, NO_MARKER, "")
+
+
+def strip_managed_headers(headers) -> list[str]:
+    """Remove TokenPak-internal headers from a forward-bound header map.
+
+    Removes every header in the internal namespace (see
+    :func:`is_internal_header`). Mutates ``headers`` in place
+    (case-insensitive) and returns the list of header names actually removed.
+    These markers are re-synthesised at each hop and MUST NEVER be forwarded
+    upstream — even to a TokenPak-managed downstream proxy. A no-op (returns
+    ``[]``) when none are present or ``headers`` is not a mutable mapping.
+    """
+    removed: list[str] = []
+    try:
+        keys = list(headers.keys())
+    except AttributeError:
+        return removed
+    for key in keys:
+        if is_internal_header(key):
+            try:
+                del headers[key]
+            except (KeyError, TypeError):
+                continue
+            removed.append(key)
+    return removed

--- a/tokenpak/proxy/vault_bridge.py
+++ b/tokenpak/proxy/vault_bridge.py
@@ -4,6 +4,9 @@ and startup initialization for vault retrieval, term resolver, and capsule build
 
 Extracted from runtime/proxy.py (L1177-1498) as part of TPK-RESTRUCTURE-004.
 """
+
+import codecs
+import hashlib
 import json
 import logging
 import math
@@ -11,9 +14,16 @@ import os
 import re
 import threading
 import time
+from array import array as _array
+from bisect import bisect_left as _bisect_left
+from collections import Counter as _Counter
+from collections import OrderedDict as _OrderedDict
+from dataclasses import dataclass as _dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from tokenpak.vault.walker import MAX_FILE_SIZE as _VAULT_BLOCK_MAX_BYTES
 
 if TYPE_CHECKING:
     from .request import ProxyRequest
@@ -28,6 +38,12 @@ from .config import (
     VAULT_INDEX_PATH,
     VAULT_INDEX_RELOAD_INTERVAL,
     _cfg,
+)
+from .config import (
+    VAULT_CACHE_MAX_BYTES as _VAULT_CACHE_MAX_BYTES,
+)
+from .config import (
+    VAULT_CACHE_PRELOAD as _VAULT_CACHE_PRELOAD,
 )
 from .token_cache import count_tokens
 
@@ -54,9 +70,7 @@ else:
     ENABLE_CAPSULE_BUILDER = _cfg(
         "features.capsule_builder", False, "TOKENPAK_CAPSULE_BUILDER_ENABLED", bool
     )
-CAPSULE_MIN_CHARS: int = _cfg(
-    "features.capsule_min_chars", 400, "TOKENPAK_CAPSULE_MIN_CHARS", int
-)
+CAPSULE_MIN_CHARS: int = _cfg("features.capsule_min_chars", 400, "TOKENPAK_CAPSULE_MIN_CHARS", int)
 CAPSULE_HOT_WINDOW: int = _cfg(
     "features.capsule_hot_window", 12, "TOKENPAK_CAPSULE_HOT_WINDOW", int
 )
@@ -76,6 +90,7 @@ try:
     from tokenpak.vault.query_expansion import (
         tokenize as _qe_tokenize,
     )
+
     _QE_AVAILABLE = True
 except ImportError:
     _QE_AVAILABLE = False
@@ -83,6 +98,78 @@ except ImportError:
 # ---------------------------------------------------------------------------
 # VaultIndex — BM25-searchable read-only index
 # ---------------------------------------------------------------------------
+
+
+@_dataclass(frozen=True)
+class _ContentRecord:
+    """File identity pinned to the BM25 generation built from its content."""
+
+    path: str
+    content_hash: str
+    mtime_ns: Optional[int]
+    ctime_ns: Optional[int]
+    file_size: Optional[int]
+    device: Optional[int]
+    inode: Optional[int]
+    metadata_hash_stale: bool
+    actual_tokens: Optional[int]
+
+
+@_dataclass(frozen=True)
+class _HydratedContent:
+    """A bounded, generation-verified UTF-8 content value."""
+
+    text: str
+    utf8_bytes: int
+    source_bytes: int
+    source_bytes_loaded: int
+    truncated: bool
+
+
+@_dataclass
+class _HydrationFlight:
+    """One physical read shared by concurrent readers of a generation key."""
+
+    event: threading.Event
+    result: Optional[_HydratedContent] = None
+
+
+class _OversizedVaultBlock(Exception):
+    """Raised internally when a block exceeds the canonical walker limit."""
+
+
+@_dataclass(frozen=True)
+class _IndexGeneration:
+    """One atomically published, read-only BM25 generation."""
+
+    generation_id: int
+    blocks: Dict[str, dict]
+    content_records: Dict[str, _ContentRecord]
+    block_ids: Tuple[str, ...]
+    postings: Dict[str, _array]
+    block_dl: _array
+    avg_dl: float
+    doc_count: int
+    index_mtime: float
+    stale_content_hashes: int
+    skipped_blocks: int
+    oversized_blocks: int
+
+
+_CONTENT_GENERATION_MISMATCH = (
+    "[TokenPak: vault block content changed after indexing; reload required]"
+)
+_CONTENT_READ_CHUNK_BYTES = 64 * 1024
+
+
+def _utf8_prefix(text: str, byte_limit: int) -> str:
+    """Return the longest valid UTF-8 prefix whose encoding fits the limit."""
+    if byte_limit <= 0:
+        return ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= byte_limit:
+        return text
+    return encoded[:byte_limit].decode("utf-8", errors="ignore")
 
 
 class VaultIndex:
@@ -93,22 +180,81 @@ class VaultIndex:
 
     def __init__(self, tokenpak_dir: str):
         self.tokenpak_dir = Path(tokenpak_dir)
-        self.blocks: Dict[str, dict] = {}  # block_id -> {meta + content}
         self._last_loaded = 0
-        self._last_mtime = 0
         self._lock = threading.Lock()
+        self._cache_condition = threading.Condition(self._lock)
         self._reload_lock = threading.Lock()
-        # BM25 precomputed
-        self._df: Dict[str, int] = {}
-        self._block_tfs: Dict[str, Dict[str, int]] = {}
-        self._block_dl: Dict[str, int] = {}  # precomputed doc lengths (sum of tf values)
-        self._avg_dl: float = 0
-        self._doc_count: int = 0
-        self._inverted: Dict[str, set] = {}  # term -> set(block_ids)
+        # Compact BM25 state. Each posting is one packed uint64:
+        # (document_index << 32) | term_frequency. This keeps each term string
+        # once instead of duplicating it in every document TF dict and in a
+        # second set-based inverted index.
+        self._generation = _IndexGeneration(
+            generation_id=0,
+            blocks={},
+            content_records={},
+            block_ids=(),
+            postings={},
+            block_dl=_array("I"),
+            avg_dl=0.0,
+            doc_count=0,
+            index_mtime=0.0,
+            stale_content_hashes=0,
+            skipped_blocks=0,
+            oversized_blocks=0,
+        )
+        # Full block content is loaded only for selected results and retained
+        # in a byte-bounded, generation-keyed LRU.
+        self._content_cache: _OrderedDict[Tuple[int, str], _HydratedContent] = _OrderedDict()
+        self._cache_bytes = 0
+        self._hydration_reserved_bytes = 0
+        self._max_managed_content_bytes = 0
+        self._hydration_flights: Dict[Tuple[int, str], _HydrationFlight] = {}
+        self._max_cache_bytes = max(0, _VAULT_CACHE_MAX_BYTES)
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cache_evictions = 0
+        self._coalesced_hydrations = 0
+        self._physical_hydration_reads = 0
+        self._hydration_failures = 0
 
     @property
     def available(self) -> bool:
-        return len(self.blocks) > 0
+        return self._snapshot_generation().doc_count > 0
+
+    def _snapshot_generation(self) -> _IndexGeneration:
+        """Return one coherent generation pointer under the publication lock."""
+        with self._lock:
+            return self._generation
+
+    # Compatibility views for existing metrics/debug consumers. Search never
+    # reads these separately; it captures one _IndexGeneration instead.
+    @property
+    def blocks(self) -> Dict[str, dict]:
+        return self._snapshot_generation().blocks
+
+    @property
+    def _block_ids(self) -> Tuple[str, ...]:
+        return self._snapshot_generation().block_ids
+
+    @property
+    def _postings(self) -> Dict[str, _array]:
+        return self._snapshot_generation().postings
+
+    @property
+    def _block_dl(self) -> _array:
+        return self._snapshot_generation().block_dl
+
+    @property
+    def _avg_dl(self) -> float:
+        return self._snapshot_generation().avg_dl
+
+    @property
+    def _doc_count(self) -> int:
+        return self._snapshot_generation().doc_count
+
+    @property
+    def _last_mtime(self) -> float:
+        return self._snapshot_generation().index_mtime
 
     def maybe_reload(self):
         """Reload if index file changed or enough time passed."""
@@ -122,7 +268,8 @@ class VaultIndex:
 
         try:
             mtime = index_path.stat().st_mtime
-            if mtime == self._last_mtime and self.blocks:
+            generation = self._snapshot_generation()
+            if mtime == generation.index_mtime and generation.doc_count:
                 self._last_loaded = now
                 return
         except OSError:
@@ -135,7 +282,8 @@ class VaultIndex:
 
             try:
                 mtime = index_path.stat().st_mtime
-                if mtime == self._last_mtime and self.blocks:
+                generation = self._snapshot_generation()
+                if mtime == generation.index_mtime and generation.doc_count:
                     self._last_loaded = now
                     return
             except OSError:
@@ -144,16 +292,75 @@ class VaultIndex:
             self._load(index_path, mtime)
             self._last_loaded = now
 
-    def _load(self, index_path: Path, mtime: float):
-        """Load index + block contents, precompute BM25 stats."""
+    @staticmethod
+    def _scan_content_file(
+        content_file: Path, expected_hash: Optional[str]
+    ) -> Optional[Tuple[Dict[str, int], int, _ContentRecord]]:
+        """Build BM25 from one stable block without retaining corpus content."""
         try:
-            data = json.loads(index_path.read_text())
+            with content_file.open("rb") as handle:
+                stat_before = os.fstat(handle.fileno())
+                if stat_before.st_size > _VAULT_BLOCK_MAX_BYTES:
+                    raise _OversizedVaultBlock
+                raw_content = handle.read(stat_before.st_size)
+                stat_after = os.fstat(handle.fileno())
+        except OSError:
+            return None
+
+        if (
+            stat_before.st_mtime_ns != stat_after.st_mtime_ns
+            or stat_before.st_ctime_ns != stat_after.st_ctime_ns
+            or stat_before.st_dev != stat_after.st_dev
+            or stat_before.st_ino != stat_after.st_ino
+            or len(raw_content) != stat_before.st_size
+        ):
+            return None
+
+        content = raw_content.decode("utf-8", errors="replace")
+        actual_hash = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+        metadata_hash_stale = expected_hash is not None and expected_hash != actual_hash
+        tf, document_length = _bm25_count_document(content)
+        record = _ContentRecord(
+            path=str(content_file),
+            content_hash=actual_hash,
+            mtime_ns=stat_after.st_mtime_ns,
+            ctime_ns=stat_after.st_ctime_ns,
+            file_size=stat_after.st_size,
+            device=stat_after.st_dev,
+            inode=stat_after.st_ino,
+            metadata_hash_stale=metadata_hash_stale,
+            actual_tokens=count_tokens(content) if metadata_hash_stale else None,
+        )
+        return tf, document_length, record
+
+    def _load(self, index_path: Path, mtime: float):
+        """Load metadata and build compact BM25 postings.
+
+        Block text is consumed one document at a time and is not retained in
+        the index, and selected results are hydrated through the bounded
+        content cache, so steady-state memory does not hold the full block
+        text. Postings, vocabulary, and per-block index metadata still scale
+        with corpus size (block count and distinct terms), so index memory
+        grows with the corpus even though raw block bytes are not retained.
+        """
+        try:
+            data = json.loads(index_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as e:
             print(f"  ⚠️ Vault index load error: {e}")
             return
 
         blocks_dir = self.tokenpak_dir / "blocks"
         new_blocks: Dict[str, dict] = {}
+        content_records: Dict[str, _ContentRecord] = {}
+        block_ids: List[str] = []
+        posting_lists: Dict[str, List[int]] = {}
+        block_dl = _array("I")
+        preload_candidates: List[Tuple[float, str]] = []
+        total_dl = 0
+        total_raw_tokens = 0
+        stale_content_hashes = 0
+        unreadable_blocks = 0
+        oversized_blocks = 0
 
         raw_blocks = data.get("blocks", {})
         if isinstance(raw_blocks, dict):
@@ -162,89 +369,375 @@ class VaultIndex:
             return  # unexpected format
 
         for bid, bdata in items:
-            content = ""
+            if not isinstance(bdata, dict):
+                print(f"  ⚠️ Vault index load error: invalid block metadata for {bid}")
+                return
+
             content_file = blocks_dir / f"{bid}.txt"
-            if content_file.exists():
-                try:
-                    content = content_file.read_text(errors="replace")
-                except OSError:
-                    continue
+            raw_expected_hash = bdata.get("content_hash")
+            expected_hash = (
+                raw_expected_hash
+                if isinstance(raw_expected_hash, str) and raw_expected_hash
+                else None
+            )
+            try:
+                scanned = self._scan_content_file(content_file, expected_hash)
+            except _OversizedVaultBlock:
+                oversized_blocks += 1
+                continue
+            if scanned is None:
+                unreadable_blocks += 1
+                continue
+            tf, dl, content_record = scanned
+            if content_record.metadata_hash_stale:
+                stale_content_hashes += 1
+
+            doc_idx = len(block_ids)
+            block_ids.append(bid)
+            raw_tokens = bdata.get("raw_tokens", 0)
 
             new_blocks[bid] = {
                 "block_id": bid,
                 "source_path": bdata.get("source_path", bid),
                 "risk_class": bdata.get("risk_class", "narrative"),
                 "must_keep": bdata.get("must_keep", False),
-                "raw_tokens": bdata.get("raw_tokens", 0),
+                "raw_tokens": raw_tokens,
                 "source_type": bdata.get("source_type", "filesystem"),
                 "claude_transcript": bdata.get("claude_transcript"),
-                "content": content,
+                "_content_file": str(content_file),
             }
+            if content_record.metadata_hash_stale:
+                new_blocks[bid]["_content_metadata_stale"] = True
+                new_blocks[bid]["_content_tokens_actual"] = content_record.actual_tokens
+            content_records[bid] = content_record
+            total_raw_tokens += raw_tokens
 
-        # Precompute BM25
-        df: Dict[str, int] = {}
-        block_tfs: Dict[str, Dict[str, int]] = {}
-        block_dl: Dict[str, int] = {}  # precomputed doc lengths
-        total_dl = 0
-
-        for bid, block in new_blocks.items():
-            terms = _bm25_tokenize(block["content"])
-            tf: Dict[str, int] = {}
-            for t in terms:
-                tf[t] = tf.get(t, 0) + 1
-            dl = len(terms)
-            block_tfs[bid] = tf
-            block_dl[bid] = dl  # store precomputed length
+            block_dl.append(dl)
             total_dl += dl
-            for t in set(terms):
-                df[t] = df.get(t, 0) + 1
+
+            for term, term_frequency in tf.items():
+                posting = posting_lists.get(term)
+                if posting is None:
+                    posting = []
+                    posting_lists[term] = posting
+                posting.append((doc_idx << 32) | term_frequency)
+
+            if content_record.mtime_ns is not None:
+                preload_candidates.append((content_record.mtime_ns / 1_000_000_000, bid))
 
         doc_count = len(new_blocks)
         avg_dl = total_dl / doc_count if doc_count > 0 else 0
 
-        # Build inverted index: term -> set(block_ids)
-        inverted: Dict[str, set] = {}
-        for bid, tf in block_tfs.items():
-            for term in tf:
-                if term not in inverted:
-                    inverted[term] = set()
-                inverted[term].add(bid)
+        # Python lists make the one-time build substantially faster. Convert
+        # and release them one at a time so the published state is compact and
+        # conversion does not retain a second complete representation.
+        postings: Dict[str, _array] = {}
+        while posting_lists:
+            term, posting = posting_lists.popitem()
+            postings[term] = _array("Q", posting)
 
         # Atomic swap — all heavy work done above, lock held briefly
+        with self._cache_condition:
+            generation_id = self._generation.generation_id + 1
+            new_generation = _IndexGeneration(
+                generation_id=generation_id,
+                blocks=new_blocks,
+                content_records=content_records,
+                block_ids=tuple(block_ids),
+                postings=postings,
+                block_dl=block_dl,
+                avg_dl=avg_dl,
+                doc_count=doc_count,
+                index_mtime=mtime,
+                stale_content_hashes=stale_content_hashes,
+                skipped_blocks=unreadable_blocks + oversized_blocks,
+                oversized_blocks=oversized_blocks,
+            )
+            self._generation = new_generation
+            self._content_cache = _OrderedDict()
+            self._cache_bytes = 0
+            self._cache_hits = 0
+            self._cache_misses = 0
+            self._cache_evictions = 0
+            self._coalesced_hydrations = 0
+            self._physical_hydration_reads = 0
+            self._hydration_failures = 0
+            self._max_managed_content_bytes = self._hydration_reserved_bytes
+            self._cache_condition.notify_all()
+
+        # Warm the new generation through the same bounded admission path as
+        # request-time hydration. Old-generation reads remain separately keyed.
+        if _VAULT_CACHE_PRELOAD > 0 and self._max_cache_bytes > 0:
+            preload_candidates.sort(reverse=True)
+            for _, bid in preload_candidates[:_VAULT_CACHE_PRELOAD]:
+                self._hydrate_content(new_generation, bid)
+
         with self._lock:
-            self.blocks = new_blocks
-            self._df = df
-            self._block_tfs = block_tfs
-            self._block_dl = block_dl
-            self._avg_dl = avg_dl
-            self._doc_count = doc_count
-            self._inverted = inverted
-            self._last_mtime = mtime
+            if self._generation is new_generation:
+                cache_entries = sum(key[0] == generation_id for key in self._content_cache)
+                cache_bytes = self._cache_bytes
+            else:
+                cache_entries = 0
+                cache_bytes = 0
 
         print(
-            f"  📚 Vault index loaded: {doc_count} blocks, {sum(b['raw_tokens'] for b in new_blocks.values()):,} tokens"
+            f"  📚 Vault index loaded: {doc_count} blocks, {total_raw_tokens:,} tokens"
+            f" | content cache: {cache_entries} blocks ({cache_bytes // 1024 // 1024}MB)"
         )
+        if stale_content_hashes:
+            print(
+                "  ⚠️ Vault index metadata had "
+                f"{stale_content_hashes} stale content hash(es); indexed stable block bytes"
+            )
+        if unreadable_blocks:
+            print(f"  ⚠️ Vault index skipped {unreadable_blocks} unreadable or missing block(s)")
+        if oversized_blocks:
+            print(
+                f"  ⚠️ Vault index skipped {oversized_blocks} block(s) over "
+                f"{_VAULT_BLOCK_MAX_BYTES} bytes"
+            )
+
+    @staticmethod
+    def _record_matches_stat(record: _ContentRecord, stat_result: os.stat_result) -> bool:
+        """Return whether an open file still has the pinned generation identity."""
+        return (
+            record.mtime_ns is not None
+            and record.ctime_ns is not None
+            and record.file_size is not None
+            and record.device is not None
+            and record.inode is not None
+            and stat_result.st_mtime_ns == record.mtime_ns
+            and stat_result.st_ctime_ns == record.ctime_ns
+            and stat_result.st_size == record.file_size
+            and stat_result.st_dev == record.device
+            and stat_result.st_ino == record.inode
+        )
+
+    @classmethod
+    def _read_pinned_prefix(
+        cls, record: _ContentRecord, byte_limit: int
+    ) -> Optional[_HydratedContent]:
+        """Read at most ``byte_limit`` bytes and return a valid UTF-8 prefix."""
+        if record.file_size is None or byte_limit < 0:
+            return None
+
+        try:
+            with Path(record.path).open("rb") as handle:
+                stat_before = os.fstat(handle.fileno())
+                if not cls._record_matches_stat(record, stat_before):
+                    return None
+
+                target_bytes = min(byte_limit, record.file_size)
+                bytes_read = 0
+                decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+                pieces: List[str] = []
+                digest = hashlib.sha256()
+                while bytes_read < target_bytes:
+                    raw_chunk = handle.read(
+                        min(_CONTENT_READ_CHUNK_BYTES, target_bytes - bytes_read)
+                    )
+                    if not raw_chunk:
+                        return None
+                    bytes_read += len(raw_chunk)
+                    decoded = decoder.decode(raw_chunk, final=False)
+                    if decoded:
+                        pieces.append(decoded)
+                        digest.update(decoded.encode("utf-8", errors="replace"))
+
+                source_truncated = target_bytes < record.file_size
+                decoded = decoder.decode(b"", final=not source_truncated)
+                if decoded:
+                    pieces.append(decoded)
+                    digest.update(decoded.encode("utf-8", errors="replace"))
+                stat_after = os.fstat(handle.fileno())
+        except OSError:
+            return None
+
+        if not cls._record_matches_stat(record, stat_after):
+            return None
+        content = "".join(pieces)
+        content_size = len(content.encode("utf-8"))
+        truncated = source_truncated
+        if content_size > byte_limit:
+            content = _utf8_prefix(content, byte_limit)
+            content_size = len(content.encode("utf-8"))
+            truncated = True
+        if not truncated and digest.hexdigest() != record.content_hash:
+            return None
+        return _HydratedContent(
+            text=content,
+            utf8_bytes=content_size,
+            source_bytes=record.file_size,
+            source_bytes_loaded=content_size,
+            truncated=truncated,
+        )
+
+    def _evict_for_reservation(self, requested_bytes: int) -> None:
+        """Free LRU bytes for a hydration reservation. Lock must be held."""
+        while (
+            self._content_cache
+            and self._cache_bytes + self._hydration_reserved_bytes + requested_bytes
+            > self._max_cache_bytes
+        ):
+            _, evicted = self._content_cache.popitem(last=False)
+            self._cache_bytes -= evicted.utf8_bytes
+            self._cache_evictions += 1
+
+    def _hydrate_content(
+        self, generation: _IndexGeneration, block_id: str
+    ) -> Optional[_HydratedContent]:
+        """Hydrate one generation key through bounded cache and singleflight."""
+        record = generation.content_records.get(block_id)
+        if record is None:
+            return None
+        source_bytes = record.file_size or 0
+        if self._max_cache_bytes == 0:
+            return _HydratedContent("", 0, source_bytes, 0, source_bytes > 0)
+
+        cache_key = (generation.generation_id, block_id)
+        with self._lock:
+            cached = self._content_cache.pop(cache_key, None)
+            if cached is not None:
+                self._content_cache[cache_key] = cached
+                self._cache_hits += 1
+                return cached
+            self._cache_misses += 1
+            flight = self._hydration_flights.get(cache_key)
+            if flight is None:
+                flight = _HydrationFlight(threading.Event())
+                self._hydration_flights[cache_key] = flight
+                owns_flight = True
+            else:
+                self._coalesced_hydrations += 1
+                owns_flight = False
+
+        if not owns_flight:
+            flight.event.wait()
+            return flight.result
+
+        requested_bytes = min(source_bytes, self._max_cache_bytes)
+        reserved = False
+        result: Optional[_HydratedContent] = None
+        try:
+            with self._cache_condition:
+                while True:
+                    self._evict_for_reservation(requested_bytes)
+                    managed_bytes = (
+                        self._cache_bytes + self._hydration_reserved_bytes + requested_bytes
+                    )
+                    if managed_bytes <= self._max_cache_bytes:
+                        self._hydration_reserved_bytes += requested_bytes
+                        self._max_managed_content_bytes = max(
+                            self._max_managed_content_bytes, managed_bytes
+                        )
+                        reserved = True
+                        break
+                    self._cache_condition.wait()
+                self._physical_hydration_reads += 1
+            result = self._read_pinned_prefix(record, requested_bytes)
+        except Exception:
+            result = None
+        finally:
+            with self._cache_condition:
+                if reserved:
+                    self._hydration_reserved_bytes -= requested_bytes
+                if result is not None and self._generation is generation:
+                    existing = self._content_cache.pop(cache_key, None)
+                    if existing is not None:
+                        self._cache_bytes -= existing.utf8_bytes
+                    self._content_cache[cache_key] = result
+                    self._cache_bytes += result.utf8_bytes
+                elif result is None:
+                    self._hydration_failures += 1
+                flight.result = result
+                if self._hydration_flights.get(cache_key) is flight:
+                    self._hydration_flights.pop(cache_key)
+                flight.event.set()
+                self._cache_condition.notify_all()
+        return result
+
+    @staticmethod
+    def _fit_hydration(hydrated: _HydratedContent, byte_limit: int) -> _HydratedContent:
+        """Clip one hydrated value to a search's remaining aggregate budget."""
+        if hydrated.utf8_bytes <= byte_limit:
+            return hydrated
+        content = _utf8_prefix(hydrated.text, byte_limit)
+        content_size = len(content.encode("utf-8"))
+        return _HydratedContent(
+            text=content,
+            utf8_bytes=content_size,
+            source_bytes=hydrated.source_bytes,
+            source_bytes_loaded=min(hydrated.source_bytes_loaded, content_size),
+            truncated=True,
+        )
+
+    def _get_content(self, block_id: str, *, generation: Optional[_IndexGeneration] = None) -> str:
+        """Compatibility helper returning one globally bounded content string."""
+        if generation is None:
+            generation = self._snapshot_generation()
+        hydrated = self._hydrate_content(generation, block_id)
+        if hydrated is not None:
+            return hydrated.text
+        return _utf8_prefix(_CONTENT_GENERATION_MISMATCH, self._max_cache_bytes)
+
+    @property
+    def cache_stats(self) -> dict:
+        """Return a thread-safe snapshot of bounded content-cache metrics."""
+        with self._lock:
+            accesses = self._cache_hits + self._cache_misses
+            generation = self._generation
+            return {
+                "vault_cache_entries": len(self._content_cache),
+                "vault_cache_memory_mb": round(self._cache_bytes / 1024 / 1024, 2),
+                "vault_cache_max_mb": round(self._max_cache_bytes / 1024 / 1024, 2),
+                "vault_cache_reserved_memory_mb": round(
+                    self._hydration_reserved_bytes / 1024 / 1024, 2
+                ),
+                "vault_cache_active_hydrations": len(self._hydration_flights),
+                "vault_cache_hits": self._cache_hits,
+                "vault_cache_misses": self._cache_misses,
+                "vault_cache_evictions": self._cache_evictions,
+                "vault_cache_coalesced_hydrations": self._coalesced_hydrations,
+                "vault_cache_physical_reads": self._physical_hydration_reads,
+                "vault_cache_hydration_failures": self._hydration_failures,
+                "vault_cache_hit_rate": round(self._cache_hits / accesses if accesses else 0.0, 3),
+                "vault_index_stale_content_hashes": generation.stale_content_hashes,
+                "vault_index_skipped_blocks": generation.skipped_blocks,
+                "vault_index_oversized_blocks": generation.oversized_blocks,
+            }
 
     def search(
         self, query: str, top_k: int = 5, min_score: float = 2.0
     ) -> List[Tuple[dict, float]]:
         """BM25 search across vault blocks. Returns [(block_dict, score), ...]."""
+        return self._search(query, top_k=top_k, min_score=min_score, include_internal=False)
+
+    def _search(
+        self,
+        query: str,
+        top_k: int,
+        min_score: float,
+        *,
+        include_internal: bool,
+    ) -> List[Tuple[dict, float]]:
+        """Search with optional private metadata for the injection compiler."""
         query_terms = _bm25_tokenize_query(query)
-        if not query_terms or not self.blocks:
+        generation = self._snapshot_generation()
+        if not query_terms or generation.doc_count == 0:
             return []
 
-        # Snapshot refs atomically under GIL — no lock held during scoring
-        df = self._df
-        block_tfs = self._block_tfs
-        block_dl = self._block_dl  # precomputed doc lengths — avoids sum(tf.values()) per request
-        avg_dl = self._avg_dl
-        doc_count = self._doc_count
-        blocks = self.blocks
-        inverted = self._inverted
+        # One immutable generation keeps IDs, postings, lengths, and metadata
+        # coherent while reload work builds and publishes its successor.
+        block_ids = generation.block_ids
+        postings = generation.postings
+        block_dl = generation.block_dl
+        avg_dl = generation.avg_dl
+        doc_count = generation.doc_count
+        blocks = generation.blocks
 
         k1 = 1.5
         b_param = 0.75
-        scores: Dict[str, float] = {}
+        scores: Dict[int, float] = {}
 
         # IDF-gated candidate expansion with MAX_CANDIDATES cap:
         # 1. Skip terms appearing in >40% of docs (too common to discriminate).
@@ -257,52 +750,119 @@ class VaultIndex:
         _selective: List[Tuple[str, int]] = []
         _fallback: List[str] = []
         for qt in query_terms:
-            if qt not in inverted:
+            posting = postings.get(qt)
+            if posting is None:
                 continue
-            term_freq = df.get(qt, 0)
+            term_freq = len(posting)
             if doc_count > 0 and term_freq / doc_count > _idf_gate:
                 _fallback.append(qt)
             else:
                 _selective.append((qt, term_freq))
         _selective.sort(key=lambda x: x[1])  # most selective first
 
-        candidates: set = set()
+        candidates: set[int] = set()
         if _selective:
             for qt, _ in _selective:
-                candidates.update(inverted[qt])
+                posting = postings[qt]
+                candidates.update(packed >> 32 for packed in posting)
                 if len(candidates) >= _max_candidates:
                     break  # enough; less selective terms contribute diminishing returns
         if not candidates:
             # All terms are corpus-wide — fall back to common terms (fast path)
             for qt in _fallback:
-                candidates.update(inverted[qt])
+                posting = postings[qt]
+                candidates.update(packed >> 32 for packed in posting)
         if not candidates:
             return []
 
-        for bid in candidates:
-            tf = block_tfs.get(bid, {})
-            dl = block_dl.get(bid, 0)  # O(1) lookup instead of O(terms) sum
-            score = 0.0
-            for qt in query_terms:
-                if qt not in df:
-                    continue
-                idf = math.log((doc_count - df[qt] + 0.5) / (df[qt] + 0.5) + 1)
-                term_freq = tf.get(qt, 0)
-                if term_freq == 0:
-                    continue
-                numerator = term_freq * (k1 + 1)
-                denominator = term_freq + k1 * (1 - b_param + b_param * dl / avg_dl)
-                score += idf * numerator / denominator
-            if score >= min_score:
-                scores[bid] = score
+        # Score directly from compact postings. Query-term duplication is
+        # intentionally preserved because the prior implementation added each
+        # expanded term occurrence independently.
+        for qt in query_terms:
+            posting = postings.get(qt)
+            if posting is None:
+                continue
+            df = len(posting)
+            idf = math.log((doc_count - df + 0.5) / (df + 0.5) + 1)
+            if len(posting) > len(candidates) * 4:
+                # Posting doc IDs are sorted. For a selective candidate set,
+                # binary lookup avoids scanning corpus-wide common terms.
+                for doc_idx in candidates:
+                    position = _bisect_left(posting, doc_idx << 32)
+                    if position >= len(posting):
+                        continue
+                    packed = posting[position]
+                    if packed >> 32 != doc_idx:
+                        continue
+                    term_freq = packed & 0xFFFFFFFF
+                    dl = block_dl[doc_idx]
+                    numerator = term_freq * (k1 + 1)
+                    denominator = term_freq + k1 * (1 - b_param + b_param * dl / avg_dl)
+                    scores[doc_idx] = scores.get(doc_idx, 0.0) + idf * numerator / denominator
+            else:
+                for packed in posting:
+                    doc_idx = packed >> 32
+                    if doc_idx not in candidates:
+                        continue
+                    term_freq = packed & 0xFFFFFFFF
+                    dl = block_dl[doc_idx]
+                    numerator = term_freq * (k1 + 1)
+                    denominator = term_freq + k1 * (1 - b_param + b_param * dl / avg_dl)
+                    scores[doc_idx] = scores.get(doc_idx, 0.0) + idf * numerator / denominator
 
         # Sort deterministically: score desc, then path asc, then block_id asc
         # This ensures byte-identical ordering for cache stability even on score ties
         ranked = sorted(
-            scores.items(),
-            key=lambda x: (-x[1], blocks[x[0]].get("source_path", ""), x[0]),
+            ((doc_idx, score) for doc_idx, score in scores.items() if score >= min_score),
+            key=lambda x: (
+                -x[1],
+                blocks[block_ids[x[0]]].get("source_path", ""),
+                block_ids[x[0]],
+            ),
         )[:top_k]
-        return [(blocks[bid], score) for bid, score in ranked]
+
+        # Preserve the proxy VaultIndex API: search results include content.
+        # Only top-k results are hydrated, and the retained bytes stay bounded.
+        results: List[Tuple[dict, float]] = []
+        remaining_content_bytes = self._max_cache_bytes
+        for doc_idx, score in ranked:
+            bid = block_ids[doc_idx]
+            record = generation.content_records.get(bid)
+            source_bytes = record.file_size if record and record.file_size else 0
+            if remaining_content_bytes > 0:
+                hydrated = self._hydrate_content(generation, bid)
+            else:
+                hydrated = _HydratedContent(
+                    text="",
+                    utf8_bytes=0,
+                    source_bytes=source_bytes,
+                    source_bytes_loaded=0,
+                    truncated=source_bytes > 0,
+                )
+            if hydrated is None:
+                marker = _utf8_prefix(_CONTENT_GENERATION_MISMATCH, remaining_content_bytes)
+                hydrated = _HydratedContent(
+                    text=marker,
+                    utf8_bytes=len(marker.encode("utf-8")),
+                    source_bytes=source_bytes,
+                    source_bytes_loaded=0,
+                    truncated=True,
+                )
+            hydrated = self._fit_hydration(hydrated, remaining_content_bytes)
+            remaining_content_bytes -= hydrated.utf8_bytes
+
+            block = dict(blocks[bid])
+            block.pop("_content_file", None)
+            if not include_internal:
+                block.pop("_content_metadata_stale", None)
+                block.pop("_content_tokens_actual", None)
+            block["content"] = hydrated.text
+            if hydrated.truncated:
+                block["content_truncated"] = True
+                block["content_bytes_total"] = hydrated.source_bytes
+                block["content_bytes_loaded"] = hydrated.source_bytes_loaded
+            results.append((block, score))
+        return results
 
     def compile_injection(
         self, query: str, budget: int = 4000, top_k: int = 5, min_score: float = 2.0
@@ -311,39 +871,65 @@ class VaultIndex:
         Search vault and compile injection text within budget.
         Returns (injection_text, tokens_used, source_refs).
         """
-        results = self.search(query, top_k=top_k, min_score=min_score)
+        results = self._search(
+            query,
+            top_k=top_k,
+            min_score=min_score,
+            include_internal=True,
+        )
         if not results:
             return "", 0, []
 
         injection_parts = []
         tokens_used = 0
         source_refs = []
+        header = "\n\n## Retrieved Context\n"  # fixed header for cache stability
 
         for block, score in results:
             content = block["content"]
-            block_tokens = block["raw_tokens"]
+            if not content and block.get("content_truncated"):
+                continue
+            source_path = block["source_path"]
+            part_prefix = f"--- [{source_path}] (relevance: {score:.1f}) ---\n"
 
             # Budget check
             remaining = budget - tokens_used
             if remaining <= 100:
                 break
 
-            # Truncate if needed
-            if block_tokens > remaining:
-                # Rough char-to-token truncation
-                char_limit = remaining * 4
-                content = content[:char_limit].rsplit("\n", 1)[0]
-                block_tokens = count_tokens(content)
+            complete_parts = injection_parts + [part_prefix + content]
+            complete_tokens = count_tokens(header + "\n\n".join(complete_parts))
+            if complete_tokens <= budget:
+                injection_parts = complete_parts
+                tokens_used = complete_tokens
+                source_refs.append(source_path)
+                continue
 
-            source_path = block["source_path"]
-            injection_parts.append(f"--- [{source_path}] (relevance: {score:.1f}) ---\n{content}")
-            tokens_used += block_tokens
+            # The complete next result does not fit. Find the largest content
+            # prefix whose fully rendered injection, including fixed headers
+            # and separators, stays within the hard token budget.
+            low = 0
+            high = len(content)
+            best = 0
+            while low <= high:
+                midpoint = (low + high) // 2
+                candidate_parts = injection_parts + [part_prefix + content[:midpoint]]
+                candidate_tokens = count_tokens(header + "\n\n".join(candidate_parts))
+                if candidate_tokens <= budget:
+                    best = midpoint
+                    low = midpoint + 1
+                else:
+                    high = midpoint - 1
+            if best == 0:
+                break
+            injection_parts.append(part_prefix + content[:best])
+            tokens_used = count_tokens(header + "\n\n".join(injection_parts))
             source_refs.append(source_path)
+            break
 
         if not injection_parts:
             return "", 0, []
 
-        header = "\n\n## Retrieved Context\n"  # fixed header for cache stability
         injection_text = header + "\n\n".join(injection_parts)
         # Recount with header
         tokens_used = count_tokens(injection_text)
@@ -359,6 +945,12 @@ class VaultIndex:
 @lru_cache(maxsize=512)
 def _bm25_tokenize(text: str) -> List[str]:
     return re.findall(r"[a-z0-9_]+", text.lower())
+
+
+def _bm25_count_document(text: str) -> Tuple[Dict[str, int], int]:
+    """Count document terms without retaining the document in the query LRU."""
+    terms = re.findall(r"[a-z0-9_]+", text.lower())
+    return _Counter(terms), len(terms)
 
 
 @lru_cache(maxsize=512)
@@ -439,9 +1031,11 @@ def _init_singletons() -> None:
 
         # Start background auto-reindex timer (rebuilds index from source files)
         if VAULT_AUTO_REINDEX_INTERVAL > 0:
+
             def _vault_auto_reindex_timer() -> None:
                 try:
                     from tokenpak.vault.vault_health import VaultHealth
+
                     # VAULT_INDEX_PATH points to the .tokenpak dir inside vault
                     # VaultHealth expects the vault root (parent of .tokenpak)
                     vault_dir = Path(VAULT_INDEX_PATH).parent
@@ -538,6 +1132,7 @@ def get_capsule_builder() -> Optional[object]:
 # will still see the correct object after first access.
 # ---------------------------------------------------------------------------
 
+
 class _LazyAlias:
     """Descriptor-like proxy that forwards attribute access to the real singleton."""
 
@@ -580,6 +1175,7 @@ def inject_vault_context(
         body_bytes = request.body
     # Lazy imports for proxy-layer dependencies (transferred to subpackages in A2c)
     from tokenpak.proxy.adapters.utils import _detect_adapter, extract_query_signal
+
     try:
         from tokenpak.core.runtime.proxy import SESSION  # type: ignore[import]
     except ImportError:


### PR DESCRIPTION
Brings public `main@6214dd1d193cd96e9b67b3a3c4d8b7e038b5b115` to content parity with staging `main@e9993a8938f0ddc73afc1cdca3b7000e8789973b` in one bounded promotion commit.

Summary:

- Hardens proxy client lifecycle, listener admission, managed-request classification, upstream header handling, spend-guard failure behavior, and vault memory bounds.
- Isolates parallel Codex session state while preserving retained handoffs, setup behavior, diagnostics, and uninstall cleanup.
- Expands focused regression coverage and updates the related CLI and spend-guard documentation.

Scope: source, documentation, and tests only. No version change, dependency lockfile change, release workflow change, or publication action is included.

Manifest: exactly 34 files—10 added and 24 modified—with 12,376 insertions and 990 deletions.