### PR TITLE
release: v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.15.0] — 2026-07-24
+
+> Minor release: a canonical, importable map from paid features to the license
+> tier that introduces them, replacing per-consumer assumptions about which tier
+> a feature belongs to.
+
+### Added
+
+- **Canonical license tier and feature map** (`tokenpak.agent.license`). Exposes
+  `LicenseTier`, `TIER_FEATURES`, and `required_tier_for(feature)`. Tiers form an
+  ordered ladder — `free < pro < team < enterprise` — and each feature is
+  introduced by exactly one tier, so `required_tier_for` returns the *lowest*
+  tier that grants it.
+
+  Before this, a consumer with no way to look a feature up had to assume one.
+  The map makes the answer explicit and checkable: `tokenpak_server`,
+  `seat_management`, and `team_analytics` resolve to `team`; the nine Pro
+  features — including `multipak_capture` — resolve to `pro`; `audit_log` and
+  `sla` resolve to `enterprise`.
+
+### Fixed
+
+- **Enterprise tier features are no longer unassigned.** The map initially
+  shipped with an empty enterprise list, leaving `audit_log` and `sla` — both in
+  active use — with no tier anywhere. That is worse than an absent feature:
+  `required_tier_for` returns `None` for both "no such feature" and "feature
+  exists but is unassigned", so a caller cannot tell a typo from a gap. Both are
+  now assigned, and a regression test rejects an empty feature list on any paid
+  tier.
+
+### Upgrade notes
+
+Purely additive; no migration required. Nothing in an existing installation
+changes behaviour, and no previously granted entitlement is altered — the map
+records tier membership, it does not itself gate anything. Consumers that
+hardcoded a tier for these feature names should switch to `required_tier_for`.
+
+**Rollback:** `pip install tokenpak==1.14.0`. The added module is standalone, so
+downgrading only removes it.
+
+**Known issues:** none specific to this release.
+
+**Breaking changes / deprecations:** none.
+
 ## [1.14.0] — 2026-07-21
 
 > Minor release: verified Codex contention recovery with typed diagnostics,

--- a/tokenpak/__init__.py
+++ b/tokenpak/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 __author__ = "TokenPak Contributors"
 __license__ = "Apache-2.0"
 __description__ = "Deterministic compression for multi-agent AI workflows"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "tokenpak_version": "1.14.0",
+  "tokenpak_version": "1.15.0",
   "asserted_tip_version": "TIP-1.0",
   "pinned_registry_schema_tag": "schema-2026-07-18",
   "pinned_docs_revision": "v1.13.0-docs"


### PR DESCRIPTION
## Release v1.15.0

Bumps the package version and machine release metadata, and adds the changelog entry covering the canonical license tier and feature map.

### Contents since v1.14.0

| Commit | Change |
|---|---|
| `7269f3dc8a` | `feat(license)` — canonical license tier and feature map |
| `cf9f6bfedb` | `fix(license)` — assign the enterprise-tier features |

### Why minor, not patch

The release adds a **new importable module and public symbols**: `tokenpak.agent.license`, exposing `LicenseTier`, `TIER_FEATURES` and `required_tier_for`. Semver reserves patch for backwards-compatible bug fixes; shipping added API under a patch version would tell anyone pinned to a compatible range that no surface changed, which is false. Nothing is removed or changed incompatibly, so minor — not major — is correct.

### Version-bearing surfaces

- `tokenpak/__init__.py` → `1.15.0`
- `version.json` → `tokenpak_version: "1.15.0"`
- `pyproject.toml` — dynamic from the package version source
- `CHANGELOG.md` — full entry with upgrade notes, rollback, known issues, breaking changes

### Packaging verification

`tokenpak/agent/` is a namespace package (no `__init__.py`), so wheel inclusion was verified rather than assumed. A built `tokenpak-1.15.0-py3-none-any.whl` contains both `tokenpak/agent/license/__init__.py` and `tokenpak/agent/license/validator.py`.

### Local verification

222 passed across version-coherence, license, output-formatter and release-check suites; lint clean.