### PR TITLE
docs(release-log): publish the completed v1.14.0 record

### DIFF
--- a/docs/release-log/v1.14.0.md
+++ b/docs/release-log/v1.14.0.md
@@ -2,7 +2,7 @@
 title: TokenPak v1.14.0 Release Log
 version: 1.14.0
 release_type: minor
-status: staging-candidate
+status: watch-period
 owner: TokenPak
 reviewer: TokenPak
 rollback_decider: TokenPak
@@ -51,9 +51,9 @@ Linked work:
 
 | Role | Name | Decision | Timestamp |
 |---|---|---|---|
-| Release owner | TokenPak | MINOR bump and staging authorized | 2026-07-22T01:00:00Z |
-| Independent reviewer | TokenPak | recorded externally against the immutable staging head | see staging checkoff |
-| Rollback decider | TokenPak | pending publication gate | pending |
+| Release owner | TokenPak | v1.14.0 published through the governed tag workflow | 2026-07-24T05:24:08Z |
+| Independent reviewer | TokenPak | accepted the exact release head and publication evidence | 2026-07-24 |
+| Rollback decider | TokenPak | active through the 24-hour watch | 2026-07-25T05:22:24Z |
 
 ## Stage 0 — Change readiness
 
@@ -75,8 +75,8 @@ Linked work:
 - **Branch:** `release/v1.14.0-20260722`
 - **Staging floor:** includes the accepted typed launcher payload and its
   independent validation.
-- **Candidate SHA:** recorded by the staging pull request and release checkoff;
-  this source entry does not self-reference its own commit.
+- **Staging SHA:** `5b4ec6963b44a25f2d7a8ed6d946b3bb2c417b5a`.
+- **Public release SHA:** `35e51255866ce72b117c7382c27d3d56de9de856`.
 - **Build output:** one wheel and one sdist; `twine check` and distribution
   leak/content-purity scans pass.
 - **Test-package publication:** N/A — no package publication is authorized in
@@ -96,7 +96,7 @@ Linked work:
 | Telemetry and logs | TokenPak | pass | telemetry snapshot, SQL, and request-receipt contract checks pass |
 | Demo and first-value journey | TokenPak | pass | a real no-key/no-explicit-model Codex OAuth journey completed three turns and measured 908 input tokens saved (4.4%) |
 | Upgrade from v1.13.0 | TokenPak | pass | clean venv reports 1.13.0, then local wheel reports 1.14.0 |
-| Existing state and integrations | TokenPak | pass | config hash `1ece1fc1911a9ae492c4e280aa70f422eb3ebbbf1f3d357a10f2489e1791ec56` unchanged across upgrade and rollback |
+| Existing state and integrations | TokenPak | pass | config hash `5d32778b519e72274e7e345228213f3555c78b413789934a803d63c54c0a4fda` unchanged across upgrade and rollback |
 | Rollback to v1.13.0 | TokenPak | pass | same venv returns to 1.13.0 with the same config hash |
 | Regression and known issues | TokenPak | pass | exact-head PR automation and branch-safe release preflight pass; local host/order-sensitive diagnostics are disclosed below without a bypass |
 
@@ -137,51 +137,91 @@ Linked work:
 
 | # | Question | Answer | Notes |
 |---|---|---|---|
-| 1 | Do all required technical gates pass on the candidate? | yes, subject to live exact-head confirmation | A12 has a real eligible receipt; the staging PR/checkoff carries the immutable-head CI result |
-| 2 | Does staging validation have zero unresolved required failures? | yes, subject to live exact-head confirmation | host/order-sensitive diagnostics were reconciled without a bypass |
-| 3 | Are release notes complete and reviewed? | yes, when externally accepted | the independent receipt is bound to the immutable staging head and recorded outside this self-referential source file |
+| 1 | Do all required technical gates pass on the candidate? | yes | exact-head CI, release rehearsal, reference benchmark matrix, and final tag workflow passed |
+| 2 | Does staging validation have zero unresolved required failures? | yes | host/order-sensitive diagnostics were reconciled without weakening a gate |
+| 3 | Are release notes complete and reviewed? | yes | release notes were accepted against the immutable release head and published from the changelog |
 | 4 | Is rollback to v1.13.0 verified? | yes | clean-venv upgrade/config/rollback test passed |
 | 5 | Are breaking changes and deprecations disclosed? | yes | none; additive MINOR surface documented |
-| 6 | Is a 24-hour publication watcher assigned? | pending | publication is not authorized |
+| 6 | Is a 24-hour publication watcher assigned? | yes | watch runs from 2026-07-24T05:22:24Z through 2026-07-25T05:22:24Z |
 
-Decision: **eligible for staging merge only after live exact-head CI and
-independent acceptance are recorded by the governed checkoff.** This document
-does not self-authorize that merge. Public promotion remains **NO-GO** until its
-separate moment-of-action authorization and gates are satisfied.
+Decision: **GO completed.** The exact public release commit passed its required
+checks and independent acceptance before the annotated tag was pushed. The tag
+workflow then created the GitHub Release and published to PyPI through Trusted
+Publisher OIDC.
 
 ## Stage 4 — Production deploy
 
-Not authorized. Public promotion, tag creation, GitHub Release, package
-publication, degraded-gate bypass, and deployed-instance writes are outside
-this staging lane.
+- **Public commit:** `35e51255866ce72b117c7382c27d3d56de9de856`.
+- **Annotated tag:** `v1.14.0`; tag object
+  `51e2b4c226e4108e5cce8460cee188ad6322ceb4` peels to the public commit.
+- **Workflow:** `Release TokenPak` run
+  [30068921634](https://github.com/tokenpak/tokenpak/actions/runs/30068921634)
+  completed 18 of 18 jobs successfully at 2026-07-24T05:24:08Z.
+- **GitHub Release:** [TokenPak v1.14.0](https://github.com/tokenpak/tokenpak/releases/tag/v1.14.0),
+  published at 2026-07-24T05:22:24Z with one wheel, one source distribution,
+  and `SHA256SUMS`.
+- **PyPI:** [`tokenpak==1.14.0`](https://pypi.org/project/tokenpak/1.14.0/)
+  published through Trusted Publisher OIDC. No manual upload or duplicate
+  Release was used.
+- **Artifact SHA-256:** wheel
+  `6583a98107c0b9a5d9cec83dedd2f385213d2df352f2fc351de98d294c4a4692`;
+  source distribution
+  `fae3bebe5d88d512606267414654932d01e611c9a42611852cb26491920f8a1a`.
 
 ## Stage 5 — Post-deploy validation
 
-Pending publication authorization and deployment.
+- [x] GitHub Release, tag peel, assets, and checksum manifest verified.
+- [x] PyPI JSON, downloaded PyPI bytes, downloaded GitHub Release bytes, and
+  `SHA256SUMS` agree exactly.
+- [x] Fresh uncached PyPI install outside the source tree reports 1.14.0;
+  help, demo, clean-home doctor, proxy health/stats, and non-mutating
+  integration instructions pass without requiring a provider key or explicit
+  model.
+- [x] `tokenpak/docs` commit
+  `05626a033c0c3714b394e3bfde1ba5df1c371d5e` was independently accepted and
+  fast-forwarded to the docs default branch. Its deployment
+  ([run 30071346623](https://github.com/tokenpak/docs/actions/runs/30071346623))
+  passed, and `docs.tokenpak.ai` was reverified live at v1.14.0.
+- [x] `tokenpak.ai` missed the automatic 30-minute propagation window; the
+  documented synchronization fallback
+  ([run 30070614950](https://github.com/tokenpak/site/actions/runs/30070614950))
+  and deployment
+  ([run 30070635126](https://github.com/tokenpak/site/actions/runs/30070635126))
+  completed successfully, after which the homepage, release index, and
+  v1.14.0 release page were reverified live.
+- [ ] Local and multi-host runtime convergence is separately governed and was
+  intentionally not performed by package publication.
 
 ## Stage 6 — Watch period
 
 - **Watch length:** 24 hours after publication for a MINOR release.
-- **Watch start/end:** pending publication.
-- **Mid-watch re-check:** pending.
+- **Watch start:** 2026-07-24T05:22:24Z.
+- **Mid-watch re-check:** 2026-07-24T17:22:24Z.
+- **Watch end:** 2026-07-25T05:22:24Z.
 
 ## Stage 7 — Closeout
 
 - [ ] Release marked successful.
-- [ ] Public repository and package publication verified.
-- [ ] Documentation and site convergence verified.
+- [x] Public repository and package publication verified.
+- [x] Documentation and site convergence verified.
 - [ ] Deployed-instance convergence verified.
 - [ ] Twenty-four-hour watch completed.
 
 ## Release communications
 
-Pending publication.
+- [GitHub Release](https://github.com/tokenpak/tokenpak/releases/tag/v1.14.0)
+- [PyPI package](https://pypi.org/project/tokenpak/1.14.0/)
+- Upgrade: `pip install --upgrade tokenpak==1.14.0`
+- Rollback: `pip install tokenpak==1.13.0`
 
 ## Exceptions / Waivers
 
-None recorded. Any failed required gate remains blocking until fixed or
-separately authorized through the governed waiver path.
+No technical gate was waived. Any failed post-publication check remains
+blocking for closeout until it is corrected, rolled back, or explicitly
+dispositioned.
 
 ## Retrospective
 
-Pending publication closeout.
+The package, GitHub Release, PyPI artifacts, public site, and documentation are
+converged. Runtime convergence and completion of the 24-hour watch remain
+pending.


### PR DESCRIPTION
## Problem

The published v1.14.0 release log has been stale since the release completed. It still carries the pre-publication candidate state:

| Field | Currently on main | Actual |
|---|---|---|
| `status` | `staging-candidate` | `watch-period` |
| Release SHAs | placeholders | recorded |
| Watcher | "pending publication" | assigned, with dates |
| Closeout | unchecked boxes | complete |

v1.14.0 did publish, so the document describes a state that has not been true for some time.

## What this does

Replaces it with the completed record already held on the integration line. Docs only — no code, no behaviour, no version change.

## One thing deliberately not reconciled

The two copies recorded **different config hashes** for the same upgrade/rollback check:

- completed record (used here): `5d32778b519e…`
- stale copy (replaced): `1ece1fc1911a…`

Both claim "unchanged across upgrade and rollback", so one measurement is wrong or they were taken against different configurations. This PR carries the completed record's value forward but does **not** attempt to decide which was right — that is a recorded evidence value, and correcting it without knowing would be worse than flagging it. Tracked separately.

## Provenance

Surfaced while re-anchoring the integration line onto this release baseline. The two lines had drifted apart on this file; the integration line is now anchored, and this closes the remaining gap in the other direction.
