### PR TITLE
promote: post-release corrections for v1.16.0 (2026-07-26)

### DIFF
--- a/docs/release-log/v1.16.0.md
+++ b/docs/release-log/v1.16.0.md
@@ -2,12 +2,12 @@
 title: TokenPak v1.16.0 Release Log
 version: 1.16.0
 release_type: minor
-status: in-progress
+status: complete
 owner: TokenPak
 reviewer: TokenPak
 rollback_decider: TokenPak
 started: 2026-07-26T16:00:00Z
-closed:
+closed: 2026-07-26T18:10:00Z
 ---
 
 # TokenPak v1.16.0 Release Log
@@ -34,9 +34,18 @@ partial release.
 
 ## Public-surface compatibility ruling
 
-**Six public symbols are removed.** A strict SemVer reading calls for a major
+**Eleven public symbols are removed.** A strict SemVer reading calls for a major
 version; this ships as a minor on an explicit project ruling, recorded in the
 changelog where a reader will see it rather than discovering it from a broken build.
+
+This table originally listed six, and six is where the changelog got the number
+too. The count came from enumerating the symbols the work had touched, rather
+than from asking the gate. Run against 1.15.0 **as published** —
+`scripts/release_gate/api_snapshot_diff.py github/main <staging>` — it is eleven:
+the five `companion.codex.launcher` entries below were missed. Each was then
+confirmed genuinely absent from the built package, so none of this is snapshot
+noise from a differing install shape. A removal count is only meaningful against
+the published baseline.
 
 | Symbol | Ruling |
 |---|---|
@@ -46,6 +55,11 @@ changelog where a reader will see it rather than discovering it from a broken bu
 | `tokenpak.cli.commands.preview.register_preview` | **Remove.** Same module. |
 | `tokenpak.cli.commands.license_cmd.DEFAULT_UPGRADE_URL` | **Remove, no replacement default.** Pointed at a page returning HTTP 404. |
 | `tokenpak.cli.commands.status.DEFAULT_UPGRADE_URL` | **Remove, no replacement default.** Same. |
+| `tokenpak.companion.codex.launcher.FallbackDecision` | **Remove.** Internal launcher type the snapshot gate counts as public; no external caller contract. |
+| `tokenpak.companion.codex.launcher.PreflightEvaluation` | **Remove.** Same. |
+| `tokenpak.companion.codex.launcher.PreflightEvidence` | **Remove.** Same. |
+| `tokenpak.companion.codex.launcher.PreflightStatus` | **Remove.** Same. |
+| `tokenpak.companion.codex.launcher.TemporarySessionChoice` | **Remove.** Same. |
 
 Affected pin shapes: `~=1.15.0` is **not** affected (PEP 440 excludes 1.16.0).
 `~=1.15`, `>=1.15,<2.0` and unpinned installs **are**.
@@ -86,6 +100,17 @@ modules in a subprocess and asserts nothing appears on disk.
   targets Linux and no Mac or Windows host was available. Unverified, not passing.
 - `proxy_watchdog`'s remaining module-scope resolution was removed here; a related
   cleanup for `CooldownManager`'s call sites is tracked separately.
+- **The release workflow failed once, on a flaky test rather than on this release.**
+  `test_half_closed_upstream_sockets_and_fds_plateau_at_session_cap` asserts an
+  absolute descriptor ceiling of `baseline + cap + 4`; it observed 41 against a
+  ceiling of 40 on one of twelve matrix cells. The leak guard it exists to enforce
+  passed — the plateau had variance zero and CLOSE-WAIT sat exactly on the cap.
+  `wait_ready()` returns while its own readiness socket is still open, so the
+  baseline read 5 if sampled at once and 4 a moment later, and the fitted `+ 4`
+  held only in the first case. The test is unchanged since before v1.15.0 and
+  passed the other eleven cells. Recovered by re-running the failed job; the tag
+  was untouched and no code changed. Fixed separately by making both operands
+  measured rather than fitted.
 
 ## Rollback
 
@@ -101,8 +126,18 @@ back by symlink flip.
 | Beta-unblock merged to staging | 2026-07-26T16:01:28Z | `bb96dd6f5c` |
 | Release commit on staging branch | 2026-07-26T16:2xZ | `5367619778` |
 | Staging release PR | 2026-07-26 | tokenpak-staging #628 |
-| Public promotion | | |
-| Tag pushed | | |
-| GitHub Release | | |
-| PyPI | | |
-| Fleet rollout complete | | |
+| Staging release PR merged | 2026-07-26T16:44:27Z | `c93d072503` |
+| Public promotion — content parity | 2026-07-26T16:58:54Z | `eb23596b18`, #286 |
+| Removal-count correction on staging | 2026-07-26T16:59:34Z | `4a1e978221`, tokenpak-staging #629 |
+| Public promotion — release commit | 2026-07-26T17:12:17Z | `aa325855bf`, #287 |
+| Tag pushed | 2026-07-26T17:12:58Z | `v1.16.0` → `aa325855bf` |
+| GitHub Release | 2026-07-26T17:28:48Z | `TokenPak v1.16.0`, 3 assets |
+| PyPI | 2026-07-26T18:02:08Z | wheel + sdist, Trusted Publisher OIDC |
+| Fleet rollout complete | 2026-07-26T18:1xZ | SueWu / TrixBot / CaliBOT — CLI, expected and running proxy all `1.16.0` |
+
+The release workflow was run twice. The first run failed on one of twelve test
+matrix cells and skipped build, release and publish; the second was a re-run of
+the failed job only. The tag was not moved, deleted, or re-pointed, and no code
+changed between the two — see "Known issues" for the defect. Publication was
+gated on the `pypi` environment approval, which is why the GitHub Release and
+PyPI timestamps sit apart.

--- a/tests/docs/test_release_log_present.py
+++ b/tests/docs/test_release_log_present.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The version being shipped must have a release log.
+
+v1.15.0 shipped with no release log at all, and nothing objected. The control
+was real and documented; what was missing was anything that evaluated it, so it
+read as satisfied for as long as nobody looked. That is the same shape as a gate
+whose ingest never runs.
+
+Scope is deliberately the *current* version only. Most historical releases have
+no log either, and asserting over every tag would demand a backfill of records
+nobody can now reconstruct honestly -- it would fail loudly and be silenced,
+which is worse than not existing. Guarding `__version__` makes the next release
+carry a log without inventing evidence for old ones.
+
+`status` is not required to be `complete` here: the log is opened before
+publication and closed after it, so at the moment this test runs on a release PR
+the correct state is `in-progress`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import tokenpak
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_LOG_DIR = REPO_ROOT / "docs" / "release-log"
+
+_FRONTMATTER = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+_ALLOWED_STATUS = {"in-progress", "complete"}
+
+
+def _log_path() -> Path:
+    return RELEASE_LOG_DIR / f"v{tokenpak.__version__}.md"
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    match = _FRONTMATTER.match(text)
+    if not match:
+        return {}
+    fields: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, sep, value = line.partition(":")
+        if sep:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def test_release_log_exists_for_the_shipped_version():
+    path = _log_path()
+    assert path.is_file(), (
+        f"no release log for the version being shipped: expected {path.relative_to(REPO_ROOT)}. "
+        "Open one before the release PR merges — it is the record of what shipped, and after "
+        "the tag is public nobody reconstructs it accurately."
+    )
+
+
+def test_release_log_frontmatter_agrees_with_the_package():
+    fields = _frontmatter(_log_path().read_text(encoding="utf-8"))
+    assert fields, "release log has no YAML frontmatter"
+    assert fields.get("version") == tokenpak.__version__, (
+        f"release log says version {fields.get('version')!r}, package says "
+        f"{tokenpak.__version__!r} — a copied log that was never re-pointed"
+    )
+
+
+@pytest.mark.parametrize("field", ["release_type", "status", "owner"])
+def test_release_log_declares_its_governance_fields(field):
+    fields = _frontmatter(_log_path().read_text(encoding="utf-8"))
+    assert fields.get(field), f"release log frontmatter is missing {field!r}"
+
+
+def test_release_log_status_is_a_known_state():
+    status = _frontmatter(_log_path().read_text(encoding="utf-8")).get("status")
+    assert status in _ALLOWED_STATUS, (
+        f"release log status {status!r} is not one of {sorted(_ALLOWED_STATUS)}"
+    )

--- a/tests/proxy/test_connection_pool_socket_bound.py
+++ b/tests/proxy/test_connection_pool_socket_bound.py
@@ -167,6 +167,34 @@ def _wait_for_live_drain(proxy: ProxyProc, remote_port: int, timeout: float = 5.
     pytest.fail(f"proxy did not drain half-closed sockets while live: {last}")
 
 
+def _settled_fd_count(pid: int, *, timeout: float = 5.0) -> int:
+    """Descriptor count after start-up transients have closed.
+
+    `wait_ready()` returns while its own readiness connection is still open, so
+    sampling immediately counts a socket that closes moments later. That made
+    the baseline race: 5 descriptors if read at once, 4 a half-second on. The
+    ceiling below has single-digit headroom, so a one-off baseline decided
+    whether it held — the assertion passed only when it happened to catch the
+    transient, and failed on the runner that did not.
+    """
+    deadline = time.monotonic() + timeout
+    previous = -1
+    while time.monotonic() < deadline:
+        current = len(list(Path(f"/proc/{pid}/fd").iterdir()))
+        if current == previous:
+            return current
+        previous = current
+        time.sleep(0.25)
+    return previous
+
+
+# Descriptors the proxy opens on its first request and then holds: the dated
+# proxy log, monitor.db (opened twice), and its -wal and -shm companions.
+# Enumerated by reading /proc/<pid>/fd link targets, not fitted to a passing
+# run. Session sockets are counted separately as _CAP.
+_POST_BASELINE_FDS = 5
+
+
 def test_half_closed_upstream_sockets_and_fds_plateau_at_session_cap():
     upstream = ThreadingHTTPServer(("127.0.0.1", 0), _HalfCloseUpstreamHandler)
     upstream.connections = set()  # type: ignore[attr-defined]
@@ -180,7 +208,7 @@ def test_half_closed_upstream_sockets_and_fds_plateau_at_session_cap():
     samples: list[tuple[int, int]] = []
     try:
         proxy.wait_ready()
-        baseline_fds = len(list(Path(f"/proc/{proxy.proc.pid}/fd").iterdir()))
+        baseline_fds = _settled_fd_count(proxy.proc.pid)
 
         for round_index in range(_ROUNDS):
             start = round_index * _CAP
@@ -196,10 +224,11 @@ def test_half_closed_upstream_sockets_and_fds_plateau_at_session_cap():
         assert all(0 < count <= _CAP for count in close_wait_counts), samples
         assert max(close_wait_counts) - min(close_wait_counts) <= 1, samples
         assert max(fd_counts) - min(fd_counts) <= 2, samples
-        # Session sockets plus the monitor DB's WAL/SHM descriptors. The
-        # plateau assertion above is the primary leak guard; this absolute
-        # ceiling prevents a stable but unexpectedly large offset.
-        assert max(fd_counts) <= baseline_fds + _CAP + 4, samples
+        # The plateau assertion above is the primary leak guard; this absolute
+        # ceiling prevents a stable but unexpectedly large offset. Both operands
+        # are measured rather than fitted -- see _settled_fd_count and
+        # _POST_BASELINE_FDS.
+        assert max(fd_counts) <= baseline_fds + _CAP + _POST_BASELINE_FDS, samples
 
         health = _health(proxy)
         metrics = health.get("connection_pool", health.get("pool", {}))


### PR DESCRIPTION
Three follow-ups to v1.16.0. Tree byte-identical to validated staging `772e6cd0de`. No shipped behaviour changes — one documentation record and two test files.

## 1. The release log and the changelog disagreed on public

Both are on this repository and they contradicted each other: the changelog says **eleven** public symbols removed, the release log said **six**.

Eleven is correct, and this log is where six came from — the changelog copied it. Six was an enumeration of the symbols the work had touched; the gate, run against 1.15.0 **as published** (`api_snapshot_diff.py`), reports eleven. The five `companion.codex.launcher` entries were missing, and each was confirmed genuinely absent from the built package.

The log now agrees with the changelog, states the correction rather than folding it in silently, and closes the record with per-stage evidence — promotion, tag, GitHub Release, PyPI, fleet rollout.

## 2. The fd ceiling that failed the release run

The v1.16.0 release workflow went red on one of twelve matrix cells: `assert 41 <= ((4 + 32) + 4)`.

**The leak guard was never in question** — the plateau assertion above it passed with variance *zero* and CLOSE-WAIT sat exactly on the cap. `wait_ready()` returns while its own readiness socket is still open, so the baseline read 5 when sampled immediately and 4 a moment later; the fitted `+ 4` held only in the first case. Eleven runners caught the transient, one did not.

Both operands are measured now: a settled baseline, and a named constant whose comment enumerates the five descriptors it covers (dated proxy log, `monitor.db` ×2, `-wal`, `-shm`), read from `/proc/<pid>/fd` link targets rather than fitted to a green run.

## 3. A release log is now required for the version being shipped

v1.15.0 shipped with no release log and nothing objected — nothing evaluated the control, so it read as satisfied for as long as nobody looked.

Scoped to the current version deliberately. Most historical releases have no log either; asserting over every tag would demand backfilling records nobody can reconstruct honestly, which fails loudly and gets silenced with an exclusion list. Verified non-vacuous: fails for v1.15.0 and v1.13.0, passes for v1.16.0.

## Gate receipt

| Gate | Result |
|---|---|
| G-1 diff | 3 files vs public `aa325855bf`; tree identical to staging `772e6cd0de` |
| G-2 forbidden-surface scan | clean over added lines |
| G-3 secrets / private paths | clean |
| G-4 identity | author **and** committer `TokenPak <hello@tokenpak.ai>`; 0 co-authored-by |
| G-5 CI on exact head | pending — recorded here once complete |
| G-6 authority | post-release correction lane under the v1.16.0 release packet |

§16.5 observed: no version bump, no tag, no publication.