### PR TITLE
fix(license): assign the enterprise-tier features in the canonical map

### DIFF
--- a/tests/license/test_tier_feature_map.py
+++ b/tests/license/test_tier_feature_map.py
@@ -36,7 +36,10 @@ EXPECTED_TIER_FEATURES = {
         "seat_management",
         "team_analytics",
     ],
-    LicenseTier.ENTERPRISE: [],
+    LicenseTier.ENTERPRISE: [
+        "audit_log",
+        "sla",
+    ],
 }
 
 
@@ -87,8 +90,23 @@ def test_each_feature_is_introduced_by_exactly_one_tier() -> None:
         ("team_analytics", "team"),
         ("compression_advanced", "pro"),
         ("multipak_capture", "pro"),
+        ("audit_log", "enterprise"),
+        ("sla", "enterprise"),
         ("unknown_thing", None),
     ],
 )
 def test_required_tier_for(feature: str, expected_tier: str | None) -> None:
     assert required_tier_for(feature) == expected_tier
+
+
+def test_every_tier_above_free_introduces_at_least_one_feature() -> None:
+    """A paid tier with no features of its own is a gap, not a design.
+
+    An empty list here silently un-gates any command that names one of that
+    tier's features: ``required_tier_for`` returns ``None`` and callers cannot
+    tell "no such feature" from "feature exists but is unassigned".
+    """
+    for tier in LicenseTier.ladder():
+        if tier is LicenseTier.FREE:
+            continue
+        assert TIER_FEATURES[tier], f"{tier.value} tier introduces no features"

--- a/tokenpak/agent/license/validator.py
+++ b/tokenpak/agent/license/validator.py
@@ -45,7 +45,10 @@ TIER_FEATURES: dict[LicenseTier, list[str]] = {
         "seat_management",
         "team_analytics",
     ],
-    LicenseTier.ENTERPRISE: [],
+    LicenseTier.ENTERPRISE: [
+        "audit_log",
+        "sla",
+    ],
 }
 
 


### PR DESCRIPTION
## Problem

The canonical tier map shipped with `LicenseTier.ENTERPRISE: []`. Two feature names in active use therefore had no tier assignment anywhere in the map:

| Feature | Gates |
|---|---|
| `sla` | `compliance`, `sla`, `maintenance` |
| `audit_log` | `policy`, `vault` |

An unassigned feature is worse than a missing one. `required_tier_for` returns `None` for both *"no such feature"* and *"feature exists, nobody assigned it a tier"*, so a caller cannot tell a typo from a gap.

This surfaced immediately downstream: the premium package validates its command registry's feature names against this map. That check had been passing vacuously because the module it imports did not exist until the map landed — it was written to skip on `ImportError`. With the map present the check runs for the first time and fails on a name that is entirely legitimate.

## Fix

Assign both to enterprise:

- They gate the `compliance`, `sla`, `maintenance`, `policy` and `vault` commands, which are grouped under the enterprise section of the consumer's registry and whose implementations live under its `enterprise/` namespace.
- Neither appears in the canonical pro feature set, so this adds nothing to pro or team and changes no existing entitlement.

Also adds `test_every_tier_above_free_introduces_at_least_one_feature`, which rejects an empty feature list on any paid tier — the exact shape of the original gap.

## Verification

- `tests/license/test_tier_feature_map.py` — 13 passed
- Lint + format clean
- The downstream registry check that was failing now passes against the amended map (4 passed)